### PR TITLE
[#984] [3.0] Grid Sort 관련

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.1.52",
+  "version": "3.1.53",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -102,10 +102,16 @@
                 {{ column.caption }}
               </span>
               <!--Sort Icon-->
-              <ev-icon
-                v-if="sortField === column.field"
-                :icon="`${sortOrder === 'desc' ? 'ev-icon-triangle-down' : 'ev-icon-triangle-up'}`"
-              />
+              <template v-if="sortField === column.field">
+                <ev-icon
+                  v-if="sortOrder === 'desc'"
+                  icon="ev-icon-triangle-down"
+                />
+                <ev-icon
+                  v-if="sortOrder === 'asc'"
+                  icon="ev-icon-triangle-up"
+                />
+              </template>
               <!--Filter Button-->
               <span
                 v-if="isFilterButton(column.field)"
@@ -387,7 +393,7 @@ export default {
       selectedRow: props.selected,
     });
     const sortInfo = reactive({
-      setSorting: false,
+      isSorting: false,
       sortField: '',
       sortOrder: 'desc',
     });
@@ -473,11 +479,19 @@ export default {
     const ROW_CHECK_INDEX = 1;
     const ROW_DATA_INDEX = 2;
     watch(
-      () => sortInfo.setSorting,
+      () => props.columns,
+      () => {
+        sortInfo.isSorting = false;
+        sortInfo.sortField = '';
+        setSort();
+      }, { deep: true },
+    );
+    watch(
+      () => sortInfo.isSorting,
       (value) => {
         if (value) {
           setStore(stores.originStore, false);
-          sortInfo.setSorting = !value;
+          sortInfo.isSorting = !value;
         }
       },
     );

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -467,7 +467,7 @@ export const sortEvent = (params) => {
   const { sortInfo, stores, getColumnIndex } = params;
   const { props } = getCurrentInstance();
   function OrderQueue() {
-    this.orders = ['desc', 'asc', 'init'];
+    this.orders = ['asc', 'desc', 'init'];
     this.dequeue = () => this.orders.shift();
     this.enqueue = o => this.orders.push(o);
   }
@@ -479,7 +479,7 @@ export const sortEvent = (params) => {
    */
   const onSort = (field) => {
     if (sortInfo.sortField !== field) {
-      order.orders = ['desc', 'asc', 'init'];
+      order.orders = ['asc', 'desc', 'init'];
       sortInfo.sortField = field;
     }
     sortInfo.sortOrder = order.dequeue();


### PR DESCRIPTION
#####################
- Grid > 컬럼 정보 변경 시 sort 초기화 로직 적용
- 그리드 컬럼 클릭 시 asc, desc, default 로 상태 값 변경

### [AS-IS]
![sort_before_2](https://user-images.githubusercontent.com/61657275/146729255-3affd268-2765-467d-bbe3-a438db761d6c.gif)
- 컬럼이 변경되어도 이전 sort 관련 데이터가 남아있다.
![sort_before_1](https://user-images.githubusercontent.com/61657275/146729237-96ff9288-b664-48bb-9115-083e046c974f.gif)
- desc <-> asc 로 toggle 된다.

**[TO-BE]**
![sort_after_2](https://user-images.githubusercontent.com/61657275/146729327-f9132343-63f2-45cb-b1c1-b79135dd9f30.gif)
- 컬럼이 변경되면 sort 데이터도 초기화된다.
![sort_before_12](https://user-images.githubusercontent.com/61657275/146732772-8e00eeac-5303-45b2-9d64-61db11f32098.gif)
- asc -> desc -> 기본 순서대로 toggle 된다.

※ 'RTS Port' 의 데이터 타입은 String입니다.



