### PR TITLE
[#1121] Chart > drawDoughnutHole 관련 에러로그 발생

### DIFF
--- a/src/components/chart/plugins/plugins.pie.js
+++ b/src/components/chart/plugins/plugins.pie.js
@@ -27,6 +27,10 @@ const modules = {
 
     const chartWidth = centerX - (padding.left + padding.right);
     const chartHeight = centerY - (padding.bottom + padding.top);
+    if (chartWidth < 0 || chartHeight < 0) {
+      return;
+    }
+
     const innerRadius = Math.min(chartWidth, chartHeight) * pieOption.doughnutHoleSize;
     const outerRadius = Math.min(chartWidth, chartHeight);
 
@@ -109,8 +113,13 @@ const modules = {
 
     const centerX = width / 2;
     const centerY = height / 2;
+
     const chartWidth = centerX - (padding.left + padding.right);
     const chartHeight = centerY - (padding.bottom + padding.top);
+    if (chartWidth < 0 || chartHeight < 0) {
+      return;
+    }
+
     const innerRadius = Math.min(chartWidth, chartHeight) * pieOption.doughnutHoleSize;
     const outerRadius = Math.min(chartWidth, chartHeight);
 
@@ -190,8 +199,13 @@ const modules = {
 
     const centerX = width / 2;
     const centerY = height / 2;
+
     const chartWidth = centerX - (padding.left + padding.right);
     const chartHeight = centerY - (padding.bottom + padding.top);
+    if (chartWidth < 0 || chartHeight < 0) {
+      return;
+    }
+
     const radius = Math.min(chartWidth, chartHeight) * pieOption.doughnutHoleSize;
 
     ctx.save();

--- a/src/components/chart/plugins/plugins.pie.js
+++ b/src/components/chart/plugins/plugins.pie.js
@@ -27,7 +27,8 @@ const modules = {
 
     const chartWidth = centerX - (padding.left + padding.right);
     const chartHeight = centerY - (padding.bottom + padding.top);
-    if (chartWidth < 0 || chartHeight < 0) {
+    if ((typeof chartWidth === 'number' && chartWidth < 0)
+      || (typeof chartHeight === 'number' && chartHeight < 0)) {
       return;
     }
 
@@ -116,7 +117,8 @@ const modules = {
 
     const chartWidth = centerX - (padding.left + padding.right);
     const chartHeight = centerY - (padding.bottom + padding.top);
-    if (chartWidth < 0 || chartHeight < 0) {
+    if ((typeof chartWidth === 'number' && chartWidth < 0)
+      || (typeof chartHeight === 'number' && chartHeight < 0)) {
       return;
     }
 
@@ -202,7 +204,8 @@ const modules = {
 
     const chartWidth = centerX - (padding.left + padding.right);
     const chartHeight = centerY - (padding.bottom + padding.top);
-    if (chartWidth < 0 || chartHeight < 0) {
+    if ((typeof chartWidth === 'number' && chartWidth < 0)
+      || (typeof chartHeight === 'number' && chartHeight < 0)) {
       return;
     }
 


### PR DESCRIPTION
## 이슈내용
- Pie Chart DOM의 크기가 chartOptions> padding 값 보다 작은 상태에서 draw할 경우,  radius값이 음수로 나와 canvasRenderingContext2 관련 에러로그 발생 
- ![image](https://user-images.githubusercontent.com/53548023/161887580-c3c10ea0-2d4b-4cd9-8940-6b39f83fa4e0.png)

## 작업내용
1. Pie 차트를 그릴때 width 혹은 height이 0보다 작은 경우 로직을 수행하지 않도록 예외 처리