### PR TITLE
[#1154] Chart > Tooltip > Title 관련 Formatter 옵션 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -242,7 +242,21 @@ const chartData = {
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
-| formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | ({x, y, name}) => y + '%' |
+| formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
+```
+const chartOptions = {
+    tooltip: {
+        // 이전 버전 호환용으로 valueFormatter를 이전버전과 같이 사용 가능
+        formatter: ({ x, y, name }) => ... ,
+        
+        // value + title Formatter
+        formatter: {
+            title: ({ x, y }) => ...,
+            value: ({ x, y, name }) => ...,
+        }
+    },
+}
+```
 
 #### indicator
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -166,7 +166,21 @@ const chartData =
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
-| formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | ({x, y, name}) => y + '%' |
+| formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
+```
+const chartOptions = {
+    tooltip: {
+        // 이전 버전 호환용으로 valueFormatter를 이전버전과 같이 사용 가능
+        formatter: ({ x, y, value }) => ... ,
+        
+        // value + title Formatter
+        formatter: {
+            title: ({ x, y }) => ...,
+            value: ({ x, y, value }) => ...,
+        }
+    },
+}
+```
 
 #### heatMapColor
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/heatMap/example/Time.vue
+++ b/docs/views/heatMap/example/Time.vue
@@ -107,7 +107,10 @@ import { onBeforeUnmount, reactive, ref, watch } from 'vue';
         },
         tooltip: {
           use: true,
-          formatter: ({ value }) => `value: ${value}`,
+          formatter: {
+            title: ({ x }) => dayjs(x).format('HH:mm:ss'),
+            value: ({ value }) => `${value}`,
+          },
         },
       };
 

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -211,7 +211,21 @@ const chartData =
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
-| formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | ({x, y, name}) => y + '%' |
+| formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
+```
+const chartOptions = {
+    tooltip: {
+        // 이전 버전 호환용으로 valueFormatter를 이전버전과 같이 사용 가능
+        formatter: ({ x, y, name }) => ... ,
+        
+        // value + title Formatter
+        formatter: {
+            title: ({ x, y }) => ...,
+            value: ({ x, y, name }) => ...,
+        }
+    },
+}
+```
 
 #### indicator
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/lineChart/example/Tooltip.vue
+++ b/docs/views/lineChart/example/Tooltip.vue
@@ -202,7 +202,10 @@
           maxWidth,
           maxHeight,
           textOverflow,
-          formatter: ({ x, y, name }) => console.log(`X: ${x}, Y: ${y}, series name: ${name}`),
+          formatter: {
+            title: ({ x }) => dayjs(x).format('YYYY-MM-DD HH:mm:ss'),
+            value: ({ y }) => `${y}%`,
+          },
         },
       });
 

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -109,8 +109,20 @@ const chartData =
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
-| formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | ({ value, name }) => value + '%' |
-
+| formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
+```
+const chartOptions = {
+    tooltip: {
+        // 이전 버전 호환용으로 valueFormatter를 이전버전과 같이 사용 가능
+        formatter: ({ name, value }) => ... ,
+        
+        // 새로운 버전
+        formatter: {
+            value: ({ name, value }) => ...,
+        }
+    },
+}
+```
 #### selectItem
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 | --- | ---- | ----- | --- | ----------|

--- a/docs/views/pieChart/example/Default.vue
+++ b/docs/views/pieChart/example/Default.vue
@@ -34,6 +34,9 @@
           show: true,
           position: 'right',
         },
