### PR TITLE
[#1212] Chart > decimalPoint를 지정하지 않았을 때 축의 값이 0과 1이 반복되어 보이는 현상

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -371,7 +371,7 @@ class EvChart {
         minSteps: this.labelRange.x[index].min,
         maxSteps: this.labelRange.x[index].max,
       };
-      return axis.calculateSteps(range, axis.decimalPoint);
+      return axis.calculateSteps(range);
     });
 
     const axesYMinMax = this.axesY.map((axis, index) => {
@@ -381,8 +381,7 @@ class EvChart {
         minSteps: this.labelRange.y[index].min,
         maxSteps: this.labelRange.y[index].max,
       };
-
-      return axis.calculateSteps(range, axis.decimalPoint);
+      return axis.calculateSteps(range);
     });
 
     return { x: axesXMinMax, y: axesYMinMax };

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -371,7 +371,7 @@ class EvChart {
         minSteps: this.labelRange.x[index].min,
         maxSteps: this.labelRange.x[index].max,
       };
-      return axis.calculateSteps(range);
+      return axis.calculateSteps(range, axis.decimalPoint);
     });
 
     const axesYMinMax = this.axesY.map((axis, index) => {
@@ -382,7 +382,7 @@ class EvChart {
         maxSteps: this.labelRange.y[index].max,
       };
 
-      return axis.calculateSteps(range);
+      return axis.calculateSteps(range, axis.decimalPoint);
     });
 
     return { x: axesXMinMax, y: axesYMinMax };

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -105,11 +105,10 @@ class Scale {
   /**
    * With range information, calculate how many labels in axis
    * @param {object} range    min/max information
-   * @param {number | undefined} decimalPoint
    *
    * @returns {object} steps, interval, min/max graph value
    */
-  calculateSteps(range, decimalPoint) {
+  calculateSteps(range) {
     const { maxValue, minValue } = range;
     let { maxSteps } = range;
 
@@ -128,7 +127,7 @@ class Scale {
     numberOfSteps = Math.round(graphRange / interval);
 
     if (maxValue === 1) {
-      if (!decimalPoint) {
+      if (!this.decimalPoint) {
         interval = 1;
         numberOfSteps = 1;
         maxSteps = 1;

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -105,10 +105,11 @@ class Scale {
   /**
    * With range information, calculate how many labels in axis
    * @param {object} range    min/max information
+   * @param {number | undefined} decimalPoint
    *
    * @returns {object} steps, interval, min/max graph value
    */
-  calculateSteps(range) {
+  calculateSteps(range, decimalPoint) {
     const { maxValue, minValue } = range;
     let { maxSteps } = range;
 
@@ -127,7 +128,11 @@ class Scale {
     numberOfSteps = Math.round(graphRange / interval);
 
     if (maxValue === 1) {
-      if (maxSteps > 2) {
+      if (!decimalPoint) {
+        interval = 1;
+        numberOfSteps = 1;
+        maxSteps = 1;
+      } else if (maxSteps > 2) {
         interval = 0.2;
         numberOfSteps = 5;
         maxSteps = 5;


### PR DESCRIPTION
### 작업 내용 `#1`
![image](https://user-images.githubusercontent.com/81760347/173517846-070ef744-088b-4593-b87f-18310c221673.png)
- decimalPoint를 지정하지 않은 차트(default: 0)에서 초기 데이터가 없다면 축에 0, 1로 렌더링하도록 수정
### 작업 내용 `#2`
![image](https://user-images.githubusercontent.com/81760347/173517588-6fc9c1d3-968d-4afd-b0ad-7ce249544c80.png)
- decimalPoint를 지정하지 않은 차트(default: 0)의 데이터가 1보다 작으면 축에 0, 1로 렌더링하도록 수정
### 작업 내용 `#3`
- 축의 step을 결정하는 `calculateSteps`함수에 decimalPoint 인자를 받도록 수정하였습니다.
- `calculateSteps`함수에서 최대값이 1이고, decimalPoint가 false인 경우에 동작하도록 로직을 추가하였습니다.