### PR TITLE
[#825] Chart Tooltip label명 길어질 때 잘림 현상

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -136,7 +136,9 @@ class EvChart {
     this.drawAxis();
     this.drawSeries();
     this.drawTip(hitInfo);
-    this.displayCtx.drawImage(this.bufferCanvas, 0, 0);
+    if (this.bufferCanvas) {
+      this.displayCtx.drawImage(this.bufferCanvas, 0, 0);
+    }
   }
 
   /**
@@ -335,9 +337,9 @@ class EvChart {
    * @returns {object} chart size information
    */
   getChartDOMRect() {
-    const rect = this.chartDOM.getBoundingClientRect();
-    const width = rect.width || 10;
-    const height = rect.height || 10;
+    const rect = this.chartDOM?.getBoundingClientRect();
+    const width = rect?.width || 10;
+    const height = rect?.height || 10;
 
     this.setWidth(width);
     this.setHeight(height);
@@ -613,13 +615,18 @@ class EvChart {
    */
   clear() {
     this.clearRectRatio = (this.pixelRatio < 1) ? this.pixelRatio : 1;
-
-    this.displayCtx.clearRect(0, 0, this.displayCanvas.width / this.clearRectRatio,
-      this.displayCanvas.height / this.clearRectRatio);
-    this.bufferCtx.clearRect(0, 0, this.bufferCanvas.width / this.clearRectRatio,
-      this.bufferCanvas.height / this.clearRectRatio);
-    this.overlayCtx.clearRect(0, 0, this.overlayCanvas.width / this.clearRectRatio,
-      this.overlayCanvas.height / this.clearRectRatio);
+    if (this.displayCanvas) {
+      this.displayCtx.clearRect(0, 0, this.displayCanvas.width / this.clearRectRatio,
+        this.displayCanvas.height / this.clearRectRatio);
+    }
+    if (this.bufferCanvas) {
+      this.bufferCtx.clearRect(0, 0, this.bufferCanvas.width / this.clearRectRatio,
+        this.bufferCanvas.height / this.clearRectRatio);
+    }
+    if (this.overlayCanvas) {
+      this.overlayCtx.clearRect(0, 0, this.overlayCanvas.width / this.clearRectRatio,
+        this.overlayCanvas.height / this.clearRectRatio);
+    }
   }
 
   /**

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -75,7 +75,7 @@ const modules = {
     // set tooltip canvas width (maxSeries name, label length comparison)
     const isHorizontal = !!this.options.horizontal;
     const label = isHorizontal ? items[hitInfo.hitId]?.data?.y : items[hitInfo.hitId]?.data?.x;
-    const tooltipValue = label && label.length > maxSeries.length ? label : maxSeries;
+    const tooltipValue = label?.length > maxSeries.length ? label : maxSeries;
     ctx.save();
     ctx.font = '12px Roboto';
     const nw = Math.round(ctx.measureText(tooltipValue).width);

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -72,9 +72,13 @@ const modules = {
     const calHeight = seriesCnt => boxPadding.t + (seriesCnt * textHeight)
       + (seriesCnt * lineSpacing) + boxPadding.b;
 
+    // set tooltip canvas width (maxSeries name, label length comparison)
+    const isHorizontal = !!this.options.horizontal;
+    const label = isHorizontal ? items[hitInfo.hitId]?.data?.y : items[hitInfo.hitId]?.data?.x;
+    const tooltipValue = label && label.length > maxSeries.length ? label : maxSeries;
     ctx.save();
     ctx.font = '12px Roboto';
-    const nw = Math.round(ctx.measureText(maxSeries).width);
+    const nw = Math.round(ctx.measureText(tooltipValue).width);
     const vw = Math.round(ctx.measureText(maxValue).width);
     ctx.restore();
 

--- a/src/components/chart/style/chart.scss
+++ b/src/components/chart/style/chart.scss
@@ -116,7 +116,7 @@
   border-radius: 8px;
 
   .ev-chart-tooltip-header {
-    padding: 8px 0 0 16px;
+    padding: 8px 16px 0 16px;
     font-family: Roboto, serif;
     font-size: 16px;
   }


### PR DESCRIPTION
###########################
- label 명이 길어져도 maxSeries의 값이 보이도록 수정
  : tooltipCanvas width 설정 시 label명이 더 길명 label명을 기준으로 설정
- chartDom이 없을 때(ex. display: none) 예외 처리