### PR TITLE
[#915][3.0] Chart Combo 사용 시 Tooltip 에 데이터 전체 표시

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -170,7 +170,7 @@ const chartData = {
 | maxHeight | Number |  | 툴팁의 최대 높이  | |
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
-| showByValue | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
+| showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 
 
 #### indicator

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -138,7 +138,7 @@ const chartData =
 | maxHeight | Number |  | 툴팁의 최대 높이  | |
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
-| showByValue | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
+| showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 
 #### indicator
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -20,7 +20,7 @@ const modules = {
       const { indicator, tooltip, type } = this.options;
       const offset = this.getMousePosition(e);
       const hitInfo = this.findHitItem(offset);
-      if (tooltip?.showByValue && hitInfo?.items) {
+      if (tooltip?.showAllValueInRange && hitInfo?.items) {
         const isHorizontal = !!this.options.horizontal;
         const hitItemId = Object.keys(hitInfo.items)[0];
         const hitItemData = isHorizontal


### PR DESCRIPTION
#######################
 - hitInfo에 items의 값과 동일한 axes값을 가진 series를 hitInfo.items 에 추가
```
tooltip: {
  showByValue: true,
},
```

![image](https://user-images.githubusercontent.com/61657275/136481966-9390f051-3012-48fe-8263-96d247ccdbb8.png)
![image](https://user-images.githubusercontent.com/61657275/136481976-f8e36b4a-4f8d-4c2e-ac2e-8518176210a5.png)
