### PR TITLE
[#959] [3.0] Chart > Chart Data 변경 Watch 정상 동작 하지 않음

### DIFF
--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -85,7 +85,7 @@
 
         await watch(() => props.data, (chartData) => {
           const newData = getNormalizedData(chartData);
-          const isUpdateSeries = !isEqual(newData.series, evChart.data.series);
+          const isUpdateSeries = !isEqual(newData, evChart.data);
           evChart.data = cloneDeep(newData);
           evChart.update({
             updateSeries: isUpdateSeries,


### PR DESCRIPTION
# 이슈 내용 요약

### 환경
1. `ChartData` 옵션의 `Group` 부분을 `[['series1', 'series2']]` 와 `[[]]` 사이를 왔다갔다 할 수 있게 toggle처리

### 기대 결과
1. `Group` 옵션을 on/off 할 수 있음

### 실제 결과
1. Off -> On으로는 가지만 On -> Off로 가진 않음

# 처리내용
1. `Chart Data`를  Watch하는 과정에서 Chart Data중 Series만 변경되었는지 체크하는데, group 및 data도 체크해야 제대로 차트를 다시 그릴 수 있어 로직 변경