### PR TITLE
[#1038] chart select item 옵션 관련 로직 개선

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -3,7 +3,7 @@
 
 ```
 <ev-chart
-    v-model="선택된 데이터 정보"
+    v-model:selectedItem="선택된 데이터 정보"
     :data="차트데이터"
     :options="차트속성"
     :resize-timeout="debounce wait시간(단위: ms)"

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -3,6 +3,7 @@
 
 ```
 <ev-chart
+    v-model="선택된 데이터 정보"
     :data="차트데이터"
     :options="차트속성"
     :resize-timeout="debounce wait시간(단위: ms)"
@@ -10,7 +11,19 @@
 ```
 
 >## Props
-### 1. data  
+### 1. v-model
+ - option에서 [selectItem](#selectitem) 옵션을 사용할 경우 유효한 바인딩
+ - 현재 선택된 Item에 대한 정보 (seriesID, dataIndex)
+#### Example
+```
+const selectedData = ref({
+    seriesID: 'series1', // Series ID (key)
+    dataIndex: 0, // 몇번째 데이터인지
+});
+```
+
+
+### 2. data  
   | 이름 | 타입 | 디폴트 | 설명 | 종류 |
   |------------ |-----------|---------|-------------------------|---------------------------------------------------|
   | series | Object | {} | 특정 데이터에 대한 시리즈 옵션 |  |
@@ -66,7 +79,7 @@ const chartData = {
 }
 ```
   
-### 2. options 
+### 3. options 
   | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
   |------------ |-----------|---------|-------------------------|---------------------------------------------------|
   | type | String | '' | series 별로 type값을 지정하지 않을 경우 일괄 적용될 차트의 타입 | 'bar', 'pie', 'line', 'scatter' |
@@ -241,15 +254,16 @@ const chartData = {
 | tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | tip 배경색상  | |
 | tipTextColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | tip 글자 색상  | |
 
->### Event
-| 이름 | 파라미터 | 설명 |
- |------|----------|------|
- | click | selectedItem | 클릭된 series의 label, value, seriesID 값을 반환 |
- | dbl-click | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환 |
- * 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환
 
-
-### 3. resize-timeout
+### 4. resize-timeout
 - Default : 0
 - debounce 사용. 연속으로 이벤트가 발생한 경우, 마지막 이벤트가 끝난 시점을 기준으로 `주어진 시간 (resize-timeout)` 이후 콜백 실행
+
+
+### 5. Event
+| 이름 | 파라미터 | 설명 |
+ |------|----------|------|
+| click | selectedItem | 클릭된 series의 label, value, seriesID 값을 반환 |
+| dbl-click | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환 |
+* 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환
 

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -11,12 +11,12 @@
 ```
 
 >## Props
-### 1. v-model
+### 1. v-model:selectedItem
  - option에서 [selectItem](#selectitem) 옵션을 사용할 경우 유효한 바인딩
  - 현재 선택된 Item에 대한 정보 (seriesID, dataIndex)
 #### Example
 ```
-const selectedData = ref({
+const selectedItem = ref({
     seriesID: 'series1', // Series ID (key)
     dataIndex: 0, // 몇번째 데이터인지
 });

--- a/docs/views/barChart/example/Event.vue
+++ b/docs/views/barChart/example/Event.vue
@@ -2,7 +2,7 @@
   <div class="case">
     <ev-chart
       ref="chart"
-      v-model="defaultSelectData"
+      v-model:selectedItem="defaultSelectItem"
       :data="chartData"
       :options="chartOptions"
       @click="onClick"
@@ -18,7 +18,7 @@
         <div class="badge yellow">
           기본 선택값 v-model
         </div>
-        {{ defaultSelectData }}
+        {{ defaultSelectItem }}
         <br><br>
         <div class="badge yellow">
           클릭된 라벨
@@ -102,14 +102,14 @@
         dblClickedLabel.value = target.label;
       };
 
-      const defaultSelectData = ref({
+      const defaultSelectItem = ref({
         seriesID: 'series1',
         dataIndex: 1,
       });
 
       const toggleSelectData = () => {
-        const idx = defaultSelectData.value.dataIndex;
-        defaultSelectData.value.dataIndex = idx === 1 ? 2 : 1;
+        const idx = defaultSelectItem.value.dataIndex;
+        defaultSelectItem.value.dataIndex = idx === 1 ? 2 : 1;
       };
 
       return {
@@ -118,7 +118,7 @@
         chartOptions,
         clickedLabel,
         dblClickedLabel,
-        defaultSelectData,
+        defaultSelectItem,
         onClick,
         onDblClick,
         toggleSelectData,

--- a/docs/views/barChart/example/Event.vue
+++ b/docs/views/barChart/example/Event.vue
@@ -2,6 +2,7 @@
   <div class="case">
     <ev-chart
       ref="chart"
+      v-model="defaultSelectData"
       :data="chartData"
       :options="chartOptions"
       @click="onClick"
@@ -9,11 +10,16 @@
     />
     <div class="description">
       <ev-button
-        @click="selectValue1">
-        select Value1
+        @click="toggleSelectData">
+        select toggle 1 - 2
       </ev-button>
       <br><br>
       <div>
+        <div class="badge yellow">
+          기본 선택값 v-model
+        </div>
+        {{ defaultSelectData }}
+        <br><br>
         <div class="badge yellow">
           클릭된 라벨
         </div>
@@ -38,10 +44,12 @@
       const chartData = {
         series: {
           series1: { name: 'series#1' },
+          series2: { name: 'series#2' },
         },
         labels: ['value1', 'value2', 'value3', 'value4', 'value5'],
         data: {
           series1: [100, 150, 51, 150, 350],
+          series2: [100, 150, 51, 150, 450],
         },
       };
 
@@ -75,6 +83,12 @@
         selectItem: {
           use: true,
           showTextTip: true,
+          tipBackground: '#FF00FF',
+        },
+        maxTip: {
+          use: true,
+          showTextTip: true,
+          tipBackground: '#FF0000',
         },
       };
 
@@ -88,8 +102,14 @@
         dblClickedLabel.value = target.label;
       };
 
-      const selectValue1 = () => {
-        chart.value.selectItemByLabel('value1');
+      const defaultSelectData = ref({
+        seriesID: 'series1',
+        dataIndex: 1,
+      });
+
+      const toggleSelectData = () => {
+        const idx = defaultSelectData.value.dataIndex;
+        defaultSelectData.value.dataIndex = idx === 1 ? 2 : 1;
       };
 
       return {
@@ -98,9 +118,10 @@
         chartOptions,
         clickedLabel,
         dblClickedLabel,
+        defaultSelectData,
         onClick,
         onDblClick,
-        selectValue1,
+        toggleSelectData,
       };
     },
   };

--- a/docs/views/barChart/example/Time.vue
+++ b/docs/views/barChart/example/Time.vue
@@ -62,10 +62,12 @@
       const chartData = reactive({
         series: {
           series1: { name: 'series#1' },
+          series2: { name: 'series#2' },
         },
         labels: [],
         data: {
           series1: [],
+          series2: [],
         },
       });
 

--- a/docs/views/barChart/example/Time.vue
+++ b/docs/views/barChart/example/Time.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="case">
     <ev-chart
+      v-model:selectedItem="defaultSelectItem"
       :data="chartData"
       :options="chartOptions"
     />
@@ -50,6 +51,11 @@
           use: true,
           tipBackground: '#DBDBDB',
           tipTextColor: '#000000',
+        },
+        selectItem: {
+          use: true,
+          showTextTip: true,
+          tipBackground: '#FF00FF',
         },
       };
 
@@ -103,10 +109,16 @@
         clearTimeout(liveInterval.value);
       });
 
