### PR TITLE
[#623] Docs 샘플 컴포넌트 구성

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     // don't require .vue extension when importing
     'import/extensions': 'off',
     'import/no-unresolved': 'off',
+    'import/no-webpack-loader-syntax': 'off',
     // disallow reassignment of function parameters
     // disallow parameter object manipulation except for specific exclusions
     'no-param-reassign': ['error', {

--- a/docs/components/Example.vue
+++ b/docs/components/Example.vue
@@ -6,22 +6,40 @@
       {{ description }}
     </p>
     <br><br>
-    <component
-      :is="contents"
-    />
-    <br>
-    url : {{ url }}
-    <br>
-    <hr class="example-splitter">
+    <div
+      class="example-sample"
+    >
+      <component
+        :is="contents"
+      />
+      <hr class="example-splitter">
+      <div v-highlight>
+        <pre>
+          {{ content }}
+        </pre>
+      </div>
+    </div>
   </section>
 </template>
 
 <script>
-import { ref } from 'vue';
-import axios from 'axios';
+import { parseComponent } from 'vue-template-compiler';
+import hljs from 'highlight.js';
+import CheckboxRaw from '!!raw-loader!../views/checkbox/example/Default';
+import 'highlight.js/styles/github.css';
 
 export default {
   name: 'Example',
+  directives: {
+    highlight: {
+      mounted(el) {
+        const blocks = el.querySelectorAll('pre');
+        blocks.forEach((block) => {
+          hljs.highlightBlock(block);
+        });
+      },
+    },
+  },
   components: {
   },
   props: {
@@ -42,20 +60,37 @@ export default {
       default: '',
     },
   },
-  setup(props) {
-    const codeData = ref('');
-
-    console.log(`props.url : ${props.url}`);
-    axios.get(props.url).then((result) => {
-      codeData.value = `\`\`\`html\n${result.data}\n\`\`\``;
-    });
+  setup() {
+    const { template } = parseComponent(CheckboxRaw);
+    const { content } = template;
 
     return {
-      codeData,
+      content,
+      template,
     };
   },
 };
 </script>
 
-<style scoped>
+<style lang="scss">
+.example-sample {
+  display: flex;
+  border: 1px solid #FFDD57;
+  border-radius: 4px;
+  div {
+    max-height: 600px;
+    flex-grow: 1;
+    padding: 15px;
+    overflow-y: auto;
+  }
+  div:last-child {
+    padding: 0;
+  }
+}
+
+.example-splitter {
+  width: 1px;
+  background-color: #FFDD57;
+  border: none;
+}
 </style>

--- a/docs/router/index.js
+++ b/docs/router/index.js
@@ -107,6 +107,11 @@ const routes = [
     name: 'ReactivityChart',
     component: () => import(/* webpackChunkName: "reactivityChart" */ '../views/reactivityChart'),
   },
+  {
+    path: '/:catchAll(.*)',
+    name: 'PageNotFound',
+    component: () => import(/* webpackChunkName: "pageNotFound" */ '../views/PageNotFound'),
+  },
 ];
 
 const router = createRouter({

--- a/docs/views/PageNotFound.vue
+++ b/docs/views/PageNotFound.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    PageNotFound
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'PageNotFound',
+  components: {},
+  setup() {},
+};
+</script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2185,17 +2185,6 @@
             "unique-filename": "^1.1.1"
           }
         },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -2341,21 +2330,6 @@
             "source-map": "^0.6.1",
             "terser": "^4.6.12",
             "webpack-sources": "^1.4.3"
-          }
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.0.0-beta.7",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.0.0-beta.7.tgz",
-          "integrity": "sha512-xQ8/GZmRPdQ3EinnE0IXwdVoDzh7Dowo0MowoyBuScEBXrRabw6At5/IdtD3waKklKW5PGokPsm8KRN6rvQ1cw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@types/mini-css-extract-plugin": "^0.9.1",
-            "chalk": "^3.0.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^1.2.3",
-            "merge-source-map": "^1.1.0",
-            "source-map": "^0.6.1"
           }
         },
         "wrap-ansi": {
@@ -4571,6 +4545,12 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "highlight.js": {
+          "version": "9.18.3",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+          "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
+          "dev": true
+        },
         "locate-path": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -5868,6 +5848,12 @@
         "mimer": "^0.3.2",
         "semver": "^5.5.0"
       }
