### PR TITLE
[#809][3.0] bar chart _ border radius 관련 에러 메시지 처리

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -354,8 +354,10 @@ class EvChart {
     const { width, height } = this.getChartDOMRect();
 
     const padding = this.options.padding;
-    const chartWidth = width - padding.left - padding.right;
-    const chartHeight = height - padding.top - padding.bottom;
+    const horizontalPadding = padding.left + padding.right;
+    const verticalPadding = padding.top + padding.bottom;
+    const chartWidth = width > horizontalPadding ? width - horizontalPadding : width;
+    const chartHeight = height > verticalPadding ? height - verticalPadding : height;
 
     const x1 = padding.left;
     const x2 = Math.max(width - padding.right, x1 + 2);


### PR DESCRIPTION
### 이슈 요약
 - 차트의 너비/높이에서  기본 padding값을 빼고, 그려야 하는 데이터의 label들 중 축을 벗어나는 만큼을 또 빼면서 series(막대, 라인...)을 그릴때 차트의 너비/높이가 음수로 전환되는 현상 발생
 - 음수값을 가지고 Canvas의 arcTo 메소드를 호출하다가 Error 발생
 

### 작업내용
- 차트 너비/높이에서 padding값을 빼는 로직에 음수로 전환되지 않도록 조건 문 추가
- 막대차트 // 모서리가 둥근 막대를 그리는 과정에서 에러 발생 시 일반 막대를 그리도록 예외처리


### 보류
 -  차트의 최소 너비/높이 값 지정 