### PR TITLE
[#724][3.0] Tab 내 scroll 버그 수정

### DIFF
--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -1,5 +1,10 @@
 <template>
   <section
+    v-resize="onResize"
+    v-observe-visibility="{
+      callback: onResize,
+      once: true,
+    }"
     class="ev-tabs"
     :class="{
       closable,
@@ -85,7 +90,7 @@
 import {
   ref, reactive, computed,
   provide, triggerRef,
-  onBeforeUpdate, nextTick, onUpdated,
+  onBeforeUpdate, nextTick,
 } from 'vue';
 
 export default {
@@ -215,16 +220,6 @@ export default {
       }
     });
 
-    // 최초 렌더링 시 El의 너비 확인
-    nextTick(() => {
-      observeListEl();
-    });
-
-    // 화면 업데이트 시 El의 너비 확인
-    onUpdated(() => {
-      observeListEl();
-    });
-
     /**
      *  탭 클릭 로직
      */
@@ -342,6 +337,10 @@ export default {
       tabCloneList.value.splice(0);
     };
 
+    const onResize = () => {
+      observeListEl();
+    };
+
     return {
       mv,
       computedTabList,
@@ -359,6 +358,8 @@ export default {
       dragendTab,
       dragSelectCls,
       selectIdxCls,
+
+      onResize,
     };
   },
 };


### PR DESCRIPTION
################
- 너비 계산 후 스크롤 및 양쪽 끝 아이콘이 나타나는 로직에 대한 버그를 해결하기 위해 grid, chart에서 사용 중인 resize, observe-visibility 라이브러리를 이용하여 정상 동작하도록 함