### PR TITLE
[#1066] Chart > selectItem > showTextTip옵션 개선

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -245,8 +245,9 @@ const chartData = {
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 | --- | ---- | ----- | --- | ----------|
 | use | Boolean | false | 차트 아이템 선택 기능  | |
-| showTextTip | Boolean | false | 선택한 label의 최대값 표시  | |
-| showTip | Boolean | false | 선택한 label의 상단에 화살표 표시  | |
+| showTextTip | Boolean | false | 선택한 위치의 TextTip(text 포함 화살표, 흡사 말풍선) 생성 여부  | |
+| tipText | String | 'value' | 선택한 위치에 TextTip을 생성한다면 어떤 값  | 'value', 'label |
+| showTip | Boolean | false | 선택한 위치의 Tip(화살표) 생성 여부  | |
 | showIndicator | Boolean | false | 선택한 label의 indicator 표시  | |
 | fixedPosTop | Boolean | false | indicator 및 tip의 위치를 최대값으로 고정  | |
 | useApproximateValue | Boolean | false | 가까운 label을 선택  | |

--- a/docs/views/barChart/example/Time.vue
+++ b/docs/views/barChart/example/Time.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="case">
     <ev-chart
-      v-model:selectedItem="defaultSelectItem"
       :data="chartData"
       :options="chartOptions"
     />
@@ -51,11 +50,6 @@
           use: true,
           tipBackground: '#DBDBDB',
           tipTextColor: '#000000',
-        },
-        selectItem: {
-          use: true,
-          showTextTip: true,
-          tipBackground: '#FF00FF',
         },
       };
 
@@ -111,16 +105,10 @@
         clearTimeout(liveInterval.value);
       });
 
-      const defaultSelectItem = ref({
-        seriesID: 'series1',
-        dataIndex: 9,
-      });
-
       return {
         chartData,
         chartOptions,
         isLive,
-        defaultSelectItem,
       };
     },
   };

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -212,8 +212,9 @@ const chartData =
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 | --- | ---- | ----- | --- | ----------|
 | use | Boolean | false | 차트 아이템 선택 기능  | |
-| showTextTip | Boolean | false | 선택한 label의 최대값 표시  | |
-| showTip | Boolean | false | 선택한 label의 상단에 화살표 표시  | |
+| showTextTip | Boolean | false | 선택한 위치의 TextTip(text 포함 화살표, 흡사 말풍선) 생성 여부  | |
+| tipText | String | 'value' | 선택한 위치에 TextTip을 생성한다면 어떤 값  | 'value', 'label |
+| showTip | Boolean | false | 선택한 위치의 Tip(화살표) 생성 여부  | |
 | showIndicator | Boolean | false | 선택한 label의 indicator 표시  | |
 | fixedPosTop | Boolean | false | indicator 및 tip의 위치를 최대값으로 고정  | |
 | useApproximateValue | Boolean | false | 가까운 label을 선택  | |

--- a/docs/views/lineChart/example/Event.vue
+++ b/docs/views/lineChart/example/Event.vue
@@ -9,6 +9,11 @@
     />
     <div class="description">
       <div class="badge yellow">
+        기본 선택값 v-model
+      </div>
+      {{ defaultSelectItem }}
+      <br><br>
+      <div class="badge yellow">
         클릭된 라벨
       </div>
       {{ clickedLabel }}
@@ -69,11 +74,18 @@
           type: 'linear',
           showGrid: true,
           startToZero: true,
-          autoScaleRatio: 0.1,
+          autoScaleRatio: 0.3,
         }],
         selectItem: {
           use: true,
           showTextTip: true,
+          tipText: 'label',
+          fixedPosTop: true,
+          showIndicator: true,
+        },
+        maxTip: {
+          use: true,
+          tipBackground: '#FF00FF',
         },
       };
 
@@ -89,7 +101,7 @@
 
       const defaultSelectItem = ref({
         seriesID: 'series1',
-        dataIndex: chartData.data.series1.length - 1,
+        dataIndex: 3,
       });
 
       return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -73,6 +73,7 @@ const DEFAULT_OPTIONS = {
   selectItem: {
     use: false,
     showTextTip: false,
+    tipText: 'value',
     showTip: false,
     showIndicator: false,
     fixedPosTop: false,


### PR DESCRIPTION
## 이슈 내용
- https://github.com/ex-em/EVUI/issues/1066

### 작업 내용
1. 'tipText' 옵션 추가 
   - 'value' 혹은 'label'
   - 기본값 : 'value'
2. maxTip이 selectedTip보다 나중에 그려지도록 함
3. 관련 docs 수정
4. time 관련 example code에서 selectItem관련 옵션 제거
5. line, bar chart의 Event 관련 example code 수정
6. **EVUI version update (3.3.5 -> 3.3.6)**

### 결과 (tipText: 'label')
![tipText_label](https://user-images.githubusercontent.com/53548023/153818512-bcbafa16-e2ee-4a1b-b2d5-c3d3e48015ed.gif)

