### PR TITLE
[#963] [3.0] Chart > 높이 혹은 너비계산시 NaN이 리턴되는 현상

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.1.47",
+  "version": "3.1.48",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -282,9 +282,8 @@ const modules = {
    */
   addData(gdata, ldata, odata = null, bdata = null, isTop = true) {
     let data;
-    const gdataValue = gdata?.value ?? gdata;
-    const odataValue = odata?.value ?? odata;
-    const dataColor = gdata?.color ?? odata?.color;
+    const gdataValue = Object.hasOwnProperty.call(gdata, 'value') ? gdata.value : gdata;
+    const odataValue = Object.hasOwnProperty.call(gdata, 'value') ? odata.value : odata;
 
     if (this.options.horizontal) {
       data = { x: gdataValue, y: ldata, o: odataValue, b: bdata };
@@ -296,8 +295,11 @@ const modules = {
     data.yp = null;
     data.w = null;
     data.h = null;
-    data.dataColor = dataColor || null;
     data.isTop = isTop;
+
+    const gDataColor = Object.hasOwnProperty.call(gdata, 'color') ? gdata.color : null;
+    const oDataColor = Object.hasOwnProperty.call(odata, 'color') ? odata.color : null;
+    data.dataColor = gDataColor ?? oDataColor;
 
     return data;
   },


### PR DESCRIPTION
### 작업내용
1. data의 값이 단순 숫자가 아닌 color 프로퍼티를 포함한 `{value: undefined, color: '#FFFFFF'}` 일 경우를 대비해 value 프로퍼티를 검사하는 로직을 `data.value ?? ...`에서 `hasOwnProperty`로 변경
2. EVUI 버전 업데이트 (47 -> 48)