### PR TITLE
[3.0] Chart > series > showValue 옵션에 align 항목 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -22,9 +22,17 @@
   |------------ |-----------|---------|-------------------------|---------------------------------------------------|
   | name | String | series-${index} | 특정 데이터에 대한 시리즈 옵션 |  |
   | type | String | 'bar' | 시리즈에 해당하는 데이터 표현 방식 | 'bar', 'pie', 'line', 'scatter' |
-  | color | String | COLOR[index] | 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용 |  |
-  | showValue | Object | { use: false, fontSize: 12, textColor: '#000000' } | 막대 위에 값 표시 여부 및 속성 |  |
-  
+  | color | HexCode(String) | COLOR[index] | 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용 |  |
+  | showValue | Object | ([상세](#showvalue)) | 막대 위에 값 표시 여부 및 속성 |  |
+
+#### showValue
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+| --- | ---- | ----- | --- | ----------|
+| use | Boolean | false | data label 표시 여부 | true /false |
+| fontColor | HexCode(String) | '#000000' | 글자 색상  | |
+| fontSize | Number | 12 | 글자 크기 | |
+| align | String | 'end' | tooltip 테두리 색상  | 'start', 'center', 'end', 'out' |
+
 #### data example
 ```
 const chartData = {

--- a/docs/views/barChart/example/Column.vue
+++ b/docs/views/barChart/example/Column.vue
@@ -10,8 +10,8 @@
     setup() {
       const chartData = {
         series: {
-          series1: { name: 'series#1', color: '#FF00FF' },
-          series2: { name: 'series#2', color: '#00FF00' },
+          series1: { name: 'series#1', color: '#FEC64F', showValue: { use: true } },
+          series2: { name: 'series#2', color: '#48D1CC', showValue: { use: true } },
         },
         labels: [
           'value1',

--- a/docs/views/barChart/example/Default.vue
+++ b/docs/views/barChart/example/Default.vue
@@ -1,19 +1,8 @@
 <template>
-  <div class="case">
-    <ev-chart
-      :data="chartData"
-      :options="chartOptions"
-    />
-  </div>
-  <div class="case">
-    <ev-chart
-      :data="chartData2"
-      :options="chartOptions"
-    />
-    <div class="description">
-      막대 별 값 표시. ( 막대가 작은 경우 표시되지 않음 )
-    </div>
-  </div>
+  <ev-chart
+    :data="chartData"
+    :options="chartOptions"
+  />
 </template>
 
 <script>
@@ -29,48 +18,21 @@
         },
       };
 
-      const chartData2 = {
-        series: {
-          series1: { name: 'series#1', showValue: { use: true, fontSize: 12, textColor: '#ffffff' } },
-        },
-        labels: ['value1', 'value2', 'value3', 'value5', 'value5'],
-        data: {
-          series1: [100, 150, 51, 150, 350],
-        },
-      };
-
       const chartOptions = {
         type: 'bar',
-        thickness: 0.8,
-        width: '100%',
-        title: {
-          text: 'Chart Title',
-          show: true,
-        },
-        legend: {
-          show: true,
-          position: 'right',
-        },
         axesX: [{
           type: 'step',
-          showGrid: false,
-          labelStyle: {
-            fitWidth: true,
-            fitDir: 'left',
-          },
         }],
         axesY: [{
           showAxis: true,
           type: 'linear',
           startToZero: true,
           autoScaleRatio: 0.1,
-          showGrid: false,
         }],
       };
 
       return {
         chartData,
-        chartData2,
         chartOptions,
       };
     },

--- a/docs/views/barChart/example/Horizontal.vue
+++ b/docs/views/barChart/example/Horizontal.vue
@@ -10,11 +10,11 @@
     setup() {
       const chartData = {
         series: {
-          series1: { name: 'series#1', showValue: { use: true, fontSize: 12, textColor: '#ffffff' } },
+          series1: { name: 'series#1', showValue: { use: true, fontSize: 12, textColor: '#000000', align: 'out' } },
         },
         labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
         data: {
-          series1: [100, 150, 51, 40, 50],
+          series1: [1500, 80, 120, 30, 0],
         },
       };
 
@@ -36,12 +36,15 @@
           type: 'linear',
           startToZero: true,
           autoScaleRatio: 0.1,
-          showGrid: false,
+          showGrid: true,
         }],
         axesY: [{
           type: 'step',
           showGrid: false,
         }],
+        indicator: {
+          use: false,
+        },
       };
 
       return {

--- a/docs/views/barChart/example/Stack.vue
+++ b/docs/views/barChart/example/Stack.vue
@@ -10,10 +10,10 @@
     setup() {
       const chartData = {
         series: {
-          series1: { name: 'series#1', showValue: { use: true, fontSize: 12, textColor: '#ffffff' } },
-          series2: { name: 'series#2', showValue: { use: true, fontSize: 12, textColor: '#ffffff' } },
-          series3: { name: 'series#3', showValue: { use: true, fontSize: 12, textColor: '#ffffff' } },
-          series4: { name: 'series#4', showValue: { use: true, fontSize: 12, textColor: '#000000' } },
+          series1: { name: 'series#1' },
+          series2: { name: 'series#2' },
+          series3: { name: 'series#3' },
+          series4: { name: 'series#4' },
         },
         groups: [
           ['series1', 'series2', 'series3', 'series4'],

--- a/docs/views/barChart/example/Time.vue
+++ b/docs/views/barChart/example/Time.vue
@@ -35,28 +35,31 @@
         horizontal: false,
         axesX: [{
           type: 'time',
-          showGrid: true,
+          showGrid: false,
           categoryMode: true,
-          timeFormat: 'HH:mm:ss',
+          timeFormat: 'mm:ss',
           interval: 'second',
         }],
         axesY: [{
           type: 'linear',
           startToZero: true,
           autoScaleRatio: 0.1,
-          showGrid: false,
+          showGrid: true,
         }],
+        maxTip: {
+          use: true,
+          tipBackground: '#DBDBDB',
+          tipTextColor: '#000000',
+        },
       };
 
       const chartData = reactive({
         series: {
           series1: { name: 'series#1' },
-          series2: { name: 'series#2' },
         },
         labels: [],
         data: {
           series1: [],
-          series2: [],
         },
       });
 

--- a/docs/views/barChart/props.js
+++ b/docs/views/barChart/props.js
@@ -17,27 +17,27 @@ export default {
   mdText,
   components: {
     Default: {
-      description: 'Bar Chart는 Category 기반의 데이터를 표현하는 차트로, 각 Category에 대한 값에 따라 Bar의 높이가 결정됩니다. 계열이 여러 개 존재할 경우 동일한 넓이의 Bar를 생성하여 Category 기준으로 각 계열을 표현합니다.',
+      description: 'Bar Chart(막대그래프)는 표현 값에 비례 하여 높이와 길이를 가진 직사각형 막대로 데이터를 표현하는 차트입니다.',
       component: Default,
       parsedData: parseComponent(DefaultRaw),
     },
     Column: {
-      description: 'Category 기반의 막대 데이터를 누적하여 표현합니다.',
+      description: '세로 형태로 사용할 수 있으며 각 Series별로 색상을 직접 지정할 수 있습니다.',
       component: Column,
       parsedData: parseComponent(ColumnRaw),
     },
-    Stack: {
-      description: 'Category 기반의 막대 데이터를 누적하여 표현합니다.',
-      component: Stack,
-      parsedData: parseComponent(StackRaw),
-    },
     Horizontal: {
-      description: 'Horizontal Bar Chart는 각 Category에 대한 Bar의 널이가 나타내는 값에 비례합니다. 계열이 여러개가 존재할 경우 동일한 높이의 Bar를 생성하여 Category 기준으로 각 계열을 표현합니다.',
+      description: '가로 형태로 사용할 수 있으며 Series별로 데이터 라벨 표시 여부 및 속성을 설정 할 수 있습니다.',
       component: Horizontal,
       parsedData: parseComponent(HorizontalRaw),
     },
+    Stack: {
+      description: '동일한 그룹으로 묶인 series들의 데이터를 한 막대에 누적하여 표현할 수 있습니다.',
+      component: Stack,
+      parsedData: parseComponent(StackRaw),
+    },
     Time: {
-      description: 'RealTime 처리를 위한 차트입니다.',
+      description: '실시간으로 데이터를 받아 표현할 수 있으며, 가장 큰 값에 해당하는 막대위에 Tip을 붙일 수 있습니다.',
       component: Time,
       parsedData: parseComponent(TimeRaw),
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.1.11",
+  "version": "3.1.13",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",


### PR DESCRIPTION
### 작업내용
1. Bar차트의 showValue 옵션 중 'align' 항목 추가
>   - 결과 샘플 https://www.notion.so/f91f4384184b4fa9946ab23230c686e2
   
2. BarChart API 내용 수정 
>    -  Default: Default 값으로만 표현되도록 추가 지정했던 속성들 모두 제거 후 예제에 필수값만 남김
>   -  Column: showValue > align 예제 포함시킴
>   -  Stack : showValue 예제 제외 시킴
>   - Time: 실시간으로 데이타를 업데이트 하는 예제에만 집중하기 위해 series 줄이고 grid 속성 조정
>   - Horizontal: showValue > align 예제 포함시키고 데이터 값 조정 (0, 적은수, 중간수, 큰수가 모두 보이도록) 
>   - .md : 설명이 내용과 상이하여 조정함

3. 버전 수정
>   - 3.1.11 -> 3.1.13