### PR TITLE
[#1200] Chart > Axis > Decimal Point 동작하지 않는 현상 발생

### DIFF
--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -173,8 +173,6 @@ export default {
       label = assignLabelWith(value, milli, 'M');
     } else if (value >= killo) {
       label = assignLabelWith(value, 1000, 'K');
-    } else if (value < 1 && value > 0) {
-      label = value.toFixed(1);
     } else {
       label = value.toFixed(decimalPoint);
     }


### PR DESCRIPTION
### 이슈 내용
- axis > `linear` 혹은 `log` 타입에서 0 이하의 숫자들로 데이터가 들어올 경우 축에 소수점을 포함하여 표시해야 하지만 정수만 표시되는 현상 발생
- ![image](https://user-images.githubusercontent.com/53548023/171789729-08953438-1a10-4711-9102-e79bb799bb3f.png)
```
        axesX: [{
          type: 'log',
          showGrid: true,
        }],
```

### 처리 내용
- 불필요한 조건문을 제거하여 사용자로부터 받은 `decimalPoint` 속성이 반영되도록 함
- ![image](https://user-images.githubusercontent.com/53548023/171789715-4ae82cca-7cd9-49e0-9079-233958a3af2a.png)
```
        axesX: [{
          type: 'log',
          decimalPoint: 6,
          showGrid: true,
        }],
```