### PR TITLE
[#1036] Scatter Chart > Tooltip false 일 경우, Point에 mouse over하더라도 Hig…

### DIFF
--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -48,7 +48,9 @@ const modules = {
       this.overlayClear();
 
       if (Object.keys(hitInfo.items).length) {
-        this.drawItemsHighlight(hitInfo, ctx);
+        if (this.options.type !== 'scatter' || tooltip.use) {
+          this.drawItemsHighlight(hitInfo, ctx);
+        }
 
         if (tooltip.use) {
           this.setTooltipLayoutPosition(hitInfo, e);


### PR DESCRIPTION
## 요구사항 내용 
1. Scatter Chart 는 분포도를 확인하는 차트이기 때문에 Tooltip 이 활성화 되어 있지 않는 이상 데이터(점, Point)에 마우스 오버하더라도 Highlight 표시 될 필요 없다고 판단됨

## 수정내용
1. highlight 표시하는 함수 호출 전 조건문 추가

## 결과
   - ![scatter_highlight](https://user-images.githubusercontent.com/53548023/149698051-60763348-accc-45a0-b177-87d458c4c08f.gif)
- 상 : Tooltip > use : true
- 하 : Tooltip > use : false ( default)