### PR TITLE
[#1017][3.0] chart > drag-select 이벤트로 지정된 영역 해지 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.1.59",
+  "version": "3.2.0",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.1.58",
+  "version": "3.1.59",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -147,6 +147,7 @@ const modules = {
       const { dragSelection, type } = this.options;
 
       if (dragSelection.use && (type === 'scatter' || type === 'line')) {
+        this.removeSelectionArea();
         this.dragStart(e, type);
       }
     };
@@ -270,8 +271,7 @@ const modules = {
       }
 
       if (!this.options.dragSelection.keepDisplay) {
-        this.dragInfoBackup = null;
-        this.overlayClear();
+        this.removeSelectionArea();
       }
 
       this.dragInfo = null;
@@ -297,6 +297,14 @@ const modules = {
     ctx.globalAlpha = opacity;
     ctx.fillRect(xsp, ysp, width, height);
     ctx.globalAlpha = 1;
+  },
+
+  /** Remove drag selection area
+   *
+   */
+  removeSelectionArea() {
+    this.dragInfoBackup = null;
+    this.overlayClear();
   },
 
   /**


### PR DESCRIPTION
## 작업내용
- 드래그 영역이 활성화 되어 있는 상태에서 차트의 다른 부분을 클릭하면 영역이 지워지는 이벤트 추가

## Before
![scatter_drag_selection_before](https://user-images.githubusercontent.com/53548023/148893433-9e40d8ed-3ea7-49ac-b588-e683e19c013d.gif)

## After
![scatter_drag_selection_after](https://user-images.githubusercontent.com/53548023/148893443-5036e266-b466-4bb1-a1df-ddf85ea9062a.gif)

