### PR TITLE
[#478] 차트 버그 수정

### DIFF
--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -42,7 +42,7 @@ const modules = {
         const offset = this.getMousePosition(e);
         const hitInfo = this.findClickedData(offset, selectItem.useApproximateValue);
         const args = {};
-        if (hitInfo) {
+        if (hitInfo && hitInfo.value !== null) {
           this.redraw(hitInfo);
         }
 
@@ -58,7 +58,7 @@ const modules = {
         const hitInfo = this.findClickedData(offset);
 
         const args = {};
-        if (hitInfo) {
+        if (hitInfo && hitInfo.value !== null) {
           this.redraw(hitInfo);
         }
 


### PR DESCRIPTION
########
 - click, dblclick시, value값이 null일 경우 redraw를 하지 않도록 변경
 - findClickedData 함수에서 value의 기본 값이 null이기 때문에 예외처리는 null만 함.