### PR TITLE
[#954][3.0] DatePicker > range 모드인 경우 timeFormat이 없을 때 shortcut클릭 안되는 버그 수정

### DIFF
--- a/src/components/datePicker/uses.js
+++ b/src/components/datePicker/uses.js
@@ -333,16 +333,21 @@ export const useShortcuts = (param) => {
     }
 
     const shortcutDate = targetShortcut.shortcutDate;
+    const timeFormat = props.options?.timeFormat;
 
     if (isRange) {
       const [fromDate, toDate] = shortcutDate();
       if (props.mode === 'dateTimeRange') {
-        const [fromTimeFormat, toTimeFormat] = props.options?.timeFormat;
+        if (timeFormat?.length) {
+          const [fromTimeFormat, toTimeFormat] = timeFormat;
 
-        mv.value = [
-          getChangedValueByTimeFormat(fromTimeFormat, formatDateTime(fromDate)),
-          getChangedValueByTimeFormat(toTimeFormat, formatDateTime(toDate)),
-        ];
+          mv.value = [
+            getChangedValueByTimeFormat(fromTimeFormat, formatDateTime(fromDate)),
+            getChangedValueByTimeFormat(toTimeFormat, formatDateTime(toDate)),
+          ];
+        } else {
+          mv.value = [formatDateTime(fromDate), formatDateTime(toDate)];
+        }
       } else {
         mv.value = [formatDate(fromDate), formatDate(toDate)];
       }
@@ -350,7 +355,7 @@ export const useShortcuts = (param) => {
       const sDate = shortcutDate();
       mv.value = props.mode === 'dateTime'
           ? getChangedValueByTimeFormat(
-              props.options?.timeFormat,
+              timeFormat,
               formatDateTime(sDate))
           : formatDate(sDate);
     }


### PR DESCRIPTION
작업 내용
- range 모드인 경우 timeFormat이 없을 때 shortcut클릭 안됨
  원인: range 모드인 경우 timeFormat이 Array로 들어오는데 값이 없을 때 destructuring하여 오류 발생
  해결 : destructuring전 사전 체크 로직 추가