### PR TITLE
[#1041] TreeGrid 검색 스펙 변경

### DIFF
--- a/docs/views/treeGrid/example/Toolbar.vue
+++ b/docs/views/treeGrid/example/Toolbar.vue
@@ -98,88 +98,37 @@ export default {
       clickedRowMV.value = JSON.stringify(rowData);
     };
     const getData = () => {
-      tableData.value = [{
-        id: 'Exem 1',
-        date: '2016-05-01',
-        name: '1',
-        expand: true,
-        children: [{
-          id: 'Exem 2',
-          date: '2016-05-02',
-          name: '2',
-          expand: false,
-          children: [{
-            id: 'Exem 3',
-            date: '2016-05-02',
-            name: '3',
-          }, {
-            id: 'Exem 4',
-            date: '2016-05-02',
-            name: '4',
-            expand: false,
-            children: [{
-              id: 'Exem 5',
-              date: '2016-05-02',
-              name: '5',
-              children: [{
-                id: 'Exem 51',
-                date: '2016-05-02',
-                name: '51',
-                children: [{
-                  id: 'Exem 52',
-                  date: '2016-05-02',
-                  name: '52',
-                }],
-              }],
-            }, {
-              id: 'Exem 6',
-              date: '2016-05-02',
-              name: '6',
-            }],
-          }],
-        }, {
-          id: 'Exem 7',
-          date: '2016-05-03',
-          name: '7',
-          children: [{
-            id: 'Exem 8',
-            date: '2016-05-03',
-            name: '8',
-          }, {
-            id: 'Exem 9',
-            date: '2016-05-03',
-            name: '9',
-          }, {
-            id: 'Exem 10',
-            date: '2016-05-03',
-            name: '10',
-          }],
-        }, {
-          id: 'Exem 11',
-          date: '2016-05-04',
-          name: '11',
-        }],
-      }, {
-        id: 'Exem 12',
-        date: '2016-05-01',
-        name: '12',
-        expand: true,
-        children: [{
-          id: 'Exem 13',
-          date: '2016-05-02',
-          name: '13',
-          expand: false,
-          children: [{
-            id: 'Exem 14',
-            date: '2016-05-02',
-            name: '14',
-          }],
-        }, {
-          id: 'Exem 15',
-          date: '2016-05-03',
-          name: '15',
-        }],
-      }];
+      tableData.value = [
+        {
+          id: 'attributes.ini',
+          children: [
+            {
+              id: 'pythontrace',
+              children: [
+                { id: 'level' },
+                { id: 'trace_errors' },
+                { id: 'trace_indexes' },
+                { id: 'truncate_doclists' },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'diserver.ini',
+          children: [
+            { id: 'api' },
+            { id: 'blobs' },
+            { id: 'connection' },
+            { id: 'make' },
+          ],
+        },
+        {
+          id: 'docstore.ini',
+          children: [
+            { id: 'docstore' },
+          ],
+        },
+      ];
     };
     const columns = ref([
       { caption: 'ID', field: 'id', type: 'number' },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -522,17 +522,15 @@ export default {
         checkInfo.checkedRows = checkedList;
         checkInfo.isHeaderChecked = false;
         checkInfo.checkedIndex.clear();
-        if (checkedList.length) {
-          const store = stores.store;
+        const store = stores.store;
+        if (store.length) {
           store.forEach((row) => {
             row[ROW_CHECK_INDEX] = checkedList.includes(row[ROW_DATA_INDEX]);
             if (row[ROW_CHECK_INDEX]) {
               checkInfo.checkedIndex.add(row[ROW_INDEX]);
             }
           });
-          if (checkedList.length === store.length) {
-            checkInfo.isHeaderChecked = true;
-          }
+          checkInfo.isHeaderChecked = checkedList.length === store.length;
         }
         updateVScroll();
       },

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -341,18 +341,20 @@ export default {
     });
     watch(
       () => props.checked,
-      (value) => {
+      (checkedList) => {
         let store = stores.treeStore;
         if (stores.searchStore.length > 0) {
           store = stores.searchStore;
         }
-        const isCheck = store.length > 0 && store.every(n => n.checked === true);
+        checkInfo.checkedRows = checkedList;
         checkInfo.isHeaderChecked = false;
-        checkInfo.checkedRows = value;
-        for (let ix = 0; ix < store.length; ix++) {
-          store[ix].checked = value.includes(store[ix]);
+        if (store.length) {
+          store.forEach((row) => {
+            row.checked = checkedList.includes(row);
+          });
+          checkInfo.isHeaderChecked = store.every(n => n.checked === true);
         }
-        checkInfo.isHeaderChecked = isCheck;
+        updateVScroll();
       },
     );
     watch(

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -346,7 +346,7 @@ export default {
         if (stores.searchStore.length > 0) {
           store = stores.searchStore;
         }
-        const isCheck = store.every(n => n.checked === true);
+        const isCheck = store.length > 0 && store.every(n => n.checked === true);
         checkInfo.isHeaderChecked = false;
         checkInfo.checkedRows = value;
         for (let ix = 0; ix < store.length; ix++) {

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -655,9 +655,26 @@ export const filterEvent = (params) => {
     }
     const { parent } = data;
     parent.show = true;
-    parent.expand = true;
     parent.isFilter = true;
     makeParentShow(parent);
+  };
+  const makeChildShow = (data) => {
+    if (!data?.children) {
+      return;
+    }
+    const { children } = data;
+    children.forEach((node) => {
+      const childNode = node;
+      if (childNode.parent.show && childNode.parent.expand) {
+        childNode.show = true;
+      } else {
+        childNode.show = false;
+      }
+      childNode.isFilter = true;
+      if (childNode.hasChild) {
+        makeChildShow(childNode);
+      }
+    });
   };
   let timer = null;
   const onSearch = (searchWord) => {
@@ -695,19 +712,28 @@ export const filterEvent = (params) => {
         });
         filterStores.forEach((row) => {
           row.show = true;
+          if (row.parent && !row.parent.expand) {
+            row.show = false;
+          }
           row.isFilter = true;
           makeParentShow(row);
+          makeChildShow(row);
         });
       } else {
         store.forEach((row) => {
           row.show = true;
           row.isFilter = false;
         });
+        store.forEach((row) => {
+          if (row.hasChild) {
+            makeChildShow(row);
+          }
+        });
       }
       if (stores.searchStore.length > 0) {
         store = stores.searchStore;
       }
-      const isCheck = store.every(n => n.checked === true);
+      const isCheck = store.length > 0 && store.every(n => n.checked === true);
       checkInfo.isHeaderChecked = isCheck;
       calculatedColumn();
       updateVScroll();


### PR DESCRIPTION
#####################
**- 검색 대상의 자식 노드도 보여주기**
[AS-IS]
![treegrid_before1](https://user-images.githubusercontent.com/61657275/149949942-742480a0-4ea1-42bb-b156-d0b3a3a7abe7.gif)
[TO-BE]
![treegrid_after1](https://user-images.githubusercontent.com/61657275/149950054-12a1df25-a4a8-46cf-8339-56920b4063a4.gif)

**- 노드의 펼침/접힘 상태 유지**
[AS-IS]
_검색 시 검색 대상의 부모 노드가 접힘-> 펼침으로 변경됨_
 _검색어를 지우면서 모든 노드가 show_ 
![treegrid_before2](https://user-images.githubusercontent.com/61657275/149950527-34b394af-d157-4ceb-96dd-9d9d3b97e9fc.gif)
[TO-BE]
![treegrid_after2](https://user-images.githubusercontent.com/61657275/149950355-99f5376e-aa61-49ba-8c59-9edf614f0a90.gif)

**- 전체 체크 확인 시 데이터가 있는지 확인 조건 추가**

