### PR TITLE
[#957][3.0] DatePicker > shortcut 연속으로 눌렀을 때 active 해제되는 버그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.1.44",
+  "version": "3.1.45",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/datePicker/uses.js
+++ b/src/components/datePicker/uses.js
@@ -361,6 +361,7 @@ export const useShortcuts = (param) => {
     }
 
     clearShortcuts();
+    activeShortcut(targetKey);
   };
 
   watch(


### PR DESCRIPTION
- 작업 내용
1. shortcut 연속으로 눌렀을 때 active 해제
   원인: click 눌렀을 때 modelValue를 변경해 watch를 타서 button active를 시키도록 했었음
           값이 동일할 경우 watch를 타지 않아 active가 되지 않음
   해결: click한 key를 알고 있기 때문에 바로 active 시키도록 변경