### PR TITLE
[#776][3.0] Chart legend 영역에서 Series label mouseleave event handler 이슈

### DIFF
--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -322,7 +322,7 @@ const modules = {
         chartRect = this.chartDOM.getBoundingClientRect();
 
         boxStyle.width = `${opt.legend.width - 10}px`; // legendDOM left padding
-        boxStyle.height = `${chartRect.height}px`;
+        boxStyle.maxHeight = `${chartRect.height}px`;
 
         legendStyle.paddingLeft = '10px';
         legendStyle.top = `${title}px`;
@@ -371,7 +371,7 @@ const modules = {
         chartRect = this.chartDOM.getBoundingClientRect();
 
         boxStyle.width = `${opt.legend.width}px`;
-        boxStyle.height = `${chartRect.height}px`;
+        boxStyle.maxHeight = `${chartRect.height}px`;
         boxStyle.display = 'absolute';
         boxStyle.bottom = '0px';
 


### PR DESCRIPTION
### 원인
- label에서 mouseleave를 해도 legend DOM안에 머물러 있어 Sereis 활성화 되었던 부분이 해제되지 않음
- legend DOM의 높이는 차트의 높이와 동일해서 legend 영역의 빈공간으로 마우스를 옮겨도 mouseleave가 아니기 때문에 이벤트 핸들러가 발생하지 않았음
![image](https://user-images.githubusercontent.com/53548023/110595640-9bf30b80-81c1-11eb-95bc-2c793bc8b2c4.png)

### 수정내용
- 차트 높이와 동일하게 지정하던 것은 maxHeight으로 변경하고 height은 별도로 지정하지 않도록함
![image](https://user-images.githubusercontent.com/53548023/110595729-bcbb6100-81c1-11eb-8332-917f37d8874b.png)
