### PR TITLE
[#806][3.0] Chart padding 옵션 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -81,6 +81,7 @@ const chartData = {
   | indicator | Object | ([상세](#indicator)) | 지표선 | |
   | maxTip | Object | ([상세](#maxtip)) | 최대값에 tip 표시(값 표시) 여부 및 속성 | |
   | selectItem | Object | ([상세](#selectitem)) | 차트 아이템 선택 기능 활성화 여부 및 속성 | | 
+  | padding | Object | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값 | | 
 
 #### axesX axesY
 ##### type 공통

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -62,6 +62,7 @@ const chartData =
   | indicator | Object | ([상세](#indicator)) | 지표선 | |
   | maxTip | Object | ([상세](#maxtip)) | 최대값에 tip 표시(값 표시) 여부 및 속성 | |
   | selectItem | Object | ([상세](#selectitem)) | 차트 아이템 선택 기능 활성화 여부 및 속성 | | 
+  | padding | Object | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값 | 
 
 #### axesX axesY
 ##### type 공통

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -44,7 +44,8 @@ const chartData =
   | height | String / Number | '100%' | 차트의 높이 | '100%', '150px', 150 |
   | title | Object | ([상세](#title)) | 차트 상단에 위치할 차트 제목 표시 여부 및 속성 |  |
   | legend | Object | ([상세](#legend)) | 차트의 범례 표시 여부 및 속성 |  |
-
+  | padding | Object | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값 |
+   
 #### title
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 | --- | ---- | ----- | --- | ----------|

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -61,6 +61,7 @@ const chartData =
   | legend | Object | ([상세](#legend)) | 차트의 범례 표시 여부 및 속성 |  |
   | indicator | Object | ([상세](#indicator)) | 지표선 | |
   | dragSelection | Object | ([상세](#dragselection)) | drag-select의 사용 여부 | |
+  | padding | Object | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값 | 
   
 #### axesX axesY
 ##### type 공통

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -353,7 +353,7 @@ class EvChart {
   getChartRect() {
     const { width, height } = this.getChartDOMRect();
 
-    const padding = { top: 20, right: 2, left: 2, bottom: 4 };
+    const padding = this.options.padding;
     const chartWidth = width - padding.left - padding.right;
     const chartHeight = height - padding.top - padding.bottom;
 

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -3,6 +3,12 @@ import { defaultsDeep } from 'lodash-es';
 import { getQuantity } from '@/common/utils';
 
 const DEFAULT_OPTIONS = {
+  padding: {
+    top: 20,
+    right: 2,
+    left: 2,
+    bottom: 4,
+  },
   border: 2,
   title: {
     show: false,


### PR DESCRIPTION
### 작업내용
- padding 옵션화 기능 추가
   - 기본값:  { top : 20, left: 2, right: 2, bottom: 4 } 
- 관련 설명 .md 파일에 추가

### 사용 예시
```
const chartOptions = {
  padding: { top: 0 },
  ...
}
```