+      const defaultSelectItem = ref({
+        seriesID: 'series1',
+        dataIndex: 9,
+      });
+
       return {
         chartData,
         chartOptions,
         isLive,
+        defaultSelectItem,
       };
     },
   };

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -3,6 +3,7 @@
 
 ```
 <ev-chart
+    v-model="선택된 데이터 정보"
     :data="차트데이터"
     :options="차트속성"
     :resize-timeout="debounce wait시간(단위: ms)"
@@ -10,7 +11,19 @@
 ```
 
 >## Props
-### 1. data  
+### 1. v-model
+- option에서 [selectItem](#selectitem) 옵션을 사용할 경우 유효한 바인딩
+- 현재 선택된 Item에 대한 정보 (seriesID, dataIndex)
+#### Example
+```
+const selectedData = ref({
+    seriesID: 'series1', // Series ID (key)
+    dataIndex: 0, // 몇번째 데이터인지
+});
+```
+
+
+### 2. data  
   | 이름 | 타입 | 디폴트 | 설명 | 종류 |
   |------------ |-----------|---------|-------------------------|---------------------------------------------------|
   | series | Object | {} | 특정 데이터에 대한 시리즈 옵션 |  |
@@ -55,7 +68,7 @@ const chartData =
 };
 ```
   
-### 2. options 
+### 3. options 
   | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
   |------------ |-----------|---------|-------------------------|---------------------------------------------------|
   | type | String | '' | series 별로 type값을 지정하지 않을 경우 일괄 적용될 차트의 타입 | 'bar', 'pie', 'line', 'scatter' |
@@ -216,15 +229,16 @@ const chartData =
 | fillColor | Hex, RGB, RGBA Code(String) | '#38ACEC' | 선택 영역 색상 | |
 | opacity | Number | 0.65 | 선택 영역 불투명도 | 0 ~ 1 |
 
->### Event
-| 이름 | 파라미터 | 설명 |
- |------|----------|------|
- | click | selectedItem | 클릭된 series의 label, value, seriesID 값을 반환 |
- | dbl-click | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환 |
- | drag-select | data, range | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
- * 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환
 
-
-### 3. resize-timeout
+### 4. resize-timeout
 - Default : 0
 - debounce 사용. 연속으로 이벤트가 발생한 경우, 마지막 이벤트가 끝난 시점을 기준으로 `주어진 시간 (resize-timeout)` 이후 콜백 실행
+
+
+### 5. Event
+| 이름 | 파라미터 | 설명 |
+ |------|----------|------|
+| click | selectedItem | 클릭된 series의 label, value, seriesID 값을 반환 |
+| dbl-click | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환 |
+| drag-select | data, range | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
+* 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -3,7 +3,7 @@
 
 ```
 <ev-chart
