### PR TITLE
[#1047] Grid, TreeGrid > 사용자가 입력했을 경우에만 검색 가능

### DIFF
--- a/docs/views/grid/example/Toolbar.vue
+++ b/docs/views/grid/example/Toolbar.vue
@@ -31,7 +31,7 @@
       @dblclick-row="onDoubleClickRow"
     >
       <!-- toolbar -->
-      <template #toolbar>
+      <template #toolbar="{ item }">
         <ev-button
           type="primary"
           class="refresh"
@@ -61,6 +61,7 @@
           class="search"
           type="search"
           placeholder="Search"
+          @input="item.onSearch"
         />
       </template>
       <!-- cell renderer -->

--- a/docs/views/grid/example/Toolbar.vue
+++ b/docs/views/grid/example/Toolbar.vue
@@ -52,9 +52,8 @@
         </ev-button>
         <ev-button
           type="info"
-          @click="onClickCustom2"
         >
-          Custom2
+          Custom
         </ev-button>
         <ev-text-field
           v-model="searchVm"
@@ -181,10 +180,6 @@ export default {
     const onClickCustom = () => {
       searchVm.value = 'AIX';
     };
-    const onClickCustom2 = () => {
-      console.log('On click custom button');
-    };
-
     getData(7, 0);
     return {
       columns,
@@ -212,7 +207,6 @@ export default {
       onDoubleClickRow,
       onClickRow,
       onClickCustom,
-      onClickCustom2,
     };
   },
 };

--- a/docs/views/grid/example/Toolbar.vue
+++ b/docs/views/grid/example/Toolbar.vue
@@ -18,6 +18,7 @@
           mode: checkboxModeMV,
           headerCheck: headerCheckMV,
         },
+        searchValue: searchVm,
         // customContextMenu: menuItems,
         style: {
           stripe: stripeMV,
@@ -30,18 +31,16 @@
       @dblclick-row="onDoubleClickRow"
     >
       <!-- toolbar -->
-      <template #toolbar="{ item }">
+      <template #toolbar>
         <ev-button
           type="primary"
           class="refresh"
-          @click="item.onRefresh"
         >
           Refresh
         </ev-button>
         <ev-button
           type="primary"
           class="delete"
-          @click="item.onDelete"
         >
           Delete
         </ev-button>
@@ -49,11 +48,11 @@
           type="info"
           @click="onClickCustom"
         >
-          Custom1
+          Set Search Value
         </ev-button>
         <ev-button
           type="info"
-          @click="onClickCustom"
+          @click="onClickCustom2"
         >
           Custom2
         </ev-button>
@@ -62,7 +61,6 @@
           class="search"
           type="search"
           placeholder="Search"
-          @input="item.onSearch"
         />
       </template>
       <!-- cell renderer -->
@@ -180,6 +178,9 @@ export default {
       tableData.value = temp;
     };
     const onClickCustom = () => {
+      searchVm.value = 'AIX';
+    };
+    const onClickCustom2 = () => {
       console.log('On click custom button');
     };
 
@@ -210,6 +211,7 @@ export default {
       onDoubleClickRow,
       onClickRow,
       onClickCustom,
+      onClickCustom2,
     };
   },
 };

--- a/docs/views/treeGrid/example/Toolbar.vue
+++ b/docs/views/treeGrid/example/Toolbar.vue
@@ -31,7 +31,7 @@
       @dblclick-row="onDoubleClickRow"
     >
       <!-- toolbar -->
-      <template #toolbar>
+      <template #toolbar="{ item }">
         <ev-button
           type="info"
           @click="addNode"
@@ -49,6 +49,7 @@
           class="search"
           type="search"
           placeholder="Search"
+          @input="item.onSearch"
         />
       </template>
     </ev-tree-grid>

--- a/docs/views/treeGrid/example/Toolbar.vue
+++ b/docs/views/treeGrid/example/Toolbar.vue
@@ -18,6 +18,7 @@
           mode: checkboxModeMV,
           headerCheck: headerCheckMV,
         },
+        searchValue: searchVm,
         customContextMenu: menuItems,
         style: {
           stripe: stripeMV,
@@ -30,19 +31,24 @@
       @dblclick-row="onDoubleClickRow"
     >
       <!-- toolbar -->
-      <template #toolbar="{ item }">
+      <template #toolbar>
         <ev-button
           type="info"
           @click="addNode"
         >
           Add
         </ev-button>
+        <ev-button
+          type="info"
+          @click="onClickCustom"
+        >
+          Set Search Value
+        </ev-button>
         <ev-text-field
           v-model="searchVm"
           class="search"
           type="search"
           placeholder="Search"
-          @input="item.onSearch"
         />
       </template>
     </ev-tree-grid>
@@ -136,7 +142,7 @@ export default {
       { caption: 'Name', field: 'name', type: 'number' },
     ]);
     const onClickCustom = () => {
-      console.log('On click custom button');
+      searchVm.value = 'diserver';
     };
 
     const addNode = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -7,7 +7,10 @@
     <!-- Toolbar -->
     <toolbar v-if="!!$slots.toolbar" >
       <template #toolbarWrapper>
