### PR TITLE
[#965] [3.0] Chart > keep-alive 엘리먼트와 함께 사용했을 때 Tooltip이 사라지지 않음

### DIFF
--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script>
-  import { onMounted, onBeforeUnmount, watch } from 'vue';
+import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
   import { cloneDeep, isEqual, debounce } from 'lodash-es';
   import EvChart from './chart.core';
   import { useModel, useWrapper } from './uses';
@@ -96,6 +96,10 @@
 
       onBeforeUnmount(() => {
         evChart.destroy();
+      });
+
+      onDeactivated(() => {
+        evChart.destroyTooltip();
       });
 
       const redrawChart = () => {

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -692,12 +692,7 @@ class EvChart {
       this.overlayCanvas.removeEventListener('click', this.onClick);
     }
 
-    if (this.options.tooltip.use) {
-      this.tooltipCanvas.remove();
-      this.tooltipCanvas = null;
-      this.tooltipDOM.remove();
-      this.tooltipDOM = null;
-    }
+    this.destroyTooltip();
 
     this.wrapperDOM = null;
     this.chartDOM = null;
@@ -712,6 +707,20 @@ class EvChart {
 
     while (target.hasChildNodes()) {
       target.removeChild(target.firstChild);
+    }
+  }
+
+  /**
+   * destroy chart tooltip
+   *
+   * @returns {undefined}
+   */
+  destroyTooltip() {
+    if (this.options.tooltip.use) {
+      this.tooltipCanvas.remove();
+      this.tooltipCanvas = null;
+      this.tooltipDOM.remove();
+      this.tooltipDOM = null;
     }
   }
 }


### PR DESCRIPTION
### 이슈 내용
- keep-alive 엘리먼트와 함께 차트를 사용했을 때 화면에 차트가 표시되지 않는 상태임에도 Tooltip은 그대로 남아있는 현상 발생

### 작업내용
1. onDeactivated hook 추가 하여 destroyTooltip 메서드 호출하게함
2. destroyTooltip() 메서드 추가
