### PR TITLE
[#1038] Chart > selectItem 옵션 개선

### DIFF
--- a/docs/views/lineChart/example/Tooltip.vue
+++ b/docs/views/lineChart/example/Tooltip.vue
@@ -77,6 +77,7 @@
           <ev-input-number
             v-model="shadowOpacity"
             :step="0.05"
+            :precision="2"
             :min="0"
             :max="1"
           />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -555,7 +555,6 @@ class EvChart {
       if (!updateSelTip.keepDomain) {
         this.lastTip.pos = null;
         this.lastHitInfo = null;
-        this.defaultSelectInfo = null;
       }
     }
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -712,6 +712,8 @@ class EvChart {
       this.overlayCanvas.removeEventListener('mouseleave', this.onMouseLeave);
       this.overlayCanvas.removeEventListener('dblclick', this.onDblClick);
       this.overlayCanvas.removeEventListener('click', this.onClick);
+      this.overlayCanvas.removeEventListener('mousedown', this.onMouseDown);
+      this.overlayCanvas.removeEventListener('wheel', this.onWheel);
     }
 
     if (this.options.tooltip.use) {

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -160,15 +160,17 @@ const modules = {
       }
     };
 
-    if (this.options?.tooltip?.useScrollbar) {
-      this.overlayCanvas.addEventListener('wheel', (e) => {
-        const isTooltipVisible = this.tooltipDOM.style.display === 'block';
+    this.onWheel = (e) => {
+      const isTooltipVisible = this.tooltipDOM.style.display === 'block';
 
-        if (isTooltipVisible) {
-          e.preventDefault();
-          this.tooltipBodyDOM.scrollTop += e.deltaY;
-        }
-      });
+      if (isTooltipVisible) {
+        e.preventDefault();
+        this.tooltipBodyDOM.scrollTop += e.deltaY;
+      }
+    };
+
+    if (this.options?.tooltip?.useScrollbar) {
+      this.overlayCanvas.addEventListener('wheel', this.onWheel, { passive: false });
     }
 
     this.overlayCanvas.addEventListener('mousemove', this.onMouseMove);

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -408,6 +408,7 @@ const modules = {
    * @returns {boolean}
    */
   selectItemByData(targetInfo) {
+    this.defaultSelectInfo = targetInfo;
     const foundInfo = this.getItem(targetInfo, false);
 
     if (foundInfo) {


### PR DESCRIPTION
### 작업내용
1. data가 변하면 v-model로 받은 defaultSelectItem을 무시하기로 했었으나 다시 고정하기로 변경
2. EVUI Revision update (3.3.4 -> 3.3.5)

### 결과
![default_select](https://user-images.githubusercontent.com/53548023/153140207-c4378005-9abc-4025-8138-a29721b6529a.gif)

### 추가 작업 내용
1. removeEventListener 누락된 부분 추가
2. console에 warning message 뜨는 부분 2건 픽스
   1. Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive.
   2. [EVUI][InputNumber] It cannot be calculated because the step is smaller than the precision setting.