### PR TITLE
[#1108] Chart > HeatMap 개발 - min 값 조정 및 사이즈 계산 버그 수정

### DIFF
--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -108,7 +108,7 @@ class HeatMap {
     const xsp = chartRect.x1 + labelOffset.left;
     const ysp = chartRect.y2 - labelOffset.bottom;
 
-    this.size.w = Math.ceil(xArea / (this.spaces.x || (minmaxX.graphMax - minmaxX.graphMin)));
+    this.size.w = Math.floor(xArea / (this.spaces.x || (minmaxX.graphMax - minmaxX.graphMin)));
     this.size.h = Math.floor(yArea / (this.spaces.y || (minmaxY.graphMax - minmaxY.graphMin)));
 
     this.data.forEach((item) => {

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -441,7 +441,7 @@ const modules = {
 
     if (!opt.startToZero || targetMin > 0) {
       const targetSpace = space ? (space - 1) : (targetMax - targetMin);
-      const targetStep = targetInterval || Math.ceil((max - targetMin) / targetSpace);
+      const targetStep = Math.ceil((max - targetMin) / targetSpace);
         targetMin = targetMin < targetStep ? 0 : targetMin - targetStep;
     }
 


### PR DESCRIPTION
재현 스텝
1. x축 type time, interval: 'second'
2. 보내는 x축 데이터 간격 2 second
3. heatmap 확인

기대 결과
1. heatmap 간격이 겹치지 않고 정상적으로 그려짐

실제 결과
1. 겹쳐서 그려짐