### PR TITLE
[#1097] Line Chart > Legend 영역 fill: true 옵션 표시

### DIFF
--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -106,13 +106,24 @@ const modules = {
       if (isActive) {
         this.seriesInfo.count--;
         colorDOM.style.backgroundColor = opt.inactive;
+        colorDOM.style.borderColor = opt.inactive;
         nameDOM.style.color = opt.inactive;
       } else {
         this.seriesInfo.count++;
+
+        let seriesColor;
         if (typeof series.color !== 'string') {
-          colorDOM.style.backgroundColor = series.color[series.color.length - 1][1];
+          seriesColor = series.color[series.color.length - 1][1];
         } else {
-          colorDOM.style.backgroundColor = series.color;
+          seriesColor = series.color;
+        }
+
+        if (series.type === 'line' && series.fill) {
+          colorDOM.style.height = '8px';
+          colorDOM.style.backgroundColor = `${seriesColor}80`;
+          colorDOM.style.border = `1px solid ${seriesColor}`;
+        } else {
+          colorDOM.style.backgroundColor = seriesColor;
         }
 
         nameDOM.style.color = opt.color;
@@ -264,7 +275,7 @@ const modules = {
     containerDOM.className = 'ev-chart-legend-container';
     colorDOM.className = 'ev-chart-legend-color';
 
-    if (series.type === 'line' && series.point) {
+    if (series.type === 'line' && series.point && !series.fill) {
       colorDOM.className += ' ev-chart-legend-color--point-line';
     }
 
@@ -272,10 +283,19 @@ const modules = {
 
     nameDOM.series = series;
 
+    let seriesColor;
     if (typeof series.color !== 'string') {
-      colorDOM.style.backgroundColor = series.color[series.color.length - 1][1];
+      seriesColor = series.color[series.color.length - 1][1];
     } else {
-      colorDOM.style.backgroundColor = series.color;
+      seriesColor = series.color;
+    }
+
+    if (series.type === 'line' && series.fill) {
+      colorDOM.style.height = '8px';
+      colorDOM.style.backgroundColor = `${seriesColor}80`;
+      colorDOM.style.border = `1px solid ${seriesColor}`;
+    } else {
+      colorDOM.style.backgroundColor = seriesColor;
     }
 
     colorDOM.dataset.type = 'color';


### PR DESCRIPTION
## 작업내용
1. fill: true 옵션을 가진 series는 legend영역의 colorDOM을 다른 스타일로 표시

### Before
![image](https://user-images.githubusercontent.com/53548023/158763632-2d8075af-42e6-41c7-92b4-859665eeb1ad.png)

### After
![image](https://user-images.githubusercontent.com/53548023/158763661-8207f685-f765-45d7-9417-61ff1962550f.png)