### PR TITLE
[#1034] Chart > Legend영역 resize-bar 비활성화 관련 옵션 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -192,6 +192,7 @@ const chartData = {
 | width | Number | 140 | Legend의 넓이 *('left', 'right'의 경우 조절)* | | 
 | height | Number | 24 | Legend의 높이 *('top', 'bottom'의 경우 조절)* | | 
 | padding | Object | { top: 0, right: 0, left: 0, bottom: 0 } | Legend 내부 padding 값 | | 
+| allowResize | Boolean | false | Legend 영역 리사이즈 가능 여부 | | 
 
 #### tooltip
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -159,6 +159,7 @@ const chartData =
 | width | Number | 140 | Legend의 넓이 *('left', 'right'의 경우 조절)* | | 
 | height | Number | 24 | Legend의 높이 *('top', 'bottom'의 경우 조절)* | | 
 | padding | Object | { top: 0, right: 0, left: 0, bottom: 0 } | Legend 내부 padding 값 | |
+| allowResize | Boolean | false | Legend 영역 리사이즈 가능 여부 | |
 
 #### tooltip
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -70,6 +70,7 @@ const chartData =
 | width | Number | 140 | Legend의 넓이 *('left', 'right'의 경우 조절)* | | 
 | height | Number | 24 | Legend의 높이 *('top', 'bottom'의 경우 조절)* | | 
 | padding | Object | { top: 0, right: 0, left: 0, bottom: 0 } | Legend 내부 padding 값 | |
+| allowResize | Boolean | false | Legend 영역 리사이즈 가능 여부 | |
 
 
 ### 3. resize-timeout

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -148,6 +148,7 @@ const chartData =
 | width | Number | 140 | Legend의 넓이 *('left', 'right'의 경우 조절)* | | 
 | height | Number | 24 | Legend의 높이 *('top', 'bottom'의 경우 조절)* | | 
 | padding | Object | { top: 0, right: 0, left: 0, bottom: 0 } | Legend 내부 padding 값 | |
+| allowResize | Boolean | false | Legend 영역 리사이즈 가능 여부 | |
     
 #### dragSelection
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -9,12 +9,15 @@ const modules = {
     this.legendDOM.className = 'ev-chart-legend';
     this.legendBoxDOM = document.createElement('div');
     this.legendBoxDOM.className = 'ev-chart-legend-box';
-    this.resizeDOM = document.createElement('div');
-    this.resizeDOM.className = 'ev-chart-resize-bar';
-    this.ghostDOM = document.createElement('div');
-    this.ghostDOM.className = 'ev-chart-resize-ghost';
 
-    this.wrapperDOM.appendChild(this.resizeDOM);
+    if (this.options?.legend?.allowResize) {
+      this.resizeDOM = document.createElement('div');
+      this.resizeDOM.className = 'ev-chart-resize-bar';
+      this.ghostDOM = document.createElement('div');
+      this.ghostDOM.className = 'ev-chart-resize-ghost';
+      this.wrapperDOM.appendChild(this.resizeDOM);
+    }
+
     this.legendDOM.appendChild(this.legendBoxDOM);
     this.wrapperDOM.appendChild(this.legendDOM);
   },
@@ -212,10 +215,12 @@ const modules = {
     this.legendBoxDOM.addEventListener('click', this.onLegendBoxClick);
     this.legendBoxDOM.addEventListener('mouseover', this.onLegendBoxOver);
     this.legendBoxDOM.addEventListener('mouseleave', this.onLegendBoxLeave);
-    this.resizeDOM.addEventListener('mousedown', this.onResizeMouseDown);
 
-    this.mouseMove = this.onMouseMove.bind(this); // resizing function
-    this.mouseUp = this.onMouseUp.bind(this); // resizing function
+    if (this.resizeDOM) {
+      this.resizeDOM.addEventListener('mousedown', this.onResizeMouseDown);
+      this.mouseMove = this.onMouseMove.bind(this); // resizing function
+      this.mouseUp = this.onMouseUp.bind(this); // resizing function
+    }
   },
 
   /**
@@ -338,14 +343,16 @@ const modules = {
         legendStyle.width = `${chartRect.width}px`;
         legendStyle.height = `${opt.legend.height + 4}px`; // 4 resize bar size
 
-        resizeStyle.top = `${positionTop}px`;
-        resizeStyle.right = '';
-        resizeStyle.bottom = '';
-        resizeStyle.left = '';
+        if (resizeStyle) {
+          resizeStyle.top = `${positionTop}px`;
+          resizeStyle.right = '';
+          resizeStyle.bottom = '';
+          resizeStyle.left = '';
 
-        resizeStyle.width = `${chartRect.width}px`;
-        resizeStyle.height = '4px';
-        resizeStyle.cursor = 'row-resize';
+          resizeStyle.width = `${chartRect.width}px`;
+          resizeStyle.height = '4px';
+          resizeStyle.cursor = 'row-resize';
+        }
         break;
       case 'right':
         wrapperStyle.padding = `${title}px ${opt.legend.width}px 0 0`;
@@ -363,14 +370,16 @@ const modules = {
         legendStyle.width = `${opt.legend.width}px`;
         legendStyle.height = `${chartRect.height}px`;
 
-        resizeStyle.top = `${title}px`;
-        resizeStyle.right = `${opt.legend.width}px`;
-        resizeStyle.bottom = '';
-        resizeStyle.left = '';
+        if (resizeStyle) {
+          resizeStyle.top = `${title}px`;
+          resizeStyle.right = `${opt.legend.width}px`;
+          resizeStyle.bottom = '';
+          resizeStyle.left = '';
 
-        resizeStyle.width = '4px';
-        resizeStyle.height = `${chartRect.height}px`;
-        resizeStyle.cursor = 'col-resize';
+          resizeStyle.width = '4px';
+          resizeStyle.height = `${chartRect.height}px`;
+          resizeStyle.cursor = 'col-resize';
+        }
         break;
       case 'bottom':
         wrapperStyle.padding = `${title}px 0 ${opt.legend.height}px 0`;
@@ -387,14 +396,16 @@ const modules = {
         legendStyle.width = `${chartRect.width}px`;
         legendStyle.height = `${opt.legend.height + 4}px`; // 4 resize bar size
 
-        resizeStyle.top = '';
-        resizeStyle.right = '';
-        resizeStyle.bottom = `${opt.legend.height}px`;
-        resizeStyle.left = '';
+        if (resizeStyle) {
+          resizeStyle.top = '';
+          resizeStyle.right = '';
+          resizeStyle.bottom = `${opt.legend.height}px`;
+          resizeStyle.left = '';
 
-        resizeStyle.width = `${chartRect.width}px`;
-        resizeStyle.height = '4px';
-        resizeStyle.cursor = 'row-resize';
+          resizeStyle.width = `${chartRect.width}px`;
+          resizeStyle.height = '4px';
+          resizeStyle.cursor = 'row-resize';
+        }
         break;
       case 'left':
         wrapperStyle.padding = `${title}px 0 0 ${opt.legend.width}px`;
@@ -413,14 +424,16 @@ const modules = {
         legendStyle.width = `${opt.legend.width}px`;
         legendStyle.height = `${chartRect.height}px`;
 
-        resizeStyle.top = `${title}px`;
-        resizeStyle.right = '';
-        resizeStyle.bottom = '';
-        resizeStyle.left = `${opt.legend.width}px`;
+        if (resizeStyle) {
+          resizeStyle.top = `${title}px`;
+          resizeStyle.right = '';
+          resizeStyle.bottom = '';
+          resizeStyle.left = `${opt.legend.width}px`;
 
-        resizeStyle.width = '4px';
-        resizeStyle.height = `${chartRect.height}px`;
-        resizeStyle.cursor = 'col-resize';
+          resizeStyle.width = '4px';
+          resizeStyle.height = `${chartRect.height}px`;
+          resizeStyle.cursor = 'col-resize';
+        }
         break;
       default:
         break;
@@ -599,12 +612,13 @@ const modules = {
    * @returns {undefined}
    */
   showLegend() {
-    if (!this.resizeDOM || !this.legendDOM) {
-      return;
+    if (this.resizeDOM) {
+      this.resizeDOM.style.display = 'block';
     }
 
-    this.resizeDOM.style.display = 'block';
-    this.legendDOM.style.display = 'block';
+    if (this.legendDOM) {
+      this.legendDOM.style.display = 'block';
+    }
   },
 
   /**
@@ -619,13 +633,15 @@ const modules = {
     const legendStyle = this.legendDOM?.style;
     const title = opt?.title?.show ? opt?.title?.height : 0;
 
-    if (!resizeStyle || !legendStyle || !wrapperStyle) {
+    if (!legendStyle || !wrapperStyle) {
       return;
     }
 
-    resizeStyle.display = 'none';
-    legendStyle.display = 'none';
+    if (resizeStyle) {
+      resizeStyle.display = 'none';
+    }
 
+    legendStyle.display = 'none';
     legendStyle.width = '0';
     legendStyle.height = '0';
     wrapperStyle.padding = `${title}px 0 0 0`;

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -27,6 +27,7 @@ const DEFAULT_OPTIONS = {
     inactive: '#aaa',
     width: 140,
     height: 24,
+    allowResize: false,
   },
   itemHighlight: true,
   seriesHighlight: true,


### PR DESCRIPTION
## resize-bar 란
- Legend(범례) 영역의 사이즈를 조절할 수 있는 막대 
![legend_splitter](https://user-images.githubusercontent.com/53548023/149461621-1633bf11-6ccf-41a2-8d96-7573435870fa.gif)

## 작업내용
1. chartOption > legend > allowResize 옵션 추가 (**기본값 false**)
2. 관련 문서 내용 추가


