### PR TITLE
[#986] [3.0] [3.0] Chart - MaxTip draw 관련 조건 수정

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -532,6 +532,7 @@ class EvChart {
 
       if (!updateSelTip.keepDomain) {
         this.lastTip.pos = null;
+        this.lastHitInfo = null;
       }
     }
 


### PR DESCRIPTION
## 이슈 내용
1.  특정 막대를 클릭하고 (series3이 가장 상단에 위치하는 막대)  ChartData를 변경하여 전체를 다시 그릴때 가장 값이 큰 막대에 Tip이 위치하는데, 이전에 클릭했던 Series3을 기억하여 Tip의 위치가 막대 중간에 표시됨
![evui-chart-max-tip-position-issue](https://user-images.githubusercontent.com/53548023/147050114-bffe436e-cdf5-4847-a1e1-ae2bd3038473.gif)


## 작업내용
- 예를들어 ChartData 수정과 같은 크게 Update된 일이 있을 경우 이전에 클릭했던 정보를 담는 변수를 초기화 하도록 함
![evui-chart-max-tip-position-issue-fix](https://user-images.githubusercontent.com/53548023/147049770-09074775-f1da-416e-b1b5-99fd1e927520.gif)

