### PR TITLE
[#965][3.0]Chart>keep-alive 엘리먼트와 함께 사용했을 때 Tooltip이 사라지지 않는 현상 발생

### DIFF
--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -99,7 +99,7 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
       });
 
       onDeactivated(() => {
-        evChart.destroyTooltip();
+        evChart.hideTooltip();
       });
 
       const redrawChart = () => {

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script>
-  import { onMounted, onBeforeUnmount, watch } from 'vue';
+import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
   import { cloneDeep, isEqual, debounce } from 'lodash-es';
   import EvChart from './chart.core';
   import { useModel, useWrapper } from './uses';
@@ -96,6 +96,10 @@
 
       onBeforeUnmount(() => {
         evChart.destroy();
+      });
+
+      onDeactivated(() => {
+        evChart.destroyTooltip();
       });
 
       const redrawChart = () => {

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -692,7 +692,12 @@ class EvChart {
       this.overlayCanvas.removeEventListener('click', this.onClick);
     }
 
-    this.destroyTooltip();
+    if (this.options.tooltip.use) {
+      this.tooltipCanvas.remove();
+      this.tooltipCanvas = null;
+      this.tooltipDOM.remove();
+      this.tooltipDOM = null;
+    }
 
     this.wrapperDOM = null;
     this.chartDOM = null;
@@ -711,16 +716,13 @@ class EvChart {
   }
 
   /**
-   * destroy chart tooltip
+   * hide chart tooltip
    *
    * @returns {undefined}
    */
-  destroyTooltip() {
+  hideTooltip() {
     if (this.options.tooltip.use) {
-      this.tooltipCanvas.remove();
-      this.tooltipCanvas = null;
-      this.tooltipDOM.remove();
-      this.tooltipDOM = null;
+      this.tooltipDOM.style.display = 'none';
     }
   }
 }

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -692,12 +692,7 @@ class EvChart {
       this.overlayCanvas.removeEventListener('click', this.onClick);
     }
 
-    if (this.options.tooltip.use) {
-      this.tooltipCanvas.remove();
-      this.tooltipCanvas = null;
-      this.tooltipDOM.remove();
-      this.tooltipDOM = null;
-    }
+    this.destroyTooltip();
 
     this.wrapperDOM = null;
     this.chartDOM = null;
@@ -712,6 +707,20 @@ class EvChart {
 
     while (target.hasChildNodes()) {
       target.removeChild(target.firstChild);
+    }
+  }
+
+  /**
+   * destroy chart tooltip
+   *
+   * @returns {undefined}
+   */
+  destroyTooltip() {
+    if (this.options.tooltip.use) {
+      this.tooltipCanvas.remove();
+      this.tooltipCanvas = null;
+      this.tooltipDOM.remove();
+      this.tooltipDOM = null;
     }
   }
 }


### PR DESCRIPTION
### 이슈 내용
- Keep-alive를 사용하고 있고 브라우저의 뒤로가기 / 앞으로 가기 기능으로 화면을 이동했을 때 이전 화면에서 보던 Tooltip이 제거 되지 않음
   - ![EVUI_chart_keep_alive](https://user-images.githubusercontent.com/53548023/145943263-543048c9-c937-4cc3-a679-7774f385f046.gif)


### 수정내용
1. `onDeactivated` hook 추가
2. `hideTooltip` 메소드 추가
   - ![keep-alive-chart](https://user-images.githubusercontent.com/53548023/145943373-fe5e43d4-de4e-46e4-937a-1aea2d919f44.gif)



