### PR TITLE
[#433] Messagebox > 프로퍼티 명시가 없을 경우, 이전에 사용했던 내용으로 진행되는 버그 수정

### DIFF
--- a/src/components/message-box/message-box.js
+++ b/src/components/message-box/message-box.js
@@ -9,13 +9,23 @@ document.body.appendChild(root);
 
 let instance;
 export default function messageBox(options = {}) {
+  const dataOptions = Object.assign(
+    {
+      title: '',
+      message: '',
+      type: 'info',
+      onClosed: null,
+    },
+    options,
+  );
+
   if (!instance) {
     instance = new MsgVue({
-      data: options,
+      data: dataOptions,
     });
     instance.$mount();
     root.appendChild(instance.$el);
   }
-  Object.assign(instance._data, options);
+  Object.assign(instance._data, dataOptions);
   instance.visible = true;
 }


### PR DESCRIPTION
###################################################
messagebox 쓸때 title 이나 onClosed 필요없다해서 빼고 쓰면
이전에 호출했었던 title 이랑 callback 함수가 실행되는 버그가 있어서
명시를 안해주면 디폴트값을 새로 부여해주도록 수정