### PR TITLE
[#478] Chart Bug 수정

### DIFF
--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -230,7 +230,7 @@ const modules = {
         if (p.x >= minmax.maxX) {
           minmax.maxX = (p.x === null) ? 0 : p.x;
 
-          if (isHorizontal) {
+          if (isHorizontal && p.x !== null) {
             minmax.maxDomain = p.y;
             minmax.maxDomainIndex = index;
           }
@@ -238,7 +238,7 @@ const modules = {
         if (p.y >= minmax.maxY) {
           minmax.maxY = (p.y === null) ? 0 : p.y;
 
-          if (!isHorizontal) {
+          if (!isHorizontal && p.y !== null) {
             minmax.maxDomain = p.x;
             minmax.maxDomainIndex = index;
           }


### PR DESCRIPTION
#########
 - 차트 전체 데이터값이 0이고, 데이터 끝 부분에 null이 존재할 경우, domain의 값을 null값에도 적용시키는 이슈 해소