-    v-model="선택된 데이터 정보"
+    v-model:selectedItem="선택된 데이터 정보"
     :data="차트데이터"
     :options="차트속성"
     :resize-timeout="debounce wait시간(단위: ms)"

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -11,12 +11,12 @@
 ```
 
 >## Props
-### 1. v-model
+### 1. v-model:selectedItem
 - option에서 [selectItem](#selectitem) 옵션을 사용할 경우 유효한 바인딩
 - 현재 선택된 Item에 대한 정보 (seriesID, dataIndex)
 #### Example
 ```
-const selectedData = ref({
+const selectedItem = ref({
     seriesID: 'series1', // Series ID (key)
     dataIndex: 0, // 몇번째 데이터인지
 });

--- a/docs/views/lineChart/example/Event.vue
+++ b/docs/views/lineChart/example/Event.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="case">
     <ev-chart
-      v-model="defaultSelectItem"
+      v-model:selectedItem="defaultSelectItem"
       :data="chartData"
       :options="chartOptions"
       @click="onClick"

--- a/docs/views/lineChart/example/Event.vue
+++ b/docs/views/lineChart/example/Event.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="case">
     <ev-chart
+      v-model="defaultSelectItem"
       :data="chartData"
       :options="chartOptions"
       @click="onClick"
@@ -86,11 +87,17 @@
         dblClickedLabel.value = dayjs(target.label).format('YYYY-MM-DD');
       };
 
+      const defaultSelectItem = ref({
+        seriesID: 'series1',
+        dataIndex: chartData.data.series1.length - 1,
+      });
+
       return {
         chartData,
         chartOptions,
         clickedLabel,
         dblClickedLabel,
+        defaultSelectItem,
         onClick,
         onDblClick,
       };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -16,7 +16,7 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
   export default {
     name: 'EvChart',
     props: {
-      modelValue: {
+      selectedItem: {
         type: Object,
         default: null,
       },
@@ -37,7 +37,7 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
       'click',
       'dbl-click',
       'drag-select',
-      'update:modelValue',
+      'update:selectedItem',
     ],
     setup(props) {
       let evChart = {};
@@ -101,7 +101,7 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
           });
         }, { deep: true });
 
