### PR TITLE
[#1214] Chart > legend - update 호출 이후 모든 series hiding 이 가능해지는 버그

### DIFF
--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -453,6 +453,7 @@ const modules = {
     while (legendDOM.hasChildNodes()) {
       legendDOM.removeChild(legendDOM.firstChild);
     }
+    this.seriesInfo.count = 0;
   },
 
   /**


### PR DESCRIPTION
### 이슈 내용
- 차트 legend 클릭으로 series 를 hide 할때 최소 1개는 보여지는 것이 스펙이지만, 차트의 update 함수 호출 이후 모두 hide 가 가능해짐
- ![legend](https://user-images.githubusercontent.com/46586573/173725036-1a472be4-d89b-4b10-95cb-1bd838b3e99f.gif)

### 원인
- 차트 update 가 호출된 이후에 visible counter 역할을 하는 seriesInfo.count 가 초기화 되지 않아서 updateLegend 를 호출하면 counter 가 증가하며, [실제 시리즈 갯수 x 2]개 의 count 를 갖게되어 legend 코드에서 의도한 것으로 보이는 최소 한개를 보여주는 스펙이 동작하지 않음.

### 처리 내용
- `resetLegend` 함수에서 count 를 초기화