### PR TITLE
[#676] ev-messagebox 헤더 아이콘 숨김 옵션(showHeaderIcon) 추가

### DIFF
--- a/src/components/message-box/message-box.vue
+++ b/src/components/message-box/message-box.vue
@@ -16,7 +16,7 @@
       >
         <div class="ev-message-box-top-title">
           <ev-icon
-            v-if="type!==''"
+            v-if="showHeaderIcon"
             :cls="headerTypeIconInfo.cls"
             :style="headerTypeIconInfo.style"
           />
@@ -99,6 +99,7 @@
         confirmButtonDisabled: false,
         cancelButtonClass: '',
         callback: null,
+        showHeaderIcon: true,
         useHTMLString: false,
         headerTypeIconInfo: {
           cls: '',


### PR DESCRIPTION
##########
- ev-messagebox 헤더 아이콘 숨김 옵션 추가
- showHeaderIcon 옵션의 default는 true로 헤더 영역의 icon을 보여줌