### PR TITLE
[#1019][3.0] chart > PlotLine & PlotBand 영역 차트 이탈 현상 발생

### DIFF
--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -312,10 +312,20 @@ class Scale {
         if (this.type === 'x') {
           fromPos = Canvas.calculateX(from ?? minX, axisMin, axisMax, xArea, minX);
           toPos = Canvas.calculateX(to ?? maxX, axisMin, axisMax, xArea, minX);
+
+          if (fromPos === null || toPos === null) {
+            return;
+          }
+
           this.drawXPlotBand(fromPos, toPos, minX, maxX, minY, maxY);
         } else {
           fromPos = Canvas.calculateY(from ?? axisMin, axisMin, axisMax, yArea, maxY);
           toPos = Canvas.calculateY(to ?? axisMax, axisMin, axisMax, yArea, maxY);
+
+          if (fromPos === null || toPos === null) {
+            return;
+          }
+
           this.drawYPlotBand(fromPos, toPos, minX, maxX, minY, maxY);
         }
 
@@ -341,9 +351,19 @@ class Scale {
         let dataPos;
         if (this.type === 'x') {
           dataPos = Canvas.calculateX(value, axisMin, axisMax, xArea, minX);
+
+          if (dataPos === null) {
+            return;
+          }
+
           this.drawXPlotLine(dataPos, minX, maxX, minY, maxY);
         } else {
           dataPos = Canvas.calculateY(value, axisMin, axisMax, yArea, maxY);
+
+          if (dataPos === null) {
+            return;
+          }
+
           this.drawYPlotLine(dataPos, minX, maxX, minY, maxY);
         }
 


### PR DESCRIPTION
## 작업내용
- plot line 혹은 plot band 가 그려질 위치 값으로 null이 반환되는 경우 draw로직을 수행하지 않도록 예외처리 추가

## Before
![image](https://user-images.githubusercontent.com/53548023/148894091-7068cc80-ad79-42e0-8be1-2576ac78ce02.png)

## After
![plotline_issue_fix](https://user-images.githubusercontent.com/53548023/148894111-50519284-b339-423a-beef-07f73fcdf0ca.gif)
