### PR TITLE
[#1181] Chart 툴팁 너비 계산 버그

### DIFF
--- a/docs/views/lineChart/example/Tooltip.vue
+++ b/docs/views/lineChart/example/Tooltip.vue
@@ -204,7 +204,7 @@
           textOverflow,
           formatter: {
             title: ({ x }) => dayjs(x).format('YYYY-MM-DD HH:mm:ss'),
-            value: ({ y }) => `${y}%`,
+            value: ({ y }) => `${y.toFixed(2)}`,
           },
         },
       });
@@ -215,7 +215,7 @@
         chartData.labels.push(dayjs(timeValue));
 
         Object.values(chartData.data).forEach((seriesData) => {
-          seriesData.push(Math.floor(Math.random() * ((5000 - 5) + 1)) + 5);
+          seriesData.push(Math.random());
         });
       };
 

--- a/docs/views/scatterChart/example/SelectItem.vue
+++ b/docs/views/scatterChart/example/SelectItem.vue
@@ -91,6 +91,7 @@
         }],
         tooltip: {
           use: true,
+          formatter: ({ x, y }) => `${x}, ${y}`,
         },
         selectItem: {
           use: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.23",
+  "version": "3.3.24",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -376,6 +376,10 @@ const modules = {
     const items = {};
     const isHorizontal = !!this.options.horizontal;
     const ctx = this.tooltipCtx;
+    const tooltipOpt = this.options.tooltip;
+    const tooltipValueFormatter = typeof tooltipOpt.formatter === 'function'
+      ? tooltipOpt.formatter
+      : tooltipOpt.formatter?.value;
 
     let hitId = null;
     let maxs = '';
@@ -410,15 +414,41 @@ const modules = {
             item.axis = { x: series.xAxisIndex, y: series.yAxisIndex };
             items[sId] = item;
 
-            const cg = numberWithComma(gdata);
+            let formattedTxt = '';
+            if (tooltipValueFormatter) {
+              if (this.options.type === 'pie') {
+                formattedTxt = tooltipValueFormatter({
+                  value: gdata,
+                  name: sName,
+                });
+              } else if (this.options.type === 'heatMap') {
+                formattedTxt = tooltipValueFormatter({
+                  x: item.data.x,
+                  y: item.data.y,
+                  value: gdata > -1 ? gdata : 'error',
+                });
+              } else {
+                formattedTxt = tooltipValueFormatter({
+                  x: this.options.horizontal ? gdata : item.data.x,
+                  y: this.options.horizontal ? item.data.y : gdata,
+                  name: sName,
+                });
+              }
+            }
+
+            if (!tooltipValueFormatter || typeof formattedTxt !== 'string') {
+              formattedTxt = numberWithComma(gdata);
+            }
+
+            item.data.formatted = formattedTxt;
 
             if (maxsw < sw) {
               maxs = sName;
               maxsw = sw;
             }
 
-            if (maxv.length <= `${cg}`.length) {
-              maxv = `${cg}`;
+            if (maxv.length <= `${formattedTxt}`.length) {
+              maxv = `${formattedTxt}`;
             }
 
             if (maxg === null || maxg <= gdata) {

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -187,7 +187,6 @@ const modules = {
     const boxPadding = { t: 8, b: 8, r: 20, l: 16 };
     const isHorizontal = this.options.horizontal;
     const opt = this.options.tooltip;
-    const valueFormatter = typeof opt.formatter === 'function' ? opt.formatter : opt.formatter?.value;
     const titleFormatter = opt.formatter?.title;
 
     // draw tooltip Title(axis label) and add style class for wrap line about too much long label.
@@ -258,14 +257,7 @@ const modules = {
       const gdata = seriesList[ix].data;
       const color = seriesList[ix].color;
       const name = seriesList[ix].name;
-
-      let value;
-
-      if (gdata.o === null) {
-        value = isHorizontal ? gdata.x : gdata.y;
-      } else if (!isNaN(gdata.o)) {
-        value = gdata.o;
-      }
+      const valueText = gdata.formatted;
 
       let itemX = x + 4;
       let itemY = y + (textLineCnt * TEXT_HEIGHT);
@@ -324,28 +316,8 @@ const modules = {
       ctx.save();
 
       // 3. Draw value
-      let formattedTxt;
-      if (valueFormatter) {
-        if (this.options.type === 'pie') {
-          formattedTxt = valueFormatter({
-            value,
-            name,
-          });
-        } else {
-          formattedTxt = valueFormatter({
-            x: this.options.horizontal ? value : hitItem.x,
-            y: this.options.horizontal ? hitItem.y : value,
-            name,
-          });
-        }
-      }
-
-      if (!valueFormatter || typeof formattedTxt !== 'string') {
-        formattedTxt = numberWithComma(value);
-      }
-
       ctx.textAlign = 'right';
-      ctx.fillText(formattedTxt, this.tooltipDOM.offsetWidth - boxPadding.r, itemY);
+      ctx.fillText(valueText, this.tooltipDOM.offsetWidth - boxPadding.r, itemY);
       ctx.restore();
       ctx.closePath();
 
@@ -376,7 +348,6 @@ const modules = {
     const boxPadding = { t: 8, b: 8, r: 20, l: 16 };
     const isHorizontal = this.options.horizontal;
     const opt = this.options.tooltip;
-    const valueFormatter = typeof opt.formatter === 'function' ? opt.formatter : opt.formatter?.value;
     const titleFormatter = opt.formatter?.title;
     const series = Object.values(this.seriesList)[0];
 
@@ -422,7 +393,7 @@ const modules = {
 
     const itemX = boxPadding.l + 2;
     const itemY = boxPadding.t + TEXT_HEIGHT + 2;
-    const itemValue = hitItem.o > -1 ? hitItem.o : 'error';
+    const valueText = hitItem.formatted;
 
     ctx.font = fontStyle;
 
@@ -450,21 +421,8 @@ const modules = {
     }
 
     // 3. Draw value
-    let formattedTxt = itemValue;
-    if (valueFormatter) {
-      formattedTxt = valueFormatter({
-        x: hitItem.x,
-        y: hitItem.y,
-        value: itemValue,
-      });
-    }
-
-    if ((!valueFormatter || typeof formattedTxt !== 'string') && itemValue !== 'error') {
-      formattedTxt = numberWithComma(itemValue);
-    }
-
     ctx.textAlign = 'right';
-    ctx.fillText(formattedTxt, this.tooltipDOM.offsetWidth - boxPadding.r, itemY);
+    ctx.fillText(valueText, this.tooltipDOM.offsetWidth - boxPadding.r, itemY);
     ctx.closePath();
 
     this.setTooltipDOMStyle(opt);
@@ -482,7 +440,6 @@ const modules = {
     const seriesKeys = this.alignSeriesList(Object.keys(items));
     const boxPadding = { t: 8, b: 8, r: 8, l: 8 };
     const opt = this.options.tooltip;
-    const xAxisOpt = this.options.axesX[0];
 
     let x = 2;
     let y = 2;
@@ -533,13 +490,7 @@ const modules = {
       const gdata = seriesList[ix].data;
       const color = seriesList[ix].color;
       const name = seriesList[ix].name;
-      const xValue = gdata.x;
-      let yValue;
-      if (gdata.o === null) {
-        yValue = gdata.y;
-      } else if (!isNaN(gdata.o)) {
-        yValue = gdata.o;
-      }
+      const valueText = gdata.formatted;
 
       let itemX = x + 4;
       let itemY = y + (textLineCnt * TEXT_HEIGHT);
@@ -598,26 +549,8 @@ const modules = {
       ctx.save();
 
       // 3. Draw value
-      let formattedTxt;
-      const formatter = typeof opt.formatter === 'function' ? opt.formatter : opt.formatter?.value;
-      if (formatter) {
-        formattedTxt = formatter({
-          x: xValue,
-          y: yValue,
-          name,
-        });
-      }
-
-      if (!formatter || typeof formattedTxt !== 'string') {
-        const formattedXValue = xAxisOpt.type === 'time'
-          ? dayjs(xValue).format(xAxisOpt.timeFormat)
-          : numberWithComma(xValue);
-        const formattedYValue = numberWithComma(yValue);
-        formattedTxt = `${formattedXValue}, ${formattedYValue}`;
-      }
-
       ctx.textAlign = 'right';
-      ctx.fillText(formattedTxt, this.tooltipDOM.offsetWidth - boxPadding.r, itemY);
+      ctx.fillText(valueText, this.tooltipDOM.offsetWidth - boxPadding.r, itemY);
       ctx.restore();
       ctx.closePath();
 


### PR DESCRIPTION
### 이슈 내용
- Formatter 적용 전 데이터를 기반으로 Tooltip의 value 표시 영역의 너비를 계산하여 실제 Text보다 더 넓거나 좁게 보일 수 있음 
- 실제 데이터
   - ![image](https://user-images.githubusercontent.com/53548023/169971392-d705f1f8-f6e8-476a-9e1b-3d5c1ae4b6ec.png)
- formatter를 적용한 데이터 
   - ![image](https://user-images.githubusercontent.com/53548023/169971428-7076f212-4d5a-4aa0-b02e-5f5aff4d6f7b.png)
   - formatter를 적용하여 Text가 짧아졌음에도 불구하고 value 영역이 넓게 잡힘


### 처리 내용
1.  툴팁 DOM의 너비를 결정할 때 original Data가 아닌Formatter 적용 이후의 text를 참조하도록 로직 변경
   - ![image](https://user-images.githubusercontent.com/53548023/169971578-725c58b3-97cb-4030-aba8-0d0a613954ca.png)

