### PR TITLE
[#478] Axis Grid Line 버그

### DIFF
--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -187,13 +187,13 @@ class Scale {
     let labelCenter = null;
     let linePosition = null;
 
-    ctx.beginPath();
     ctx.strokeStyle = this.gridLineColor;
     ctx.lineWidth = 1;
     aliasPixel = Util.aliasPixel(ctx.lineWidth);
 
     let labelText;
     for (let ix = 0; ix <= steps; ix++) {
+      ctx.beginPath();
       ticks[ix] = axisMin + (ix * stepValue);
 
       labelCenter = Math.round(startPoint + (labelGap * ix));
@@ -236,9 +236,8 @@ class Scale {
       }
 
       ctx.stroke();
+      ctx.closePath();
     }
-
-    ctx.closePath();
   }
 }
 


### PR DESCRIPTION
########
 - Context의 beginPath, closePath의 위치를 잘못 잡아 계속 덮어쓰는 현상 수정