### PR TITLE
[#1039] Chart > Tooltip 사용 여부 기본 값 적용 버그

### DIFF
--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -100,11 +100,13 @@ export const useModel = () => {
   const { emit } = getCurrentInstance();
 
   const getNormalizedOptions = (options) => {
+    const normalizedOptions = defaultsDeep({}, options, DEFAULT_OPTIONS);
+
     if (options.type === 'scatter') {
-      DEFAULT_OPTIONS.tooltip.use = false;
+      normalizedOptions.tooltip.use = false;
     }
 
-    return defaultsDeep({}, options, DEFAULT_OPTIONS);
+    return normalizedOptions;
   };
   const getNormalizedData = data => defaultsDeep(data, DEFAULT_DATA);
 


### PR DESCRIPTION
### 수정 내용
1. Default 옵션을 가지고 있는 객체를 직접 수정하는 로직 제거