### PR TITLE
[#724][3.0] Tab 내부의 ctx 로직 삭제

### DIFF
--- a/src/components/tabPanel/TabPanel.vue
+++ b/src/components/tabPanel/TabPanel.vue
@@ -31,7 +31,7 @@ export default {
   },
   setup(props) {
     const evTabs = inject('evTabs', null);
-    const mv = computed(() => evTabs.ctx.mv);
+    const mv = computed(() => evTabs);
     const isSelected = computed(() => props.value === mv.value);
 
     return {

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -84,7 +84,7 @@
 <script>
 import {
   ref, reactive, computed,
-  provide, getCurrentInstance, triggerRef,
+  provide, triggerRef,
   onBeforeUpdate, nextTick, onUpdated,
 } from 'vue';
 
@@ -131,9 +131,6 @@ export default {
     change: [String, Number],
   },
   setup(props, { emit }) {
-    const instance = getCurrentInstance();
-    provide('evTabs', instance);
-
     const mv = computed({
       get: () => props.modelValue,
       set: (val) => {
@@ -141,6 +138,8 @@ export default {
         emit('change', val);
       },
     });
+
+    provide('evTabs', mv.value);
     const tabList = computed({
       get: () => props.panels,
       set: val => emit('update:panels', val),


### PR DESCRIPTION
################
- getCurrentInstance() 내 ctx 가져오는 로직을 지우고 mv의 값을 바로 provide로 넘김