### PR TITLE
[#478] 차트 버그 수정

### DIFF
--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -56,7 +56,7 @@ class Scale {
     }
 
     if (this.autoScaleRatio) {
-      maxValue = Math.round(maxValue * (this.autoScaleRatio + 1));
+      maxValue = Math.ceil(maxValue * (this.autoScaleRatio + 1));
     }
 
     if (this.startToZero) {


### PR DESCRIPTION
Axis Scale 시, round 처리가 되면 실제 최대 데이터보다 Axis의 Max가 작아지는 현상이 발생 (작은 숫자의 경우) 하여 올림으로 변경