### PR TITLE
[#1133] Pie Chart > selectItem 옵션 사용중일 때 legend영역 마우스 오버시 에러로그 발생

### DIFF
--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -1,3 +1,5 @@
+import Util from '@/components/chart/helpers/helpers.util';
+
 const modules = {
   /**
    * Create legend DOM
@@ -200,10 +202,15 @@ const modules = {
           ? 'highlight' : 'downplay';
       });
 
+      let hitInfo = null;
+      if (Util.isPieType(this.options.type)) {
+        hitInfo = { sId: targetId, type: this.options.type };
+      }
+
       this.update({
         updateSeries: false,
         updateSelTip: { update: false, keepDomain: false },
-        hitInfo: { sId: targetId, type: this.options.type },
+        hitInfo,
       });
     };
 

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -203,7 +203,7 @@ const modules = {
       this.update({
         updateSeries: false,
         updateSelTip: { update: false, keepDomain: false },
-        hitInfo: { sId: targetId },
+        hitInfo: { sId: targetId, type: this.options.type },
       });
     };
 


### PR DESCRIPTION
###################################
1. type 전달이 누락되어 있어 추가
2. Pie Chart 일 경우에만 hit 정보를 series draw시에 넘겨줘야하기 때문에 조건문 추가
   - https://github.com/ex-em/EVUI/issues/1143