### PR TITLE
[#787][3.0] scatter chart 드래그 기능 추가

### DIFF
--- a/docs/views/comboChart/example/LineBar.vue
+++ b/docs/views/comboChart/example/LineBar.vue
@@ -87,12 +87,12 @@
           addRandomChartData();
           liveInterval.value = setInterval(addRandomChartData, 1000);
         } else {
-          clearTimeout(liveInterval.value);
+          clearInterval(liveInterval.value);
         }
       });
 
       onBeforeUnmount(() => {
-        clearTimeout(liveInterval.value);
+        clearInterval(liveInterval.value);
       });
 
       return {

--- a/docs/views/comboChart/example/LineStackBar.vue
+++ b/docs/views/comboChart/example/LineStackBar.vue
@@ -92,12 +92,12 @@
           addRandomChartData();
           liveInterval.value = setInterval(addRandomChartData, 1000);
         } else {
-          clearTimeout(liveInterval.value);
+          clearInterval(liveInterval.value);
         }
       });
 
       onBeforeUnmount(() => {
-        clearTimeout(liveInterval.value);
+        clearInterval(liveInterval.value);
       });
 
       return {

--- a/docs/views/comboChart/example/StackLineBar.vue
+++ b/docs/views/comboChart/example/StackLineBar.vue
@@ -92,12 +92,12 @@
           addRandomChartData();
           liveInterval.value = setInterval(addRandomChartData, 1000);
         } else {
-          clearTimeout(liveInterval.value);
+          clearInterval(liveInterval.value);
         }
       });
 
       onBeforeUnmount(() => {
-        clearTimeout(liveInterval.value);
+        clearInterval(liveInterval.value);
       });
 
       return {

--- a/docs/views/comboChart/example/StackLineStackBar.vue
+++ b/docs/views/comboChart/example/StackLineStackBar.vue
@@ -95,12 +95,12 @@
           addRandomChartData();
           liveInterval.value = setInterval(addRandomChartData, 1000);
         } else {
-          clearTimeout(liveInterval.value);
+          clearInterval(liveInterval.value);
         }
       });
 
       onBeforeUnmount(() => {
-        clearTimeout(liveInterval.value);
+        clearInterval(liveInterval.value);
       });
 
       return {

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -43,7 +43,7 @@ const chartData =
     dayjs(time),
     dayjs(time).add(1, 'day'),
     dayjs(time).add(2, 'day'),
-    momdayjsme).add(3, 'day'),
+    dayjs(time).add(3, 'day'),
   ],
 };
 ```

--- a/docs/views/lineChart/example/Default.vue
+++ b/docs/views/lineChart/example/Default.vue
@@ -92,12 +92,12 @@
           addRandomChartData();
           liveInterval.value = setInterval(addRandomChartData, 1000);
         } else {
-          clearTimeout(liveInterval.value);
+          clearInterval(liveInterval.value);
         }
       });
 
       onBeforeUnmount(() => {
-        clearTimeout(liveInterval.value);
+        clearInterval(liveInterval.value);
       });
 
       return {

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -61,6 +61,7 @@ const chartData =
   | legend | Object | ([상세](#legend)) | 차트의 범례 표시 여부 및 속성 |  |
   | indicator | Object | ([상세](#indicator)) | 지표선 | |
   | dragSelection | Object | ([상세](#dragselection)) | drag-select의 사용 여부 | |
+  
 #### axesX axesY
 ##### type 공통
   | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -6,6 +6,7 @@
     :data="차트데이터"
     :options="차트속성"
     :resize-timeout="debounce wait시간(단위: ms)"
+    @drag-select="callback_function"
 />
 ```
 
@@ -25,7 +26,7 @@
   | type | String | 'bar' | 시리즈에 해당하는 데이터 표현 방식 | 'bar', 'pie', 'line', 'scatter' |
   | color | String | COLOR[index] | 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용 |  |
   | pointSize | Number | 3 | 차트에 표시될 점의 사이즈 |  |
