### PR TITLE
[#995][3.0] Chart > 브라우저 확대/축소 시 Resize 이벤트가 정상적으로 수행되지 않음

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.1.55",
+  "version": "3.1.56",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -106,14 +106,8 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
       });
 
       const redrawChart = () => {
-        if (isInit) {
-          evChart.update({
-            updateSeries: false,
-            updateSelTip: {
-              update: false,
-              keepDomain: false,
-            },
-          });
+        if (evChart && 'resize' in evChart && isInit) {
+          evChart.resize();
         }
       };
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -90,7 +90,6 @@ class EvChart {
     this.axesRange = this.getAxesRange();
     this.labelOffset = this.getLabelOffset();
 
-    this.initScale();
     this.drawChart();
 
     if (tooltip.use) {
@@ -131,6 +130,7 @@ class EvChart {
    * @returns {undefined}
    */
   drawChart(hitInfo) {
+    this.initScale();
     this.labelRange = this.getAxesLabelRange();
     this.axesSteps = this.calculateSteps();
     this.drawAxis(hitInfo);
@@ -644,8 +644,8 @@ class EvChart {
     this.bufferCtx.restore();
     this.bufferCtx.save();
 
-    this.getChartDOMRect();
     this.initScale();
+    this.chartRect = this.getChartRect();
     this.drawChart();
   }
 
@@ -658,7 +658,6 @@ class EvChart {
   render(hitInfo) {
     this.clear();
     this.chartRect = this.getChartRect();
-    this.initScale();
     this.drawChart(hitInfo);
   }
 


### PR DESCRIPTION
### 이슈 내용
![evui-chart-zoom-before](https://user-images.githubusercontent.com/53548023/148009528-c1244335-d026-4e35-8b59-31a62d85722c.gif)
 - 브라우저 기능 중 확대 <-> 축소를 하다보면 차트의 일부분이 잘리는 현상 발생
 - 위 이미지상 X축 Label이 보이지 않음

### 작업 내용
- Chart.vue파일 내 resize 이벤트 발생 시 Chart class의 resize method를 사용하도록 수정
- resize시 scale(해상도) 설정 부분이 누락되어 있어 추가

### 결과
![evui-chart-zoom-after](https://user-images.githubusercontent.com/53548023/148009656-ff76ef56-0e1b-4226-bfca-58a01c901c62.gif)

