### PR TITLE
[#820] [3.0] Bar Chart 그라데이션 값 rgba 지원 __ 투명값 0 처리

### DIFF
--- a/src/components/chart/helpers/helpers.canvas.js
+++ b/src/components/chart/helpers/helpers.canvas.js
@@ -253,7 +253,7 @@ export default {
 
     for (let ix = 0; ix < stops.length; ix++) {
       const stopIdx = stops[ix][0] ?? 0;
-      const stopColor = stops[ix][1] ?? 'rgba(0, 0, 0, 0)';
+      const stopColor = stops[ix][1] ?? 'rgba(255, 255, 255, 0)';
       const noneDownplayOpacity = stopColor.includes('rgba') ? Util.getOpacity(stopColor) : 1;
       const opacity = isDownplay ? 0.1 : noneDownplayOpacity;
 

--- a/src/components/chart/helpers/helpers.canvas.js
+++ b/src/components/chart/helpers/helpers.canvas.js
@@ -253,7 +253,7 @@ export default {
 
     for (let ix = 0; ix < stops.length; ix++) {
       const stopIdx = stops[ix][0] ?? 0;
-      const stopColor = stops[ix][1] ?? '#FFFFFF';
+      const stopColor = stops[ix][1] ?? 'rgba(0, 0, 0, 0)';
       const noneDownplayOpacity = stopColor.includes('rgba') ? Util.getOpacity(stopColor) : 1;
       const opacity = isDownplay ? 0.1 : noneDownplayOpacity;
 

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -36,7 +36,7 @@ export default {
     const noneWhiteSpaceColorStr = colorStr.replace(/ /g, '');
     const isHEX = /^#(?:[A-Fa-f0-9]{3}){1,2}$/.exec(noneWhiteSpaceColorStr);
     const isRGB = /^rgb[(](?:\s*0*(?:\d\d?(?:\.\d+)?(?:\s*%)?|\.\d+\s*%|100(?:\.0*)?\s*%|(?:1\d\d|2[0-4]\d|25[0-5])(?:\.\d+)?)\s*(?:,(?![)])|(?=[)]))){3}[)]$/.exec(noneWhiteSpaceColorStr);
-    const isRGBA = /^rgba[(](?:\s*0*(?:\d\d?(?:\.\d+)?(?:\s*%)?|\.\d+\s*%|100(?:\.0*)?\s*%|(?:1\d\d|2[0-4]\d|25[0-5])(?:\.\d+)?)\s*,){3}\s*0*(?:\.\d+|1(?:\.0*)?)\s*[)]$/.exec(noneWhiteSpaceColorStr);
+    const isRGBA = /^rgba[(](?:\s*0*(?:\d\d?(?:\.\d+)?(?:\s*%)?|\.\d+\s*%|100(?:\.0*)?\s*%|(?:1\d\d|2[0-4]\d|25[0-5])(?:\.\d+)?)\s*,){3}\s*0*(?:\.\d+|1?)\s*[)]$/.exec(noneWhiteSpaceColorStr);
     let result = '';
 
     if (isHEX) {


### PR DESCRIPTION
### 작업내용
1.  rgba에서 투명도 값으로 0을 지정할 경우 rgba 입력값인지 판단하는 정규표현식에서 false 처리하여 수정
2. 그라데이션 입력에서 startColor 값을 지정안 할 경우 '#FFFFFF'으로 임의 처리하였지만 투명도 100으로 보이게끔 rgba(255, 255, 255, 0)으로 변경