### PR TITLE
[#376] calendar 컴포넌트 누락

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lodash-es": "^4.17.11",
     "marked": "^0.6.2",
     "vue": "^2.6.9",
+    "vue-i18n": "^8.12.0",
     "vue-resize-directive": "^1.2.0",
     "vue-router": "^3.0.2",
     "vuex": "^3.1.0"

--- a/src/components/datepicker/index.js
+++ b/src/components/datepicker/index.js
@@ -1,3 +1,7 @@
 import Datepicker from './datepicker';
+import Calendar from './calendar';
 
-export default Datepicker;
+export {
+  Datepicker,
+  Calendar,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ import EvTable from './components/table';
 import EvTimepicker from './components/timepicker';
 import EvToggle from './components/toggle';
 import EvLabel from './components/label';
-import EvDatepicker from './components/datepicker';
+import { Calendar as EvCalendar, Datepicker as EvDatepicker } from './components/datepicker';
 import EvWindow from './components/window';
 import { tabs as EvTabs, tab as EvTabPanel } from './components/tabs';
 import { TreeTable as EvTreeTable } from './components/tree';
@@ -49,6 +49,7 @@ const components = {
   EvToggle,
   EvLabel,
   EvWindow,
+  EvCalendar,
   EvDatepicker,
   EvTabs,
   EvTabPanel,


### PR DESCRIPTION
###########################
- 단독으로 calendar 컴포넌트를 사용하는 경우 오류 발생
- EvCalendar가 누락되어있어 추가하여 단독 컴포넌트로 사용할 수 있도록 함
- vue-i18n 패키지 추가