### PR TITLE
[#866] [3.0] build 후 적용시 Tree 컴포넌트의 하위 컴포넌트가 보이지 않는 현상 수정

### DIFF
--- a/src/components/tree/Tree.vue
+++ b/src/components/tree/Tree.vue
@@ -7,6 +7,7 @@
       :use-checkbox="useCheckbox"
       :expand-icon="expandIcon"
       :collapse-icon="collapseIcon"
+      :comp="component"
       @update-checked-info="updateCheckedInfo"
       @click-node="clickContent"
       @dblclick-node="dblClickContent"
@@ -69,6 +70,7 @@ export default {
     let allNodeInfo = [];
     const contextMenu = ref(null);
     let contextMenuFlag = false; // flag for showing contextMenu or not
+    const component = TreeNode;
 
     function updateTreeUp(nodeKey) {
       const parentKey = allNodeInfo[nodeKey].parent;
@@ -296,6 +298,7 @@ export default {
     return {
       treeNodeData,
       contextMenu,
+      component,
       updateCheckedInfo,
       clickContent,
       dblClickContent,

--- a/src/components/tree/TreeNode.vue
+++ b/src/components/tree/TreeNode.vue
@@ -41,7 +41,8 @@
         </span>
       </div>
       <transition-group name="fade">
-        <tree-node
+        <component
+          :is="comp"
           v-for="(child, i) in childrenInfo"
           v-if="treeData.expand"
           :key="`${child.value}-${i}`"
@@ -49,6 +50,7 @@
           :use-checkbox="useCheckbox"
           :expand-icon="expandIcon"
           :collapse-icon="collapseIcon"
+          :comp="comp"
           @update-checked-info="emitCheckedInfo"
           @click-node="emitClickedContent"
           @dblclick-node="emitDblClickedContent"
@@ -81,6 +83,10 @@ export default {
     collapseIcon: {
       type: String,
       default: '',
+    },
+    comp: {
+      type: Object,
+      default: () => {},
     },
   },
   emits: {


### PR DESCRIPTION
## 버그내용
![image](https://user-images.githubusercontent.com/78329640/130383287-a975c129-7d98-4f64-96d5-d38a79c6dfe1.png)
- 최신 vue3 문법에서 자기 자신의 컴포넌트를 재귀적으로 사용하는 것을 막아놔서 위 코드를 사용하면 에러 발생
---
## 참고사항
![image](https://user-images.githubusercontent.com/78329640/130383335-55c875f2-8e35-4ff1-8e0a-6e08acea15e5.png)
![image](https://user-images.githubusercontent.com/78329640/130383359-1afccffe-114a-4d83-8314-547c9467e3a2.png)
- EVUI의 Menu.vue 컴포넌트에서도 같은 이슈가 발생하여 수정된 히스토리가 있어서 해당 부분 참고
- [Creating a Recursive Tree Component in Vue.js](https://www.digitalocean.com/community/tutorials/vuejs-recursive-components)
- [Dynamic & Async Components](https://v3.vuejs.org/guide/component-dynamic-async.html#dynamic-async-components)
---
## 수정사항
- 최신 vue3에서는 자기 자신의 컴포넌트를 재귀적으로 사용하게 되면 `[Vue warn]: Failed to resolve component: _self` 에러가 발생
- 따라서 기존에 EVUI의 Tree컴포넌트에서 구현된 재귀적인 방법 대신 다른 방법을 사용 필요
- Menu.vue 컴포넌트를 참고하여 상위 컴포넌트(Tree.vue)가 하위 컴포넌트(TreeNode.vue)에게 props로 TreeNode 컴포넌트를 넘겨주고 `<component>`로 TreeNode 컴포넌트를 동적 생성하는 방법으로 수정
---