-  | pointStyle | String | 'circle' | 차트에 표시될 점의 모양 | 'triangle', 'rect', 'rectRounded', 'rectRot', 'cross', 'crossRot', 'star', 'line', 'dash' |
+  | pointStyle | String | 'circle' | 차트에 표시될 점의 모양 | 'triangle', 'rect', 'rectRounded', 'rectRot', 'cross', 'crossRot', 'star', 'line' |
   
 #### data example
 ```
@@ -59,7 +60,7 @@ const chartData =
   | title | Object | ([상세](#title)) | 차트 상단에 위치할 차트 제목 표시 여부 및 속성 |  |
   | legend | Object | ([상세](#legend)) | 차트의 범례 표시 여부 및 속성 |  |
   | indicator | Object | ([상세](#indicator)) | 지표선 | |
-
+  | dragSelection | Object | ([상세](#dragselection)) | drag-select의 사용 여부 | |
 #### axesX axesY
 ##### type 공통
   | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
@@ -118,7 +119,25 @@ const chartData =
 | use | Boolean | true | indicator 사용 여부 | |
 | color | HexCode(String) | '#EE7F44' | 색상  | |
 
+    
+#### dragSelection
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+| --- | ---- | ----- | --- | ----------|
+| use | Boolean | true | drag-select 사용 여부 | true / false |
+| keepDisplay | Boolean | true | 드래그 후 선택영역 유지 여부  | true / false  |
+| fillColor | HexCode(String) | '#38ACEC' | 선택 영역 색상 | |
+| opacity | Number | 0.65 | 선택 영역 불투명도 | 0 ~ 1 |
 
 ### 3. resize-timeout
 - Default : 0
 - debounce 사용. 연속으로 이벤트가 발생한 경우, 마지막 이벤트가 끝난 시점을 기준으로 `주어진 시간 (resize-timeout)` 이후 콜백 실행
+
+
+>### Event
+
+| 이름 | 파라미터 | 설명 |
+ |------|----------|------|
+ | drag-select | data, range | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
+ 
+ * drag-select는  `dragSelection` 옵션의 `use`값이 `true` 일 때 이벤트를 발생 시킬 수 있다. 
+ 그리고 선택영역은 그래프에 표시된 데이터의 중앙이 포함 되어야 선택영역 내 데이터로 인식 한다.

--- a/docs/views/scatterChart/props.js
+++ b/docs/views/scatterChart/props.js
@@ -2,6 +2,8 @@ import { parseComponent } from 'vue-template-compiler';
 import mdText from '!!raw-loader!./api/scatterChart.md';
 import Default from './example/Default';
 import DefaultRaw from '!!raw-loader!./example/Default';
+import Event from './example/Event';
+import EventRaw from '!!raw-loader!./example/Event';
 
 export default {
   mdText,
@@ -10,6 +12,11 @@ export default {
       description: 'Scatter Chart는 데이터의 분포를 시각적으로 인지하도록 합니다.',
       component: Default,
       parsedData: parseComponent(DefaultRaw),
+    },
+    Event: {
+      description: 'Drag Select 이벤트 등록이 가능 합니다',
+      component: Event,
+      parsedData: parseComponent(EventRaw),
     },
   },
 };

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -32,6 +32,7 @@
     emits: [
       'click',
       'dbl-click',
+      'drag-select',
     ],
     setup(props) {
       let evChart = {};

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -566,6 +566,11 @@ class EvChart {
     this.labelOffset = this.getLabelOffset();
 
     this.render();
+
+    const isDragMove = this.dragInfo && this.drawSelectionArea;
+    if (isDragMove) {
+      this.drawSelectionArea(this.dragInfo);
+    }
   }
 
   /**

--- a/src/components/chart/element/element.scatter.js
+++ b/src/components/chart/element/element.scatter.js
@@ -79,6 +79,23 @@ class Scatter {
       }
     });
   }
+
+  /**
+   *Returns items in range
+   * @param {object} params  range values
+   *
+   * @returns {array}
+   */
+  findItems({ xsp, ysp, width, height }) {
+    const gdata = this.data;
+    const xep = xsp + width;
+    const yep = ysp + height;
+    const items = gdata.filter(seriesData =>
+        (xsp - 1 <= seriesData.xp && seriesData.xp <= xep + 1
+        && ysp - 1 <= seriesData.yp && seriesData.yp <= yep + 1));
+
+    return items;
+  }
 }
 
 export default Scatter;

--- a/src/components/chart/helpers/helpers.canvas.js
+++ b/src/components/chart/helpers/helpers.canvas.js
@@ -175,12 +175,6 @@ export default {
         ctx.lineTo(x + radius, y);
         ctx.closePath();
         break;
-      case 'dash':
-        ctx.beginPath();
-        ctx.moveTo(x, y);
-        ctx.lineTo(x + radius, y);
-        ctx.closePath();
-        break;
       default:
         ctx.beginPath();
         ctx.arc(x, y, radius, 0, Math.PI * 2);

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -168,48 +168,6 @@ const modules = {
     };
 
     /**
-     * Calculate drag-section position and size, and drawing drag-section
-     *
-     * @returns {undefined}
-     */
-    // const dragMove = (e) => {
-    //   e.preventDefault();
-    //
-    //   const [aOffsetX, aOffsetY] = this.getMousePosition(e);
-    //   const dragInfo = this.dragInfo;
-    //   const { xcp, ycp, range: aRange } = dragInfo;
-    //
-    //   let xep;
-    //   let yep;
-    //
-    //   dragInfo.isMove = true;
-    //
-    //   if (aOffsetX < aRange.x1) {
-    //     xep = aRange.x1;
-    //   } else if (aOffsetX > aRange.x2) {
-    //     xep = aRange.x2;
-    //   } else {
-    //     xep = aOffsetX;
-    //   }
-    //
-    //   if (aOffsetY < aRange.y1) {
-    //     yep = aRange.y1;
-    //   } else if (aOffsetY > aRange.y2) {
-    //     yep = aRange.y2;
-    //   } else {
-    //     yep = aOffsetY;
-    //   }
-    //
-    //   dragInfo.xsp = Math.min(xcp, xep);
-    //   dragInfo.ysp = Math.min(ycp, yep);
-    //   dragInfo.width = Math.ceil(Math.abs(xep - xcp));
-    //   dragInfo.height = Math.ceil(Math.abs(yep - ycp));
-    //
-    //   this.overlayClear();
-    //   this.drawSelectionArea(dragInfo);
-    // };
-
-    /**
      * invoking user custom click event width items and range in drag-section
      *
      * @returns {undefined}
@@ -241,6 +199,11 @@ const modules = {
     window.addEventListener('mouseup', dragEnd);
   },
 
+  /**
+   * Calculate drag-section position and size, and drawing drag-section
+   *
+   * @returns {undefined}
+   */
   dragMove(e) {
     const [offsetX, offsetY] = this.getMousePosition(e);
     const dragInfo = this.dragInfo;

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -13,10 +13,10 @@ const modules = {
      * @returns {undefined}
      */
     this.onMouseMove = (e) => {
-      const { indicator, tooltip, type } = this.options;
       const offset = this.getMousePosition(e);
       const hitInfo = this.findHitItem(offset);
       const ctx = this.overlayCtx;
+      const { indicator, tooltip, type } = this.options;
 
       this.overlayClear();
 

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -13,10 +13,10 @@ const modules = {
      * @returns {undefined}
      */
     this.onMouseMove = (e) => {
+      const { indicator, tooltip, type } = this.options;
       const offset = this.getMousePosition(e);
       const hitInfo = this.findHitItem(offset);
       const ctx = this.overlayCtx;
-      const { indicator, tooltip } = this.options;
 
       this.overlayClear();
 
@@ -31,8 +31,11 @@ const modules = {
         this.hideTooltipDOM();
       }
 
-      const isPieChart = this.seriesInfo.charts.pie.length;
-      if (indicator.use && !isPieChart) {
+      if (type === 'scatter' && this.dragInfo) {
+        this.dragMove(e);
+      }
+
+      if (indicator.use && type !== 'pie') {
         this.drawIndicator(offset, indicator.color);
       }
     };
@@ -43,12 +46,17 @@ const modules = {
      * @returns {undefined}
      */
     this.onMouseLeave = () => {
-      if (this.options.tooltip.throttledMove) {
+      const { tooltip, dragSelection } = this.options;
+
+      if (tooltip.throttledMove) {
         this.onMouseMove.cancel();
       }
-      this.overlayClear();
 
-      if (this.options.tooltip.use) {
+      if (!dragSelection.use || !dragSelection.keepDisplay) {
+        this.overlayClear();
+      }
+
+      if (tooltip.use) {
         this.tooltipClear();
       }
     };
@@ -97,9 +105,18 @@ const modules = {
 
         ({ label: args.label, value: args.value, sId: args.seriesId } = hitInfo);
       }
+    };
 
-      if (typeof this.listeners.click === 'function') {
-        this.listeners.click(args);
+    /**
+     * Start drag-select when dragSelection use option is True and graph type is 'scatter'
+     *
+     * @returns {undefined}
+     */
+    this.onMouseDown = (e) => {
+      const { dragSelection, type } = this.options;
+
+      if (dragSelection.use && type === 'scatter') {
+        this.dragStart(e);
       }
     };
 
@@ -118,6 +135,161 @@ const modules = {
     this.overlayCanvas.addEventListener('mouseleave', this.onMouseLeave);
     this.overlayCanvas.addEventListener('dblclick', this.onDblClick);
     this.overlayCanvas.addEventListener('click', this.onClick);
+    this.overlayCanvas.addEventListener('mousedown', this.onMouseDown);
+  },
+
+  /**
+   * Start drag-move when the mouse pointer is in the graph
+   *
+   * @returns {undefined}
+   */
+  dragStart(evt) {
+    const [offsetX, offsetY] = this.getMousePosition(evt);
+    const chartRect = this.chartRect;
+    const labelOffset = this.labelOffset;
+    const range = {
+      x1: chartRect.x1 + labelOffset.left,
+      x2: chartRect.x2 - labelOffset.right,
+      y1: chartRect.y1 + labelOffset.top,
+      y2: chartRect.y2 - labelOffset.bottom,
+    };
+
+    // check graph range
+    if (offsetX < range.x1 || offsetX > range.x2
+        || offsetY < range.y1 || offsetY > range.y2
+    ) {
+      return;
+    }
+
+    this.dragInfo = {
+      xcp: offsetX,
+      ycp: offsetY,
+      range,
+    };
+
+    /**
+     * Calculate drag-section position and size, and drawing drag-section
+     *
+     * @returns {undefined}
+     */
+    // const dragMove = (e) => {
+    //   e.preventDefault();
+    //
+    //   const [aOffsetX, aOffsetY] = this.getMousePosition(e);
+    //   const dragInfo = this.dragInfo;
+    //   const { xcp, ycp, range: aRange } = dragInfo;
+    //
+    //   let xep;
+    //   let yep;
+    //
+    //   dragInfo.isMove = true;
+    //
+    //   if (aOffsetX < aRange.x1) {
+    //     xep = aRange.x1;
+    //   } else if (aOffsetX > aRange.x2) {
+    //     xep = aRange.x2;
+    //   } else {
+    //     xep = aOffsetX;
+    //   }
+    //
+    //   if (aOffsetY < aRange.y1) {
+    //     yep = aRange.y1;
+    //   } else if (aOffsetY > aRange.y2) {
+    //     yep = aRange.y2;
+    //   } else {
+    //     yep = aOffsetY;
+    //   }
+    //
+    //   dragInfo.xsp = Math.min(xcp, xep);
+    //   dragInfo.ysp = Math.min(ycp, yep);
+    //   dragInfo.width = Math.ceil(Math.abs(xep - xcp));
+    //   dragInfo.height = Math.ceil(Math.abs(yep - ycp));
+    //
+    //   this.overlayClear();
+    //   this.drawSelectionArea(dragInfo);
+    // };
+
+    /**
+     * invoking user custom click event width items and range in drag-section
+     *
+     * @returns {undefined}
+     */
+    const dragEnd = (e) => {
+      e.preventDefault();
+      const dragInfo = this.dragInfo;
+
+      if (dragInfo?.isMove) {
+        if (!this.options.dragSelection.keepDisplay) {
+          this.overlayClear();
+        }
+
+        const args = {
+          data: this.findSelectedItems(dragInfo),
+          range: this.getSelectionRage(dragInfo),
+        };
+
+        if (typeof this.listeners['drag-select'] === 'function') {
+          this.listeners['drag-select'](args);
+        }
+      }
+
+      this.dragInfo = null;
+
+      window.removeEventListener('mouseup', dragEnd);
+    };
+
+    window.addEventListener('mouseup', dragEnd);
+  },
+
+  dragMove(e) {
+    const [offsetX, offsetY] = this.getMousePosition(e);
+    const dragInfo = this.dragInfo;
+    const { xcp, ycp, range } = dragInfo;
+
+    let xep;
+    let yep;
+
+    dragInfo.isMove = true;
+
+    if (offsetX < range.x1) {
+      xep = range.x1;
+    } else if (offsetX > range.x2) {
+      xep = range.x2;
+    } else {
+      xep = offsetX;
+    }
+
+    if (offsetY < range.y1) {
+      yep = range.y1;
+    } else if (offsetY > range.y2) {
+      yep = range.y2;
+    } else {
+      yep = offsetY;
+    }
+
+    dragInfo.xsp = Math.min(xcp, xep);
+    dragInfo.ysp = Math.min(ycp, yep);
+    dragInfo.width = Math.ceil(Math.abs(xep - xcp));
+    dragInfo.height = Math.ceil(Math.abs(yep - ycp));
+
+    this.overlayClear();
+    this.drawSelectionArea(dragInfo);
+  },
+
+
+/**
+   * Draw selection-area
+   *
+   * @returns {undefined}
+   */
+  drawSelectionArea({ xsp, ysp, width, height }) {
+    const ctx = this.overlayCtx;
+    const { fillColor, opacity } = this.options.dragSelection;
+
+    ctx.fillStyle = fillColor;
+    ctx.globalAlpha = opacity;
+    ctx.fillRect(xsp, ysp, width, height);
+    ctx.globalAlpha = 1;
   },
 
   /**
@@ -328,6 +500,86 @@ const modules = {
     }
 
     return { dsIndex, sId };
+  },
+
+  /**
+   * Find items by series within a range
+   * @param {object} param  object for find series items
+   *
+   * @returns {object}
+   */
+  findSelectedItems(range) {
+    const items = [];
+    const sIds = Object.keys(this.seriesList);
+    for (let ix = 0; ix < sIds.length; ix++) {
+      const sId = sIds[ix];
+      const series = this.seriesList[sId];
+      const findFn = series.findItems;
+      if (findFn) {
+        const item = findFn.call(series, range);
+        if (item && item.length) {
+          items.push({
+            seriesName: series.name,
+            seriesId: sId,
+            items: item,
+          });
+        }
+      }
+    }
+
+    return items;
+  },
+
+  /**
+   * Returns the data-based range value for a selection
+   * @param {object} object for calculating data-based range
+   *                 object.range: coordinate-based range in graph
+   * @returns {object}
+   */
+  getSelectionRage({ xsp, ysp, width, height, range }) {
+    const dataRangeX = this.axesSteps.x.length ? this.axesSteps.x[0] : null;
+    const dataRangeY = this.axesSteps.y.length ? this.axesSteps.y[0] : null;
+
+    if (!dataRangeX || !dataRangeY) {
+      return null;
+    }
+
+    const xep = xsp + width;
+    const yep = ysp + height;
+    const graphWidth = dataRangeX.graphMax - dataRangeX.graphMin;
+    const graphHeight = dataRangeY.graphMax - dataRangeY.graphMin;
+
+    const xMinRatio = this.getRatioInRange(range.x1, range.x2, xsp);
+    const xMaxRatio = this.getRatioInRange(range.x1, range.x2, xep);
+    const yMinRatio = this.getRatioInRange(range.y1, range.y2, yep);
+    const yMaxRatio = this.getRatioInRange(range.y1, range.y2, ysp);
+
+    const xMin = dataRangeX.graphMin + graphWidth * xMinRatio;
+    const xMax = dataRangeX.graphMin + graphWidth * xMaxRatio;
+    const yMin = dataRangeY.graphMin + graphHeight * (1 - yMinRatio);
+    const yMax = dataRangeY.graphMin + graphHeight * (1 - yMaxRatio);
+
+    return {
+      xMin: +parseFloat(xMin).toFixed(3),
+      xMax: +parseFloat(xMax).toFixed(3),
+      yMin: +parseFloat(yMin).toFixed(3),
+      yMax: +parseFloat(yMax).toFixed(3),
+    };
+  },
+
+  /**
+   * Returns the position ratio of 'value' between 'min' and 'max'
+   * @param {number} min    min value
+   * @param {number} max    max value
+   * @param {number} value  value is between min and max
+   *
+   * @returns {number}
+   */
+  getRatioInRange(min, max, value) {
+    const total = max - min;
+    const targetValue = value - min;
+
+    return targetValue / total;
   },
 };
 

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -70,6 +70,12 @@ const DEFAULT_OPTIONS = {
     tipBackground: '#000000',
     tipTextColor: '#FFFFFF',
   },
+  dragSelection: {
+    use: true,
+    keepDisplay: true,
+    fillColor: '#38acec',
+    opacity: 0.65,
+  },
 };
 
 const DEFAULT_DATA = {
@@ -93,6 +99,10 @@ export const useModel = () => {
     'dbl-click': async (e) => {
       await nextTick();
       emit('dbl-click', e);
+    },
+    'drag-select': async (e) => {
+      await nextTick();
+      emit('drag-select', e);
     },
   };
 


### PR DESCRIPTION
- scatter chart 드래그 기능 추가
- lineChart.md 오타 수정
- 드래그 추가에 따른 scatterChart.md, example 화면 추가에 따른 수정
- scatterChart example - default 화면에 X axis 갯수, series 갯수 변경 기능 추가
- scatterChart pointStyle 중 'dash' 삭제 (드래그 이벤트 스펙과 상이한 점이있어서, 데이터 좌표가 중앙에 있지 않음)
- 차트 예제 중 setInterval 인데 clearTimeout 처리한 부분 => clearInterval 로 수정