### PR TITLE
[#1160] TreeGrid > Highlight 시 자식 노드 안보이는 이슈

### DIFF
--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -524,6 +524,7 @@ export default {
         };
         const setParentShow = (data) => {
           if (!data?.parent) {
+            setChildShow(data);
             return;
           }
           const { parent } = data;


### PR DESCRIPTION
####################
- parent가 없는 최상의 노드일 경우 자식노드 show 처리될 수 있도록 수정

[AS-IS]
![before](https://user-images.githubusercontent.com/61657275/167056290-01fb02c5-0f1d-4b2d-8e5d-6959f2604ee8.gif)
[TO-BE]
![after](https://user-images.githubusercontent.com/61657275/167056301-1e95ef2d-5439-48fc-9ff3-36f4c2ecb0c8.gif)

