### PR TITLE
[#478] Chart 버그 수정

### DIFF
--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -70,35 +70,38 @@ const modules = {
     let cp;
     let halfBarSize;
     let dp;
+    let ldata;
+
+    ldata = type === 'bar' ? maxDomainIndex : maxDomain;
+
+    if (tipType === 'sel') {
+      if (hitInfo && hitInfo.label !== null) {
+        lastTip.pos = hitInfo.label;
+        ldata = lastTip.pos;
+      } else if (lastTip.label !== null) {
+        ldata = lastTip.pos;
+      }
+    }
 
     // domain pos
     if (type === 'bar') {
       if (isHorizontal) {
         halfBarSize = Math.round(size.h / 2);
-        cp = ysp - (size.cat * maxDomainIndex) - size.cPad;
+        cp = ysp - (size.cat * ldata) - size.cPad;
         dp = (cp - ((size.bar * size.ix) - (size.h + size.bPad))) + halfBarSize;
       } else {
         halfBarSize = Math.round(size.w / 2);
-        cp = xsp + (size.cat * maxDomainIndex) + size.cPad;
+        cp = xsp + (size.cat * ldata) + size.cPad;
         dp = cp + ((size.bar * size.ix) - (size.w + size.bPad)) + halfBarSize;
       }
     } else if (type === 'line') {
       dp = Canvas.calculateX(
-        maxDomain,
+        ldata,
         graphX.graphMin,
         graphX.graphMax,
         xArea - size.comboOffset,
         xsp + (size.comboOffset / 2),
       );
-    }
-
-    if (tipType === 'sel') {
-      if (hitInfo && hitInfo.pos !== null) {
-        dp = type === 'bar' ? hitInfo.pos + halfBarSize : hitInfo.pos;
-        lastTip.pos = dp;
-      } else if (lastTip.pos !== null) {
-        dp = lastTip.pos;
-      }
     }
 
     // graph value

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -25,7 +25,7 @@ class Scale {
 
     if (type === 'x') {
       chartSize = chartRect.chartWidth;
-      bufferedTickSize = tickSize + (Math.floor(chartSize * 0.1));
+      bufferedTickSize = Math.floor(tickSize * 1.2);
       axisOffset = [labelOffset.left, labelOffset.right];
     } else {
       chartSize = chartRect.chartHeight;
@@ -35,7 +35,7 @@ class Scale {
 
     const drawRange = chartSize - (axisOffset[0] + axisOffset[1]);
     const minSteps = 1;
-    const maxSteps = Math.max(Math.floor(drawRange / bufferedTickSize), 1);
+    const maxSteps = Math.max(Math.floor(drawRange / bufferedTickSize) - 1, 1);
 
     return {
       min: minSteps,
@@ -106,6 +106,7 @@ class Scale {
     while (numberOfSteps > maxSteps) {
       interval *= 2;
       numberOfSteps = Math.round(graphRange / interval);
+      interval = Math.ceil(graphRange / numberOfSteps);
     }
 
     if (graphMax - graphMin > (numberOfSteps * interval)) {


### PR DESCRIPTION
########
 - 이전에 찍혀있던 Indicator값을 좌표로 처리하다보니 Chart의 사이즈가 외부 요건에 의해 달라졌을 때 좌표가 맞지 않게 되어 값을 기억했다가 사이즈에 맞춘 좌표값을 찾도록 변경
 - Scale 처리 시, tickSize 계산에 오류가 있어 해당 부분 수정