-        await watch(() => props.modelValue, (newValue) => {
+        await watch(() => props.selectedItem, (newValue) => {
           if (newValue?.seriesID && !isNaN(newValue?.dataIndex)) {
             evChart.selectItemByData(newValue);
           }

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -16,6 +16,10 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
   export default {
     name: 'EvChart',
     props: {
+      modelValue: {
+        type: Object,
+        default: null,
+      },
       options: {
         type: Object,
         default: () => ({}),
@@ -33,6 +37,7 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
       'click',
       'dbl-click',
       'drag-select',
+      'update:modelValue',
     ],
     setup(props) {
       let evChart = {};
@@ -40,6 +45,7 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
 
       const {
         eventListeners,
+        selectInfo,
         getNormalizedData,
         getNormalizedOptions,
       } = useModel();
@@ -60,6 +66,7 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
           normalizedData,
           normalizedOptions,
           eventListeners,
+          selectInfo,
         );
       };
 
@@ -93,6 +100,12 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
             updateSelTip: { update: true, keepDomain: false },
           });
         }, { deep: true });
+
+        await watch(() => props.modelValue, (newValue) => {
+          if (newValue?.seriesID && !isNaN(newValue?.dataIndex)) {
+            evChart.selectItemByData(newValue);
+          }
+        }, { deep: true });
       });
 
       onBeforeUnmount(() => {
@@ -120,16 +133,11 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
         }
       }, props.resizeTimeout);
 
