### PR TITLE
[#928] [3.0] Chart > legend padding 옵션 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -154,6 +154,7 @@ const chartData = {
 | inactive | Hex, RGB, RGBA Code(String) | '#aaa' | 비활성화 상태의 폰트 색상 | | 
 | width | Number | 140 | Legend의 넓이 *('left', 'right'의 경우 조절)* | | 
 | height | Number | 24 | Legend의 높이 *('top', 'bottom'의 경우 조절)* | | 
+| padding | Object | { top: 0, right: 0, left: 0, bottom: 0 } | Legend 내부 padding 값 | | 
 
 #### tooltip
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/barChart/example/Gradient.vue
+++ b/docs/views/barChart/example/Gradient.vue
@@ -36,6 +36,15 @@
           startToZero: true,
           autoScaleRatio: 0.1,
         }],
+        legend: {
+          show: true,
+          position: 'bottom',
+          height: 50,
+          padding: {
+            left: 60,
+            top: 20,
+          },
+        },
       };
 
       return {

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -122,6 +122,7 @@ const chartData =
 | inactive | Hex, RGB, RGBA Code(String) | '#aaa' | 비활성화 상태의 폰트 색상 | | 
 | width | Number | 140 | Legend의 넓이 *('left', 'right'의 경우 조절)* | | 
 | height | Number | 24 | Legend의 높이 *('top', 'bottom'의 경우 조절)* | | 
+| padding | Object | { top: 0, right: 0, left: 0, bottom: 0 } | Legend 내부 padding 값 | |
 
 #### tooltip
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -69,6 +69,7 @@ const chartData =
 | inactive | Hex, RGB, RGBA Code(String) | '#aaa' | 비활성화 상태의 폰트 색상 | | 
 | width | Number | 140 | Legend의 넓이 *('left', 'right'의 경우 조절)* | | 
 | height | Number | 24 | Legend의 높이 *('top', 'bottom'의 경우 조절)* | | 
+| padding | Object | { top: 0, right: 0, left: 0, bottom: 0 } | Legend 내부 padding 값 | |
 
 
 ### 3. resize-timeout

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -115,6 +115,7 @@ const chartData =
 | inactive | Hex, RGB, RGBA Code(String) | '#aaa' | 비활성화 상태의 폰트 색상 | | 
 | width | Number | 140 | Legend의 넓이 *('left', 'right'의 경우 조절)* | | 
 | height | Number | 24 | Legend의 높이 *('top', 'bottom'의 경우 조절)* | | 
+| padding | Object | { top: 0, right: 0, left: 0, bottom: 0 } | Legend 내부 padding 값 | |
 
 #### indicator
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -313,15 +313,18 @@ const modules = {
 
     let chartRect;
     const title = opt?.title?.show ? opt?.title?.height : 0;
-    const top = title + opt?.legend?.height;
+    const positionTop = title + opt?.legend?.height;
+    const { top = 0, bottom = 0, left = 0, right = 0 } = opt?.legend?.padding ?? {};
 
     if (!wrapperStyle || !legendStyle) {
       return;
     }
 
+    boxStyle.padding = `${top}px ${right}px ${bottom}px ${left}px`;
+
     switch (position) {
       case 'top':
-        wrapperStyle.padding = `${top}px 0 0 0`;
+        wrapperStyle.padding = `${positionTop}px 0 0 0`;
         chartRect = this.chartDOM.getBoundingClientRect();
 
         boxStyle.width = '100%';
@@ -335,7 +338,7 @@ const modules = {
         legendStyle.width = `${chartRect.width}px`;
         legendStyle.height = `${opt.legend.height + 4}px`; // 4 resize bar size
 
-        resizeStyle.top = `${top}px`;
+        resizeStyle.top = `${positionTop}px`;
         resizeStyle.right = '';
         resizeStyle.bottom = '';
         resizeStyle.left = '';


### PR DESCRIPTION
## 작업내용
1. Chart Legend 옵션에 Padding옵션 추가 
   - padding > top과 변수명이 겹쳐, position > top을 의미하는 변수명을  `top`에서 `positionTop`으로 변경 
2. 관련 설명 Docs에 추가
3. Bar Chart > Gradient Sample Code에 적용

## Example
### Before
![image](https://user-images.githubusercontent.com/53548023/139613614-983e19f1-d528-4abf-94b0-106b3c651c82.png)

### After
![image](https://user-images.githubusercontent.com/53548023/139613625-87752133-2341-4675-a0ce-13cbfa762f02.png)
![image](https://user-images.githubusercontent.com/53548023/139613586-480c9d06-231a-4b3b-8c65-2ece47df56d6.png)
