### PR TITLE
[#1127] Line Chart > 특정 조건에서 데이터와 무관한 line 발생

### DIFF
--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -102,7 +102,8 @@ class Line {
     const getXPos = val => Canvas.calculateX(val, minmaxX.graphMin, minmaxX.graphMax, xArea, xsp);
     const getYPos = val => Canvas.calculateY(val, minmaxY.graphMin, minmaxY.graphMax, yArea, ysp);
 
-    this.data.reduce((prev, curr, ix, item) => {
+    // draw line
+    this.data.reduce((prev, curr, ix) => {
       x = getXPos(curr.x);
       y = getYPos(curr.y);
 
@@ -110,22 +111,12 @@ class Line {
         x += Util.aliasPixel(x);
       }
 
-      if (y === null || x === null) {
-        if (ix - 1 > -1) {
-          // draw fill(area) series not stacked
-          if (this.fill && prev.y !== null && !this.stackIndex) {
-            ctx.stroke();
-            ctx.lineTo(prev.xp, endPoint);
-            ctx.lineTo(item[startFillIndex].xp, endPoint);
+      if (ix === 0) {
+        ctx.moveTo(x, y);
+      }
 
-            ctx.fill();
-            ctx.beginPath();
-          }
-        }
-
-        startFillIndex = ix + 1;
-      } else if (ix === 0 || prev.y === null || curr.y === null
-        || prev.x === null || curr.x === null) {
+      const isNullValue = prev.y === null || curr.y === null || prev.x === null || curr.x === null;
+      if (isNullValue) {
         ctx.moveTo(x, y);
       } else {
         ctx.lineTo(x, y);
@@ -139,39 +130,45 @@ class Line {
 
     ctx.stroke();
 
-    const dataLen = this.data.length;
+    // draw fill
+    if (this.fill && this.data.length) {
+      ctx.beginPath();
 
-    if (this.fill && dataLen) {
       ctx.fillStyle = Util.colorStringToRgba(mainColor, fillOpacity);
 
-      if (this.stackIndex) {
-        const reversedDataList = this.data.slice().reverse();
-        reversedDataList.forEach((curr, ix) => {
-          x = getXPos(curr.x);
-          y = getYPos(curr.b);
+      this.data.forEach((currData, ix) => {
+        const isEmptyPoint = data => data?.x === null || data?.y === null
+          || data?.x === undefined || data?.y === undefined;
 
-          const prev = reversedDataList[ix - 1];
-          if (curr.o !== null) {
-            if (prev && prev.o == null) {
-              ctx.moveTo(x, getYPos(curr.b + curr.o));
-            }
+        const nextData = this.data[ix + 1];
 
-            ctx.lineTo(x, y);
+        if (isEmptyPoint(currData)) {
+          startFillIndex = ix + 1;
 
-            if (ix === reversedDataList.length - 1) {
-              ctx.lineTo(x, getYPos(curr.b + curr.o));
-            }
-          } else if (prev && prev.o) {
-            ctx.lineTo(getXPos(prev.x), getYPos(prev.b + prev.o));
+          if (!isEmptyPoint(nextData)) {
+            ctx.moveTo(nextData.xp, nextData.yp);
           }
-        });
-      } else if (startFillIndex < dataLen) {
-        ctx.lineTo(this.data[dataLen - 1].xp, endPoint);
-        ctx.lineTo(this.data[startFillIndex].xp, endPoint);
-      }
+
+          return;
+        }
+
+        ctx.lineTo(currData.xp, currData.yp);
+
+        if (isEmptyPoint(nextData)) {
+          for (let jx = ix; jx >= startFillIndex; jx--) {
+            const prevData = this.data[jx];
+            const xp = prevData.xp;
+            const bp = getYPos(prevData.b) ?? endPoint;
+            ctx.lineTo(xp, bp);
+          }
+
+          ctx.closePath();
+        }
+      });
 
       ctx.fill();
     }
+
     if (this.point || isExistSelectedLabel) {
       ctx.strokeStyle = Util.colorStringToRgba(mainColor, mainColorOpacity);
       const focusStyle = Util.colorStringToRgba(pointFillColor, 1);


### PR DESCRIPTION
### 이슈 내용
- ![canvas_zoom2](https://user-images.githubusercontent.com/53548023/164184200-edbf054d-2c49-48cc-b572-a51c77062c74.gif)
   - 차트 크기에 따라 간혈적으로 데이터와 무관한 선이 보임

### 이슈 원인
-  ![image](https://user-images.githubusercontent.com/53548023/164186386-3fb66c1b-554a-4644-909b-011645fee702.png)
- 기존 로직 : 실제 데이터선 (빨간색) 을 그린뒤 바로 fill 영역(노란선)까지 한 획으로 그린뒤 fill 호출
- fill 호출 을 기준으로 노란선을 따라 그렸던 도형은 닫히지 않았다고 판단되는 듯 함
- closePath를 호출할 경우 위의 회색 라인이 표시되는데 이슈 현상과 동일한 위치임

### 이슈 해결
- ![image](https://user-images.githubusercontent.com/53548023/164186263-e7c72673-7d10-431f-9e8e-d2809c2388fb.png)
- 그려야할 다음 지점이 null이면 명확하게 closePath를 호출하도록 수정함


