### PR TITLE
[#963] [3.0] Chart > Falsy Value Issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.1.49",
+  "version": "3.1.50",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -288,15 +288,15 @@ const modules = {
     let odataColor = null;
 
     if (gdata !== null && typeof gdata === 'object') {
-      gdataValue = Object.hasOwnProperty.call(gdata, 'value') ? gdata.value : null;
-      gdataColor = Object.hasOwnProperty.call(gdata, 'color') ? gdata.color : null;
+      gdataValue = gdata.value;
+      gdataColor = gdata.color;
     } else {
       gdataValue = gdata;
     }
 
     if (odata !== null && typeof odata === 'object') {
-      odataValue = Object.hasOwnProperty.call(odata, 'value') ? odata.value : null;
-      odataColor = Object.hasOwnProperty.call(odata, 'color') ? odata.color : null;
+      odataValue = odata.value;
+      odataColor = odata.color;
     } else {
       odataValue = odata;
     }

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -287,14 +287,18 @@ const modules = {
     let gdataColor = null;
     let odataColor = null;
 
-    if (gdata) {
-      gdataValue = Object.hasOwnProperty.call(gdata, 'value') ? gdata.value : gdata;
+    if (gdata !== null && typeof gdata === 'object') {
+      gdataValue = Object.hasOwnProperty.call(gdata, 'value') ? gdata.value : null;
       gdataColor = Object.hasOwnProperty.call(gdata, 'color') ? gdata.color : null;
+    } else {
+      gdataValue = gdata;
     }
 
-    if (odata) {
-      odataValue = Object.hasOwnProperty.call(odata, 'value') ? odata.value : odata;
+    if (odata !== null && typeof odata === 'object') {
+      odataValue = Object.hasOwnProperty.call(odata, 'value') ? odata.value : null;
       odataColor = Object.hasOwnProperty.call(odata, 'color') ? odata.color : null;
+    } else {
+      odataValue = odata;
     }
 
     if (this.options.horizontal) {


### PR DESCRIPTION
### 이슈 원인
1. 값이 null 혹은 undefined이 아닐경우를 체크하기 위해 사용했던  `if (gdata)` 조건에 0도 걸려 에러 발생

### 작업내용 
1. 값이 object 타입일 경우 외에는 원래 값이 들어가도록 로직 수정
2. EVUI 버전 업데이트 (3.1.49 -> 3.1.50)