### PR TITLE
[#1056] MessageBox 열려 있을 때 포커스 설정

### DIFF
--- a/docs/views/messageBox/api/messageBox.md
+++ b/docs/views/messageBox/api/messageBox.md
@@ -73,17 +73,18 @@ ctx.$messagebox({
 
 ### Props
 
-| 이름 | 타입 | 디폴트 | 설명 | 종류 |
-| --- | ---- | ----- | ---- | --- |
-| type | String | '' | 메시지 스타일. type입력 시 좌측 상단에 타입에 맞는 아이콘 노출됨 | 'info', 'success', 'warning', 'error' |
-| message | String | '' | 메시지 창에 띄울 문구 | |
-| title | String | '' | 메시지 상단 타이틀 문구 | |
-| iconClass | String | '' | 메시지 창 좌측에 띄울 아이콘 클래스 명 | |
-| onClose | Function | null | 메시지 창이 닫힌 후 동작. 매개변수로 클릭한 버튼 타입을 받음(ok, cancel). 닫기 버튼 및 모달 레이어 클릭으로 닫을 시 cancel | |
-| showClose | Boolean | true | 닫기 버튼 노출 여부 | true, false |
-| showConfirmBtn | Boolean | true | 확인 버튼 노출 여부 | true, false |
-| showCancelBtn | Boolean | true | 취소 버튼 노출 여부 | true, false |
-| confirmBtnText | String | 'OK' | 확인 버튼 문구 | |
-| cancelBtnText | String | 'Cancel' | 취소 버튼 문구 | |
-| closeOnClickModal | Boolean | true | 모달 레이어 클릭 시 메시지 창 닫기 여부 | true, false |
-| useHTML | Boolean | false | 메시지 창 문구에 HTML 사용 여부. 사용 시 message 속성에 함께 작성 | |
+| 이름 | 타입 | 디폴트 | 설명                                                                                     | 종류                                    |
+| --- | ---- | ----- |----------------------------------------------------------------------------------------|---------------------------------------|
+| type | String | '' | 메시지 스타일. type입력 시 좌측 상단에 타입에 맞는 아이콘 노출됨                                                | 'info', 'success', 'warning', 'error' |
+| message | String | '' | 메시지 창에 띄울 문구                                                                           |                                       |
+| title | String | '' | 메시지 상단 타이틀 문구                                                                          |                                       |
+| iconClass | String | '' | 메시지 창 좌측에 띄울 아이콘 클래스 명                                                                 |                                       |
+| onClose | Function | null | 메시지 창이 닫힌 후 동작. 매개변수로 클릭한 버튼 타입을 받음(ok, cancel). 닫기 버튼 및 모달 레이어 클릭으로 닫을 시 cancel       |                                       |
+| showClose | Boolean | true | 닫기 버튼 노출 여부                                                                            | true, false                           |
+| showConfirmBtn | Boolean | true | 확인 버튼 노출 여부                                                                            | true, false                           |
+| showCancelBtn | Boolean | true | 취소 버튼 노출 여부                                                                            | true, false                           |
+| confirmBtnText | String | 'OK' | 확인 버튼 문구                                                                               |                                       |
+| cancelBtnText | String | 'Cancel' | 취소 버튼 문구                                                                               |                                       |
+| closeOnClickModal | Boolean | true | 모달 레이어 클릭 시 메시지 창 닫기 여부                                                                | true, false                           |
+| useHTML | Boolean | false | 메시지 창 문구에 HTML 사용 여부. 사용 시 message 속성에 함께 작성                                           |                                       |
+| focusable | Boolean | false | confirmBtn, cancelBtn, 메시지박스 순서대로 높은 우선순위를 가지며, 존재하는 컴포넌트 중 가장 높은 우선순위 가진 컴포넌트에 포커스 부여 | true, false                               |

--- a/docs/views/messageBox/example/Default.vue
+++ b/docs/views/messageBox/example/Default.vue
@@ -142,7 +142,7 @@ export default {
     };
     const showConfirm = () => {
       ctx.$messagebox({
-        title: 'On/Off Element',
+        title: 'On/Off Element And Focusable',
         message: 'Hide cancel button.',
         iconClass: 'ev-icon-getmore',
         showCancelBtn: false,
@@ -152,7 +152,7 @@ export default {
     };
     const showCancel = () => {
       ctx.$messagebox({
-        title: 'On/Off Element',
+        title: 'On/Off Element And Focusable',
         message: 'Hide confirm button.',
         iconClass: 'ev-icon-getmore',
         showConfirmBtn: false,
@@ -162,7 +162,7 @@ export default {
     };
     const showClose = () => {
       ctx.$messagebox({
-        title: 'On/Off Element',
+        title: 'On/Off Element And Focusable',
         message: 'Hide close button.',
         iconClass: 'ev-icon-getmore',
         showClose: false,
@@ -172,7 +172,7 @@ export default {
     };
     const showPlain = () => {
       ctx.$messagebox({
-        title: 'On/Off Element',
+        title: 'On/Off Element And Focusable',
         message: 'Hide cancel, confirm button.',
         iconClass: 'ev-icon-getmore',
         showCancelBtn: false,

--- a/docs/views/messageBox/example/Default.vue
+++ b/docs/views/messageBox/example/Default.vue
@@ -43,7 +43,7 @@
     </ev-button>
   </div>
   <div class="case">
-    <p class="case-title">On/Off Element</p>
+    <p class="case-title">On/Off Element And Focusable</p>
     <ev-button
       @click="showConfirm"
     >
@@ -58,6 +58,11 @@
       @click="showClose"
     >
       Hide Close
+    </ev-button>
+    <ev-button
+      @click="showPlain"
+    >
+      Hide Cancel, Confirm
     </ev-button>
   </div>
   <div class="case">
@@ -141,6 +146,8 @@ export default {
         message: 'Hide cancel button.',
         iconClass: 'ev-icon-getmore',
         showCancelBtn: false,
+        focusable: true,
+        onClose: type => console.log(`[ type = '${type}' ] Hide Cancel`),
       });
     };
     const showCancel = () => {
@@ -149,6 +156,8 @@ export default {
         message: 'Hide confirm button.',
         iconClass: 'ev-icon-getmore',
         showConfirmBtn: false,
+        focusable: true,
+        onClose: type => console.log(`[ type = '${type}' ] Hide Confirm`),
       });
     };
     const showClose = () => {
@@ -157,6 +166,19 @@ export default {
         message: 'Hide close button.',
         iconClass: 'ev-icon-getmore',
         showClose: false,
+        focusable: true,
+        onClose: type => console.log(`[ type = '${type}' ] Hide Close`),
+      });
+    };
+    const showPlain = () => {
+      ctx.$messagebox({
+        title: 'On/Off Element',
+        message: 'Hide cancel, confirm button.',
+        iconClass: 'ev-icon-getmore',
+        showCancelBtn: false,
+        showConfirmBtn: false,
+        focusable: true,
+        onClose: type => console.log(`[ type = '${type}' ] Hide Cancel, Confirm`),
       });
     };
     const showCustomText = () => {
@@ -195,6 +217,7 @@ export default {
       showConfirm,
       showCancel,
       showClose,
+      showPlain,
       showCustomText,
       onCloseMsg,
       showOnClose,

--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -1,5 +1,6 @@
 <template>
   <button
+    ref="buttonRef"
     class="ev-button"
     :class="{
       disabled,
@@ -17,6 +18,8 @@
 </template>
 
 <script>
+import { onMounted, ref } from 'vue';
+
 export default {
   name: 'EvButton',
   props: {
@@ -51,6 +54,19 @@ export default {
   },
   emits: {
     click: null,
+  },
+  setup(props) {
+    const buttonRef = ref(null);
+
+    onMounted(() => {
+      if (props.autoFocus) {
+        buttonRef.value.focus();
+      }
+    });
+
+    return {
+      buttonRef,
+    };
   },
 };
 </script>

--- a/src/components/messageBox/MessageBox.vue
+++ b/src/components/messageBox/MessageBox.vue
@@ -14,11 +14,12 @@
           ref="msgRef"
           class="ev-message-box"
           :class="{
-          [`type-${type}`]: !!type,
-          'show-close': showClose,
-          'has-icon': !!iconClass,
-          'has-title': !!title,
-        }"
+            [`type-${type}`]: !!type,
+            'show-close': showClose,
+            'has-icon': !!iconClass,
+            'has-title': !!title,
+          }"
+          tabindex="-1"
         >
           <span
             v-if="iconClass"
@@ -52,6 +53,7 @@
               v-if="showCancelBtn"
               size="small"
               class="ev-message-box-cancel"
+              :auto-focus="hasFocus('cancelBtn')"
               @click="closeMsg('cancel')"
             >
               {{ cancelBtnText }}
@@ -61,6 +63,7 @@
               type="primary"
               size="small"
               class="ev-message-box-confirm"
+              :auto-focus="hasFocus('confirmBtn')"
               @click="closeMsg('ok')"
             >
               {{ confirmBtnText }}
@@ -80,7 +83,7 @@
 </template>
 
 <script>
-import { reactive, toRefs, watch, onMounted } from 'vue';
+import { reactive, toRefs, watch, onMounted, ref } from 'vue';
 import EvButton from '@/components/button/Button.vue';
 
 export default {
@@ -142,8 +145,14 @@ export default {
       type: Function,
       default: null,
     },
+    focusable: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props) {
+    const msgRef = ref(null);
+
     const state = reactive({
       isShow: true,
       iconClass: '',
@@ -190,9 +199,27 @@ export default {
       }
     };
 
+    const hasFocus = (type) => {
+      if (!props.focusable) return false;
+
+      switch (type) {
+        case 'confirmBtn':
+          return props.showConfirmBtn;
+        case 'cancelBtn':
+          return !props.showConfirmBtn && props.showCancelBtn;
+        case 'messagebox':
+          return !props.showConfirmBtn && !props.showCancelBtn;
+        default:
+          return false;
+      }
+    };
+
     onMounted(() => {
       setState();
       document.addEventListener('keydown', keydown);
+      if (hasFocus('messagebox')) {
+        msgRef.value.focus();
+      }
     });
     watch(() => state.isShow, (val) => {
       if (!val) {
@@ -202,6 +229,8 @@ export default {
     return {
       closeMsg,
       ...toRefs(state),
+      msgRef,
+      hasFocus,
     };
   },
 };


### PR DESCRIPTION
### 이슈

1. 버튼 클릭
2. MessageBox 열림
3. 포커스가 MessageBox가 아닌 버튼에 있어 Enter 키를 누르면 버튼이 계속 눌려 MessageBox가 계속 열림

### 수정 내용

1. MessageBox 컴포넌트에 focusable prop 추가
2. confirm 버튼, cancel 버튼, 메시지박스 컴포넌트 순으로 포커스 주었으며, 버튼에 포커스가 있는 경우 엔터를 누르면 닫힙니다.
3. ev-button에서 autoFocus prop이 true인 경우 focus() 메서드 호출하도록 추가
4. 예제 코드 추가