### PR TITLE
[#848] [3.0] chart tool-tip 위치 계산 이슈

### DIFF
--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -105,12 +105,19 @@ const modules = {
     // set tooltipDOM's positions
     const bodyWidth = document.body.clientWidth;
     const bodyHeight = document.body.clientHeight;
-    this.tooltipDOM.style.left = mouseX > bodyWidth - contentsWidth - 20
-      ? `${mouseX - contentsWidth - 20}px`
-      : `${mouseX + 20}px`;
-    this.tooltipDOM.style.top = mouseY > bodyHeight - (titleHeight + contentsHeight) - 20
-      ? `${mouseY - (titleHeight + contentsHeight) - 20}px`
-      : `${mouseY + 20}px`;
+    const distanceMouseAndTooltip = 20;
+    const maximumPosX = bodyWidth - contentsWidth - distanceMouseAndTooltip;
+    const maximumPosY = bodyHeight - (titleHeight + contentsHeight) - distanceMouseAndTooltip;
+    const expectedPosX = mouseX + distanceMouseAndTooltip;
+    const expectedPosY = mouseY + distanceMouseAndTooltip;
+    const reversedPosX = mouseX - contentsWidth - distanceMouseAndTooltip;
+    const reversedPosY = mouseY - (titleHeight + contentsHeight) - distanceMouseAndTooltip;
+    this.tooltipDOM.style.left = expectedPosX > maximumPosX
+      ? `${reversedPosX}px`
+      : `${expectedPosX}px`;
+    this.tooltipDOM.style.top = expectedPosY > maximumPosY
+      ? `${reversedPosY}px`
+      : `${expectedPosY}px`;
   },
 
   /**


### PR DESCRIPTION
### 이슈 내용
![image](https://user-images.githubusercontent.com/53548023/127261278-3f798403-ad6a-4a07-b610-0a4ed41034f4.png)
- tooltip이 body 태그의 clientWidth을 벗어날 경우 반대쪽에 그리는 로직이 정상적으로 수행되지 않음 


### 작업내용
- 차트 툴팁의 위치를 정하는 로직에서 특정 값(마우스 위치 <-> 툴팁 위치 사이 값: 20) 이 누락되어 이를 수정함