### PR TITLE
[#678] ContextMenu 화면 벗어나는 현상 수정

### DIFF
--- a/src/components/contextmenu/contextmenu.vue
+++ b/src/components/contextmenu/contextmenu.vue
@@ -161,7 +161,7 @@
 
           const remainingHeight = (window.innerHeight - top)
             - (this.isHScroll ? this.scrollbarSize : 0);
-          const remainingWidth = (window.innerWidth - (clientRectLeft + parentWidth))
+          const remainingWidth = (window.innerWidth - (parentClientRect.x + parentWidth))
             - (this.isVScroll ? this.scrollbarSize : 0);
 
           if (this.height > remainingHeight) {

--- a/src/components/contextmenu/contextmenu.wrap.vue
+++ b/src/components/contextmenu/contextmenu.wrap.vue
@@ -129,7 +129,7 @@
       },
       setPosition(e, x, y) {
         const scrollEl = document.scrollingElement || document.documentElement || document.body;
-        const scrollbarSize = window.innerWidth - document.documentElement.clientWidth;
+        const scrollbarSize = window.innerWidth - scrollEl.clientWidth;
         const isHScroll = window.innerWidth < scrollEl.scrollWidth;
         const isVScroll = window.innerHeight < scrollEl.scrollHeight;
         const clientX = x || 0;

--- a/src/components/contextmenu/contextmenu.wrap.vue
+++ b/src/components/contextmenu/contextmenu.wrap.vue
@@ -138,15 +138,16 @@
           - (isVScroll ? this.scrollbarSize : 0);
         const remainingHeight = (window.innerHeight - clientY)
           - (isHScroll ? this.scrollbarSize : 0);
+        const clientRect = this.$el.firstElementChild.getClientRects()[0];
         let left = clientX + scrollEl.scrollLeft;
         let top = clientY + scrollEl.scrollTop;
 
-        if (this.width > remainingWidth) {
-          left -= (this.width - remainingWidth);
+        if (clientRect.width > remainingWidth) {
+          left -= (clientRect.width - remainingWidth);
         }
 
-        if (this.height > remainingHeight) {
-          top -= (this.height - remainingHeight);
+        if (clientRect.height > remainingHeight) {
+          top -= (clientRect.height - remainingHeight);
         }
 
         this.left = left;

--- a/src/components/contextmenu/contextmenu.wrap.vue
+++ b/src/components/contextmenu/contextmenu.wrap.vue
@@ -130,14 +130,12 @@
       setPosition(e, x, y) {
         const scrollEl = document.scrollingElement || document.documentElement || document.body;
         const scrollbarSize = window.innerWidth - scrollEl.clientWidth;
-        const isHScroll = window.innerWidth < scrollEl.scrollWidth;
-        const isVScroll = window.innerHeight < scrollEl.scrollHeight;
         const clientX = x || 0;
         const clientY = y || 0;
         const remainingWidth = (window.innerWidth - clientX)
-          - (isVScroll ? scrollbarSize : 0);
+          - scrollbarSize;
         const remainingHeight = (window.innerHeight - clientY)
-          - (isHScroll ? scrollbarSize : 0);
+          - scrollbarSize;
         const clientRect = this.$el.firstElementChild.getClientRects()[0];
         const clientWidth = clientRect.width || this.width;
         const clientHeight = clientRect.height || this.height;

--- a/src/components/contextmenu/contextmenu.wrap.vue
+++ b/src/components/contextmenu/contextmenu.wrap.vue
@@ -70,7 +70,6 @@
         width: 0,
         height: 0,
         visibility: 'hidden',
-        scrollbarSize: 16,
       };
     },
     computed: {
@@ -130,24 +129,27 @@
       },
       setPosition(e, x, y) {
         const scrollEl = document.scrollingElement || document.documentElement || document.body;
+        const scrollbarSize = window.innerWidth - document.documentElement.clientWidth;
         const isHScroll = window.innerWidth < scrollEl.scrollWidth;
         const isVScroll = window.innerHeight < scrollEl.scrollHeight;
         const clientX = x || 0;
         const clientY = y || 0;
         const remainingWidth = (window.innerWidth - clientX)
-          - (isVScroll ? this.scrollbarSize : 0);
+          - (isVScroll ? scrollbarSize : 0);
         const remainingHeight = (window.innerHeight - clientY)
-          - (isHScroll ? this.scrollbarSize : 0);
+          - (isHScroll ? scrollbarSize : 0);
         const clientRect = this.$el.firstElementChild.getClientRects()[0];
+        const clientWidth = clientRect.width || this.width;
+        const clientHeight = clientRect.height || this.height;
         let left = clientX + scrollEl.scrollLeft;
         let top = clientY + scrollEl.scrollTop;
 
-        if (clientRect.width > remainingWidth) {
-          left -= (clientRect.width - remainingWidth);
+        if (clientWidth > remainingWidth) {
+          left -= (clientWidth - remainingWidth);
         }
 
-        if (clientRect.height > remainingHeight) {
-          top -= (clientRect.height - remainingHeight);
+        if (clientHeight > remainingHeight) {
+          top -= (clientHeight - remainingHeight);
         }
 
         this.left = left;


### PR DESCRIPTION
################
- 포지션 계산할 때, 클릭된 좌표에서 창 가장 자리까지 남은 거리 계산식이 잘못 되어 수정함