### PR TITLE
[#1127] Line Chart > 특정 조건에서 데이터와 무관한 line 발생

### DIFF
--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -147,6 +147,8 @@ class Line {
       if (this.stackIndex) {
         const reversedDataList = this.data.slice().reverse();
         reversedDataList.forEach((curr, ix) => {
+          ctx.beginPath();
+
           x = getXPos(curr.x);
           y = getYPos(curr.b);
 


### PR DESCRIPTION
## 이슈 내용
- 두개이상의 line type Series를 group으로 묶어 stack line chart로 구성하고, 동일한 위치에 null 값을 넣을 경우 데이터와 무관한 line이 보임 
- ![image](https://user-images.githubusercontent.com/53548023/163097805-8def69cf-0f19-4fbd-beff-8e912365b3bb.png)

## 수정 내용
- loop돌면서 stroke를 그리는 로직에서 beginPath가 누락되어 있어 추가함
   - ![image](https://user-images.githubusercontent.com/53548023/163097854-01cedc5b-250d-4f48-af49-c39cae4faf27.png)