-        <slot name="toolbar">
+        <slot
+          name="toolbar"
+          :item="{ onSearch: onSearch }"
+        >
         </slot>
       </template>
     </toolbar>
@@ -581,7 +584,7 @@ export default {
     watch(
       () => filterInfo.searchValue,
       (value) => {
-        onSearch(value);
+        onSearch(value?.value ?? value);
       }, { immediate: true },
     );
     const isFilterButton = field => filterInfo.isFiltering && field !== 'db-icon' && field !== 'user-icon';

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -7,10 +7,7 @@
     <!-- Toolbar -->
     <toolbar v-if="!!$slots.toolbar" >
       <template #toolbarWrapper>
-        <slot
-          name="toolbar"
-          :item="{ onSearch: onSearch }"
-        >
+        <slot name="toolbar">
         </slot>
       </template>
     </toolbar>
@@ -341,7 +338,7 @@ export default {
         items: [],
       },
       isSearch: false,
-      searchWord: '',
+      searchValue: computed(() => (props.option.searchValue || '')),
     });
     const stores = reactive({
       viewStore: [],
@@ -512,7 +509,7 @@ export default {
       (value) => {
         setStore(value);
         if (filterInfo.isSearch) {
-          onSearch(filterInfo.searchWord);
+          onSearch(filterInfo.searchValue);
         }
       },
     );
@@ -580,6 +577,12 @@ export default {
         stores.filterStore = [];
         setStore([], false);
       },
+    );
+    watch(
+      () => filterInfo.searchValue,
+      (value) => {
+        onSearch(value);
+      }, { immediate: true },
     );
     const isFilterButton = field => filterInfo.isFiltering && field !== 'db-icon' && field !== 'user-icon';
     return {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -710,7 +710,6 @@ export const filterEvent = (params) => {
     }
     timer = setTimeout(() => {
       filterInfo.isSearch = false;
-      filterInfo.searchWord = searchWord;
       if (searchWord) {
         stores.searchStore = stores.store.filter((row) => {
           let isShow = false;

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -7,12 +7,7 @@
     <!-- Toolbar -->
     <toolbar v-if="!!$slots.toolbar" >
       <template #toolbarWrapper>
-        <slot
-          name="toolbar"
-          :item="{
-            onSearch,
-          }"
-        >
+        <slot name="toolbar">
         </slot>
       </template>
     </toolbar>
@@ -242,6 +237,7 @@ export default {
       resizeLine: null,
       'grid-wrapper': null,
     });
+    const searchValue = computed(() => (props.option.searchValue || ''));
     const stores = reactive({
       treeStore: [],
       viewStore: [],
@@ -395,6 +391,12 @@ export default {
         });
         onResize();
       },
+    );
+    watch(
+      () => searchValue.value,
+      (value) => {
+        onSearch(value);
+      }, { immediate: true },
     );
     const gridStyle = computed(() => ({
       width: resizeInfo.gridWidth,

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -7,7 +7,12 @@
     <!-- Toolbar -->
     <toolbar v-if="!!$slots.toolbar" >
       <template #toolbarWrapper>
-        <slot name="toolbar">
+        <slot
+          name="toolbar"
+          :item="{
+            onSearch,
+          }"
+        >
         </slot>
       </template>
     </toolbar>
@@ -395,7 +400,7 @@ export default {
     watch(
       () => searchValue.value,
       (value) => {
-        onSearch(value);
+        onSearch(value?.value ?? value);
       }, { immediate: true },
     );
     const gridStyle = computed(() => ({


### PR DESCRIPTION
- input 이벤트 없이 검색어가 변경돼도 `onSearch`가 호출될 수 있도록 수정

**▶input 이벤트 없이 `searchValue` 값을 변경하여 적용해본 결과**
- TreeGrid
![treegrid_1](https://user-images.githubusercontent.com/61657275/150834883-6b03147e-7ee6-4c4a-86e9-5cd1bdfde23b.gif)

- Grid
![treegrid_2](https://user-images.githubusercontent.com/61657275/150834903-67d85a7e-8cca-45d3-999b-5fec9727f0dc.gif)

**▶각 프로젝트 반영 시 수정사항**
- ev-grid, ev-tree-grid `option`에 `searchValue` 바인딩 값 추가
- **기존의 코드를 수정하지 않아도 정상 동작하나 위 바인딩 값을 추가해야만 input이벤트 없이 검색어를 변경했을 때 동작함**
![image](https://user-images.githubusercontent.com/61657275/150835564-58bf37f2-bc79-4e86-801a-8cf0fd6bfed0.png)
