### PR TITLE
[#963] [3.0] Chart > 높이 혹은 너비계산시 NaN이 리턴되는 현상

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.1.45",
+  "version": "3.1.46",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/helpers/helpers.canvas.js
+++ b/src/components/chart/helpers/helpers.canvas.js
@@ -12,7 +12,7 @@ export default {
    * @returns {any} position
    */
   calculateX(value, min, max, area, startPoint = 0) {
-    if (value === null) {
+    if (value === null || value === undefined) {
       return null;
     }
 
@@ -35,7 +35,7 @@ export default {
    * @returns {any} position
    */
   calculateSubX(value, min, max, area, startPoint = 0) {
-    if (value === null) {
+    if (value === null || value === undefined) {
       return null;
     }
 
@@ -56,7 +56,7 @@ export default {
   calculateY(value, min, max, area, startPoint = 0) {
     let calcY;
 
-    if (value === null) {
+    if (value === null || value === undefined) {
       return null;
     }
 


### PR DESCRIPTION
### 이슈 내용
BarChart에서 value 값으로 `undefined`값이 들어오면 막대의 높이 혹은 너비를 계산하는 로직에서 `NaN`이 리턴되어 에러로그 발생
![image](https://user-images.githubusercontent.com/53548023/144968775-1779154e-f545-4d89-ae82-a74a073629d7.png)
![image](https://user-images.githubusercontent.com/53548023/144968862-e680fc4a-1a42-49e6-8d4a-ce09a769bb77.png)


### 수정 내용
1. `null` 뿐만 아니라 `undefined`도 체크하도록 조건 추가