### PR TITLE
[#478] 차트 버그 수정

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -503,7 +503,6 @@ class EvChart {
 
     this.initScale();
     this.redraw();
-    this.render();
   }
 
   redraw() {

--- a/src/components/chart/chart.vue
+++ b/src/components/chart/chart.vue
@@ -151,7 +151,10 @@
         return sizeValue;
       },
       onResize() {
-        this.evChart.resize();
+        const timer = setTimeout(() => {
+          this.evChart.resize();
+          clearTimeout(timer);
+        }, 1);
       },
     },
   };

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -108,6 +108,10 @@ class Scale {
       numberOfSteps = Math.round(graphRange / interval);
     }
 
+    if (graphMax - graphMin > (numberOfSteps * interval)) {
+      interval = (graphMax - graphMin) / numberOfSteps;
+    }
+
     return {
       steps: numberOfSteps,
       interval,

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -109,7 +109,7 @@ class Scale {
     }
 
     if (graphMax - graphMin > (numberOfSteps * interval)) {
-      interval = (graphMax - graphMin) / numberOfSteps;
+      interval = Math.ceil((graphMax - graphMin) / numberOfSteps);
     }
 
     return {


### PR DESCRIPTION
########
- 복잡한 DOM 구조의 상황에서 차트 외부에서 DOM을 init처리 이전에 바꿨을 때, v-resize의 이벤트가 발동하여 에러가 발생하여 setTimeout으로 뒤로 미룸
- core파일에서 불필요한 render 함수 호출이 이루어져 해당 호출 건 제거
- scale에서 시간 데이터가 꼬일 경우 interval과 max값의 tick이 제대로 맞지 않는 현상 발생하여 수정처리