### PR TITLE
[#646][3.0] Select 컴포넌트 change 이벤트가 안되는 현상 수정

### DIFF
--- a/docs/views/select/api/select.md
+++ b/docs/views/select/api/select.md
@@ -57,7 +57,7 @@
 
  | 이름 | 파라미터 | 설명 |
  | ---- | ------- | ---- |
- | change | newValue, event | <셀렉트> 내 v-model 변화 이벤트 감지 |
+ | change | newValue | <셀렉트> 내 v-model 변화 이벤트 감지 |
 
 >### 참고
  - 

--- a/docs/views/select/example/Default.vue
+++ b/docs/views/select/example/Default.vue
@@ -16,7 +16,7 @@
       first selectbox value : {{ selectVal1 }}
     </div>
     <div class="description">
-      change val : {{ selectEventVal.val }} / change e : {{ selectEventVal.e }}
+      change val : {{ selectEventVal.val }}
     </div>
   </div>
   <div class="case">
@@ -142,9 +142,8 @@ export default {
         value: `value${count}`,
       });
     };
-    const changeSelect1 = (val, e) => {
+    const changeSelect1 = (val) => {
       selectEventVal.val = val;
-      selectEventVal.e = e;
     };
 
     const selectVal3 = ref('value1');

--- a/docs/views/select/example/Multiple.vue
+++ b/docs/views/select/example/Multiple.vue
@@ -6,9 +6,13 @@
       :items="items1"
       placeholder="Please select values."
       multiple
+      @change="changeEvent"
     />
     <div class="description">
       first selectbox value : {{ selectVal1 }}
+    </div>
+    <div class="description">
+      change val : {{ changeVal }}
     </div>
   </div>
   <div class="case">
@@ -104,10 +108,16 @@ export default {
         value: 'value7',
       },
     ]);
+    const changeVal = ref();
+    const changeEvent = (val) => {
+      changeVal.value = val;
+    };
 
     return {
       selectVal1,
       items1,
+      changeVal,
+      changeEvent,
     };
   },
 };

--- a/src/components/select/Select.vue
+++ b/src/components/select/Select.vue
@@ -28,7 +28,6 @@
         readonly
         :placeholder="computedPlaceholder"
         :disabled="disabled"
-        @change="changeMv"
         @click="clickSelectInput"
       />
     </template>
@@ -240,7 +239,7 @@ export default {
       changeDropboxPosition,
       clickItem,
       selectedItemClass,
-    } = useDropdown({ mv });
+    } = useDropdown({ mv, changeMv });
 
     return {
       mv,

--- a/src/components/select/uses.js
+++ b/src/components/select/uses.js
@@ -69,23 +69,24 @@ export const useModel = () => {
   };
 
   /**
-   * multiple 모드인 경우 선택된 value를 mv에서 삭제하는 로직
-   * @param val - tagWrapper에서 [x]클릭된 목록의 value
-   */
-  const removeMv = (val) => {
-    if (!props.disabled) {
-      const idx = mv.value.indexOf(val);
-      mv.value.splice(idx, 1);
-      mv.value = [...mv.value];
-    }
-  };
-
-  /**
    * 해당 컴포넌트의 v-model값이 변경(change)되는 이벤트
    */
   const changeMv = async () => {
     await nextTick();
     emit('change', mv.value);
+  };
+
+  /**
+   * multiple 모드인 경우 선택된 value를 mv에서 삭제하는 로직
+   * @param val - tagWrapper에서 [x]클릭된 목록의 value
+   */
+  const removeMv = async (val) => {
+    if (!props.disabled) {
+      const idx = mv.value.indexOf(val);
+      mv.value.splice(idx, 1);
+      mv.value = [...mv.value];
+      await changeMv();
+    }
   };
 
   return {
@@ -229,6 +230,7 @@ export const useDropdown = (param) => {
       const idx = mv.value.indexOf(val);
       mv.value.splice(idx, 1);
     }
+    changeMv();
   };
   const clickItem = !props.multiple ? singleClickItem : multipleClickItem;
 

--- a/src/components/select/uses.js
+++ b/src/components/select/uses.js
@@ -82,11 +82,10 @@ export const useModel = () => {
 
   /**
    * 해당 컴포넌트의 v-model값이 변경(change)되는 이벤트
-   * @param e
    */
-  const changeMv = async (e) => {
+  const changeMv = async () => {
     await nextTick();
-    emit('change', mv.value, e);
+    emit('change', mv.value);
   };
 
   return {
@@ -102,7 +101,7 @@ export const useModel = () => {
 
 export const useDropdown = (param) => {
   const { props } = getCurrentInstance();
-  const { mv } = param;
+  const { mv, changeMv } = param;
 
   const isDropbox = ref(false);
   const filterTextRef = ref(props.filterText);
@@ -218,6 +217,7 @@ export const useDropdown = (param) => {
     }
     mv.value = val;
     isDropbox.value = false;
+    changeMv();
   };
   const multipleClickItem = (val) => {
     if (props.filterable) {


### PR DESCRIPTION
###### 상세 내용
- Select 컴포넌트에서 `@change` 트리거 이벤트를 걸어도 발동되지 않는 현상
---
###### 해결 방법
1. input 요소의 change 이벤트는 blur시 발동되므로 JS로 input.focus() -> input.bulr() 하여 강제로 change 이벤트 발생 ❌
  - JS로 input value 수정 후에 focue -> blur 해도 change 이벤트가 발동되지 않음
2. input 요소의 change 이벤트를 input 이벤트로 변경 ❌
  - input 이벤트는 값이 변경되면 발동되므로 해당 이벤트로 변경했지만 마찬가지로 발동되지 않음
3. input 요소에서 change, input 이벤트가 동작하지 않아 클릭 했을 때 'change' emit하도록 로직 수정 ✔
  - 위의 두 방법이 적용되지 않아 click 이벤트 시 change를 emit하는 방법으로 수정
---