### PR TITLE
[#639] 아이콘 컴포넌트의 클릭 이벤트 stop 수식어 제거

### DIFF
--- a/src/components/icon/Icon.vue
+++ b/src/components/icon/Icon.vue
@@ -4,7 +4,7 @@
       icon,
       { [`ev-icon-${size}`]: !!size },
     ]"
-    @click.stop="onClick"
+    @click="onClick"
     @dblClick="onDblClick"
     @contextmenu="onContextMenu"
   />


### PR DESCRIPTION
click 이벤트에 stop 수식어 제거(버블링 허용)