### PR TITLE
[#478] Chart Bug fix

### DIFF
--- a/src/components/chart/chart.vue
+++ b/src/components/chart/chart.vue
@@ -53,7 +53,7 @@
           const updatedSeries = !isEqual(newData.series, this.evChart.data.series);
 
           this.evChart.data = cloneDeep(newData);
-          this.evChart.update(updatedSeries);
+          this.evChart.update(updatedSeries, true);
         },
         deep: true,
       },
@@ -83,8 +83,10 @@
       this.evChart = new EvChart(wrapper, data, options, this.createEventListener());
 
       const timer = setTimeout(() => {
-        this.evChart.init();
-        this.isInit = true;
+        if (this.evChart) {
+          this.evChart.init();
+          this.isInit = true;
+        }
         clearTimeout(timer);
       }, 1);
     },

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -125,29 +125,33 @@ class StepScale extends Scale {
   }
 
   fittingString(value, maxWidth) {
-    const ctx = this.ctx;
+    if (value) {
+      const ctx = this.ctx;
 
-    ctx.save();
-    ctx.font = Util.getLabelStyle(this.labelStyle);
-    const dir = this.labelStyle.fitDir;
+      ctx.save();
+      ctx.font = Util.getLabelStyle(this.labelStyle);
+      const dir = this.labelStyle.fitDir;
 
-    const ellipsis = '…';
-    const ellipsisWidth = ctx.measureText(ellipsis).width;
+      const ellipsis = '…';
+      const ellipsisWidth = ctx.measureText(ellipsis).width;
 
-    let str = value;
-    let width = ctx.measureText(str).width;
+      let str = value;
+      let width = ctx.measureText(str).width;
 
-    if (width <= maxWidth || width <= ellipsisWidth) {
-      return str;
+      if (width <= maxWidth || width <= ellipsisWidth) {
+        return str;
+      }
+
+      let len = str.length;
+      while (width >= maxWidth - ellipsisWidth && len-- > 0) {
+        str = dir === 'right' ? str.substring(0, len) : str.substring(1, str.length);
+        width = ctx.measureText(str).width;
+      }
+
+      return dir === 'right' ? str + ellipsis : ellipsis + str;
     }
 
-    let len = str.length;
-    while (width >= maxWidth - ellipsisWidth && len-- > 0) {
-      str = dir === 'right' ? str.substring(0, len) : str.substring(1, str.length);
-      width = ctx.measureText(str).width;
-    }
-
-    return dir === 'right' ? str + ellipsis : ellipsis + str;
+    return value;
   }
 }
 

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -125,33 +125,33 @@ class StepScale extends Scale {
   }
 
   fittingString(value, maxWidth) {
-    if (value) {
-      const ctx = this.ctx;
-
-      ctx.save();
-      ctx.font = Util.getLabelStyle(this.labelStyle);
-      const dir = this.labelStyle.fitDir;
-
-      const ellipsis = '…';
-      const ellipsisWidth = ctx.measureText(ellipsis).width;
-
-      let str = value;
-      let width = ctx.measureText(str).width;
-
-      if (width <= maxWidth || width <= ellipsisWidth) {
-        return str;
-      }
-
-      let len = str.length;
-      while (width >= maxWidth - ellipsisWidth && len-- > 0) {
-        str = dir === 'right' ? str.substring(0, len) : str.substring(1, str.length);
-        width = ctx.measureText(str).width;
-      }
-
-      return dir === 'right' ? str + ellipsis : ellipsis + str;
+    if (!value) {
+      return '';
     }
 
-    return value;
+    const ctx = this.ctx;
+
+    ctx.save();
+    ctx.font = Util.getLabelStyle(this.labelStyle);
+    const dir = this.labelStyle.fitDir;
+
+    const ellipsis = '…';
+    const ellipsisWidth = ctx.measureText(ellipsis).width;
+
+    let str = value;
+    let width = ctx.measureText(str).width;
+
+    if (width <= maxWidth || width <= ellipsisWidth) {
+      return str;
+    }
+
+    let len = str.length;
+    while (width >= maxWidth - ellipsisWidth && len-- > 0) {
+      str = dir === 'right' ? str.substring(0, len) : str.substring(1, str.length);
+      width = ctx.measureText(str).width;
+    }
+
+    return dir === 'right' ? str + ellipsis : ellipsis + str;
   }
 }
 


### PR DESCRIPTION
########
 - Chart init 예외 처리 추가
   - real DOM이 mounting 및 box size가 정리된 상태에서 Chart를 그리기 위해 setTimeout을 사용했으나, setTimeout이 발동되기 전에 Vue가 destroy될 경우 this.evChart가 존재하지 않아 에러가 발생함
 - 빈 문자열일 경우 step에서 ellipsis 처리를 할 때 에러가 남