### PR TITLE
[#1179] Tree Grid > 클릭이벤트시 컬럼의 dataset 을 읽어오지 못하는 현상

### DIFF
--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -360,10 +360,12 @@ export const clickEvent = (params) => {
   const getClickedRowData = (event, row) => {
     const tagName = event.target.tagName.toLowerCase();
     let cellInfo = {};
-    if (tagName === 'td') {
-      cellInfo = event.target.dataset;
-    } else {
-      cellInfo = event.target.closest('td').dataset;
+    if (event.target.offsetParent) {
+      if (tagName === 'td') {
+        cellInfo = event.target.dataset;
+      } else {
+        cellInfo = event.target.closest('td').dataset;
+      }
     }
     return {
       event,


### PR DESCRIPTION
####################
- 타겟의 offsetParent 생성되어 존재할 때 dataset 꺼내도록 수정