### PR TITLE
[#999][3.0] Chart > Stack모드일때 Tooltip 의 정렬기능이 동작하지 않음

### DIFF
--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -219,11 +219,11 @@ const modules = {
         let prev = a.data.o;
         let next = b.data.o;
 
-        if (!prev) {
+        if (prev === null || prev === undefined) {
           prev = isHorizontal ? a.data.x : a.data.y;
         }
 
-        if (!next) {
+        if (next === null || next === undefined) {
           next = isHorizontal ? b.data.x : b.data.y;
         }
         return next - prev;


### PR DESCRIPTION
### 이슈 내용
![image](https://user-images.githubusercontent.com/53548023/147722303-e1b21db8-23fd-452c-af2e-2b66509405b4.png)
- Stack 모드이고 값이 0이 포함된 경우 Tooltip의 `sortByValue` 옵션이 정상 동작하지 않는 현상

### 이슈 원인
- 정렬하는 로직에서 값이 없음을 판단하는 조건문에 0도 포함되어 수행하였기 때문에 의도와 다르게 계산되었음

### 수정 내용
- null또는 undefined만 감지하도록 조건문 수정
