### PR TITLE
[#988] [3.0] Chart > Legend 영역만 생기고 내부 Series 정보가 그려지지 않음

### DIFF
--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -85,7 +85,8 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
 
         await watch(() => props.data, (chartData) => {
           const newData = getNormalizedData(chartData);
-          const isUpdateSeries = !isEqual(newData, evChart.data);
+          const isUpdateSeries = !isEqual(newData.series, evChart.data.series)
+              || !isEqual(newData.groups, evChart.data.groups);
           evChart.data = cloneDeep(newData);
           evChart.update({
             updateSeries: isUpdateSeries,

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -523,7 +523,7 @@ class EvChart {
       this.createSeriesSet(series, options.type, options.horizontal);
 
       if (this.legendDOM) {
-        this.resetLegend();
+        this.updateLegend();
       }
     }
 


### PR DESCRIPTION
### 이슈 내용
![image](https://user-images.githubusercontent.com/53548023/147516730-0b936004-38a6-4087-9860-b6f234a464ac.png)
- 재현 스텝
   1. Legend - show : false,  groups: [] 상태의 차트 생성
   2. Legend show 값을 true로 변경했다가 다시 false로 원복
   3. stack 모드가 되도록 groups 의 값을 변경했다가 다시 원복 
   4. Legend show 값을 true로 설정

- 결과
   - 4번 이후 나타나는 legend영역에 sereis정보가 안보였었지만 보여지도록 로직 수정함

### 수정내용
- 차트의 Series 혹은 groups가 업데이트 될 때 legend영역을 update(reset + init) 해야 하는데 reset(series 정보 제거) 하는 로직만 있어 수정함 