### PR TITLE
[#519] 프로젝트 버전 변경 커맨드 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "docs_build": "webpack --config build/webpack.docs.conf.js --mode=production",
     "maxgauge": "webpack-dev-server --progress --config build/webpack.maxgauge.conf.js",
     "liteplus": "webpack-dev-server --progress --config build/webpack.liteplus.conf.js",
-    "liteplus_build": "webpack --config build/webpack.liteplus.conf.js --mode=production"
+    "liteplus_build": "webpack --config build/webpack.liteplus.conf.js --mode=production",
+    "pub:patch": "npm version patch --no-git-tag-version",
+    "pub:minor": "npm version minor --no-git-tag-version",
+    "pub:major": "npm version major --no-git-tag-version"
   },
   "main": "dist/evui.min.js",
   "module": "dist/evui.min.js",


### PR DESCRIPTION
별 차이는 없는데 수동으로 올리시는 것 같길래 한 번 넣어봤습니다.

### 설명
`> npm run pub:patch` 를 실행하면 `package.json`, `package-lock.json` 파일의 patch 버전이 1 올라갑니다. 계속 실행하면 계속 올라갑니다.

예를 들어 `2.3.5` 까지 올라온 상태에서,
`> npm run pub:patch` 를 실행하면 `package.json`, `package-lock.json` 의 버전은 `2.3.6` 이 됩니다.
`> npm run pub:minor` 를 실행하면, `2.4.0` 이 됩니다. patch 버전을 0 으로 초기화 시키고 minor 버전을 1 올립니다. 

같은 원리로 `> npm run pub:major` 도 진행할 수 있습니다.
`--no-git-tag-version` 은 버전을 올릴 때 태그를 자동으로 생성하는 것을 막아줍니다.

작게보면 숫자 하나만 바꾸는데 굳이 커맨드 명령어를 입력해야하나? 겠지만
조금만 크게보면 명령어를 사용했을 때는 휴먼에러가 발생할 일이 없습니다.