### PR TITLE
[#846] [3.0] chart- props.data / props.option update 로직 이슈

### DIFF
--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -9,7 +9,7 @@
 
 <script>
   import { onMounted, onBeforeUnmount, watch } from 'vue';
-  import { cloneDeep, defaultsDeep, isEqual, debounce } from 'lodash-es';
+  import { cloneDeep, isEqual, debounce } from 'lodash-es';
   import EvChart from './chart.core';
   import { useModel, useWrapper } from './uses';
 
@@ -40,9 +40,12 @@
 
       const {
         eventListeners,
-        normalizedData,
-        normalizedOptions,
+        getNormalizedData,
+        getNormalizedOptions,
       } = useModel();
+
+      const normalizedData = getNormalizedData(props.data);
+      const normalizedOptions = getNormalizedOptions(props.options);
 
       const {
         wrapper,
@@ -71,8 +74,8 @@
         await createChart();
         await drawChart();
 
-        await watch(() => props.options, (curr) => {
-          const newOpt = defaultsDeep({}, curr, normalizedOptions);
+        await watch(() => props.options, (chartOpt) => {
+          const newOpt = getNormalizedOptions(chartOpt);
           evChart.options = cloneDeep(newOpt);
           evChart.update({
             updateSeries: false,
@@ -80,8 +83,8 @@
           });
         }, { deep: true });
 
-        await watch(() => props.data, (curr) => {
-          const newData = defaultsDeep({}, curr, normalizedData);
+        await watch(() => props.data, (chartData) => {
+          const newData = getNormalizedData(chartData);
           const isUpdateSeries = !isEqual(newData.series, evChart.data.series);
           evChart.data = cloneDeep(newData);
           evChart.update({

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -93,10 +93,10 @@ const DEFAULT_DATA = {
 };
 
 export const useModel = () => {
-  const { props, emit } = getCurrentInstance();
+  const { emit } = getCurrentInstance();
 
-  const normalizedOptions = defaultsDeep({}, props.options, DEFAULT_OPTIONS);
-  const normalizedData = defaultsDeep(props.data, DEFAULT_DATA);
+  const getNormalizedOptions = options => defaultsDeep({}, options, DEFAULT_OPTIONS);
+  const getNormalizedData = data => defaultsDeep(data, DEFAULT_DATA);
 
   const eventListeners = {
     click: async (e) => {
@@ -115,8 +115,8 @@ export const useModel = () => {
 
   return {
     eventListeners,
-    normalizedData,
-    normalizedOptions,
+    getNormalizedData,
+    getNormalizedOptions,
   };
 };
 


### PR DESCRIPTION
### 기존 문제점
```
        await watch(() => props.data, (curr) => {
          const newData = defaultsDeep({}, curr, normalizedData);
```
- props.data 데이터를 watch하는 과정에서 신규 데이터(curr)와 차트의 기본 데이터 (DEFAULT_DATA)를 합쳐야 하는데 
- normalizedData( 컴포넌트 생성시점의 props.data + DEFAULT_DATA)와 합쳐 문제 발생

### 해결
1.  인자로 전달받아 normalized된 데이터를 반환하는 함수 생성
    - 해당 함수는 전달받은 데이터와 사전 정의된 차트의 기본데이터를 합치는 일만 함
 

