### PR TITLE
[#1082] Pie Chart 2차 개선  - event, selectItem 기능 추가

### DIFF
--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -3,6 +3,7 @@
 
 ```
 <ev-chart
+    v-model:selectedItem="선택된 데이터 정보"
     :data="차트데이터"
     :options="차트속성"
     :resize-timeout="debounce wait시간(단위: ms)"
@@ -10,7 +11,17 @@
 ```
 
 >## Props
-### 1. data  
+### 1. v-model:selectedItem
+- option에서 [selectItem](#selectitem) 옵션을 사용할 경우 유효한 바인딩
+- 현재 선택된 Item에 대한 정보 (seriesID)
+#### Example
+```
+const selectedItem = ref({
+    seriesID: 'series1', // Series ID (key)
+});
+```
+
+### 2. data  
   | 이름 | 타입 | 디폴트 | 설명 | 종류 |
   |------------ |-----------|---------|-------------------------|---------------------------------------------------|
   | series | Object | {} | 특정 데이터에 대한 시리즈 옵션 |  |
@@ -38,7 +49,7 @@ const chartData =
 };
 ```
   
-### 2. options 
+### 3. options 
   | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
   |------------ |-----------|---------|-------------------------|---------------------------------------------------|
   | type | String | '' | series 별로 type값을 지정하지 않을 경우 일괄 적용될 차트의 타입 | 'bar', 'pie', 'line', 'scatter' |
@@ -91,6 +102,18 @@ const chartData =
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | ({ value, name }) => value + '%' |
 
-### 3. resize-timeout
+#### selectItem
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+| --- | ---- | ----- | --- | ----------|
+| use | Boolean | false | 차트 아이템 선택 기능  | |
+
+### 4. resize-timeout
 - Default : 0
 - debounce 사용. 연속으로 이벤트가 발생한 경우, 마지막 이벤트가 끝난 시점을 기준으로 `주어진 시간 (resize-timeout)` 이후 콜백 실행
+
+### 5. Event
+| 이름 | 파라미터 | 설명 |
+ |------|----------|------|
+| click | selectedItem | 클릭된 series의 value, seriesID 값을 반환 |
+| dbl-click | selectedItem | 더블 클릭된 series의 value, seriesID 값을 반환 |
+* 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -48,6 +48,7 @@ const chartData =
   | legend | Object | ([상세](#legend)) | 차트의 범례 표시 여부 및 속성 |  |
   | doughnutHoleSize | number | 0 | 내부 hole 사이즈 | 0 ~ 1 |
   | pieStroke | Object | { show: true, color: '#FFFFFF', lineWidth: 2 } | 차트의 테두리선 표시 여부 및 색상, 두께를 설정하는 옵션 | |
+  | tooltip | Object | ([상세](#tooltip)) | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성 | |
    
 #### title
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
@@ -72,6 +73,23 @@ const chartData =
 | padding | Object | { top: 0, right: 0, left: 0, bottom: 0 } | Legend 내부 padding 값 | |
 | allowResize | Boolean | false | Legend 영역 리사이즈 가능 여부 | |
 
+#### tooltip
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+| --- | ---- | ----- | --- | ----------|
+| use | Boolean | true | tooltip 표시 여부 | true /false |
+| backgroundColor | Hex, RGB, RGBA Code(String) | '#4C4C4C' | tooltip 배경 색상  | |
+| borderColor | Hex, RGB, RGBA Code(String) | '#666666' | tooltip 테두리 색상  | |
+| useShadow | Boolean | false | 그림자 사용 여부  | |
+| shadowOpacity | Number | 0.25 | 그림자 투명도  | |
+| throttledMove | Boolean | false | 데이터 조회 Throttling 처리 유무  | |
+| debouncedHide | Boolean | false | 좌표 이동 시 tooltip hide 여부  | |
+| sortByValue | Boolean | true | 값을 기준으로 정렬할지의 여부  | |
+| useScrollbar | Boolean | false | 스크롤바 사용 여부  | |
+| maxHeight | Number |  | 툴팁의 최대 높이  | |
+| maxWidth | Number |  | 툴팁의 최대 너비  | |
+| textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
+| showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
+| formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | ({ value, name }) => value + '%' |
 
 ### 3. resize-timeout
 - Default : 0

--- a/docs/views/pieChart/example/Default.vue
+++ b/docs/views/pieChart/example/Default.vue
@@ -48,5 +48,6 @@
 <style lang="scss" scoped>
   .case {
     height: 100%;
+    background-color: #EEEEEE;
   }
 </style>

--- a/docs/views/pieChart/example/Default.vue
+++ b/docs/views/pieChart/example/Default.vue
@@ -4,37 +4,22 @@
       :data="chartData"
       :options="chartOptions"
     />
-    <ev-chart
-      :data="chartData2"
-      :options="chartOptions"
-    />
   </div>
 </template>
 
 <script>
   export default {
     setup() {
-      const commonSeries = {
-        series1: { name: 'series#1' },
-        series2: { name: 'series#2' },
-        series3: { name: 'series#3' },
-      };
-
       const chartData = {
-        series: commonSeries,
+        series: {
+          series1: { name: 'series#1' },
+          series2: { name: 'series#2' },
+          series3: { name: 'series#3' },
+        },
         data: {
           series1: [10],
           series2: [20],
           series3: [70],
-        },
-      };
-
-      const chartData2 = {
-        series: commonSeries,
-        data: {
-          series1: [10, 20, 10],
-          series2: [20, 70, 90],
-          series3: [70, 10, 0],
         },
       };
 
@@ -54,7 +39,6 @@
 
       return {
         chartData,
-        chartData2,
         chartOptions,
       };
     },

--- a/docs/views/pieChart/example/Default.vue
+++ b/docs/views/pieChart/example/Default.vue
@@ -26,7 +26,6 @@
       const chartOptions = {
         type: 'pie',
         width: '100%',
-        height: '50%',
         title: {
           text: 'Chart Title',
           show: true,

--- a/docs/views/pieChart/example/Doughnut.vue
+++ b/docs/views/pieChart/example/Doughnut.vue
@@ -28,7 +28,6 @@
       const chartOptions = {
         type: 'pie',
         width: '100%',
-        height: '50%',
         title: {
           text: 'Chart Title',
           show: true,

--- a/docs/views/pieChart/example/Doughnut.vue
+++ b/docs/views/pieChart/example/Doughnut.vue
@@ -4,10 +4,6 @@
       :data="chartData"
       :options="chartOptions"
     />
-    <ev-chart
-      :data="chartData2"
-      :options="chartOptions"
-    />
   </div>
 </template>
 
@@ -29,15 +25,6 @@
         },
       };
 
-      const chartData2 = {
-        series: commonSeries,
-        data: {
-          series1: [10, 20, 10],
-          series2: [20, 70, 90],
-          series3: [70, 10, 0],
-        },
-      };
-
       const chartOptions = {
         type: 'pie',
         width: '100%',
@@ -55,7 +42,6 @@
 
       return {
         chartData,
-        chartData2,
         chartOptions,
       };
     },

--- a/docs/views/pieChart/example/Event.vue
+++ b/docs/views/pieChart/example/Event.vue
@@ -1,0 +1,107 @@
+<template>
+  <div class="case">
+    <ev-chart
+      v-model:selectedItem="defaultSelectItem"
+      :data="chartData"
+      :options="chartOptions"
+      @click="onClick"
+      @dbl-click="onDblClick"
+    />
+    <div class="description">
+      <ev-button
+          @click="toggleSelectData">
+        select toggle 1 - 2
+      </ev-button>
+      <br><br>
+      <div>
+        <div class="badge yellow">
+          기본 선택값 v-model
+        </div>
+        {{ defaultSelectItem }}
+        <br><br>
+        <div class="badge yellow">
+          클릭된 정보
+        </div>
+        {{ clickedInfo }}
+        <br><br>
+        <div class="badge yellow">
+          더블 클릭된 정보
+        </div>
+        {{ dblClickedInfo }}
+    </div>
+  </div>
+</div></template>
+
+<script>
+import { reactive, ref } from 'vue';
+
+  export default {
+    setup() {
+      const chartData = reactive({
+        series: {
+          series1: { name: 'series#1' },
+          series2: { name: 'series#2' },
+          series3: { name: 'series#3' },
+        },
+        data: {
+          series1: [10],
+          series2: [20],
+          series3: [70],
+        },
+      });
+
+      const chartOptions = {
+        type: 'pie',
+        width: '100%',
+        height: '50%',
+        title: {
+          text: 'Chart Title',
+          show: true,
+        },
+        legend: {
+          show: true,
+          position: 'right',
+        },
+        selectItem: {
+          use: true,
+        },
+      };
+
+      const clickedInfo = ref("''");
+      const onClick = (target) => {
+        clickedInfo.value = target;
+      };
+
+      const dblClickedInfo = ref("''");
+      const onDblClick = (target) => {
+        dblClickedInfo.value = target;
+      };
+
+      const defaultSelectItem = ref({
+        seriesID: 'series1',
+      });
+
+      const toggleSelectData = () => {
+        const seriesID = defaultSelectItem.value.seriesID;
+        defaultSelectItem.value.seriesID = seriesID === 'series1' ? 'series2' : 'series1';
+      };
+
+      return {
+        chartData,
+        chartOptions,
+        clickedInfo,
+        dblClickedInfo,
+        defaultSelectItem,
+        onClick,
+        onDblClick,
+        toggleSelectData,
+      };
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  .case {
+    height: 100%;
+  }
+</style>

--- a/docs/views/pieChart/example/Event.vue
+++ b/docs/views/pieChart/example/Event.vue
@@ -28,9 +28,10 @@
           더블 클릭된 정보
         </div>
         {{ dblClickedInfo }}
+      </div>
     </div>
   </div>
-</div></template>
+</template>
 
 <script>
 import { reactive, ref } from 'vue';

--- a/docs/views/pieChart/props.js
+++ b/docs/views/pieChart/props.js
@@ -6,6 +6,8 @@ import Doughnut from './example/Doughnut';
 import DoughnutRaw from '!!raw-loader!./example/Doughnut';
 import Sunburst from './example/Sunburst';
 import SunburstRaw from '!!raw-loader!./example/Sunburst';
+import Event from './example/Event';
+import EventRaw from '!!raw-loader!./example/Event';
 
 export default {
   mdText,
@@ -24,6 +26,11 @@ export default {
       description: 'Sunburst Chart는 Doughnut을 계층적으로 데이터를 시각화 합니다.',
       component: Sunburst,
       parsedData: parseComponent(SunburstRaw),
+    },
+    Event: {
+      description: 'Click, Double Click 등 이벤트 등록이 가능합니다.',
+      component: Event,
+      parsedData: parseComponent(EventRaw),
     },
   },
 };

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -102,9 +102,12 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
         }, { deep: true });
 
         await watch(() => props.selectedItem, (newValue) => {
-          if (newValue?.seriesID && !isNaN(newValue?.dataIndex)) {
-            evChart.selectItemByData(newValue);
+          if (!newValue?.seriesID) {
+            return;
           }
+
+          const chartType = props.options?.type;
+          evChart.selectItemByData(newValue, chartType);
         }, { deep: true });
       });
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -193,7 +193,7 @@ class EvChart {
           }
 
           if (this.options.doughnutHoleSize > 0) {
-            this.drawDoughnutHole(series);
+            this.drawDoughnutHole();
           }
           break;
         }

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -1,5 +1,6 @@
 import throttle from '@/common/utils.throttle';
 import Model from './model';
+import Util from './helpers/helpers.util';
 import TimeScale from './scale/scale.time';
 import LinearScale from './scale/scale.linear';
 import LogarithmicScale from './scale/scale.logarithmic';
@@ -136,7 +137,7 @@ class EvChart {
     this.labelRange = this.getAxesLabelRange();
     this.axesSteps = this.calculateSteps();
     this.drawAxis(hitInfo);
-    this.drawSeries();
+    this.drawSeries(hitInfo);
     this.drawTip(hitInfo);
     if (this.bufferCanvas) {
       this.displayCtx.drawImage(this.bufferCanvas, 0, 0);
@@ -148,7 +149,7 @@ class EvChart {
    *
    * @returns {undefined}
    */
-  drawSeries() {
+  drawSeries(hitInfo) {
     const maxTip = this.options.maxTip;
 
     const opt = {
@@ -186,10 +187,14 @@ class EvChart {
             showIndex++;
           }
         } else {
+          const selectInfo = hitInfo
+            ?? this.lastHitInfo
+            ?? { sId: this.defaultSelectInfo?.seriesID };
+
           if (this.options.sunburst) {
-            this.drawSunburst();
+            this.drawSunburst(selectInfo);
           } else {
-            this.drawPie();
+            this.drawPie(selectInfo);
           }
 
           if (this.options.doughnutHoleSize > 0) {
@@ -206,6 +211,10 @@ class EvChart {
    * @param hitInfo
    */
   drawTip(hitInfo) {
+    if (Util.isPieType(hitInfo?.type)) {
+      return;
+    }
+
     let tipLocationInfo;
 
     if (hitInfo) {

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -177,7 +177,7 @@ class Bar {
   /**
    * Draw item highlight
    * @param {object}  item       object for drawing series data
-   * @param {object}  context    canvas context
+   * @param {CanvasRenderingContext2D}  context    canvas context
    *
    * @returns {undefined}
    */

--- a/src/components/chart/element/element.pie.js
+++ b/src/components/chart/element/element.pie.js
@@ -71,6 +71,26 @@ class Pie {
   }
 
   /**
+   * Find graph item
+   * @param {array}    offset          mouse position
+   *
+   * @returns {object} graph item
+   */
+  findGraphData([offsetX, offsetY]) {
+    const item = { data: null, hit: false, color: null, index: -1 };
+
+    if (this.show && this.ctx?.isPointInPath(this.slice, offsetX, offsetY)) {
+      item.type = this.type;
+      item.data = this.data;
+      item.hit = true;
+      item.color = this.color;
+      item.index = 0;
+    }
+
+    return item;
+  }
+
+  /**
    * Draw item highlight
    *
    * @param item {object} object for drawing series data

--- a/src/components/chart/element/element.pie.js
+++ b/src/components/chart/element/element.pie.js
@@ -71,32 +71,6 @@ class Pie {
   }
 
   /**
-   * Find graph item
-   * @param {array}    offset          mouse position
-   *
-   * @returns {object} graph item
-   */
-  findGraphRange(offset) {
-    const xp = offset[0];
-    const yp = offset[1];
-    const item = { data: null, hit: false, color: this.color };
-    const gdata = this.data;
-
-    let s = 0;
-    let e = gdata.length - 1;
-
-    if (this.show && this.ctx?.isPointInPath(this.slice, offsetX, offsetY)) {
-      item.type = this.type;
-      item.data = this.data;
-      item.hit = true;
-      item.color = this.color;
-      item.index = 0;
-    }
-
-    return item;
-  }
-
-  /**
    * Draw item highlight
    *
    * @param item {object} object for drawing series data

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -312,4 +312,12 @@ export default {
     ctx.restore();
     ctx.beginPath();
   },
+
+  isPieType(type) {
+    return type === 'pie' || type === 'doughnut' || type === 'sunburst';
+  },
+
+  isDoughnutHole(type) {
+    return type === 'doughnut' || type === 'sunburst';
+  },
 };

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -11,19 +11,19 @@ const modules = {
    */
   createDataSet(data, label) {
     Object.keys(this.seriesInfo.charts).forEach((typeKey) => {
-      const type = this.seriesInfo.charts[typeKey];
+      const seriesIDs = this.seriesInfo.charts[typeKey];
 
-      if (type.length) {
+      if (seriesIDs.length) {
         if (typeKey === 'pie') {
           if (this.options.sunburst) {
             this.createSunburstDataSet(data);
           } else {
-            this.createPieDataSet(data, type);
+            this.createPieDataSet(data, seriesIDs);
           }
         } else if (typeKey === 'scatter') {
-          seriesIDs.forEach((sId) => {
-            const series = this.seriesList[sId];
-            const sData = data[sId];
+          seriesIDs.forEach((seriesID) => {
+            const series = this.seriesList[seriesID];
+            const sData = data[seriesID];
 
             if (series && sData) {
               series.data = this.addSeriesDSforScatter(sData);

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -31,13 +31,13 @@ const modules = {
             }
           });
         } else {
-          seriesIDs.forEach((sId) => {
-            const series = this.seriesList[sId];
-            const sData = data[sId];
+          seriesIDs.forEach((seriesID) => {
+            const series = this.seriesList[seriesID];
+            const sData = data[seriesID];
 
             if (series && sData) {
               if (series.isExistGrp && series.stackIndex) {
-                series.data = this.addSeriesStackDS(sData, label, series.bsIds, series.stackIndex);
+                series.data = this.addSeriesStackDS(sData, label, series.sbsIds, series.stackIndex);
               } else {
                 series.data = this.addSeriesDS(sData, label);
               }

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -10,17 +10,17 @@ const modules = {
    */
   createDataSet(data, label) {
     Object.keys(this.seriesInfo.charts).forEach((typeKey) => {
-      const type = this.seriesInfo.charts[typeKey];
+      const seriesIDs = this.seriesInfo.charts[typeKey];
 
-      if (type.length) {
+      if (seriesIDs.length) {
         if (typeKey === 'pie') {
           if (this.options.sunburst) {
             this.createSunburstDataSet(data);
           } else {
-            this.createPieDataSet(data, type);
+            this.createPieDataSet(data, seriesIDs);
           }
         } else if (typeKey === 'scatter') {
-          type.forEach((sId) => {
+          seriesIDs.forEach((sId) => {
             const series = this.seriesList[sId];
             const sData = data[sId];
 
@@ -30,7 +30,7 @@ const modules = {
             }
           });
         } else {
-          type.forEach((sId) => {
+          seriesIDs.forEach((sId) => {
             const series = this.seriesList[sId];
             const sData = data[sId];
 
@@ -153,25 +153,22 @@ const modules = {
 
   /**
    * Take chart data and to create normalized pie data
-   * @param {object}  data    chart series info
+   * @param {object}  data    chart data
+   * @param {String[]}  seriesIDs     chart series info
    *
    * @returns {undefined}
    */
-  createPieDataSet(data, pie) {
+  createPieDataSet(data, seriesIDs) {
     this.pieDataSet = [];
     const ds = this.pieDataSet;
+    ds[0] = { data: [], ir: 0, or: 0, total: 0 };
 
-    pie.forEach((sId) => {
-      data[sId].forEach((value, index) => {
-        if (!ds[index]) {
-          ds[index] = { data: [], ir: 0, or: 0, total: 0 };
-        }
-
-        if (this.seriesList[sId].show) {
-          ds[index].total += value || 0;
-          ds[index].data.push({ id: sId, value, sa: 0, ea: 0 });
-        }
-      });
+    seriesIDs.forEach((sId) => {
+      if (this.seriesList[sId].show) {
+        const value = data[sId][0] ?? 0;
+        ds[0].total += value;
+        ds[0].data.push({ id: sId, value, sa: 0, ea: 0 });
+      }
     });
 
     ds.forEach((item) => {

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -37,7 +37,7 @@ const modules = {
 
             if (series && sData) {
               if (series.isExistGrp && series.stackIndex) {
-                series.data = this.addSeriesStackDS(sData, label, series.sbsIds, series.stackIndex);
+                series.data = this.addSeriesStackDS(sData, label, series.bsIds, series.stackIndex);
               } else {
                 series.data = this.addSeriesDS(sData, label);
               }

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -406,12 +406,27 @@ const modules = {
 
   /**
    *
-   * @param targetInfo
+   * @param targetInfo {object}  '{ dataIndex: number, seriesID: string }'
+   * @param chartType {string}  'bar', 'line', 'pie', 'scatter'
+   *
    * @returns {boolean}
    */
-  selectItemByData(targetInfo) {
+  selectItemByData(targetInfo, chartType) {
     this.defaultSelectInfo = targetInfo;
-    const foundInfo = this.getItem(targetInfo, false);
+
+    let foundInfo;
+    if (chartType === 'pie') {
+      foundInfo = {
+        type: 'pie',
+        sId: targetInfo.seriesID,
+      };
+    } else {
+      if (isNaN(targetInfo?.dataIndex)) {
+        return false;
+      }
+
+      foundInfo = this.getItem(targetInfo, false);
+    }
 
     if (foundInfo) {
       this.render(foundInfo);

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -355,7 +355,7 @@ const modules = {
       if (series.findGraphData) {
         const item = series.findGraphData(offset, isHorizontal);
 
-        if (item.data) {
+        if (item?.data) {
           let gdata;
 
           if (item.data.o === null) {

--- a/src/components/chart/plugins/plugins.pie.js
+++ b/src/components/chart/plugins/plugins.pie.js
@@ -10,6 +10,7 @@ const modules = {
     const chartRect = this.chartRect;
     const pieDataSet = this.pieDataSet;
     const pieOption = this.options;
+    const isDoughnut = !!pieOption.doughnutHoleSize;
 
     let slice;
     let value;
@@ -54,14 +55,15 @@ const modules = {
           series = this.seriesList[slice.id];
 
           if (value) {
-            series.draw({
-              ctx,
-              centerX,
-              centerY,
-              radius,
-              startAngle,
-              endAngle,
-            });
+            series.type = isDoughnut ? 'doughnut' : 'pie';
+            series.centerX = centerX;
+            series.centerY = centerY;
+            series.radius = radius;
+            series.startAngle = startAngle;
+            series.endAngle = endAngle;
+            series.data = { o: value };
+
+            series.draw(ctx);
             startAngle += sliceAngle;
           }
         }
@@ -141,14 +143,15 @@ const modules = {
           series = this.seriesList[slice.id];
 
           if (slice.value) {
-            series.draw({
-              ctx,
-              centerX,
-              centerY,
-              radius,
-              startAngle: slice.sa,
-              endAngle: slice.ea,
-            });
+            series.type = 'sunburst';
+            series.centerX = centerX;
+            series.centerY = centerY;
+            series.radius = radius;
+            series.startAngle = slice.sa;
+            series.endAngle = slice.ea;
+            series.data = { o: slice.value };
+
+            series.draw(ctx);
           }
         }
       }
@@ -170,11 +173,9 @@ const modules = {
 
   /**
    * Draw doughnut hole
-   *
-   * @returns {undefined}
+   * @param ctx
    */
-  drawDoughnutHole() {
-    const ctx = this.bufferCtx;
+  drawDoughnutHole(ctx = this.bufferCtx) {
     const pieOption = this.options;
 
     const centerX = this.chartRect.width / 2;

--- a/src/components/chart/plugins/plugins.pie.js
+++ b/src/components/chart/plugins/plugins.pie.js
@@ -188,7 +188,6 @@ const modules = {
 
     const centerX = width / 2;
     const centerY = height / 2;
-
     const chartWidth = centerX - (padding.left + padding.right);
     const chartHeight = centerY - (padding.bottom + padding.top);
     const radius = Math.min(chartWidth, chartHeight) * pieOption.doughnutHoleSize;

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -177,9 +177,11 @@ const modules = {
     const opt = this.options.tooltip;
 
     // draw tooltip Title(axis label) and add style class for wrap line about too much long label.
-    this.tooltipHeaderDOM.textContent = this.options.horizontal
-      ? this.axesY[hitAxis.y].getLabelFormat(hitItem.y)
-      : this.axesX[hitAxis.x].getLabelFormat(hitItem.x);
+    if (this.axesX.length && this.axesY.length) {
+      this.tooltipHeaderDOM.textContent = this.options.horizontal
+        ? this.axesY[hitAxis.y].getLabelFormat(hitItem.y)
+        : this.axesX[hitAxis.x].getLabelFormat(hitItem.x);
+    }
 
     if (opt.textOverflow) {
       this.tooltipHeaderDOM.classList.add(`ev-chart-tooltip-header--${opt.textOverflow}`);
@@ -303,11 +305,18 @@ const modules = {
       // 3. Draw value
       let formattedTxt;
       if (opt.formatter) {
-        formattedTxt = opt.formatter({
-          x: this.options.horizontal ? value : hitItem.x,
-          y: this.options.horizontal ? hitItem.y : value,
-          name,
-        });
+        if (this.options.type === 'pie') {
+          formattedTxt = opt.formatter({
+            value,
+            name,
+          });
+        } else {
+          formattedTxt = opt.formatter({
+            x: this.options.horizontal ? value : hitItem.x,
+            y: this.options.horizontal ? hitItem.y : value,
+            name,
+          });
+        }
       }
 
       if (!opt.formatter || typeof formattedTxt !== 'string') {
@@ -349,7 +358,12 @@ const modules = {
    */
   drawItemsHighlight(hitInfo, ctx) {
     Object.keys(hitInfo.items).forEach((sId) => {
-      this.seriesList[sId].itemHighlight(hitInfo.items[sId], ctx);
+      const series = this.seriesList[sId];
+      series.itemHighlight(hitInfo.items[sId], ctx);
+
+      if (series.type === 'sunburst' || series.type === 'doughnut') {
+        this.drawDoughnutHole(ctx);
+      }
     });
   },
 

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -361,7 +361,7 @@ const modules = {
       const series = this.seriesList[sId];
       series.itemHighlight(hitInfo.items[sId], ctx);
 
-      if (series.type === 'sunburst' || series.type === 'doughnut') {
+      if (Util.isDoughnutHole(series.type)) {
         this.drawDoughnutHole(ctx);
       }
     });

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -107,6 +107,15 @@ export const useModel = () => {
       normalizedOptions.tooltip.use = false;
     }
 
+    if (options.type === 'pie' && !options?.padding) {
+      normalizedOptions.padding = {
+        top: 2,
+        right: 2,
+        left: 2,
+        bottom: 4,
+      };
+}
+
     return normalizedOptions;
   };
   const getNormalizedData = data => defaultsDeep(data, DEFAULT_DATA);


### PR DESCRIPTION
##  주요 작업 내용
1. `click` , `dbl-click` 이벤트 추가 
2.  `selectItem` 옵션 사용 가능하도록 기능 추가 
   - 단 tip 표현은 할 수 없음 
3. 관련 docs 및 example code 작성 
4. chartOption > padding 값이 적용 안되는 현상 픽스 및 기본값 조정 
   - 다른 차트들은 padding-top값이 20이 기본값이지만, pie는 2로 지정함
6. 일부 코드 리팩토링

## 결과
![pie_click](https://user-images.githubusercontent.com/53548023/156527114-22802011-436a-46c5-8749-874c42f570dd.gif)

### Note
- 코드에서 seriesID, sId 등 일부 혼용해서 사용되고 있는 명칭이 있으나 최근 `seriesID` 처럼 full name으로 기재하고자 변경해나가고 있음. 
- 코드 수정범위가 커 조금씩 진행할 예정
