### PR TITLE
[#1045] Chart > drag-select 이벤트 선택 영역 사이즈 관련 이슈

### DIFF
--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -260,7 +260,7 @@ const modules = {
     const dragEnd = (e) => {
       const dragInfo = this.dragInfo;
 
-      if (dragInfo?.isMove) {
+      if (dragInfo?.isMove && dragInfo?.width > 1 && dragInfo?.height > 1) {
         const args = {
           e,
           data: this.findSelectedItems(dragInfo),
@@ -581,10 +581,10 @@ const modules = {
     const yMax = dataRangeY.graphMin + graphHeight * (1 - yMaxRatio);
 
     return {
-      xMin: +parseFloat(xMin).toFixed(3),
-      xMax: +parseFloat(xMax).toFixed(3),
-      yMin: +parseFloat(yMin).toFixed(3),
-      yMax: +parseFloat(yMax).toFixed(3),
+      xMin: Math.max(+parseFloat(xMin).toFixed(3), dataRangeX.graphMin),
+      xMax: Math.min(+parseFloat(xMax).toFixed(3), dataRangeX.graphMax),
+      yMin: Math.max(+parseFloat(yMin).toFixed(3), dataRangeY.graphMin),
+      yMax: Math.min(+parseFloat(yMax).toFixed(3), dataRangeY.graphMax),
     };
   },
 


### PR DESCRIPTION
## 이슈 내용 및 작업 내용
**1.  drag 한 영역을 표시하는 상자가 생성되지 않았을 정도로 작은 drag 였음에도 불구하고 drag 이벤트가 emit됨**
   -> drag 영역의 너비 및 높이가 1이상일 경우에만 drag-select 이벤트가 발생되도록 조건 추가

**2.  간혈적으로 drag 한 영역의 범위 값으로 차트 축의 최소, 최대가 넘는 값이 반환됨**
   -> drag 범위를 계산하는 로직에서 계산된 결괏값이 축의 min max값을 넘지 않도록 로직 추가


## 논의되었던 내용
![image](https://user-images.githubusercontent.com/53548023/150465338-b685ce64-53cf-4581-8ad3-d9a14ea585bb.png)
- 위의 행위는 전부 Click으로 간주됩니다.