### PR TITLE
[#1103] Pie Chart > 브라우저 확대/축소 시 Tooltip 버그 발생

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.pie.js
+++ b/src/components/chart/element/element.pie.js
@@ -27,7 +27,6 @@ class Pie {
     this.doughnutHoleSize = 0;
     this.startAngle = 0;
     this.endAngle = 0;
-    this.slice = null;
     this.state = null;
     this.ctx = null;
     this.isSelect = false;
@@ -71,8 +70,6 @@ class Pie {
     }
 
     ctx.closePath();
-
-    this.slice = slice;
     this.ctx = ctx;
   }
 
@@ -84,8 +81,19 @@ class Pie {
    */
   findGraphData([offsetX, offsetY]) {
     const item = { data: null, hit: false, color: null, index: -1 };
+    const {
+      radius,
+      startAngle,
+      endAngle,
+      centerX,
+      centerY,
+    } = this;
 
-    if (this.show && this.ctx?.isPointInPath(this.slice, offsetX, offsetY)) {
+    const distance = Math.sqrt((offsetX - centerX) ** 2 + (offsetY - centerY) ** 2);
+    const radian = (2.5 * Math.PI) - Math.atan2((offsetX - centerX), (offsetY - centerY));
+    const isPointInPath = radius > distance && radian >= startAngle && radian <= endAngle;
+
+    if (this.show && isPointInPath) {
       item.type = this.type;
       item.data = this.data;
       item.hit = true;


### PR DESCRIPTION
## 이슈 내용
1. 조각위에 마우스를 올려도 Tooltip이 발생하지 않음
![pie_bug](https://user-images.githubusercontent.com/53548023/159643324-89047b3d-d06b-4d0c-9e57-574f39124340.gif)

## 변경내용
1. 기존 `CanvasRenderingContext2D.isPointInPath()` 사용을 제거하고 `isPointInPath` 함수 직접 구현으로 변경

![pie_bug_fix](https://user-images.githubusercontent.com/53548023/159643521-63e74f64-2128-4366-b092-ff2c40cdc956.gif)
 

2. Revision Update (3.3.9 -> 3.3.10)