+        tooltip: {
+          formatter: ({ value }) => `${value}%`,
+        },
       };
 
       return {

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -187,7 +187,20 @@ const chartData =
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
-| formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | ({x, y, name}) => y + '%' |
+| formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
+```
+const chartOptions = {
+    tooltip: {
+        // 이전 버전 호환용으로 valueFormatter를 이전버전과 같이 사용 가능
+        formatter: ({ x, y, name }) => ... ,
+        
+        // 새로운 버전
+        formatter: {
+            value: ({ x, y, name }) => ...,
+        }
+    },
+}
+```
 
 #### selectItem
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -176,12 +176,21 @@ const modules = {
     const boxPadding = { t: 8, b: 8, r: 20, l: 16 };
     const isHorizontal = this.options.horizontal;
     const opt = this.options.tooltip;
+    const valueFormatter = typeof opt.formatter === 'function' ? opt.formatter : opt.formatter?.value;
+    const titleFormatter = opt.formatter?.title;
 
     // draw tooltip Title(axis label) and add style class for wrap line about too much long label.
     if (this.axesX.length && this.axesY.length) {
-      this.tooltipHeaderDOM.textContent = this.options.horizontal
-        ? this.axesY[hitAxis.y].getLabelFormat(hitItem.y)
-        : this.axesX[hitAxis.x].getLabelFormat(hitItem.x);
+      if (titleFormatter) {
+        this.tooltipHeaderDOM.textContent = titleFormatter({
+          x: hitItem.x,
+          y: hitItem.y,
+        });
+      } else {
+        this.tooltipHeaderDOM.textContent = this.options.horizontal
+          ? this.axesY[hitAxis.y].getLabelFormat(hitItem.y)
+          : this.axesX[hitAxis.x].getLabelFormat(hitItem.x);
+      }
     }
 
     if (opt.textOverflow) {
@@ -305,14 +314,14 @@ const modules = {
 
       // 3. Draw value
       let formattedTxt;
-      if (opt.formatter) {
+      if (valueFormatter) {
         if (this.options.type === 'pie') {
-          formattedTxt = opt.formatter({
+          formattedTxt = valueFormatter({
             value,
             name,
           });
         } else {
-          formattedTxt = opt.formatter({
+          formattedTxt = valueFormatter({
             x: this.options.horizontal ? value : hitItem.x,
             y: this.options.horizontal ? hitItem.y : value,
             name,
@@ -320,7 +329,7 @@ const modules = {
         }
       }
 
-      if (!opt.formatter || typeof formattedTxt !== 'string') {
+      if (!valueFormatter || typeof formattedTxt !== 'string') {
         formattedTxt = numberWithComma(value);
       }
 
@@ -356,6 +365,8 @@ const modules = {
     const boxPadding = { t: 8, b: 8, r: 20, l: 16 };
     const isHorizontal = this.options.horizontal;
     const opt = this.options.tooltip;
+    const valueFormatter = typeof opt.formatter === 'function' ? opt.formatter : opt.formatter?.value;
+    const titleFormatter = opt.formatter?.title;
 
     const colorAxis = Object.values(this.seriesList)[0].colorAxis;
     const isShow = colorAxis.find(({ id }) => id === hitItem.cId)?.show;
@@ -364,13 +375,16 @@ const modules = {
       return;
     }
 
-    let xValue = '';
-    let yValue = '';
-
     // draw tooltip Title(axis label) and add style class for wrap line about too much long label.
     if (this.axesX.length) {
-      xValue = this.axesX[hitAxis.x].getLabelFormat(hitItem.x);
-      this.tooltipHeaderDOM.textContent = xValue;
+      if (titleFormatter) {
+        this.tooltipHeaderDOM.textContent = titleFormatter({
+          x: hitItem.x,
+          y: hitItem.y,
+        });
+      } else {
+        this.tooltipHeaderDOM.textContent = this.axesX[hitAxis.x].getLabelFormat(hitItem.x);
+      }
     }
 
     if (opt.textOverflow) {
@@ -411,21 +425,20 @@ const modules = {
     // 2. Draw value y names
     ctx.textBaseline = 'Bottom';
     if (this.axesY.length) {
-      yValue = this.axesY[hitAxis.y].getLabelFormat(hitItem.y);
-      ctx.fillText(yValue, itemX + COLOR_MARGIN, itemY);
+      ctx.fillText(this.axesY[hitAxis.y].getLabelFormat(hitItem.y), itemX + COLOR_MARGIN, itemY);
     }
 
     // 3. Draw value
     let formattedTxt = itemValue;
-    if (opt.formatter) {
-      formattedTxt = opt.formatter({
-        x: xValue,
-        y: yValue,
+    if (valueFormatter) {
+      formattedTxt = valueFormatter({
+        x: hitItem.x,
+        y: hitItem.y,
         value: itemValue,
       });
     }
 
-    if ((!opt.formatter || typeof formattedTxt !== 'string') && itemValue !== 'error') {
+    if ((!valueFormatter || typeof formattedTxt !== 'string') && itemValue !== 'error') {
       formattedTxt = numberWithComma(itemValue);
     }
 
@@ -565,15 +578,16 @@ const modules = {
 
       // 3. Draw value
       let formattedTxt;
-      if (opt.formatter) {
-        formattedTxt = opt.formatter({
+      const formatter = typeof opt.formatter === 'function' ? opt.formatter : opt.formatter?.value;
+      if (formatter) {
+        formattedTxt = formatter({
           x: xValue,
           y: yValue,
           name,
         });
       }
 
-      if (!opt.formatter || typeof formattedTxt !== 'string') {
+      if (!formatter || typeof formattedTxt !== 'string') {
         const formattedXValue = xAxisOpt.type === 'time'
           ? dayjs(xValue).format(xAxisOpt.timeFormat)
           : numberWithComma(xValue);


### PR DESCRIPTION
### 개요
- 기존 Tooltip의 formatter는 `value` 영역 한정으로 제공되고 있었으나 title 영역에 대한 formatter 지원도 필요하여 기능 추가함

### 사용 예시
- ![image](https://user-images.githubusercontent.com/53548023/166175699-637ac913-a755-4a1d-95d4-1b82bf5674b7.png)
- 자세한 사항은 차트 타입별 docs 확인

### 작업내용
1. formatter 옵션 수정
   - 기존 formatter property에 function으로 바로 넣어서 사용하던 코드도 유지될 수 있도록 function / object type 둘다 지원하며 function타입으로 넘길 경우 valueFormatter로 동작하도록 함
3. bar, line, pie, scatter, heatmap 적용