### PR TITLE
[#445] datepicker, calendar 로직 수정

### DIFF
--- a/src/components/datepicker/calendar.core.js
+++ b/src/components/datepicker/calendar.core.js
@@ -1611,8 +1611,15 @@ class Calendar {
 
   // 외부 Input box에 입력받는 값으로 클래스 내 데이터 갱신하는 함수
   setDateTime(dateTimeValue) {
+    const isValid = dateTimeValue && dateTimeValue.isValid();
     this.options.initSelectDayFlag = true;
-    this.options.initSelectDay = new Date(dateTimeValue);
+    if (isValid) {
+      this.options.initSelectDay = new Date(dateTimeValue);
+    } else {
+      const today = new Date();
+      this.options.initSelectDay = null;
+      this.options.currentYearMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+    }
     this.options.initLimitDay = new Date();
     this.coordinate.calendarArea.selectDayArr = [];
     this.init();

--- a/src/components/datepicker/datepicker.vue
+++ b/src/components/datepicker/datepicker.vue
@@ -244,6 +244,10 @@
               if (numberValueLength > 3 && numberValueLength !== 5 && numberValueLength !== 7) {
                 vm.calendar.setDateTime(moment(setValue, vm.options.localeType));
               }
+              if (!numberValueLength) {
+                vm.calendar.setDateTime(null);
+                vm.dataValue = null;
+              }
             }
           },
         });


### PR DESCRIPTION
==============================
- datepicker 날짜 입력 란의 값을 모두 지우는 경우 calendar 값 초기화 및
  현재 날짜의 년/월에 해당하는 페이지로 이동 및 v-model 값 null 처리 로직 추가
- setDateTime의 파라미터는 moment.js 고유의 파라미터를 사용하고 있으며,
  이 값의 유효성 검사를 위해 라이브러리 .isValid() 사용