### PR TITLE
[#464] Chart 버그 수정

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -114,5 +114,16 @@ export function quadrillion(v) {
 }
 
 export function numberWithComma(v) {
-  return truthy(v) ? v.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',') : false;
+  const reg = /\B(?=(\d{3})+(?!\d))/g;
+
+  if (truthy(v)) {
+    if (Number.isInteger(v)) {
+      return v.toString().replace(reg, ',');
+    }
+
+    const part = v.toString().split('.');
+    return part[0].replace(reg, ',') + (part[1] ? `.${part[1]}` : '');
+  }
+
+  return false;
 }

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -56,8 +56,10 @@ class EvChart {
 
     this.seriesList = {};
 
-    this.overlayCanvas.onmousemove = _throttle(this.onMouseMoveEvent.bind(this), 30);
-    this.overlayCanvas.onmouseout = this.onMouseOutEvent.bind(this);
+    this.throttledMouseMove = _throttle(this.onMouseMoveEvent, 30);
+
+    this.overlayCanvas.onmousemove = this.throttledMouseMove.bind(this);
+    this.overlayCanvas.onmouseleave = this.onMouseLeaveEvent.bind(this);
     this.seriesInfo = {
       charts: {
         pie: [],
@@ -507,7 +509,7 @@ class EvChart {
 
     if (this.overlayCanvas) {
       this.overlayCanvas.onmousemove = null;
-      this.overlayCanvas.onmouseout = null;
+      this.overlayCanvas.onmouseleave = null;
     }
 
     if (this.options.useTooltip) {

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -294,11 +294,11 @@ const modules = {
               minmax.y[axisY].min = smm.minY;
             }
           }
-          if (smm.maxX > minmax.x[axisX].max) {
+          if (smm.maxX >= minmax.x[axisX].max) {
             minmax.x[axisX].max = smm.maxX;
             minmax.x[axisX].maxSID = key;
           }
-          if (smm.maxY > minmax.y[axisY].max) {
+          if (smm.maxY >= minmax.y[axisY].max) {
             minmax.y[axisY].max = smm.maxY;
             minmax.y[axisX].maxSID = key;
           }

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -2,7 +2,6 @@ import { numberWithComma } from '@/common/utils';
 
 const modules = {
   onMouseMoveEvent(e) {
-    console.log('[event] [move]');
     const offset = this.getMousePosition(e);
     const hitInfo = this.findHitItem(offset);
     const ctx = this.overlayCtx;
@@ -24,7 +23,6 @@ const modules = {
     }
   },
   onMouseLeaveEvent() {
-    console.log('[event] [out]');
     this.throttledMouseMove.cancel();
     this.overlayClear();
     this.tooltipClear();

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -98,6 +98,7 @@ const modules = {
       if (pos === 'left' || pos === 'right') {
         ghostDOM.style.top = `${title}px`;
         ghostDOM.style.left = this.resizeDOM.style.left;
+        ghostDOM.style.right = this.resizeDOM.style.right;
         ghostDOM.style.height = this.resizeDOM.style.height;
       } else {
         ghostDOM.classList.add('horizontal');

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -34,8 +34,8 @@ class Scale {
     }
 
     const drawRange = chartSize - (axisOffset[0] + axisOffset[1]);
-    const minSteps = 2;
-    const maxSteps = Math.max(Math.floor(drawRange / bufferedTickSize), 4);
+    const minSteps = 1;
+    const maxSteps = Math.max(Math.floor(drawRange / bufferedTickSize), 1);
 
     return {
       min: minSteps,


### PR DESCRIPTION
##########
- Resize Bar mousedown 시 left값이 없어 왼쪽에 뜨는 버그
- MaxTip 소수점일 경우 3자리에 컴마처리 되는 버그
- Chart의 넓이에 따라 Time Axis Label이 겹치는 버그
- Graph Data값이 null일 때 Tooltip이 나옴
- mouseout 이벤트가 제대로 트리거되지 않아 Tooltip이 살아남는 버그
- MaxTip 데이터가 0일때 나오지 않음