### PR TITLE
[#997][3.0] Scatter Chart > Drag 범위 조정

### DIFF
--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -175,7 +175,7 @@ const modules = {
    * @returns {undefined}
    */
   dragStart(evt, type) {
-    const [offsetX, offsetY] = this.getMousePosition(evt);
+    let [offsetX, offsetY] = this.getMousePosition(evt);
     const chartRect = this.chartRect;
     const labelOffset = this.labelOffset;
     const range = {
@@ -185,11 +185,20 @@ const modules = {
       y2: chartRect.y2 - labelOffset.bottom,
     };
 
-    // check graph range
-    if (offsetX < range.x1 || offsetX > range.x2
-        || offsetY < range.y1 || offsetY > range.y2
-    ) {
-      return;
+    if (offsetX < range.x1) {
+      offsetX = range.x1;
+    }
+
+    if (offsetX > range.x2) {
+      offsetX = range.x2;
+    }
+
+    if (offsetY < range.y1) {
+      offsetY = range.y1;
+    }
+
+    if (offsetY > range.y2) {
+      offsetY = range.y2;
     }
 
     this.dragInfo = {


### PR DESCRIPTION
### 작업내용
- 차트 드래그 가능 범위 조정 (Axis 바깥 쪽 label 영역 포함)

### Before
![evui-drag-event-before](https://user-images.githubusercontent.com/53548023/147714652-4f10bcc0-8fcf-4de9-a56b-1a563a010d5c.gif)

### After
![evui-drag-event-after](https://user-images.githubusercontent.com/53548023/147714636-ddba9123-95e6-47be-ad20-1a432de59a95.gif)
