### PR TITLE
[#1145] Bar Chart > cPadRatio 옵션 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -98,6 +98,7 @@ const chartData = {
   | width | String / Number | '100%' | 차트의 너비 | '100%', '150px', 150 | 
   | height | String / Number | '100%' | 차트의 높이 | '100%', '150px', 150 |
   | thickness | Number | 1 | 차트 막대의 너비 | 0.1 ~ 1 |
+  | cPadRatio | Number | 1 | 카테고리(각 라벨간)내부 padding 영역의 비율 | 0 ~ 0.5 |
   | borderRadius | Number | 0 | 막대 가장자리 부분의 border-radius 값.  | 0 ~ |
   | horizontal | Boolean | false | 차트 막대의 방향 - 수평 전환 여부 | true, false |
   | axesX | Object | 없음 | X축에 대한 속성 | [상세](#axesx-axesy) |

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -98,7 +98,7 @@ const chartData = {
   | width | String / Number | '100%' | 차트의 너비 | '100%', '150px', 150 | 
   | height | String / Number | '100%' | 차트의 높이 | '100%', '150px', 150 |
   | thickness | Number | 1 | 차트 막대의 너비 | 0.1 ~ 1 |
-  | cPadRatio | Number | 1 | 카테고리(각 라벨간)내부 padding 영역의 비율 | 0 ~ 0.5 |
+  | cPadRatio | Number | 0 | 카테고리(각 라벨간)내부 padding 영역의 비율 | 0 ~ 0.99 (1 미만) |
   | borderRadius | Number | 0 | 막대 가장자리 부분의 border-radius 값.  | 0 ~ |
   | horizontal | Boolean | false | 차트 막대의 방향 - 수평 전환 여부 | true, false |
   | axesX | Object | 없음 | X축에 대한 속성 | [상세](#axesx-axesy) |

--- a/docs/views/barChart/example/Default.vue
+++ b/docs/views/barChart/example/Default.vue
@@ -20,6 +20,7 @@
 
       const chartOptions = {
         type: 'bar',
+        cPadRatio: 0.1,
         axesX: [{
           type: 'step',
         }],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.15",
+  "version": "3.3.16",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -189,8 +189,8 @@ class EvChart {
             break;
           }
           case 'bar': {
-            const { thickness, borderRadius } = this.options;
-            series.draw({ thickness, borderRadius, showSeriesCount, showIndex, ...opt });
+            const { thickness, cPadRatio, borderRadius } = this.options;
+            series.draw({ thickness, cPadRatio, borderRadius, showSeriesCount, showIndex, ...opt });
             if (series.show) {
               showIndex++;
             }

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -67,7 +67,10 @@ class Bar {
 
     const dArea = isHorizontal ? yArea : xArea;
     const cArea = dArea / (this.data.length || 1);
-    const cPad = 2;
+    let cPad = ((isHorizontal ? yArea : xArea) * param.cPadRatio) / this.data.length;
+    if (cPad < 2) {
+      cPad = 2;
+    }
 
     let bArea;
     let w;

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -67,9 +67,13 @@ class Bar {
 
     const dArea = isHorizontal ? yArea : xArea;
     const cArea = dArea / (this.data.length || 1);
-    let cPad = ((isHorizontal ? yArea : xArea) * param.cPadRatio) / this.data.length;
-    if (cPad < 2) {
+
+    let cPad;
+    const isUnableToDrawCategoryPadding = param.cPadRatio >= 1 || param.cPadRatio <= 0;
+    if (isUnableToDrawCategoryPadding) {
       cPad = 2;
+    } else {
+      cPad = Math.max((dArea * (param.cPadRatio / 2)) / this.data.length, 2);
     }
 
     let bArea;

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -43,6 +43,7 @@ const DEFAULT_OPTIONS = {
   width: '100%',
   height: '100%',
   thickness: 1,
+  cPadRatio: 0,
   borderRadius: 0,
   combo: false,
   tooltip: {


### PR DESCRIPTION
## 작업내용 
**1. cPadRatio 옵션 추가**
 - 카테고리(라벨) 간 공간을 추가하는 옵션
 - 기본 값 : 0 
 - 0 이상 1미만 사이 값만 유효하며 유효범위를 넘을 경우 기본값 상태로 보여짐
 
**2. EVUI version Update**
  - 3.3.15 -> 3.3.16
  
**before**
![image](https://user-images.githubusercontent.com/46586573/164723158-4abdc82a-2c58-43ff-ab38-ae2872757c5c.png)

**after ( cPadRatio: 0.1 )**
![image](https://user-images.githubusercontent.com/46586573/164723048-ccc1216b-8a1e-49ee-a785-69ee7d3003d1.png)


  