### PR TITLE
[#413] tab 컴포넌트 스타일 변경

### DIFF
--- a/src/components/tabs/tabs.vue
+++ b/src/components/tabs/tabs.vue
@@ -355,7 +355,7 @@
   .ev-tabs-body {
     position: relative;
     width: 100%;
-    height: 100%;
+    height: auto;
     border: 1px solid #dddee1;
     border-top: 0;
   }


### PR DESCRIPTION
============================
- 탭 내부에 <component>태그로 불러온 컴포넌트가 아닌 일반 DOM인 경우 높이가 맞지 않는 현상 수정