### PR TITLE
[#989] [3.0] Chart > 차트에 데이터가 추가될 경우 Legend active / inactive 유지 되지 않음

### DIFF
--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -85,7 +85,8 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
 
         await watch(() => props.data, (chartData) => {
           const newData = getNormalizedData(chartData);
-          const isUpdateSeries = !isEqual(newData, evChart.data);
+          const isUpdateSeries = !isEqual(newData.series, evChart.data.series)
+              || !isEqual(newData.groups, evChart.data.groups);
           evChart.data = cloneDeep(newData);
           evChart.update({
             updateSeries: isUpdateSeries,


### PR DESCRIPTION
## Before
![chart_data_watch_issue_1224](https://user-images.githubusercontent.com/53548023/147322265-27a9dcac-e86e-41db-bd9a-6f18c38fd149.gif)
- Series2를 안보이게 처리할 상태에서 데이터가 추가될 경우 다시 Series2가 보이기 시작함

## after
![chart_data_watch_issue_fix_1224](https://user-images.githubusercontent.com/53548023/147322268-95a935e2-5c85-428f-8edc-a64938d62116.gif)
- Series2를 안보이게 처리할 상태에서 데이터가 추가되어도 안보이는 상태가 유지되도록 변경됨

## 작업내용
1. isUpdateSeries에는 data 전체 변경여부가 아닌 Series 정보를 다시 계산하고 Legend 영역을 다시 그려야 하는 일에만 true로 들어가야함 