### PR TITLE
 [#1129] HeatMap > 축 step 타입 면적에 따른 label 간격 조정 & range block 단위로 선택

### DIFF
--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -171,19 +171,19 @@ const chartData =
 #### heatMapColor
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
   |------------ |-----------|---------|-------------------------|---------------------------------------------------|
-| min | number | | min color | '#FFFFFF' |
-| max | number | | max color | '#5586EB' | 
+| min | Hex, RGB, RGBA Code(String) | '#FFFFFF' | min color |  |
+| max | Hex, RGB, RGBA Code(String) | '#5586EB' | max color |  | 
 | categoryCnt | number | 5 | color min - max 그라데이션 분류 개수 | |
 | stroke | object | ([상세](#stroke)) | series stroke 지정 |  |
-| error | string | '#FFFFFF' | series error color (value가 -1인 경우 error로 인식) |  |
+| error | Hex, RGB, RGBA Code(String) | '#FFFFFF' | series error color (value가 -1인 경우 error로 인식) |  |
 
 ##### stroke
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 | --- | ---- | ----- | --- | ----------|
 | show | boolean | false | stroke 사용 여부 | |
-| color | string | '#FFFFFF' | stroke color 지정 | |
+| color | Hex, RGB, RGBA Code(String) | '#FFFFFF' | stroke color 지정 | |
 | lineWidth | number | 1 | stroke 선 굵기 지정 | |
-| opacity | number | 1 | stroke opacity 지정 | |
+| opacity | number | 1 | stroke opacity 지정 | 0.1 ~ 1 |
 
 ### 3. resize-timeout
 - Default : 0

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -174,8 +174,16 @@ const chartData =
 | min | number | | min color | '#FFFFFF' |
 | max | number | | max color | '#5586EB' | 
 | categoryCnt | number | 5 | color min - max 그라데이션 분류 개수 | |
-| border | string | '#FF0000' | series item border color 지정 |  |
+| stroke | object | ([상세](#stroke)) | series stroke 지정 |  |
 | error | string | '#FFFFFF' | series error color (value가 -1인 경우 error로 인식) |  |
+
+##### stroke
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+| --- | ---- | ----- | --- | ----------|
+| show | boolean | false | stroke 사용 여부 | |
+| color | string | '#FFFFFF' | stroke color 지정 | |
+| lineWidth | number | 1 | stroke 선 굵기 지정 | |
+| opacity | number | 1 | stroke opacity 지정 | |
 
 ### 3. resize-timeout
 - Default : 0

--- a/docs/views/heatMap/example/Event.vue
+++ b/docs/views/heatMap/example/Event.vue
@@ -104,7 +104,6 @@ import { onMounted, reactive, ref } from 'vue';
         }],
         axesY: [{
           type: 'step',
-          autoScaleRatio: 0.1,
           showGrid: false,
         }],
         selectItem: {

--- a/docs/views/heatMap/example/Time.vue
+++ b/docs/views/heatMap/example/Time.vue
@@ -97,8 +97,8 @@ import { onBeforeUnmount, reactive, ref, watch } from 'vue';
           rangeMode: true,
         }],
         heatMapColor: {
-          min: '#e1fbad',
-          max: '#5b904b',
+          min: '#E1FBAD',
+          max: '#5B904B',
           categoryCnt: 4,
           stroke: {
             show: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.13",
+  "version": "3.3.14",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -100,7 +100,8 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
         await watch(() => props.data, (chartData) => {
           const newData = getNormalizedData(chartData);
           const isUpdateSeries = !isEqual(newData.series, evChart.data.series)
-              || !isEqual(newData.groups, evChart.data.groups);
+              || !isEqual(newData.groups, evChart.data.groups)
+              || props.options.type === 'heatMap';
           evChart.data = cloneDeep(newData);
           evChart.update({
             updateSeries: isUpdateSeries,

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -354,7 +354,7 @@ class HeatMap {
   }
 
   findBlockRange({ xcp, xep, ycp, yep, range }) {
-    const { x: labelX, y: labelY } = this.labels;
+    const labels = this.labels;
 
     const blockRange = {
       xsp: Math.min(xcp, xep),
@@ -363,10 +363,10 @@ class HeatMap {
       height: Math.ceil(Math.abs(yep - ycp)),
     };
 
-    if (labelX.length && labelY.length) {
+    if (labels.x.length && labels.y.length) {
       const { x1, x2, y1, y2 } = range;
-      const gapX = (x2 - x1) / labelX.length;
-      const gapY = (y2 - y1) / labelY.length;
+      const gapX = (x2 - x1) / labels.x.length;
+      const gapY = (y2 - y1) / labels.y.length;
 
       const point = {
         xsp: xcp,
@@ -375,43 +375,33 @@ class HeatMap {
         yep,
       };
 
-      const setPoint = (type, dir) => {
+      const setPoint = (dir, target, key) => {
         let itemPoint;
-        let list;
-        let target;
         let gap;
-        let key;
-        let start;
-        const isStart = dir === 'start';
+        let startPoint;
 
-        if (type === 'x') {
-          list = labelX;
+        if (dir === 'x') {
           gap = gapX;
-          target = isStart ? Math.min(xcp, xep) : Math.max(xcp, xep);
-          key = isStart ? 'xsp' : 'xep';
-          start = x1;
+          startPoint = x1;
         } else {
-          list = labelY;
           gap = gapY;
-          target = isStart ? Math.min(ycp, yep) : Math.max(ycp, yep);
-          key = isStart ? 'ysp' : 'yep';
-          start = y1;
+          startPoint = y1;
         }
 
-        const findItem = list.findIndex((item, index) => {
-          itemPoint = Math.round(start + (gap * index)) + Util.aliasPixel(1);
+        const findItem = labels[dir].findIndex((item, index) => {
+          itemPoint = Math.round(startPoint + (gap * index)) + Util.aliasPixel(1);
           return itemPoint <= target && target <= itemPoint + gap;
         });
 
         if (findItem > -1) {
-          point[key] = isStart ? itemPoint : itemPoint + gap;
+          point[key] = ['xsp', 'ysp'].includes(key) ? itemPoint : itemPoint + gap;
         }
       };
 
-      setPoint('x', 'start');
-      setPoint('x', 'end');
-      setPoint('y', 'start');
-      setPoint('y', 'end');
+      setPoint('x', Math.min(xcp, xep), 'xsp');
+      setPoint('x', Math.max(xcp, xep), 'xep');
+      setPoint('y', Math.min(ycp, yep), 'ysp');
+      setPoint('y', Math.max(ycp, yep), 'yep');
 
       blockRange.xsp = Math.min(point.xsp, point.xep);
       blockRange.ysp = Math.min(point.ysp, point.yep);

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -431,10 +431,12 @@ const modules = {
         maxValue = Math.max(maxValue, value);
       }
 
-      if (minValue === undefined) {
-        minValue = value;
-      } else if (value >= 0) {
-        minValue = Math.min(minValue, value);
+      if (value >= 0) {
+        if (minValue === undefined) {
+          minValue = value;
+        } else {
+          minValue = Math.min(minValue, value);
+        }
       }
 
       if (value < 0) {

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -422,12 +422,21 @@ const modules = {
     const colorOpt = this.options.heatMapColor;
     const categoryCnt = colorOpt.categoryCnt;
 
+    let minValue;
     let maxValue = 0;
+
     let isExistError = false;
     data.forEach(({ o: value }) => {
       if (maxValue < value) {
-        maxValue = value;
+        maxValue = Math.max(maxValue, value);
       }
+
+      if (minValue === undefined) {
+        minValue = value;
+      } else if (value >= 0) {
+        minValue = Math.min(minValue, value);
+      }
+
       if (value < 0) {
         isExistError = true;
       }
@@ -443,8 +452,9 @@ const modules = {
     }
 
     return {
+      min: minValue,
       max: maxValue,
-      interval: Math.ceil(maxValue / categoryCnt),
+      interval: Math.ceil((maxValue - minValue) / categoryCnt),
       existError: isExistError,
     };
   },

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -431,16 +431,12 @@ const modules = {
         maxValue = Math.max(maxValue, value);
       }
 
-      if (value >= 0) {
-        if (minValue === undefined) {
-          minValue = value;
-        } else {
-          minValue = Math.min(minValue, value);
-        }
-      }
-
       if (value < 0) {
         isExistError = true;
+      } else if (minValue === undefined) {
+        minValue = value;
+      } else {
+        minValue = Math.min(minValue, value);
       }
     });
 

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -266,12 +266,21 @@ const modules = {
         yep = aOffsetY;
       }
 
-      dragInfo.xsp = Math.min(xcp, xep);
-      dragInfo.ysp = type === 'scatter' || type === 'heatMap' ? Math.min(ycp, yep) : aRange.y1;
-      dragInfo.width = Math.ceil(Math.abs(xep - xcp));
-      dragInfo.height = type === 'scatter' || type === 'heatMap'
+      if (type === 'heatMap') {
+        const rangeInfo = { xcp, xep, ycp, yep, range: aRange };
+        const { xsp, ysp, width, height } = this.getDragInfoForHeatMap(rangeInfo);
+        dragInfo.xsp = xsp;
+        dragInfo.ysp = ysp;
+        dragInfo.width = width;
+        dragInfo.height = height;
+      } else {
+        dragInfo.xsp = Math.min(xcp, xep);
+        dragInfo.ysp = type === 'scatter' ? Math.min(ycp, yep) : aRange.y1;
+        dragInfo.width = Math.ceil(Math.abs(xep - xcp));
+        dragInfo.height = type === 'scatter'
           ? Math.ceil(Math.abs(yep - ycp))
           : aRange.y2 - aRange.y1;
+      }
 
       this.overlayClear();
       this.drawSelectionArea(dragInfo);
@@ -289,7 +298,9 @@ const modules = {
         const args = {
           e,
           data: this.findSelectedItems(dragInfo),
-          range: this.getSelectionRage(dragInfo),
+          range: type === 'heatMap'
+            ? this.getSelectionRangeForHeatMap(dragInfo)
+            : this.getSelectionRage(dragInfo),
         };
 
         this.dragInfoBackup = defaultsDeep({}, dragInfo);
@@ -590,6 +601,30 @@ const modules = {
     const targetValue = value - min;
 
     return targetValue / total;
+  },
+
+  getDragInfoForHeatMap(range) {
+    const sId = Object.keys(this.seriesList)[0];
+    return this.seriesList[sId].findBlockRange(range);
+  },
+
+  getSelectionRangeForHeatMap(range) {
+    const dataRangeX = this.axesSteps.x.length ? this.axesSteps.x[0] : null;
+    const dataRangeY = this.axesSteps.y.length ? this.axesSteps.y[0] : null;
+
+    if (!dataRangeX || !dataRangeY) {
+      return null;
+    }
+
+    const sId = Object.keys(this.seriesList)[0];
+    const { xMin, xMax, yMin, yMax } = this.seriesList[sId].findSelectionRange(range);
+
+    return {
+      xMin: xMin ?? dataRangeX.graphMin,
+      xMax: xMax ?? dataRangeX.graphMax,
+      yMin: yMin ?? dataRangeY.graphMin,
+      yMax: yMax ?? dataRangeY.graphMax,
+    };
   },
 };
 

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -80,13 +80,14 @@ const modules = {
     Object.values(seriesList).forEach((series) => {
       if (!series.isExistGrp && series.showLegend) {
         const { colorAxis, valueOpt } = series;
-        const { max, interval, existError } = valueOpt;
+        const { min, max, interval, existError } = valueOpt;
+        const endIndex = colorAxis.length - 1;
         colorAxis.forEach((colorItem, index) => {
-          const minValue = interval * index;
-          const maxValue = index === colorAxis.length - 1
-            ? max : minValue + interval - 1;
-          const name = existError && index === colorAxis.length - 1
-            ? 'error' : `${minValue} - ${maxValue}`;
+          const minValue = min + (interval * index);
+          const maxValue = index === endIndex
+            ? max : minValue + interval;
+          const name = existError && index === endIndex ? 'error' : `${minValue} - ${maxValue}`;
+
           this.addLegend({
             cId: colorItem.id,
             color: colorItem.value,

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -408,7 +408,7 @@ const modules = {
     }
 
     // 3. Draw value
-    let formattedTxt;
+    let formattedTxt = itemValue;
     if (opt.formatter) {
       formattedTxt = opt.formatter({
         x: xValue,
@@ -419,8 +419,6 @@ const modules = {
 
     if ((!opt.formatter || typeof formattedTxt !== 'string') && itemValue !== 'error') {
       formattedTxt = numberWithComma(itemValue);
-    } else {
-      formattedTxt = itemValue;
     }
 
     ctx.textAlign = 'right';

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -108,6 +108,7 @@ const DEFAULT_OPTIONS = {
       show: false,
       color: '#FFFFFF',
       lineWidth: 1,
+      opacity: 1,
     },
     error: '#FF0000',
   },


### PR DESCRIPTION
작업 내용
-
1. drag 범위 Block(HeatMap Item) 단위로 선택되도록 개선
2. Block Stroke 속성에 opacity 옵션 추가
3. 축이 step 타입인 경우 간격 별 label 조정(rangeMode인 경우만)
4. data 업데이트 시 범주 범위 업데이트
5. value 범위 표현 수정