### PR TITLE
[#126] Button 내부 컨텐츠 정렬 관련 수정

### DIFF
--- a/src/components/button/button.vue
+++ b/src/components/button/button.vue
@@ -118,6 +118,7 @@
 .evui-btn-span{
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 
 /** evui-btn > type(primary) **/


### PR DESCRIPTION
1. icon, text가 존재하는 부분의 내부 공간의 수평 정렬이 없어 min-width 적용 시 가운데 정렬안되는 문제 수정