-      const selectItemByLabel = (label) => {
-        evChart.selectItemByLabel(label);
-      };
-
       return {
         wrapper,
         wrapperStyle,
         onResize,
         redraw,
-        selectItemByLabel,
       };
     },
   };

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -555,6 +555,7 @@ class EvChart {
       if (!updateSelTip.keepDomain) {
         this.lastTip.pos = null;
         this.lastHitInfo = null;
+        this.defaultSelectInfo = null;
       }
     }
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -13,7 +13,7 @@ import Pie from './plugins/plugins.pie';
 import Tip from './element/element.tip';
 
 class EvChart {
-  constructor(target, data, options, listeners) {
+  constructor(target, data, options, listeners, defaultSelectInfo) {
     Object.keys(Model).forEach(key => Object.assign(this, Model[key]));
     Object.assign(this, Title);
     Object.assign(this, Legend);
@@ -63,6 +63,8 @@ class EvChart {
       charts: { pie: [], bar: [], line: [], scatter: [] },
       count: 0,
     };
+
+    this.defaultSelectInfo = defaultSelectInfo;
   }
 
   /**
@@ -197,6 +199,26 @@ class EvChart {
         }
       }
     }
+  }
+
+  /**
+   * Draw Tip with hitInfo and defaultSelectInfo
+   * @param hitInfo
+   */
+  drawTip(hitInfo) {
+    let tipLocationInfo;
+
+    if (hitInfo) {
+      tipLocationInfo = hitInfo;
+    } else if (this.lastHitInfo) {
+      tipLocationInfo = this.lastHitInfo;
+    } else if (this.defaultSelectInfo) {
+      tipLocationInfo = this.getItem(this.defaultSelectInfo, false);
+    } else {
+      tipLocationInfo = null;
+    }
+
+    this.drawTips(tipLocationInfo);
   }
 
   /**

--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -3,23 +3,21 @@ import Canvas from '../helpers/helpers.canvas';
 
 const modules = {
   /**
-   * Draw TextTip with hitInfo
-   * @param {object} [hitInfo=undefined]    mouse hit information
+   * Draw TextTip with tip's locationInfo
+   * @param {object} [tipLocationInfo=undefined]   tip location information
    *
    * @returns {undefined}
    */
-  drawTip(hitInfo) {
+  drawTips(tipLocationInfo) {
     const opt = this.options;
     const isHorizontal = !!opt.horizontal;
     const maxTipOpt = opt.maxTip;
     const selectItemOpt = opt.selectItem;
+    let maxArgs;
 
-    if (maxTipOpt.use || selectItemOpt.use) {
+    if (maxTipOpt.use) {
       const maxSID = this.minMax[isHorizontal ? 'x' : 'y'][0].maxSID;
-      const selSID = (hitInfo && hitInfo.sId ? hitInfo.sId : this.lastHitInfo?.sId) ?? maxSID;
-
-      const maxArgs = this.calculateTipInfo(this.seriesList[maxSID], 'max', null);
-      const selArgs = this.calculateTipInfo(this.seriesList[selSID], 'sel', hitInfo);
+      maxArgs = this.calculateTipInfo(this.seriesList[maxSID], 'max', null);
 
       if (maxTipOpt.use && maxArgs) {
         this.drawTextTip({ opt: maxTipOpt, tipType: 'max', ...maxArgs });
@@ -28,11 +26,25 @@ const modules = {
           this.drawFixedIndicator({ opt: maxTipOpt, ...maxArgs });
         }
       }
+    }
+
+    if (selectItemOpt.use && tipLocationInfo) {
+      const seriesInfo = this.seriesList[tipLocationInfo?.sId];
+
+      if (!seriesInfo?.show) {
+        return;
+      }
+
+      const selArgs = this.calculateTipInfo(
+        seriesInfo,
+        'sel',
+        tipLocationInfo,
+      );
 
       if (selectItemOpt.use && selArgs) {
         let isSamePos = false;
 
-        if (maxTipOpt.use && maxArgs && maxArgs.dp === selArgs.dp) {
+        if (maxTipOpt.use && maxArgs?.dp === selArgs.dp) {
           isSamePos = true;
         }
 
@@ -45,8 +57,8 @@ const modules = {
         }
       }
 
-      if (hitInfo && hitInfo.label !== null) {
-        this.lastHitInfo = hitInfo;
+      if (tipLocationInfo && tipLocationInfo.label !== null) {
+        this.lastHitInfo = tipLocationInfo;
       }
     }
   },

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -1,5 +1,5 @@
 import { ref, computed, getCurrentInstance, nextTick } from 'vue';
-import { defaultsDeep } from 'lodash-es';
+import { cloneDeep, defaultsDeep } from 'lodash-es';
 import { getQuantity } from '@/common/utils';
 
 const DEFAULT_OPTIONS = {
@@ -97,7 +97,7 @@ const DEFAULT_DATA = {
 };
 
 export const useModel = () => {
-  const { emit } = getCurrentInstance();
+  const { props, emit } = getCurrentInstance();
 
   const getNormalizedOptions = (options) => {
     const normalizedOptions = defaultsDeep({}, options, DEFAULT_OPTIONS);
@@ -110,9 +110,14 @@ export const useModel = () => {
   };
   const getNormalizedData = data => defaultsDeep(data, DEFAULT_DATA);
 
+  const selectInfo = cloneDeep(props.modelValue);
+
   const eventListeners = {
     click: async (e) => {
       await nextTick();
+      if (e.label) {
+        emit('update:modelValue', { seriesID: e.seriesId, dataIndex: e.dataIndex });
+      }
       emit('click', e);
     },
     'dbl-click': async (e) => {
@@ -127,6 +132,7 @@ export const useModel = () => {
 
   return {
     eventListeners,
+    selectInfo,
     getNormalizedData,
     getNormalizedOptions,
   };

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -110,13 +110,13 @@ export const useModel = () => {
   };
   const getNormalizedData = data => defaultsDeep(data, DEFAULT_DATA);
 
-  const selectInfo = cloneDeep(props.modelValue);
+  const selectInfo = cloneDeep(props.selectedItem);
 
   const eventListeners = {
     click: async (e) => {
       await nextTick();
       if (e.label) {
-        emit('update:modelValue', { seriesID: e.seriesId, dataIndex: e.dataIndex });
+        emit('update:selectedItem', { seriesID: e.seriesId, dataIndex: e.dataIndex });
       }
       emit('click', e);
     },


### PR DESCRIPTION
## 이슈 내용
1. chartOption > selectItem > use: true로 되어 있을 경우, 차트에서 데이터를 클릭한 곳으로 selectItem옵션에서 설정한 Tip 혹은 Indicator 가 옮겨지는 기능 존재
2. 기본값의 위치가 최대값으로 고정되어 있어 maxTip과 헷갈림

## 주요 수정 내용
- **v-model:selectedItem로 바인딩 된 값에 해당하는 아이템을 선택**
- **line, bar chart에만 해당됨 (pie, scatter 제외)**
- ![image](https://user-images.githubusercontent.com/53548023/152931381-cf587c13-f9e4-49cd-aad3-1c39d0c3e18f.png)
- ![image](https://user-images.githubusercontent.com/53548023/152931681-0b713934-ff7f-4973-bdda-36c9cb0157e0.png)
- ![image](https://user-images.githubusercontent.com/53548023/152931572-eb1cff65-43c5-48ab-8122-3c0b01e04ffc.png)


## 기타 수정 내용
1. md파일에 설명 추가
2. v-model:selectedItem로 받은 데이터를 기준으로 tip을 표시할 수 있도록 차트 생성 인자에 `defaultSelectInfo` 추가
3. 불필요한 함수 제거 및 코드 정리 
4.  **Version Update (3.3.3 -> 3.3.4)**