### PR TITLE
[#1172] Grid, TreeGrid > paging total 값 관련 이슈

### DIFF
--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -263,7 +263,7 @@
   <grid-pagination
     v-if="usePage && !isInfinite"
     v-model="currentPage"
-    :total="store.length"
+    :total="pageTotal"
     :per-page="perPage"
     :visible-page="visiblePage"
     :show-page-info="showPageInfo"
@@ -392,7 +392,7 @@ export default {
       startIndex: 0,
       prevPage: 0,
       currentPage: 0,
-      total: computed(() => (props.option.page?.total || 0)),
+      pageTotal: computed(() => (props.option.page?.total || 0)),
       perPage: computed(() => (props.option.page?.perPage || 20)),
       visiblePage: computed(() => (props.option.page?.visiblePage || 8)),
       order: computed(() => (props.option.page?.order || 'center')),

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -963,7 +963,7 @@ export const pagingEvent = (params) => {
         currentPage: pageInfo.currentPage,
         prevPage: pageInfo.prevPage,
         startIndex: pageInfo.startIndex,
-        total: pageInfo.total,
+        total: pageInfo.pageTotal,
         perPage: pageInfo.perPage,
       },
       sortInfo: {

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -178,7 +178,7 @@
   <grid-pagination
     v-if="usePage && !isInfinite"
     v-model="currentPage"
-    :total="showTreeStore.length"
+    :total="pageTotal"
     :per-page="perPage"
     :visible-page="visiblePage"
     :show-page-info="showPageInfo"
@@ -290,7 +290,7 @@ export default {
       startIndex: 0,
       prevPage: 0,
       currentPage: 0,
-      total: computed(() => (props.option.page?.total || 0)),
+      pageTotal: computed(() => (props.option.page?.total || 0)),
       perPage: computed(() => (props.option.page?.perPage || 20)),
       visiblePage: computed(() => (props.option.page?.visiblePage || 8)),
       order: computed(() => (props.option.page?.order || 'center')),

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -841,7 +841,7 @@ export const pagingEvent = (params) => {
         currentPage: pageInfo.currentPage,
         prevPage: pageInfo.prevPage,
         startIndex: pageInfo.startIndex,
-        total: pageInfo.total,
+        total: pageInfo.pageTotal,
         perPage: pageInfo.perPage,
       },
       searchInfo: {


### PR DESCRIPTION
####################
- grid 내부의 paging 사용 시 total 값을 입력해도 현재 가지고 있는 rows의 개수 만큼만 카운팅되는 문제 수정