### PR TITLE
[#1086] Grid > Pagination 기능 추가

### DIFF
--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -49,6 +49,16 @@
 |  |  | highlight | 지정한 row에 Highlight 효과를 설정한다. | `rowIndex` |
 |  | customContextMenu | [] | 우클릭시 보여지는 컨텍스트 메뉴를 설정한다. |  |
 |  |  | menuItems | 컨텍스트 메뉴 |  |
+|  | page | {} | 페이지 설정 |  |
+|  |  | use | 페이지 사용 여부 | Boolean |
+|  |  | isInfinite | Infinite Scroll 사용 여부 | Boolean |
+|  |  | useClient | client-side Paging 사용 여부 | Boolean |
+|  |  | total | 총 항목 수 | Number |
+|  |  | perPage | 각 페이지의 항목 수 | Number |
+|  |  | currentPage | 현재 페이지 번호 | Number |
+|  |  | visiblePage | 보여지는 Pagination 버튼 수 | Number |
+|  |  | order | Pagination 위치 | 'center', 'left', 'right' |
+|  |  | showPageInfo | 페이지 정보 표시 여부 | Boolean |
 
 ### Columns
 | 이름 | 타입 | 설명 | 종류 | 필수 |
@@ -63,8 +73,8 @@
 ### Event
 | 이름 | 파라미터 | 설명 |
  | ---- | ------- | ---- |
- | check-row | event | row의 체크박스가 체크 되었을때 호출된다. |
- | check-all | event | 헤더의 체크박스가 체크 되었을때 호출 된다. 전체 row의 체크박스를 체크한다. |
- | click-row | newValue | row가 클릭 되었을 때 호출된다. |
- | dblclick-row | newValue | row가 더블 클릭 되었을 때 호출된다. |
-
+ | check-row | event, row, index | row의 체크박스가 체크 되었을때 호출된다. |
+ | check-all | event, rows | 헤더의 체크박스가 체크 되었을때 호출 된다. 전체 row의 체크박스를 체크한다. |
+ | click-row | event, row | row가 클릭 되었을 때 호출된다. |
+ | dblclick-row | event, row | row가 더블 클릭 되었을 때 호출된다. |
+ | page-change | event | page 정보가 변경되었을 때 호출된다. |

--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -31,7 +31,7 @@
       @check-all="onCheckedRow"
       @click-row="onClickRow"
       @dblclick-row="onDoubleClickRow"
-      @request-data="onRequestData"
+      @page-change="onRequestData"
     >
       <!-- renderer start -->
       <template #user-icon>

--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -289,11 +289,12 @@ export default {
     };
     const getData = (count, startIndex) => {
       const temp = [];
+      const roles = ['Common', 'Admin'];
       for (let ix = startIndex; ix < startIndex + count; ix++) {
         temp.push([
           `user_${ix + 1}`,
           ix + 1,
-          'Common',
+          roles[ix % 2],
           '010-0000-0000',
           'kmn0827@ex-em.com',
           '2020.08.04 14:15',
@@ -312,7 +313,9 @@ export default {
       /* eslint-enable global-require */
     };
     const onRequestData = (e) => {
-      if (e?.scrollEnd && tableData.value.length < 1000) {
+      if (e.eventName?.onSort || e.eventName?.onSearch) {
+        tableData.value = getData(50, 0);
+      } else if (e.eventName?.onScrollEnd && tableData.value.length < 1000) {
         const newData = getData(50, tableData.value.length);
         tableData.value = [
           ...tableData.value,

--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -25,17 +25,13 @@
           border: borderMV,
           highlight: highlightMV,
         },
-        page: {
-          use: true, // pagination
-          dataCount: 50,
-          isInfinite: true, // use && isInfinite === infinite scroll
-        },
+        page: pageInfo,
       }"
       @check-row="onCheckedRow"
       @check-all="onCheckedRow"
       @click-row="onClickRow"
       @dblclick-row="onDoubleClickRow"
-      @scroll-end="requestRowData"
+      @request-data="onRequestData"
     >
       <!-- renderer start -->
       <template #user-icon>
@@ -220,7 +216,7 @@
 </template>
 
 <script>
-import { ref } from 'vue';
+import { ref, reactive, computed } from 'vue';
 
 export default {
   setup() {
@@ -264,7 +260,7 @@ export default {
     ]);
     const columns = ref([
       { caption: '', field: 'user-icon', type: 'string' },
-      { caption: 'Name', field: 'userName', type: 'string', width: 80 },
+      { caption: 'Name', field: 'userName', type: 'stringNumber', width: 80 },
       { caption: 'Role', field: 'role', type: 'string' },
       { caption: 'Phone', field: 'phone', type: 'string', sortable: false },
       { caption: 'Email', field: 'email', type: 'string' },
@@ -315,8 +311,8 @@ export default {
       }
       /* eslint-enable global-require */
     };
-    const requestRowData = () => {
-      if (tableData.value.length < 1000) {
+    const onRequestData = (e) => {
+      if (e?.scrollEnd && tableData.value.length < 1000) {
         const newData = getData(50, tableData.value.length);
         tableData.value = [
           ...tableData.value,
@@ -324,6 +320,13 @@ export default {
         ];
       }
     };
+    const pageInfo = reactive({
+      use: true,
+      isInfinite: true,
+      perPage: 50,
+      total: computed(() => tableData.value.length),
+      useClient: true,
+    });
 
     tableData.value = getData(50, 0);
     return {
@@ -349,13 +352,14 @@ export default {
       highlightMV,
       borderMV,
       items,
+      pageInfo,
       changeMode,
       onCheckedRow,
       onDoubleClickRow,
       onClickRow,
       resetBorderStyle,
       loadImage,
-      requestRowData,
+      onRequestData,
     };
   },
 };

--- a/docs/views/grid/example/Toolbar.vue
+++ b/docs/views/grid/example/Toolbar.vue
@@ -19,16 +19,17 @@
           headerCheck: headerCheckMV,
         },
         searchValue: searchVm,
-        // customContextMenu: menuItems,
         style: {
           stripe: stripeMV,
           border: borderMV,
         },
+        page: pageInfo,
       }"
       @check-row="onCheckedRow"
       @check-all="onCheckedRow"
       @click-row="onClickRow"
       @dblclick-row="onDoubleClickRow"
+      @request-data="onRequestData"
     >
       <!-- toolbar -->
       <template #toolbar="{ item }">
@@ -95,11 +96,43 @@
         />
       </template>
     </ev-grid>
+    <div class="description">
+      <div class="form-rows">
+        <div class="form-row">
+          <span class="badge yellow">Current Page</span>
+          <ev-input-number v-model="pageInfo.currentPage" :min="1"/>
+        </div>
+        <div class="form-row">
+          <span class="badge yellow">Visible Page</span>
+          <ev-input-number v-model="pageInfo.visiblePage" :min="7"/>
+        </div>
+      </div>
+      <div class="form-rows">
+        <div class="form-row">
+          <span class="badge yellow">Order</span>
+          <ev-select
+            v-model="pageInfo.order"
+            :items="orderItems"
+            placeholder="Please select value."
+          />
+        </div>
+        <div class="form-row">
+          <span class="badge yellow">Data per page</span>
+          <ev-input-number v-model="pageInfo.perPage" />
+        </div>
+      </div>
+      <div class="form-rows">
+        <div class="form-row">
+          <span class="badge yellow">Page Info</span>
+          <ev-toggle v-model="pageInfo.showPageInfo"/>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
-import { ref } from 'vue';
+import { ref, reactive, computed } from 'vue';
 
 export default {
   setup() {
@@ -138,7 +171,7 @@ export default {
       { caption: 'IP Address', field: 'ip_address', type: 'string', searchable: false }, // searchable
       { caption: 'RTS Port', field: 'rts_port', type: 'stringNumber' },
       { caption: 'DB Version', field: 'db-version', type: 'string' },
-      { caption: 'Lock', field: 'is_lock', type: 'boolean' },
+      { caption: 'Lock', field: 'is_lock', type: 'boolean', searchable: false },
     ]);
     const onCheckedRow = () => {
       let checkedRow = '';
@@ -171,9 +204,9 @@ export default {
       for (let ix = startIndex; ix < startIndex + count; ix++) {
         temp.push([
           dbList[ix % 4],
-          instanceList[ix],
-          instanceList[ix],
-          IPList[ix],
+          instanceList[ix % 12],
+          instanceList[ix % 12],
+          IPList[ix % 12],
           portList[ix % 3],
           dbVersionList[ix % 5],
           isLock[ix % 2],
@@ -184,10 +217,28 @@ export default {
     const onClickCustom = () => {
       searchVm.value = '2016';
     };
-    getData(7, 0);
+    const pageInfo = reactive({
+      use: true,
+      visiblePage: 7,
+      currentPage: 3,
+      perPage: 7,
+      order: 'center',
+      showPageInfo: true,
+      total: computed(() => tableData.value.length),
+      useClient: true,
+    });
+    getData(30, 0);
     const onClickAdd = () => {
       tableData.value.push(['oracle', 'LIN12G', 'LIN12G', '10.10.30.10', '2016']);
     };
+    const onRequestData = (e) => {
+      pageInfo.currentPage = e.pageInfo.currentPage;
+    };
+    const orderItems = ref([
+      { name: 'left', value: 'left' },
+      { name: 'right', value: 'right' },
+      { name: 'center', value: 'center' },
+    ]);
     return {
       columns,
       tableData,
@@ -210,36 +261,32 @@ export default {
       menuItems,
       borderMV,
       searchVm,
+      orderItems,
+      pageInfo,
       onCheckedRow,
       onDoubleClickRow,
       onClickRow,
       onClickCustom,
       onClickAdd,
+      onRequestData,
     };
   },
 };
 </script>
 
 <style lang="scss" scoped>
-.description {
-  min-width: 200px;
-}
 .form-rows {
   display: flex;
-  margin-bottom: 5px;
 }
 .form-row {
-  width: 50%;
-}
-.ev-text-field, .ev-input-number, .ev-select {
-  width: 80%;
-}
-.badge {
-  margin-bottom: 2px;
-  margin-right: 5px !important;
+  flex: 1;
+  margin: 5px;
+  .badge {
+    margin-bottom: 3px;
+  }
 }
 .ev-toggle {
-  margin-right: 10px;
+  display: block;
 }
 .db-icon {
   width: 100%;

--- a/docs/views/grid/example/Toolbar.vue
+++ b/docs/views/grid/example/Toolbar.vue
@@ -100,11 +100,17 @@
       <div class="form-rows">
         <div class="form-row">
           <span class="badge yellow">Current Page</span>
-          <ev-input-number v-model="pageInfo.currentPage" :min="1"/>
+          <ev-input-number
+            v-model="pageInfo.currentPage"
+            :min="1"
+          />
         </div>
         <div class="form-row">
           <span class="badge yellow">Visible Page</span>
-          <ev-input-number v-model="pageInfo.visiblePage" :min="7"/>
+          <ev-input-number
+            v-model="pageInfo.visiblePage"
+            :min="7"
+          />
         </div>
       </div>
       <div class="form-rows">
@@ -118,7 +124,10 @@
         </div>
         <div class="form-row">
           <span class="badge yellow">Data per page</span>
-          <ev-input-number v-model="pageInfo.perPage" />
+          <ev-input-number
+            v-model="pageInfo.perPage"
+            :min="1"
+          />
         </div>
       </div>
       <div class="form-rows">

--- a/docs/views/grid/example/Toolbar.vue
+++ b/docs/views/grid/example/Toolbar.vue
@@ -29,7 +29,7 @@
       @check-all="onCheckedRow"
       @click-row="onClickRow"
       @dblclick-row="onDoubleClickRow"
-      @request-data="onRequestData"
+      @page-change="onRequestData"
     >
       <!-- toolbar -->
       <template #toolbar="{ item }">

--- a/docs/views/pagination/example/Default.vue
+++ b/docs/views/pagination/example/Default.vue
@@ -5,7 +5,7 @@
       :total="total"
       :per-page="perPage"
       :visible-page="visiblePage"
-      :page-info="isPageInfo"
+      :show-page-info="isPageInfo"
       :order="order"
     >
     </ev-pagination>
@@ -17,7 +17,10 @@
         </div>
         <div class="form-row">
           <span class="badge yellow">Visible Page</span>
-          <ev-input-number v-model="visiblePage" />
+          <ev-input-number
+            v-model="visiblePage"
+            :min="7"
+          />
         </div>
       </div>
       <div class="form-rows">

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -322,7 +322,7 @@ export default {
     'update:checked': null,
     'check-row': null,
     'check-all': null,
-    'request-data': null,
+    'page-change': null,
   },
   setup(props) {
     const {

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -323,6 +323,9 @@ export default {
     'page-change': null,
   },
   setup(props) {
+    const ROW_INDEX = 0;
+    const ROW_CHECK_INDEX = 1;
+    const ROW_DATA_INDEX = 2;
     const {
       isRenderer,
       getComponentName,
@@ -425,6 +428,14 @@ export default {
       gridWidth: computed(() => (props.width ? setPixelUnit(props.width) : '100%')),
       gridHeight: computed(() => (props.height ? setPixelUnit(props.height) : '100%')),
     });
+    const clearCheckInfo = () => {
+      checkInfo.checkedRows = [];
+      checkInfo.checkedIndex.clear();
+      checkInfo.isHeaderChecked = false;
+      stores.store.forEach((row) => {
+        row[ROW_CHECK_INDEX] = false;
+      });
+    };
     const {
       getPagingData,
       updatePagingInfo,
@@ -435,6 +446,7 @@ export default {
       sortInfo,
       filterInfo,
       elementInfo,
+      clearCheckInfo,
     });
 
     const {
@@ -525,17 +537,6 @@ export default {
     onActivated(() => {
       onResize();
     });
-    const ROW_INDEX = 0;
-    const ROW_CHECK_INDEX = 1;
-    const ROW_DATA_INDEX = 2;
-    const clearCheckInfo = () => {
-      checkInfo.checkedRows = [];
-      checkInfo.checkedIndex.clear();
-      checkInfo.isHeaderChecked = false;
-      stores.store.forEach((row) => {
-        row[ROW_CHECK_INDEX] = false;
-      });
-    };
     watch(
       () => props.columns,
       () => {
@@ -550,6 +551,11 @@ export default {
         if (value) {
           setStore(stores.originStore, false);
           sortInfo.isSorting = !value;
+          if (pageInfo.isClientPaging) {
+            pageInfo.currentPage = 1;
+            stores.pagingStore = getPagingData();
+            clearCheckInfo();
+          }
         }
       },
     );

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -1,259 +1,270 @@
 <template>
-  <div
-    v-if="!!$slots.toolbar"
-    class="toolbar-wrapper"
-    :style="`width: ${gridWidth};`"
-  >
-    <!-- Toolbar -->
-    <toolbar v-if="!!$slots.toolbar" >
-      <template #toolbarWrapper>
-        <slot
-          name="toolbar"
-          :item="{ onSearch: onSearch }"
-        >
-        </slot>
-      </template>
-    </toolbar>
-  </div>
-  <div
-    ref="grid-wrapper"
-    v-resize="onResize"
-    v-observe-visibility="{
-      callback: onShow,
-      once: true,
-    }"
-    v-bind="$attrs"
-    class="grid-wrapper"
-    :style="`width: ${gridWidth}; height: ${gridHeight};`"
-  >
-    <!--Table-->
+  <div>
     <div
-      v-cloak
-      ref="grid"
-      :class="{
-        'ev-grid': true,
-        table: true,
-        adjust: adjust,
-        'non-header': !showHeader,
-      }"
+      v-if="$slots.toolbar"
+      class="toolbar-wrapper"
+      :style="`width: ${gridWidth};`"
     >
-      <!--Header-->
+      <!-- Toolbar -->
+      <toolbar>
+        <template #toolbarWrapper>
+          <slot
+            name="toolbar"
+            :item="{ onSearch: onSearch }"
+          />
+        </template>
+      </toolbar>
+    </div>
+    <div
+      ref="grid-wrapper"
+      v-resize="onResize"
+      v-observe-visibility="{
+        callback: onShow,
+        once: true,
+      }"
+      v-bind="$attrs"
+      class="grid-wrapper"
+      :style="`width: ${gridWidth}; height: ${gridHeight};`"
+    >
+      <!-- Table -->
       <div
-        v-show="showHeader"
-        ref="header"
+        v-cloak
+        ref="grid"
         :class="{
-          'table-header': true,
-          'non-border': !!borderStyle,
+          'ev-grid': true,
+          table: true,
+          adjust: adjust,
+          'non-header': !showHeader,
         }"
       >
-        <ul class="column-list">
-          <!--Header Checkbox-->
-          <li
-            v-if="useCheckbox.use"
-            :class="{
-              'column': true,
-              'non-border': !!borderStyle,
-            }"
-            :style="`width: ${minWidth}px;`"
-          >
-            <ev-checkbox
-              v-if="useCheckbox.use
-                && useCheckbox.headerCheck
-                && useCheckbox.mode !== 'single'"
-              v-model="isHeaderChecked"
-              @change="onCheckAll"
-            />
-          </li>
-          <!--Column List-->
-          <template
-            v-for="(column, index) in orderedColumns"
-            :key="index"
-          >
-            <li
-              v-if="!column.hide"
-              :data-index="index"
-              :class="{
-                column: true,
-                render: isRenderer(column),
-                'non-border': !!borderStyle,
-                [column.field]: column.field,
-              }"
-              :style="`
-                width: ${column.width}px;
-                min-width: ${isRenderer(column) ? rendererMinWidth : minWidth}px;`"
-            >
-              <!--Filter Status-->
-              <span
-                v-if="isFiltering && filterList[column.field]?.find(item => item.use)"
-                class="column-filter-status"
-              >
-                <ev-icon icon="ev-icon-filter"/>
-              </span>
-              <!--Column Name-->
-              <span
-                :title="column.caption"
-                class="column-name"
-                @click.stop="onSort(column)"
-              >
-                {{ column.caption }}
-              </span>
-              <!--Sort Icon-->
-              <template v-if="sortField === column.field">
-                <ev-icon
-                  v-if="sortOrder === 'desc'"
-                  icon="ev-icon-triangle-down"
-                />
-                <ev-icon
-                  v-if="sortOrder === 'asc'"
-                  icon="ev-icon-triangle-up"
-                />
-              </template>
-              <!--Filter Button-->
-              <span
-                v-if="isFilterButton(column.field)"
-                class="column-filter"
-                @click.capture="onClickFilter(column)"
-              >
-                <ev-icon icon="ev-icon-hamburger2"/>
-              </span>
-              <!--Column Resize-->
-              <span
-                class="column-resize"
-                @mousedown.stop.left="onColumnResize(index, $event)"
-              />
-            </li>
-          </template>
-        </ul>
-      </div>
-      <!--Body-->
-      <div
-        ref="body"
-        :class="{
-          'table-body': true,
-          'bottom-border': !!viewStore.length,
-          stripe: stripeStyle,
-          'non-border': !!borderStyle,
-        }"
-        @scroll="onScroll"
-        @contextmenu="onContextMenu($event)"
-        @contextmenu.prevent="menu.show"
-      >
-        <!--vScroll Top-->
+        <!-- Header -->
         <div
-          :style="`height: ${vScrollTopHeight}px;`"
-          class="vscroll-spacer"
-        />
-        <table>
-          <tbody>
-          <!--Row List-->
-          <tr
-            v-for="(row, rowIndex) in viewStore"
-            :key="rowIndex"
-            :data-index="row[0]"
-            :class="{
-              row: true,
-              selected: row[2] === selectedRow,
-              'non-border': !!borderStyle && borderStyle !== 'rows',
-              highlight: row[0] === highlightIdx,
-            }"
-            @click="onRowClick($event, row)"
-            @dblclick="onRowDblClick($event, row)"
-          >
-            <!--Row Checkbox-->
-            <td
+          v-show="showHeader"
+          ref="header"
+          :class="{
+            'table-header': true,
+            'non-border': !!borderStyle,
+          }"
+        >
+          <ul class="column-list">
+            <!-- Header Checkbox -->
+            <li
               v-if="useCheckbox.use"
               :class="{
-                cell: true,
-                'row-checkbox': true,
+                'column': true,
                 'non-border': !!borderStyle,
               }"
-              :style="`width: ${minWidth}px; height: ${rowHeight}px;`"
+              :style="`width: ${minWidth}px;`"
             >
               <ev-checkbox
-                v-model="row[1]"
-                class="row-checkbox-input"
-                @change="onCheck($event, row)"
+                v-if="useCheckbox.use && useCheckbox.headerCheck && useCheckbox.mode !== 'single'"
+                v-model="isHeaderChecked"
+                @change="onCheckAll"
               />
-            </td>
-            <!--Cell-->
-            <template v-for="(column, cellIndex) in orderedColumns" :key="cellIndex">
-              <td
+            </li>
+            <!-- Column List -->
+            <template
+              v-for="(column, index) in orderedColumns"
+              :key="index"
+            >
+              <li
                 v-if="!column.hide"
-                :data-name="column.field"
-                :data-index="column.index"
+                :data-index="index"
                 :class="{
-                  cell: true,
-                  [column.type]: column.type,
-                  [column.align]: column.align,
+                  column: true,
                   render: isRenderer(column),
                   'non-border': !!borderStyle,
                   [column.field]: column.field,
                 }"
-                :style="`
-                  width: ${column.width}px;
-                  height: ${rowHeight}px;
-                  line-height: ${rowHeight}px;
-                  min-width: ${isRenderer(column) ? rendererMinWidth : minWidth}px;`"
+                :style="{
+                  width: `${column.width}px`,
+                  'min-width': `${isRenderer(column) ? rendererMinWidth : minWidth}px`,
+                }"
               >
-                <!-- cell renderer -->
-                <template v-if="!!$slots[column.field]">
-                  <slot
-                    :name="column.field"
-                    :item="{
-                      row,
-                      column,
+                <!-- Filter Status -->
+                <span
+                  v-if="isFiltering && filterList[column.field]?.find(item => item.use)"
+                  class="column-filter-status"
+                >
+                  <ev-icon icon="ev-icon-filter"/>
+                </span>
+                <!-- Column Name -->
+                <span
+                  :title="column.caption"
+                  class="column-name"
+                  @click.stop="onSort(column)"
+                >
+                  {{ column.caption }}
+                </span>
+                <!-- Sort Icon -->
+                <template v-if="sortField === column.field">
+                  <ev-icon
+                    v-if="sortOrder === 'desc'"
+                    icon="ev-icon-triangle-down"
+                  />
+                  <ev-icon
+                    v-if="sortOrder === 'asc'"
+                    icon="ev-icon-triangle-up"
+                  />
+                </template>
+                <!-- Filter Button -->
+                <span
+                  v-if="isFilterButton(column.field)"
+                  class="column-filter"
+                  @click.capture="onClickFilter(column)"
+                >
+                  <ev-icon icon="ev-icon-hamburger2"/>
+                </span>
+                <!-- Column Resize -->
+                <span
+                  class="column-resize"
+                  @mousedown.stop.left="onColumnResize(index, $event)"
+                />
+              </li>
+            </template>
+          </ul>
+        </div>
+        <!-- Body -->
+        <div
+          ref="body"
+          :class="{
+            'table-body': true,
+            'bottom-border': !!viewStore.length,
+            stripe: stripeStyle,
+            'non-border': !!borderStyle,
+          }"
+          @scroll="onScroll"
+          @contextmenu="onContextMenu($event)"
+          @contextmenu.prevent="menu.show"
+        >
+          <!-- vScroll Top -->
+          <div
+            :style="`height: ${vScrollTopHeight}px;`"
+            class="vscroll-spacer"
+          />
+          <table>
+            <tbody>
+              <!-- Row List -->
+              <tr
+                v-for="(row, rowIndex) in viewStore"
+                :key="rowIndex"
+                :data-index="row[0]"
+                :class="{
+                  row: true,
+                  selected: row[2] === selectedRow,
+                  'non-border': !!borderStyle && borderStyle !== 'rows',
+                  highlight: row[0] === highlightIdx,
+                }"
+                @click="onRowClick($event, row)"
+                @dblclick="onRowDblClick($event, row)"
+              >
+                <!-- Row Checkbox -->
+                <td
+                  v-if="useCheckbox.use"
+                  :class="{
+                    cell: true,
+                    'row-checkbox': true,
+                    'non-border': !!borderStyle,
+                  }"
+                  :style="`width: ${minWidth}px; height: ${rowHeight}px;`"
+                >
+                  <ev-checkbox
+                    v-model="row[1]"
+                    class="row-checkbox-input"
+                    @change="onCheck($event, row)"
+                  />
+                </td>
+                <!-- Cell -->
+                <template
+                  v-for="(column, cellIndex) in orderedColumns"
+                  :key="cellIndex"
+                >
+                  <td
+                    v-if="!column.hide"
+                    :data-name="column.field"
+                    :data-index="column.index"
+                    :class="{
+                      cell: true,
+                      [column.type]: column.type,
+                      [column.align]: column.align,
+                      render: isRenderer(column),
+                      'non-border': !!borderStyle,
+                      [column.field]: column.field,
+                    }"
+                    :style="{
+                      width: `${column.width}px`,
+                      height: `${rowHeight}px`,
+                      'line-height': `${rowHeight}px`,
+                      'min-width': `${isRenderer(column) ? rendererMinWidth : minWidth}px`,
                     }"
                   >
-                  </slot>
+                    <!-- Cell Renderer -->
+                    <template v-if="!!$slots[column.field]">
+                      <slot
+                        :name="column.field"
+                        :item="{ row, column }"
+                      />
+                    </template>
+                    <!-- Cell Value -->
+                    <template v-else>
+                      <div :title="getConvertValue(column.type, row[2][column.index])">
+                        {{ getConvertValue(column.type, row[2][column.index]) }}
+                      </div>
+                    </template>
+                  </td>
                 </template>
-                <!-- cell value -->
-                <template v-else>
-                  <div :title="getConvertValue(column.type, row[2][column.index])">
-                    {{ getConvertValue(column.type, row[2][column.index]) }}
-                  </div>
-                </template>
-              </td>
-            </template>
-          </tr>
-          <tr v-if="!viewStore.length">
-            <td class="is-empty">No records</td>
-          </tr>
-          </tbody>
-        </table>
-        <!--vScroll Bottom-->
+              </tr>
+              <tr v-if="!viewStore.length">
+                <td class="is-empty">No records</td>
+              </tr>
+            </tbody>
+          </table>
+          <!-- vScroll Bottom -->
+          <div
+            :style="`height: ${vScrollBottomHeight}px;`"
+            class="vscroll-spacer"
+          />
+          <!-- Context Menu -->
+          <ev-context-menu
+            ref="menu"
+            :items="contextMenuItems"
+          />
+        </div>
+        <!-- Resize Line -->
         <div
-          :style="`height: ${vScrollBottomHeight}px;`"
-          class="vscroll-spacer"
+          v-show="showResizeLine"
+          ref="resizeLine"
+          class="table-resize-line"
         />
-        <!--Context Menu-->
-        <ev-context-menu
-          ref="menu"
-          :items="contextMenuItems"
+        <!-- Filter Window -->
+        <filter-window
+          v-show="showFilterWindow"
+          :is-show="showFilterWindow"
+          :target-column="currentFilter.column"
+          :filter-items="currentFilter.items"
+          @apply-filter="onApplyFilter"
+          @before-close="onCloseFilterWindow"
         />
       </div>
-      <!--Resize Line-->
-      <div
-        v-show="showResizeLine"
-        ref="resizeLine"
-        class="table-resize-line"
-      />
-      <!--Filter Window-->
-      <filter-window
-        v-show="showFilterWindow"
-        :is-show="showFilterWindow"
-        :target-column="currentFilter.column"
-        :filter-items="currentFilter.items"
-        @apply-filter="onApplyFilter"
-        @before-close="onCloseFilterWindow"
-      />
     </div>
+    <pagination
+      v-if="usePage && !isInfinite"
+      v-model="currentPage"
+      :total="store.length"
+      :per-page="perPage"
+      :visible-page="visiblePage"
+      :show-page-info="showPageInfo"
+      :order="order"
+    >
+    </pagination>
   </div>
 </template>
 
 <script>
-import { reactive, toRefs, computed, watch, onMounted, onActivated } from 'vue';
-import FilterWindow from './grid.filter.window';
+import { reactive, toRefs, computed, watch, onMounted, onActivated, nextTick } from 'vue';
 import Toolbar from './grid.toolbar';
+import Pagination from './grid.pagination';
+import FilterWindow from './grid.filter.window';
 import {
   commonFunctions,
   scrollEvent,
@@ -264,13 +275,15 @@ import {
   filterEvent,
   contextMenuEvent,
   storeEvent,
+  pagingEvent,
 } from './uses';
 
 export default {
   name: 'EvGrid',
   components: {
-    FilterWindow,
     Toolbar,
+    Pagination,
+    FilterWindow,
   },
   props: {
     columns: {
@@ -309,7 +322,7 @@ export default {
     'update:checked': null,
     'check-row': null,
     'check-all': null,
-    'scroll-end': null,
+    'request-data': null,
   },
   setup(props) {
     const {
@@ -348,12 +361,28 @@ export default {
       viewStore: [],
       originStore: [],
       filterStore: [],
+      pagingStore: [],
       store: computed(() => {
         const store = filterInfo.isFiltering ? stores.filterStore : stores.originStore;
         return filterInfo.isSearch ? stores.searchStore : store;
       }),
       orderedColumns: computed(() =>
         (props.columns.map((column, index) => ({ index, ...column })))),
+    });
+    const pageInfo = reactive({
+      usePage: computed(() => (props.option.page?.use || false)),
+      useClient: props.option.page?.useClient || false,
+      isInfinite: computed(() => (props.option.page?.isInfinite || false)),
+      startIndex: 0,
+      prevPage: 0,
+      currentPage: 0,
+      total: computed(() => (props.option.page?.total || 0)),
+      perPage: computed(() => (props.option.page?.perPage || 20)),
+      visiblePage: computed(() => (props.option.page?.visiblePage || 8)),
+      order: computed(() => (props.option.page?.order || 'center')),
+      showPageInfo: computed(() => (props.option.page?.showPageInfo || false)),
+      isClientPaging: computed(() =>
+        pageInfo.useClient && pageInfo.usePage && !pageInfo.isInfinite),
     });
     const checkInfo = reactive({
       prevCheckedRow: [],
@@ -398,20 +427,24 @@ export default {
       gridWidth: computed(() => (props.width ? setPixelUnit(props.width) : '100%')),
       gridHeight: computed(() => (props.height ? setPixelUnit(props.height) : '100%')),
     });
-    const pageInfo = reactive({
-      currentPage: 1,
-      prevPage: 0,
-      startIndex: 0,
-      use: computed(() => (props.option.page?.use || false)),
-      dataCount: computed(() => (props.option.page?.dataCount || 50)),
-      isInfinite: computed(() => (props.option.page?.isInfinite || false)),
-    });
+    const {
+      getPagingData,
+      updatePagingInfo,
+    } = pagingEvent({ stores, pageInfo, sortInfo, filterInfo });
 
     const {
       updateVScroll,
       updateHScroll,
       onScroll,
-    } = scrollEvent({ scrollInfo, stores, elementInfo, resizeInfo, pageInfo });
+    } = scrollEvent({
+      scrollInfo,
+      stores,
+      elementInfo,
+      resizeInfo,
+      pageInfo,
+      getPagingData,
+      updatePagingInfo,
+    });
 
     const {
       onRowClick,
@@ -421,12 +454,12 @@ export default {
     const {
       onCheck,
       onCheckAll,
-    } = checkEvent({ checkInfo, stores, filterInfo });
+    } = checkEvent({ checkInfo, stores, pageInfo, getPagingData, updatePagingInfo });
 
     const {
       onSort,
       setSort,
-    } = sortEvent({ sortInfo, stores, getColumnIndex });
+    } = sortEvent({ sortInfo, stores, getColumnIndex, updatePagingInfo });
 
     const {
       onClickFilter,
@@ -438,14 +471,16 @@ export default {
       filterInfo,
       stores,
       checkInfo,
+      pageInfo,
       getColumnIndex,
       getConvertValue,
       updateVScroll,
+      getPagingData,
+      updatePagingInfo,
     });
 
     const {
       setStore,
-      updateData,
     } = storeEvent({
       selectInfo,
       checkInfo,
@@ -463,7 +498,15 @@ export default {
       onResize,
       onShow,
       onColumnResize,
-    } = resizeEvent({ resizeInfo, elementInfo, checkInfo, stores, isRenderer, updateVScroll });
+    } = resizeEvent({
+      resizeInfo,
+      elementInfo,
+      checkInfo,
+      stores,
+      filterInfo,
+      isRenderer,
+      updateVScroll,
+    });
 
     const {
       setContextMenu,
@@ -526,7 +569,10 @@ export default {
         checkInfo.checkedRows = checkedList;
         checkInfo.isHeaderChecked = false;
         checkInfo.checkedIndex.clear();
-        const store = stores.store;
+        let store = stores.store;
+        if (pageInfo.isClientPaging) {
+          store = getPagingData();
+        }
         if (store.length) {
           store.forEach((row) => {
             row[ROW_CHECK_INDEX] = checkedList.includes(row[ROW_DATA_INDEX]);
@@ -591,9 +637,42 @@ export default {
         if (value !== undefined) {
           onSearch(value?.value ?? value);
         }
-      }, { immediate: true, deep: true },
+      }, { immediate: true },
     );
-    const isFilterButton = field => filterInfo.isFiltering && field !== 'db-icon' && field !== 'user-icon';
+    const isFilterButton = field => filterInfo.isFiltering
+      && field !== 'db-icon'
+      && field !== 'user-icon';
+    watch(
+      () => props.option.page?.currentPage,
+      (value) => {
+        const current = value <= 0 ? 1 : value;
+        pageInfo.currentPage = !props.option.page?.isInfinite ? current : 1;
+      }, { immediate: true },
+    );
+    watch(
+      () => [pageInfo.currentPage, pageInfo.perPage],
+      (currentVal, beforeVal) => {
+        nextTick(() => {
+          if (pageInfo.isClientPaging) {
+            pageInfo.prevPage = beforeVal[0];
+            if (stores.store.length <= pageInfo.perPage) {
+              stores.pagingStore = stores.store;
+            } else {
+              const start = (currentVal[0] - 1) * pageInfo.perPage;
+              const end = parseInt(start, 10) + parseInt(pageInfo.perPage, 10);
+              stores.pagingStore = stores.store.slice(start, end);
+              elementInfo.body.scrollTop = 0;
+              pageInfo.startIndex = start;
+            }
+            checkInfo.isHeaderChecked = stores.pagingStore.length
+              && stores.pagingStore.every(d => d[ROW_CHECK_INDEX]);
+          }
+          updatePagingInfo();
+
+          updateVScroll();
+        });
+      },
+    );
     return {
       showHeader,
       stripeStyle,
@@ -632,7 +711,6 @@ export default {
       onApplyFilter,
       setFilter,
       setStore,
-      updateData,
       setContextMenu,
       onContextMenu,
       onSearch,

--- a/src/components/grid/grid.filter.window.vue
+++ b/src/components/grid/grid.filter.window.vue
@@ -115,6 +115,7 @@
 import { ref, reactive, toRefs, watch, computed } from 'vue';
 
 export default {
+  name: 'EvGridFilterWindow',
   props: {
     /**
      * 필터 팝업 표시 유무

--- a/src/components/grid/grid.pagination.vue
+++ b/src/components/grid/grid.pagination.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="grid-pagination">
+    <ev-pagination
+      v-model="currentValue"
+      :total="total"
+      :per-page="perPage"
+      :visible-page="visiblePage"
+      :show-page-info="showPageInfo"
+      :order="order"
+      @change="changePage"
+    >
+    </ev-pagination>
+  </div>
+</template>
+
+<script>
+import { ref, watch } from 'vue';
+
+export default {
+  name: 'EvGridPagination',
+  props: {
+    total: {
+      type: [Number, String],
+      default: 0,
+    },
+    visiblePage: {
+      type: [Number, String],
+      default: 8,
+    },
+    perPage: {
+      type: [Number, String],
+      default: 20,
+    },
+    modelValue: {
+      type: [Number, String],
+      default: 1,
+    },
+    showPageInfo: {
+      type: Boolean,
+      default: false,
+    },
+    order: {
+      type: String,
+      default: 'left',
+      validator: val => ['left', 'right', 'center'].includes(val),
+    },
+  },
+  emits: {
+    'update:modelValue': null,
+  },
+  setup(props, { emit }) {
+    const currentValue = ref(props.modelValue);
+    const changePage = (page) => {
+      currentValue.value = page > 0 ? page : 1;
+      emit('update:modelValue', currentValue.value);
+    };
+    watch(
+      () => props.modelValue,
+      (value) => {
+        currentValue.value = value;
+      },
+    );
+    return {
+      currentValue,
+      changePage,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.grid-pagination {
+  padding-top: 8px;
+}
+</style>

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -935,6 +935,7 @@ export const pagingEvent = (params) => {
     sortInfo,
     filterInfo,
     elementInfo,
+    clearCheckInfo,
   } = params;
   const getPagingData = () => {
     const start = (pageInfo.currentPage - 1) * pageInfo.perPage;
@@ -965,6 +966,7 @@ export const pagingEvent = (params) => {
     if (pageInfo.isInfinite && (eventName?.onSearch || eventName?.onSort)) {
       pageInfo.currentPage = 1;
       elementInfo.body.scrollTop = 0;
+      clearCheckInfo();
     }
   };
   const changePage = (beforeVal) => {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -68,8 +68,15 @@ export const commonFunctions = () => {
 };
 
 export const scrollEvent = (params) => {
-  const { emit } = getCurrentInstance();
-  const { scrollInfo, stores, elementInfo, resizeInfo, pageInfo } = params;
+  const {
+    scrollInfo,
+    stores,
+    elementInfo,
+    resizeInfo,
+    pageInfo,
+    getPagingData,
+    updatePagingInfo,
+  } = params;
   /**
    * 수직 스크롤의 위치 계산 후 적용한다.
    */
@@ -77,11 +84,15 @@ export const scrollEvent = (params) => {
     const bodyEl = elementInfo.body;
     const rowHeight = resizeInfo.rowHeight;
     if (bodyEl) {
+      let store = stores.store;
+      if (pageInfo.isClientPaging) {
+        store = getPagingData();
+      }
       const rowCount = bodyEl.clientHeight > rowHeight
-        ? Math.ceil(bodyEl.clientHeight / rowHeight) : stores.store.length;
-      const totalScrollHeight = stores.store.length * rowHeight;
+        ? Math.ceil(bodyEl.clientHeight / rowHeight) : store.length;
+      const totalScrollHeight = store.length * rowHeight;
       let firstVisibleIndex = Math.floor(bodyEl.scrollTop / rowHeight);
-      if (firstVisibleIndex > stores.store.length - 1) {
+      if (firstVisibleIndex > store.length - 1) {
         firstVisibleIndex = 0;
       }
 
@@ -89,20 +100,16 @@ export const scrollEvent = (params) => {
       const firstIndex = Math.max(firstVisibleIndex, 0);
       const lastIndex = lastVisibleIndex;
 
-      stores.viewStore = stores.store.slice(firstIndex, lastIndex);
-      scrollInfo.hasVerticalScrollBar = rowCount < stores.store.length;
+      stores.viewStore = store.slice(firstIndex, lastIndex);
+      scrollInfo.hasVerticalScrollBar = rowCount < store.length;
       scrollInfo.vScrollTopHeight = firstIndex * rowHeight;
       scrollInfo.vScrollBottomHeight = totalScrollHeight - (stores.viewStore.length * rowHeight)
         - scrollInfo.vScrollTopHeight;
-      if (scrollInfo.vScrollBottomHeight === 0) {
+      if (pageInfo.isInfinite && scrollInfo.vScrollBottomHeight === 0) {
         pageInfo.prevPage = pageInfo.currentPage;
-        pageInfo.currentPage = Math.ceil(lastIndex / pageInfo.dataCount) + 1;
-        emit('scroll-end', {
-          startIndex: lastIndex,
-          dataCount: pageInfo.dataCount,
-          prevPage: pageInfo.prevPage,
-          currentPage: pageInfo.currentPage,
-        });
+        pageInfo.currentPage = Math.ceil(lastIndex / pageInfo.perPage) + 1;
+        pageInfo.startIndex = lastIndex;
+        updatePagingInfo();
       }
     }
   };
@@ -383,7 +390,7 @@ export const clickEvent = (params) => {
 };
 
 export const checkEvent = (params) => {
-  const { checkInfo, stores } = params;
+  const { checkInfo, stores, pageInfo, getPagingData } = params;
   const { emit } = getCurrentInstance();
   /**
    * row에 대한 체크 상태를 해제한다.
@@ -419,7 +426,10 @@ export const checkEvent = (params) => {
       }
       checkInfo.checkedIndex.add(row[ROW_INDEX]);
 
-      const store = stores.store;
+      let store = stores.store;
+      if (pageInfo.isClientPaging) {
+        store = getPagingData();
+      }
       const isAllChecked = store.every(d => d[ROW_CHECK_INDEX]);
       if (store.length && isAllChecked) {
         checkInfo.isHeaderChecked = true;
@@ -445,7 +455,10 @@ export const checkEvent = (params) => {
    */
   const onCheckAll = (event) => {
     const isHeaderChecked = checkInfo.isHeaderChecked;
-    const store = stores.store;
+    let store = stores.store;
+    if (pageInfo.isClientPaging) {
+      store = getPagingData();
+    }
     store.forEach((row) => {
       if (isHeaderChecked) {
         if (!checkInfo.checkedRows.includes(row[ROW_DATA_INDEX])) {
@@ -467,7 +480,7 @@ export const checkEvent = (params) => {
 };
 
 export const sortEvent = (params) => {
-  const { sortInfo, stores, getColumnIndex } = params;
+  const { sortInfo, stores, getColumnIndex, updatePagingInfo } = params;
   const { props } = getCurrentInstance();
   function OrderQueue() {
     this.orders = ['asc', 'desc', 'init'];
@@ -491,6 +504,7 @@ export const sortEvent = (params) => {
       order.enqueue(sortInfo.sortOrder);
 
       sortInfo.isSorting = true;
+      updatePagingInfo();
     }
   };
   /**
@@ -548,9 +562,12 @@ export const filterEvent = (params) => {
     filterInfo,
     stores,
     checkInfo,
+    pageInfo,
     getColumnIndex,
     getConvertValue,
     updateVScroll,
+    getPagingData,
+    updatePagingInfo,
   } = params;
   /**
    * 해당 컬럼에 대한 필터 팝업을 보여준다.
@@ -774,6 +791,12 @@ export const filterEvent = (params) => {
       } else {
         checkInfo.isHeaderChecked = false;
       }
+      if (!searchWord && pageInfo.isClientPaging && pageInfo.prevPage) {
+        pageInfo.currentPage = 1;
+        stores.pagingStore = getPagingData();
+      }
+
+      updatePagingInfo();
       updateVScroll();
     }, 500);
   };
@@ -901,18 +924,37 @@ export const storeEvent = (params) => {
       updateVScroll();
     }
   };
-  /**
-   * 컴포넌트의 변경 데이터를 store에 업데이트한다.
-   *
-   * @param {number} rowIndex - row 인덱스
-   * @param {number} cellIndex - cell 인덱스
-   * @param {number|string} newValue - 데이터
-   */
-  const updateData = (rowIndex, cellIndex, newValue) => {
-    const row = stores.store.filter(data => data[0] === rowIndex);
-    if (row) {
-      row[0][ROW_DATA_INDEX][cellIndex] = newValue;
-    }
+  return { setStore };
+};
+
+export const pagingEvent = (params) => {
+  const { emit } = getCurrentInstance();
+  const { stores, pageInfo, sortInfo, filterInfo } = params;
+  const getPagingData = () => {
+    const start = (pageInfo.currentPage - 1) * pageInfo.perPage;
+    const end = parseInt(start, 10) + parseInt(pageInfo.perPage, 10);
+    return stores.store.slice(start, end);
   };
-  return { setStore, updateData };
+  const updatePagingInfo = () => {
+    emit('request-data', {
+      pageInfo: {
+        currentPage: pageInfo.currentPage,
+        prevPage: pageInfo.prevPage,
+        startIndex: pageInfo.startIndex,
+        total: pageInfo.total,
+        perPage: pageInfo.perPage,
+      },
+      sortInfo: {
+        field: sortInfo.sortField,
+        order: sortInfo.sortOrder,
+      },
+      searchInfo: {
+        searchWord: filterInfo.searchWord,
+        searchColumns: stores.orderedColumns
+          .filter(c => !c.hide && (c?.searchable === undefined || c?.searchable))
+          .map(d => d.field),
+      },
+    });
+  };
+  return { getPagingData, updatePagingInfo };
 };

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -942,7 +942,7 @@ export const pagingEvent = (params) => {
     return stores.store.slice(start, end);
   };
   const updatePagingInfo = (eventName) => {
-    emit('request-data', {
+    emit('page-change', {
       eventName,
       pageInfo: {
         currentPage: pageInfo.currentPage,

--- a/src/components/pagination/Pagination.vue
+++ b/src/components/pagination/Pagination.vue
@@ -176,7 +176,7 @@ export default {
       () => pageCount.value,
       (value) => {
         if (current.value > value) {
-          changePage(1);
+          changePage(value);
         }
       },
     );

--- a/src/components/pagination/Pagination.vue
+++ b/src/components/pagination/Pagination.vue
@@ -1,13 +1,13 @@
 <template>
   <nav class="pagination">
     <!-- Page Info -->
-    <small v-if="pageInfo" class="pagination-info">
+    <small v-if="showPageInfo" class="pagination-info">
       <template v-if="perPage === 1">
-        {{ numberWithComma(firstData) }} / {{ numberWithComma(total) }}
+        {{ firstData }} / {{ total }}
       </template>
       <template v-else>
-        {{ numberWithComma(firstData) }} - {{ numberWithComma(Math.min(current * perPage, total)) }}
-        / {{ numberWithComma(total) }}
+        {{ firstData }} - {{ Math.min(current * perPage, total) }}
+        / {{ total }}
       </template>
     </small>
     <ul class="pagination-list" :style="listClasses">
@@ -49,7 +49,6 @@
 <script>
 import { computed, nextTick, watch } from 'vue';
 import EvIcon from '@/components/icon/Icon';
-import { numberWithComma } from '@/common/utils';
 import pageButton from './pageButton';
 
 export default {
@@ -59,8 +58,14 @@ export default {
     pageButton,
   },
   props: {
-    total: [Number, String],
-    visiblePage: [Number, String],
+    total: {
+      type: [Number, String],
+      default: 0,
+    },
+    visiblePage: {
+      type: [Number, String],
+      default: 8,
+    },
     perPage: {
       type: [Number, String],
       default: 20,
@@ -69,8 +74,10 @@ export default {
       type: [Number, String],
       default: 1,
     },
-    size: String,
-    pageInfo: Boolean,
+    showPageInfo: {
+      type: Boolean,
+      default: false,
+    },
     order: {
       type: String,
       default: 'left',
@@ -82,9 +89,10 @@ export default {
     change: null,
   },
   setup(props, { emit }) {
-    const visiblePage = computed(() => props.visiblePage || 8);
+    const visiblePage = computed(() => (props.visiblePage > 7 ? props.visiblePage : 7));
     const current = computed(() => props.modelValue);
-    const pageCount = computed(() => Math.ceil(props.total / props.perPage));
+    const pageCount = computed(() => (props.total === 0
+      ? 1 : Math.ceil(props.total / props.perPage)));
     const hasPrev = computed(() => current.value > 1);
     const hasNext = computed(() => current.value < pageCount.value);
     const firstData = computed(() => {
@@ -190,7 +198,6 @@ export default {
       current,
       changePage,
       getPage,
-      numberWithComma,
     };
   },
 };
@@ -206,9 +213,7 @@ export default {
     padding-right: 10px;
     background: center center no-repeat;
     background-size: 16px;
-    background-color: #FFFFFF;
     cursor: pointer;
-    color: #303133;
     &:hover {
       color: #1A6AFE;
     }
@@ -238,7 +243,6 @@ export default {
     cursor: not-allowed;
     opacity: 0.5;
     color: #C0C4CC;
-    background-color: #FFFFFF;
   }
   &-list {
     display: flex;
@@ -255,7 +259,6 @@ export default {
       padding: 0 4px;
       justify-content: center;
       align-items: center;
-      background: #FFFFFF;
       font-size: 14px;
       min-width: 32px;
       line-height: 32px;


### PR DESCRIPTION
#############
- Pagination 컴포넌트 콤마 제거, css 수정 (dark 테마 확인)
- grid.pagination 컴포넌트 추가
- infinite scroll, sort, search, change page 이벤트 발생 시 조건에 맞는 데이터를 요청 할 수 있도록 `request-data` emit 발생
- server-side paging 이 아닌 경우 즉, `useClient: true` 로 설정하고 전체 데이터를 초기에 가져온 경우 getPagingData()를 호출해 위 이벤트 발생 시 조건에 맞게 데이터를 변경
- infinite scroll 사용 시 sort, search 이벤트 발생하면 조건에 맞게 데이터 길이 및 스크롤 위치 초기화
- pagination 사용 시 페이지 변경하면 checked 초기화
- `request-data` -> `page-change` $emit 명칭 변경
- docs 수정 -> page 옵션 추가

<img src="https://user-images.githubusercontent.com/61657275/158508953-cc8955f0-ae40-40de-9175-6c9b60356c14.gif" width="650">