### PR TITLE
[#961] [3.0] chart > Stack Bar chart - borderRadius 옵션 추가

### DIFF
--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -151,6 +151,7 @@ class Bar {
       this.drawBar({
         ctx,
         positions: { x, y, w, h },
+        isTop: item.isTop,
       });
 
       if (showValue.use) {
@@ -212,6 +213,7 @@ class Bar {
     this.drawBar({
       ctx,
       positions: { x, y, w, h: this.isHorizontal ? -h : h },
+      isTop: item.data.isTop,
     });
 
     if (showValue.use) {
@@ -409,7 +411,7 @@ class Bar {
     ctx.restore();
   }
 
-  drawBar({ ctx, positions }) {
+  drawBar({ ctx, positions, isTop }) {
     const isHorizontal = this.isHorizontal;
     const isStackBar = 'stackIndex' in this;
     const isBorderRadius = this.borderRadius && this.borderRadius > 0;
@@ -421,7 +423,7 @@ class Bar {
       return;
     }
 
-    if (isBorderRadius && !isStackBar) {
+    if (isBorderRadius && (isStackBar && isTop)) {
       try {
         this.drawRoundedRect(ctx, positions);
       } catch (e) {


### PR DESCRIPTION
## 작업내용
1. Stack일 경우 borderRadius 옵션 유무와 상관 없이 직각 형태의 박스를 그리드록 유회 하던 로직 제거
2. Stack일 경우 가장 상단에 위치한 박스만 둥글게 그리도록 `isTop` 플래그 추가

## 결과 캡쳐
![image](https://user-images.githubusercontent.com/53548023/144772515-6e93a83c-5b61-45ed-8322-26fd0caae2d3.png)
![image](https://user-images.githubusercontent.com/53548023/144772517-350f38af-8700-4b54-914c-23ac1deaa20d.png)
![image](https://user-images.githubusercontent.com/53548023/144772522-4e55c78b-d2ed-4517-be73-03178193e8eb.png)
