### PR TITLE
[#753][3.0] 라이브러리 빌드 시 폰트가 안나오는 현상 수정

### DIFF
--- a/src/components/icon/Icon.vue
+++ b/src/components/icon/Icon.vue
@@ -11,8 +11,6 @@
 </template>
 
 <script>
-import '@/style/lib/icon.css';
-
 export default {
   name: 'EvIcon',
   props: {

--- a/src/components/icon/index.js
+++ b/src/components/icon/index.js
@@ -1,3 +1,4 @@
+import '@/style/lib/icon.css';
 import EvIcon from './Icon';
 
 EvIcon.install = (app) => {

--- a/src/style/lib/icon.css
+++ b/src/style/lib/icon.css
@@ -1,10 +1,10 @@
 @font-face {
   font-family: 'EVUI';
-  src: url('./fonts/EVUI.eot');
-  src: url('./fonts/EVUI.eot#iefix') format('embedded-opentype'),
-    url('./fonts/EVUI.ttf') format('truetype'),
-    url('./fonts/EVUI.woff') format('woff'),
-    url('./fonts/EVUI.svg') format('svg');
+  src: url('~@/style/lib/fonts/EVUI.eot');
+  src: url('~@/style/lib/fonts/EVUI.eot#iefix') format('embedded-opentype'),
+    url('~@/style/lib/fonts/EVUI.ttf') format('truetype'),
+    url('~@/style/lib/fonts/EVUI.woff') format('woff'),
+    url('~@/style/lib/fonts/EVUI.svg') format('svg');
   font-weight: normal;
   font-style: normal;
   font-display: block;

--- a/vue.config.js
+++ b/vue.config.js
@@ -19,6 +19,14 @@ module.exports = {
       .use('raw-loader')
       .loader('raw-loader')
       .end();
+
+    config.module
+      .rule('fonts')
+      .test(/\.(woff2?|eot|ttf|otf)(\?.*)?$/i)
+      .use('url-loader')
+      .loader('url-loader')
+      .options()
+      .end();
   },
   configureWebpack: {
     resolve: {
@@ -26,14 +34,6 @@ module.exports = {
         '@': path.join(__dirname, 'src/'),
         docs: path.join(__dirname, 'docs/'),
       },
-    },
-    module: {
-      rules: [
-        {
-          test: /\.(gif|jpg|png|woff|svg|eot|ttf)\??.*$/,
-          loader: 'url-loader?limit=8192',
-        },
-      ],
     },
     plugins: [
       new StyleLintPlugin({


### PR DESCRIPTION
################
- EvIcon 컴포넌트에서 폰트를 불러오는 icon.css 파일을 import하는 부분을 vue파일이 아닌 index.js로 변경
- 폰트 경로 수정
- 라이브러리 형태로 빌드 시 fonts의 확장자 파일을 url-loader로 같이 포함하여 묶는 방식으로 변경