### PR TITLE
[#1170] line Chart > select Series 관련하여 간혈적으로 에러로그 발생

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.21",
+  "version": "3.3.22",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -698,9 +698,15 @@ const modules = {
               vector: { start: position[dataIndex - 1], end: position[dataIndex] },
             }));
 
+            const isEmptyVector = (arr => !arr || !Array.isArray(arr) || arr?.length !== 2);
+
             // canvas 의 클릭 위치값은 제 4 사분면의 위치이므로 clickedY, y1, y2 의 값은 음수를 취한다.
             if (isStackChart) {
               hitSeries = vectorList.find(({ vector }) => {
+                if (isEmptyVector(vector?.start) && isEmptyVector(vector?.end)) {
+                  return false;
+                }
+
                 const [x1, y1] = vector.start;
                 const [x2, y2] = vector.end;
                 const v1 = [x2 - x1, y1 - y2];
@@ -713,6 +719,10 @@ const modules = {
               })?.sId;
             } else {
               hitSeries = vectorList.find(({ vector }) => {
+                if (isEmptyVector(vector?.start) && isEmptyVector(vector?.end)) {
+                  return false;
+                }
+
                 const [x1, y1] = vector.start;
                 const [x2, y2] = vector.end;
                 const a = (y1 - y2) / (x2 - x1);


### PR DESCRIPTION
### 이슈 원인
 - 길이가 2인 배열인 형태를 기대했으나 간혈적으로 null이 들어가는 상황이 있고, null을 대상으로 구조분해할당 시 에러로그가 발생함
 
### 작업내용
- 배열 구조 분해 할당 전 배열이 맞는지 확인하는 로직 추가
- EVUI version update (3.3.21 -> 3.3.22)