+    },
+    "de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
+      "dev": true
     },
     "deasync": {
       "version": "0.1.20",
@@ -8603,9 +8589,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.18.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
-      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.2.0.tgz",
+      "integrity": "sha512-OryzPiqqNCfO/wtFo619W+nPYALM6u7iCQkum4bqRmmlcTikOkmlL06i009QelynBPAlNByTQU6cBB2cOBQtCw==",
       "dev": true
     },
     "hmac-drbg": {
@@ -13843,6 +13829,29 @@
         "unpipe": "1.0.0"
       }
     },
+    "raw-loader": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.1.tgz",
+      "integrity": "sha512-baolhQBSi3iNh1cglJjA0mYzga+wePk7vdEX//1dTFd+v4TsQlQE0jitJSNF1OIP82rdYulH7otaVmdlDaJ64A==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^2.6.5"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        }
+      }
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -17315,6 +17324,79 @@
         }
       }
     },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.0.0-beta.7.tgz",
+      "integrity": "sha512-xQ8/GZmRPdQ3EinnE0IXwdVoDzh7Dowo0MowoyBuScEBXrRabw6At5/IdtD3waKklKW5PGokPsm8KRN6rvQ1cw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/mini-css-extract-plugin": "^0.9.1",
+        "chalk": "^3.0.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^1.2.3",
+        "merge-source-map": "^1.1.0",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "vue-router": {
       "version": "4.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.0-beta.9.tgz",
@@ -17336,6 +17418,16 @@
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
         }
+      }
+    },
+    "vue-template-compiler": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.12.tgz",
+      "integrity": "sha512-OzzZ52zS41YUbkCBfdXShQTe69j1gQDZ9HIX8miuC9C3rBCk9wIRjLiZZLrmX9V+Ftq/YEyv1JaVr5Y/hNtByg==",
+      "dev": true,
+      "requires": {
+        "de-indent": "^1.0.2",
+        "he": "^1.1.0"
       }
     },
     "vue-template-es2015-compiler": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "lint": "eslint src test docs",
-    "docs": "vue-cli-service serve --port 9999 docs/main.js"
+    "docs": "vue-cli-service serve --port 9999 docs/main.js",
+    "docs_build": "vue-cli-service build docs/main.js"
   },
   "dependencies": {
     "axios": "^0.20.0",
@@ -34,15 +35,18 @@
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.21.2",
     "eslint-plugin-vue": "^7.0.0-0",
+    "highlight.js": "^10.2.0",
     "lodash-es": "^4.17.15",
     "marked": "^1.1.1",
     "moment": "^2.27.0",
     "node-sass": "^4.12.0",
+    "raw-loader": "^4.0.1",
     "sass-loader": "^8.0.2",
     "stylelint": "^13.7.0",
     "stylelint-order": "^4.1.0",
     "stylelint-webpack-plugin": "^2.1.0",
     "typescript": "~3.9.3",
-    "vue-jest": "^5.0.0-0"
+    "vue-jest": "^5.0.0-0",
+    "vue-template-compiler": "^2.6.12"
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -4,6 +4,17 @@ module.exports = {
   devServer: {
     overlay: false,
   },
+  chainWebpack: (config) => {
+    config.module
+      .rule('raw')
+      .include
+      .add('/docs/views/*/example')
+      .end()
+      .test(/\.vue$/)
+      .use('raw-loader')
+      .loader('raw-loader')
+      .end();
+  },
   configureWebpack: {
     plugins: [
       new StyleLintPlugin({


### PR DESCRIPTION
################
- Docs의 샘플코드 컴포넌트 구성
- 임시로 체크박스 컴포넌트를 샘플로 삼아 코드를 보여줌
- view > 컴포넌트명 > example 폴더 내 존재하는 예시코드들을 raw-loader로 읽은 후 vue-template-compiler를 사용하여 parseComponent한 코드를 추출하는 로직 구현
- vue파일을 raw-loader를 사용하여 읽을 때의 import eslint 처리 및 해당 경로 지정
- highlight.js 라이브러리를 이용하여 코드텍스트에 하이라이트 구현
- page not found 시 router 예외처리 및 임시 vue파일 생성