### PR TITLE
[#673] textfield RegExp 관련 수정

### DIFF
--- a/src/components/textfield/textfield.vue
+++ b/src/components/textfield/textfield.vue
@@ -173,6 +173,11 @@
       value(val) {
         this.setCurrentValue(val);
       },
+      useRegExp(val) {
+        if (val) {
+          this.validateError(this.currentValue);
+        }
+      },
     },
     created() {
       this.validateError(this.currentValue);
@@ -253,8 +258,8 @@
           return false;
         }
 
-        const filteredValue = checked[0];
-        if (filteredValue.length !== 0) {
+        // const filteredValue = checked[0];
+        if (checked.length !== 0) {
           this.textError = true;
           this.cssError = true;
           return true;

--- a/src/components/textfield/textfield.vue
+++ b/src/components/textfield/textfield.vue
@@ -257,17 +257,9 @@
           this.cssError = false;
           return false;
         }
-
-        // const filteredValue = checked[0];
-        if (checked.length !== 0) {
-          this.textError = true;
-          this.cssError = true;
-          return true;
-        }
-
-        this.textError = false;
-        this.cssError = false;
-        return false;
+        this.textError = true;
+        this.cssError = true;
+        return true;
       },
     },
   };


### PR DESCRIPTION
##########
- 텍스트 필드의 validation 조건이 동적으로 변경될때 use-reg-exp 조건이 변경되어야 하는데, 현재 입력된 텍스트 필드의 value 가 변화가 없으므로 컴포넌트 내부의 validateError 함수를 실행하지 않아 reg exp 의 조건에 맞는 결과를 보여주지 않으므로 use-reg-exp props 에 watch를 걸어 validateError 함수를 실행 하도록 함
- 빈 문자열의 검출이 되지 않는 버그 수정