### PR TITLE
[#1093] Chart > selectItem > tip관련 에러로그 발생

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.9",
+  "version": "3.3.8",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -452,8 +452,14 @@ const modules = {
 
   getItem({ seriesID, dataIndex }, useApproximate = false) {
     const dataInfo = this.getDataByValues(seriesID, dataIndex);
+
+    if (!dataInfo || !dataInfo?.xp || !dataInfo?.yp) {
+      return null;
+    }
+
     return this.getItemByPosition([dataInfo.xp, dataInfo.yp], useApproximate);
   },
+
   /**
    *
    * @param seriesID


### PR DESCRIPTION
### 이슈 내용
- 값이 없는 변수에 대한 참조로 인해 에러 로그 발생
   - ![image](https://user-images.githubusercontent.com/53548023/158507521-f6ff856d-1bd5-431c-a9cb-8b7a42e01524.png)

### 수정내용 
- 예외 처리 추가
- minor version update 3.3.8 -> 3.3.9