### PR TITLE
[#1164] HeatMap > 높이가 작을 경우 y축 사라지는 현상 픽스

### DIFF
--- a/docs/views/heatMap/example/Gradient.vue
+++ b/docs/views/heatMap/example/Gradient.vue
@@ -78,7 +78,7 @@ import { reactive } from 'vue';
         },
         legend: {
           type: 'gradient',
-          position: 'bottom',
+          position: 'right',
         },
       };
 

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -137,7 +137,7 @@ class HeatMap {
     ctx.beginPath();
     if (this.stroke.show) {
       const { radius } = this.stroke;
-      if (radius > 0) {
+      if (radius > 0 && radius < h && radius < w) {
         ctx.moveTo(x + radius, y);
         ctx.arcTo(x + w, y, x + w, y + h, radius);
         ctx.arcTo(x + w, y + h, x, y + h, radius);

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -48,11 +48,16 @@ class StepScale extends Scale {
     if (this.rangeMode) {
       const { maxSteps } = range;
 
-      while (numberOfSteps > maxSteps * 2) {
-        interval *= 2;
-        numberOfSteps = Math.round(numberOfSteps / interval);
+      if (maxSteps > 2) {
+        while (numberOfSteps > maxSteps * 2) {
+          interval *= 2;
+          numberOfSteps = Math.round(numberOfSteps / interval);
+        }
+      } else {
+        interval = this.labels.length;
       }
     }
+
     return {
       steps: numberOfSteps,
       interval,


### PR DESCRIPTION
작업내용
-
1. 높이가 낮아 max step이 2보다 낮은 경우 예외처리
![image](https://user-images.githubusercontent.com/75718910/168236586-3cad5588-b563-487a-b6d7-d0c5a6e8c2d0.png)

2. radius보다 계산된 width, height가 작은 경우 예외처리

