### PR TITLE
[#1179] Tree Grid > 클릭이벤트시 컬럼의 dataset 을 읽어오지 못하는 현상

### DIFF
--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -363,7 +363,7 @@ export const clickEvent = (params) => {
     if (tagName === 'td') {
       cellInfo = event.target.dataset;
     } else {
-      cellInfo = event.target.parentNode.dataset;
+      cellInfo = event.target.closest('td').dataset;
     }
     return {
       event,


### PR DESCRIPTION
####################
- 클릭 이벤트 시 클릭한 target 의 가장 가까운 td의 dataset을 가져올 수 있도록 수정