### PR TITLE
[#1074] TreeGrid > row 별 disabled 속성 설정 옵션 추가

### DIFF
--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -348,12 +348,7 @@ export default {
       originStore: [],
       filterStore: [],
       store: computed(() => {
-        let store;
-        if (filterInfo.isFiltering) {
-          store = stores.filterStore;
-        } else {
-          store = stores.originStore;
-        }
+        const store = filterInfo.isFiltering ? stores.filterStore : stores.originStore;
         return filterInfo.isSearch ? stores.searchStore : store;
       }),
       orderedColumns: computed(() =>

--- a/src/components/treeGrid/TreeGridNode.vue
+++ b/src/components/treeGrid/TreeGridNode.vue
@@ -14,6 +14,7 @@
     >
       <ev-checkbox
         v-model="node.checked"
+        :disabled="node._disabled"
         class="row-checkbox-input"
         @change="onCheck($event, node)"
       />


### PR DESCRIPTION
#############
- row 데이터 속성 '_disabled: true' 일 때 checkbox disabled 처리
- checkedRows 처리 시 disabled 된 row 제외하고 계산

![tree_row_disabled](https://user-images.githubusercontent.com/61657275/155672498-b6518c0a-820b-4516-b6ea-faed33d153cb.gif)

```
{
  id: 'docstore.ini',
  _disabled: true,
  children: [
    { id: 'docstore' },
  ],
},
```
- 기존에 column 데이터와 tree 의 옵션에 대한 속성이 중복 될 수 있는 문제가 존재
- 새로 추가되는 옵션이므로 `_` 를 붙였는데 기존에 tree 옵션 속성인 `parent`, **`children`**, **`expand`**, **`checked`**, `index`, `isFilter`, `level`, `show` 도 추후 수정이 필요

