### PR TITLE
[#1043] Chart > drag-select 해지 이벤트와 click 이벤트가 동시에 발생하는 현상 수정

### DIFF
--- a/docs/views/scatterChart/example/Default.vue
+++ b/docs/views/scatterChart/example/Default.vue
@@ -164,18 +164,10 @@
           padding: { top: 0, right: 0, bottom: 0, left: 0 },
         },
         tooltip: {
-          use: true,
-          backgroundColor: '#4C4C4C',
-          borderColor: '#666666',
-          useShadow: false,
-          shadowOpacity: 0.25,
-          throttledMove: false,
-          debouncedHide: false,
-          sortByValue: true,
-          useScrollbar: false,
-          textOverflow: 'wrap',
-          showAllValueInRange: false,
-          formatter: null,
+          use: false,
+        },
+        selectItem: {
+          use: false,
         },
         dragSelection: {
           use: false,

--- a/docs/views/scatterChart/example/Event.vue
+++ b/docs/views/scatterChart/example/Event.vue
@@ -4,6 +4,8 @@
       :data="chartData"
       :options="chartOptions"
       @drag-select="onDragSelect"
+      @click="onClick"
+      @dbl-click="onDblClick"
     />
     <div class="description">
       <div class="one-row">
@@ -32,6 +34,26 @@
           <p><b>X max</b> : {{ getDateString(selectionRange.xMax) }} </p>
           <p><b>Y min</b> : {{ selectionRange.yMin }} </p>
           <p><b>Y max</b> : {{ selectionRange.yMax }} </p>
+        </div>
+      </div>
+      <div class="one-row">
+        <p class="badge yellow">
+          클릭 정보
+        </p>
+        <div v-if="clickedInfo">
+          <p><b>label</b> : {{ clickedInfo.label }} </p>
+          <p><b>value</b> : {{ clickedInfo.value }} </p>
+          <p><b>series ID</b> : {{ clickedInfo.sId }} </p>
+        </div>
+      </div>
+      <div class="one-row">
+        <p class="badge yellow">
+          더블 클릭 정보
+        </p>
+        <div v-if="dblClickedInfo">
+          <p><b>label</b> : {{ dblClickedInfo.label }} </p>
+          <p><b>value</b> : {{ dblClickedInfo.value }} </p>
+          <p><b>series ID</b> : {{ dblClickedInfo.sId }} </p>
         </div>
       </div>
     </div>
@@ -100,6 +122,12 @@
           startToZero: true,
           autoScaleRatio: 0.1,
         }],
+        selectItem: {
+          use: true,
+        },
+        tooltip: {
+          use: true,
+        },
       };
 
       const selectionItems = ref([]);
@@ -110,6 +138,21 @@
         selectionRange.value = range;
       };
 
+
+      const dblClickedInfo = ref(null);
+      const onDblClick = ({ e, label, value, sId }) => {
+        dblClickedInfo.value = { e, label, value, sId };
+      };
+
+      const clickedInfo = ref(null);
+      const onClick = ({ e, label, value, sId }) => {
+        clickedInfo.value = { e, label, value, sId };
+
+        // Clear drag selection info
+        selectionItems.value = [];
+        selectionRange.value = {};
+      };
+
       const getDateString = x => dayjs(x).format('HH:mm:ss');
 
       return {
@@ -117,7 +160,11 @@
         chartOptions,
         selectionItems,
         selectionRange,
+        clickedInfo,
+        dblClickedInfo,
         onDragSelect,
+        onClick,
+        onDblClick,
         getDateString,
       };
     },

--- a/docs/views/scatterChart/props.js
+++ b/docs/views/scatterChart/props.js
@@ -16,7 +16,7 @@ export default {
       parsedData: parseComponent(DefaultRaw),
     },
     Event: {
-      description: 'Drag Select 이벤트 등록이 가능 합니다',
+      description: 'Drag Select, Click, Double Click 이벤트 등록이 가능 합니다',
       component: Event,
       parsedData: parseComponent(EventRaw),
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -97,7 +97,7 @@ const modules = {
      */
     this.onDblClick = (e) => {
       const selectItem = this.options.selectItem;
-      const args = {};
+      const args = { e };
 
       if (selectItem.use) {
         const offset = this.getMousePosition(e);
@@ -122,8 +122,7 @@ const modules = {
      * @returns {undefined}
      */
     this.onClick = (e) => {
-      const args = {};
-
+      const args = { e };
       if (this.options.selectItem.use) {
         const offset = this.getMousePosition(e);
         const hitInfo = this.findClickedData(offset);
@@ -136,7 +135,9 @@ const modules = {
       }
 
       if (typeof this.listeners.click === 'function') {
-        this.listeners.click(args);
+        if (!this.dragInfoBackup) {
+          this.listeners.click(args);
+        }
       }
     };
 
@@ -256,11 +257,12 @@ const modules = {
      *
      * @returns {undefined}
      */
-    const dragEnd = () => {
+    const dragEnd = (e) => {
       const dragInfo = this.dragInfo;
 
       if (dragInfo?.isMove) {
         const args = {
+          e,
           data: this.findSelectedItems(dragInfo),
           range: this.getSelectionRage(dragInfo),
         };

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -102,7 +102,7 @@ export const useModel = () => {
   const getNormalizedOptions = (options) => {
     const normalizedOptions = defaultsDeep({}, options, DEFAULT_OPTIONS);
 
-    if (options.type === 'scatter') {
+    if (options.type === 'scatter' && !options?.tooltip) {
       normalizedOptions.tooltip.use = false;
     }
 


### PR DESCRIPTION
### 이슈 및 작업내용
1. Drag-select를 한 상태에서 범위 선택을 취소하기 위해 차트 영역 아무곳이나 click 하면 범위가 해제되는 기능이 추가하였었으나,  사용자가 drag-select와 click 이벤트를 함께 등록했을 경우 범위 해제하려다가 click 이벤트까지 발행되는 문제 발생
    _-> click 이벤트 emit 하기 전 drag 중이었는지 확인하는 조건문 추가_

2. 이벤트 객체를 받아볼 수 없음 
   _-> (모든 차트 공통) click, dbl-click, drag-selection에 event객체를 받아볼 수 있는 parameter 'e' 추가_

3. Scatter Chart Event 예제 코드에 drag-select 내용만 있음 
   _-> click 및 dbl-click 에 관한 코드도 추가_ 

4. Scatter Chart에 Tooltip 옵션을 true로 줘도 tooltip이 동작하지 않음 
   _-> Scatter chart tooltip 관련 조건문 수정_