### PR TITLE
WIP: [#1047] Grid, TreeGrid > 사용자가 입력했을 경우에만 검색 가능

### DIFF
--- a/docs/views/grid/example/Toolbar.vue
+++ b/docs/views/grid/example/Toolbar.vue
@@ -18,6 +18,7 @@
           mode: checkboxModeMV,
           headerCheck: headerCheckMV,
         },
+        searchValue: searchVm,
         // customContextMenu: menuItems,
         style: {
           stripe: stripeMV,
@@ -30,18 +31,16 @@
       @dblclick-row="onDoubleClickRow"
     >
       <!-- toolbar -->
-      <template #toolbar="{ item }">
+      <template #toolbar>
         <ev-button
           type="primary"
           class="refresh"
-          @click="item.onRefresh"
         >
           Refresh
         </ev-button>
         <ev-button
           type="primary"
           class="delete"
-          @click="item.onDelete"
         >
           Delete
         </ev-button>
@@ -49,11 +48,11 @@
           type="info"
           @click="onClickCustom"
         >
-          Custom1
+          Set Search Value
         </ev-button>
         <ev-button
           type="info"
-          @click="onClickCustom"
+          @click="onClickCustom2"
         >
           Custom2
         </ev-button>
@@ -62,7 +61,6 @@
           class="search"
           type="search"
           placeholder="Search"
-          @input="item.onSearch"
         />
       </template>
       <!-- cell renderer -->
@@ -180,6 +178,9 @@ export default {
       tableData.value = temp;
     };
     const onClickCustom = () => {
+      searchVm.value = 'AIX';
+    };
+    const onClickCustom2 = () => {
       console.log('On click custom button');
     };
 
@@ -210,6 +211,7 @@ export default {
       onDoubleClickRow,
       onClickRow,
       onClickCustom,
+      onClickCustom2,
     };
   },
 };

--- a/docs/views/treeGrid/example/Toolbar.vue
+++ b/docs/views/treeGrid/example/Toolbar.vue
@@ -18,6 +18,7 @@
           mode: checkboxModeMV,
           headerCheck: headerCheckMV,
         },
+        searchValue: searchVm,
         customContextMenu: menuItems,
         style: {
           stripe: stripeMV,
@@ -30,19 +31,24 @@
       @dblclick-row="onDoubleClickRow"
     >
       <!-- toolbar -->
-      <template #toolbar="{ item }">
+      <template #toolbar>
         <ev-button
           type="info"
           @click="addNode"
         >
           Add
         </ev-button>
+        <ev-button
+          type="info"
+          @click="onClickCustom"
+        >
+          Set Search Value
+        </ev-button>
         <ev-text-field
           v-model="searchVm"
           class="search"
           type="search"
           placeholder="Search"
-          @input="item.onSearch"
         />
       </template>
     </ev-tree-grid>
@@ -136,7 +142,7 @@ export default {
       { caption: 'Name', field: 'name', type: 'number' },
     ]);
     const onClickCustom = () => {
-      console.log('On click custom button');
+      searchVm.value = 'diserver';
     };
 
     const addNode = () => {

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -7,10 +7,7 @@
     <!-- Toolbar -->
     <toolbar v-if="!!$slots.toolbar" >
       <template #toolbarWrapper>
-        <slot
-          name="toolbar"
-          :item="{ onSearch: onSearch }"
-        >
+        <slot name="toolbar">
         </slot>
       </template>
     </toolbar>
@@ -341,7 +338,7 @@ export default {
         items: [],
       },
       isSearch: false,
-      searchWord: '',
+      searchValue: computed(() => (props.option.searchValue || '')),
     });
     const stores = reactive({
       viewStore: [],
@@ -512,7 +509,7 @@ export default {
       (value) => {
         setStore(value);
         if (filterInfo.isSearch) {
-          onSearch(filterInfo.searchWord);
+          onSearch(filterInfo.searchValue);
         }
       },
     );
@@ -580,6 +577,12 @@ export default {
         stores.filterStore = [];
         setStore([], false);
       },
+    );
+    watch(
+      () => filterInfo.searchValue,
+      (value) => {
+        onSearch(value);
+      }, { immediate: true },
     );
     const isFilterButton = field => filterInfo.isFiltering && field !== 'db-icon' && field !== 'user-icon';
     return {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -710,7 +710,6 @@ export const filterEvent = (params) => {
     }
     timer = setTimeout(() => {
       filterInfo.isSearch = false;
-      filterInfo.searchWord = searchWord;
       if (searchWord) {
         stores.searchStore = stores.store.filter((row) => {
           let isShow = false;

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -7,12 +7,7 @@
     <!-- Toolbar -->
     <toolbar v-if="!!$slots.toolbar" >
       <template #toolbarWrapper>
-        <slot
-          name="toolbar"
-          :item="{
-            onSearch,
-          }"
-        >
+        <slot name="toolbar">
         </slot>
       </template>
     </toolbar>
@@ -242,6 +237,7 @@ export default {
       resizeLine: null,
       'grid-wrapper': null,
     });
+    const searchValue = computed(() => (props.option.searchValue || ''));
     const stores = reactive({
       treeStore: [],
       viewStore: [],
@@ -395,6 +391,12 @@ export default {
         });
         onResize();
       },
+    );
+    watch(
+      () => searchValue.value,
+      (value) => {
+        onSearch(value);
+      }, { immediate: true },
     );
     const gridStyle = computed(() => ({
       width: resizeInfo.gridWidth,


### PR DESCRIPTION
#####################
- Grid 검색어가 입력이벤트가 아닌 watch 를 통해 변경 시에 onSearch가 호출될 수 있도록 수정

**▶입력이벤트가 아닌 search 값만 변경하여 적용해본 결과**

[TreeGrid]
![treegrid_1](https://user-images.githubusercontent.com/61657275/150741991-fd3d0969-7c2f-4e36-8ba7-f794015346e0.gif)

[Grid]
![treegrid_2](https://user-images.githubusercontent.com/61657275/150741994-7a881d32-2cdf-445c-bc10-d07cb70ac161.gif)

**▶각 프로젝트 반영 시 수정사항**

![image](https://user-images.githubusercontent.com/61657275/150742933-63326f1e-0797-4be5-b45e-78ca71a03d72.png)
1) 검색 `text-field` 의 `@input` 이벤트 및 `slot`의 `item` **제거**
2) 그리드 `option`에 `searchValue` 바인딩 값 **추가**