### PR TITLE
[#1131] Line Chart > Select Label - useLabelOpacity

### DIFF
--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -147,8 +147,6 @@ class Line {
       if (this.stackIndex) {
         const reversedDataList = this.data.slice().reverse();
         reversedDataList.forEach((curr, ix) => {
-          ctx.beginPath();
-
           x = getXPos(curr.x);
           y = getYPos(curr.b);
 

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -164,7 +164,7 @@ class Scale {
    *
    * @returns {undefined}
    */
-  draw(chartRect, labelOffset, stepInfo, hitInfo) {
+  draw(chartRect, labelOffset, stepInfo, hitInfo, selectLabelInfo) {
     const ctx = this.ctx;
     const options = this.options;
     const aPos = {
@@ -239,6 +239,13 @@ class Scale {
         linePosition = labelCenter + aliasPixel;
         labelText = this.getLabelFormat(Math.min(axisMax, ticks[ix]));
 
+        const isBlurredLabel = this.options?.selectLabel?.use
+          && this.options?.selectLabel?.useLabelOpacity
+          && (this.options.horizontal === (this.type === 'y'))
+          && selectLabelInfo?.dataIndex?.length
+          && !selectLabelInfo?.label
+            .map(t => this.getLabelFormat(Math.min(axisMax, t))).includes(labelText);
+
         const labelColor = this.labelStyle.color;
         let defaultOpacity = 1;
 
@@ -246,14 +253,17 @@ class Scale {
           defaultOpacity = Util.getOpacity(labelColor);
         }
 
-        ctx.fillStyle = Util.colorStringToRgba(labelColor, defaultOpacity);
+        ctx.fillStyle = Util.colorStringToRgba(labelColor, isBlurredLabel ? 0.1 : defaultOpacity);
 
         let labelPoint;
 
         if (this.type === 'x') {
           labelPoint = this.position === 'top' ? offsetPoint - 10 : offsetPoint + 10;
           ctx.fillText(labelText, labelCenter, labelPoint);
-          if (options?.selectItem?.showLabelTip && hitInfo?.label && !this.options?.horizontal) {
+          if (!isBlurredLabel
+            && options?.selectItem?.showLabelTip
+            && hitInfo?.label
+            && !this.options?.horizontal) {
             const selectedLabel = this.getLabelFormat(
               Math.min(axisMax, hitInfo.label + (0 * stepValue)),
             );


### PR DESCRIPTION
## 작업내용 
**1. x 축이 time 인 경우에도 `useLabelOpacity`  옵션이 적용되도록 스펙 변경**
 - 선택된 시간이 x 축에 표시된 label 인 경우만 opacity 를 변경하고, 새로운 text 를 추가하지는 않는다
![image](https://user-images.githubusercontent.com/46586573/163743769-bbc55e4c-6e31-4654-b775-fa65674a6f5f.png)
  