### PR TITLE
[3.0] Tree Grid 노드 데이터 관련 이슈

### DIFF
--- a/docs/views/treeGrid/example/Toolbar.vue
+++ b/docs/views/treeGrid/example/Toolbar.vue
@@ -33,9 +33,9 @@
       <template #toolbar="{ item }">
         <ev-button
           type="info"
-          @click="onClickCustom"
+          @click="addNode"
         >
-          Custom
+          Add
         </ev-button>
         <ev-text-field
           v-model="searchVm"
@@ -169,6 +169,14 @@ export default {
     const onClickCustom = () => {
       console.log('On click custom button');
     };
+
+    const addNode = () => {
+      tableData.value[0].children.push({
+        id: 'newenwenwenwenwenwenwenwenw',
+        date: '2016-05-02',
+        name: '3',
+      });
+    };
     getData();
     return {
       columns,
@@ -196,6 +204,7 @@ export default {
       onDoubleClickRow,
       onClickRow,
       onClickCustom,
+      addNode,
     };
   },
 };

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -162,7 +162,7 @@
 </template>
 
 <script>
-import { reactive, toRefs, computed, watch, nextTick } from 'vue';
+import { reactive, toRefs, computed, watch } from 'vue';
 import treeGridNode from './TreeGridNode';
 import Toolbar from './treeGrid.toolbar';
 import {
@@ -229,7 +229,7 @@ export default {
     'check-all': null,
     'update-tree-data': null,
   },
-  setup(props, { emit }) {
+  setup(props) {
     const {
       isRenderer,
       getComponentName,
@@ -246,7 +246,8 @@ export default {
     const stores = reactive({
       treeStore: [],
       viewStore: [],
-      treeRows: computed(() => JSON.parse(JSON.stringify(props.rows))),
+      filterStore: [],
+      treeRows: props.rows,
       showTreeStore: computed(() => stores.treeStore.filter(item => item.show)),
       orderedColumns: computed(() =>
         props.columns.map((column, index) => ({ index, ...column }))),
@@ -324,7 +325,7 @@ export default {
     } = contextMenuEvent({ contextInfo, stores, selectInfo });
 
     const {
-      setTreeStore,
+      setTreeNodeStore,
       handleExpand,
     } = treeEvent({ stores, onResize });
 
@@ -359,17 +360,16 @@ export default {
         checkInfo.isHeaderChecked = false;
       },
     );
+    stores.treeStore = setTreeNodeStore();
+
     watch(
       () => props.rows,
-      () => {
-        nextTick(() => {
-          stores.treeStore = [];
-          calculatedColumn();
-          setTreeStore(stores.treeRows, 0, true);
-          updateVScroll();
-          emit('update-tree-data', stores.treeRows);
-        });
-      }, { deep: true, immediate: true },
+      (newData) => {
+        stores.treeRows = newData;
+        stores.treeStore = setTreeNodeStore();
+        calculatedColumn();
+        updateVScroll();
+      }, { deep: true },
     );
     watch(
       () => [props.width, props.height, resizeInfo.adjust, props.option.columnWidth],

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -227,7 +227,6 @@ export default {
     'update:checked': null,
     'check-row': null,
     'check-all': null,
-    'update-tree-data': null,
   },
   setup(props) {
     const {

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -367,7 +367,7 @@ export default {
       (newData) => {
         stores.treeRows = newData;
         stores.treeStore = setTreeNodeStore();
-        calculatedColumn();
+        onResize();
         updateVScroll();
       }, { deep: true },
     );

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -550,35 +550,69 @@ export const contextMenuEvent = (params) => {
 
 export const treeEvent = (params) => {
   const { stores, onResize } = params;
-  // tree data init
-  let index = 0;
-  const filterObj = (keys, obj) => {
-    const newObj = {};
-    Object.keys(obj).forEach((key) => {
-      if (!keys.includes(key)) {
-        newObj[key] = obj[key];
+  const setTreeNodeStore = () => {
+    let nodeIndex = 0;
+    const nodeList = [];
+
+    function getDataObj(nodeObj) {
+      const newObj = {};
+      Object.keys(nodeObj).forEach((key) => {
+        if (key !== 'children') {
+          newObj[key] = nodeObj[key];
+        }
+      });
+      return newObj;
+    }
+
+    function setNodeData(nodeInfo) {
+      const { node, level, isShow, parent } = nodeInfo;
+      node.index = nodeIndex++;
+      node.level = level;
+
+      if (!Object.hasOwnProperty.call(node, 'checked')) {
+        node.checked = false;
       }
-    });
-    return newObj;
-  };
-  const setTreeStore = (rows, count, isShow, parent) => {
-    rows.forEach((nodeObj) => {
-      const node = nodeObj;
-      const dataObj = filterObj('children', nodeObj);
-      node.data = dataObj;
-      node.level = count;
-      node.expand = node.expand === undefined ? true : node.expand;
-      node.show = isShow;
-      node.checked = false;
-      node.index = index++;
-      node.parent = parent;
-      node.isFilter = false;
-      stores.treeStore.push(node);
-      if (node.children && node.children.length > 0) {
+
+      if (!Object.hasOwnProperty.call(node, 'show')) {
+        node.show = isShow;
+      }
+
+      if (!Object.hasOwnProperty.call(node, 'expand')) {
+        node.expand = true;
+      }
+
+      if (!Object.hasOwnProperty.call(node, 'isFilter')) {
+        node.isFilter = false;
+      }
+
+      if (!Object.hasOwnProperty.call(node, 'data')) {
+        node.data = getDataObj(node);
+      }
+
+      nodeList.push(node);
+
+      if (typeof parent !== 'undefined') {
+        node.parent = parent;
+      }
+      if (node.children) {
         node.hasChild = true;
-        setTreeStore(node.children, node.level + 1, node.show && node.expand, node);
+        node.children.forEach(child =>
+          setNodeData({
+            node: child,
+            level: level + 1,
+            isShow: node.show && node.expand,
+            parent: node,
+          }),
+        );
       }
+    }
+    setNodeData({
+      node: stores.treeRows[0],
+      level: 0,
+      isShow: true,
+      parent: undefined,
     });
+    return nodeList;
   };
   const setExpandNode = (children, isShow, isFilter) => {
     children.forEach((nodeObj) => {
@@ -595,7 +629,7 @@ export const treeEvent = (params) => {
     setExpandNode(data.children, data.expand, data.isFilter);
     onResize();
   };
-  return { setTreeStore, handleExpand };
+  return { setTreeNodeStore, handleExpand };
 };
 
 export const filterEvent = (params) => {

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -566,44 +566,46 @@ export const treeEvent = (params) => {
 
     function setNodeData(nodeInfo) {
       const { node, level, isShow, parent } = nodeInfo;
-      node.index = nodeIndex++;
-      node.level = level;
+      if (node !== null && typeof node === 'object') {
+        node.index = nodeIndex++;
+        node.level = level;
 
-      if (!Object.hasOwnProperty.call(node, 'checked')) {
-        node.checked = false;
-      }
+        if (!Object.hasOwnProperty.call(node, 'checked')) {
+          node.checked = false;
+        }
 
-      if (!Object.hasOwnProperty.call(node, 'show')) {
-        node.show = isShow;
-      }
+        if (!Object.hasOwnProperty.call(node, 'show')) {
+          node.show = isShow;
+        }
 
-      if (!Object.hasOwnProperty.call(node, 'expand')) {
-        node.expand = true;
-      }
+        if (!Object.hasOwnProperty.call(node, 'expand')) {
+          node.expand = true;
+        }
 
-      if (!Object.hasOwnProperty.call(node, 'isFilter')) {
-        node.isFilter = false;
-      }
+        if (!Object.hasOwnProperty.call(node, 'isFilter')) {
+          node.isFilter = false;
+        }
 
-      if (!Object.hasOwnProperty.call(node, 'data')) {
-        node.data = getDataObj(node);
-      }
+        if (!Object.hasOwnProperty.call(node, 'data')) {
+          node.data = getDataObj(node);
+        }
 
-      nodeList.push(node);
+        nodeList.push(node);
 
-      if (typeof parent !== 'undefined') {
-        node.parent = parent;
-      }
-      if (node.children) {
-        node.hasChild = true;
-        node.children.forEach(child =>
-          setNodeData({
-            node: child,
-            level: level + 1,
-            isShow: node.show && node.expand,
-            parent: node,
-          }),
-        );
+        if (typeof parent !== 'undefined') {
+          node.parent = parent;
+        }
+        if (node.children) {
+          node.hasChild = true;
+          node.children.forEach(child =>
+            setNodeData({
+              node: child,
+              level: level + 1,
+              isShow: node.show && node.expand,
+              parent: node,
+            }),
+          );
+        }
       }
     }
     setNodeData({


### PR DESCRIPTION
#######################
- 트리의 데이터가 변경되면 노드 상태(expand/show)가 초기화 되는 문제 -> 해당 값으로 grid data가 변경되어야 한다.
- checked 데이터를 변경해도 반영이 안되는 문제 해결

[AS-IS]
![treegrid_after_2](https://user-images.githubusercontent.com/61657275/145389503-740db7c3-a8d6-4d94-bebf-cf979cad4cd1.gif)


[TO-BE]
![treegrid_after](https://user-images.githubusercontent.com/61657275/145388909-aaba9799-c1a5-4c01-918b-b82bbd79c0af.gif)

