### PR TITLE
[#1290] Chart > tooltip > 값이 null인 경우 보이지 않는 현상

### DIFF
--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -511,8 +511,7 @@ const modules = {
         item.data.formatted = this.getFormattedTooltipValue({
           seriesName: series.name,
           value: hasData.o,
-          x: hasData.x,
-          y: hasData.y,
+          itemData: hasData,
         });
 
         hitInfo.items[sId] = item;


### PR DESCRIPTION
### 작업내용
- 로직 오류 수정