### PR TITLE
[#1061] TreeGrid Child Nodes 무한 루프 이슈

### DIFF
--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -1,4 +1,5 @@
 import { getCurrentInstance, nextTick } from 'vue';
+import { cloneDeep } from 'lodash-es';
 import { numberWithComma } from '@/common/utils';
 
 export const commonFunctions = () => {
@@ -613,6 +614,7 @@ export const treeEvent = (params) => {
         }
         if (node.children) {
           node.hasChild = true;
+          node.children = cloneDeep(node.children);
           node.children.forEach(child =>
             setNodeData({
               node: child,


### PR DESCRIPTION
#############
- 동일한 데이터를 ChildNodes를 중복 해서 사용할 경우 setTreeNodeStore() 호출 후 참조 값이 같아서 watch 를 무한으로 타는 현상이 발생
- Node 의 children 객체를 딥클론하여 사용하도록 수정