### PR TITLE
[#1215] Chart > Highlight 기능 우선순위 조정

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -1,6 +1,5 @@
 import throttle from '@/common/utils.throttle';
 import Model from './model';
-import Util from './helpers/helpers.util';
 import TimeScale from './scale/scale.time';
 import LinearScale from './scale/scale.linear';
 import LogarithmicScale from './scale/scale.logarithmic';

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -140,12 +140,16 @@ class Bar {
 
       const barColor = item.dataColor || this.color;
 
-      const selectLabelOption = param.selectLabel.option;
-      const selectedLabel = param.selectLabel.selected ?? { dataIndex: [] };
+      const legendHitInfo = param?.legendHitInfo;
+      const selectLabelOption = param?.selectLabel?.option;
+      const selectedLabelList = param?.selectLabel?.selected?.dataIndex ?? [];
+      let isDownplay = false;
 
-      const isDownplay = selectLabelOption.use && selectLabelOption.useSeriesOpacity
-          ? selectedLabel.dataIndex.length && !selectedLabel.dataIndex.includes(index)
-          : this.state === 'downplay';
+      if (legendHitInfo) {
+        isDownplay = legendHitInfo?.sId !== this.sId;
+      } else if (selectLabelOption?.use && selectLabelOption?.useSeriesOpacity) {
+        isDownplay = selectedLabelList.length && !selectedLabelList.includes(index);
+      }
 
       if (typeof barColor !== 'string') {
         ctx.fillStyle = Canvas.createGradient(

--- a/src/components/chart/element/element.pie.js
+++ b/src/components/chart/element/element.pie.js
@@ -27,7 +27,6 @@ class Pie {
     this.doughnutHoleSize = 0;
     this.startAngle = 0;
     this.endAngle = 0;
-    this.state = null;
     this.ctx = null;
     this.isSelect = false;
   }
@@ -48,7 +47,7 @@ class Pie {
 
     const color = this.color;
     const noneDownplayOpacity = color.includes('rgba') ? Util.getOpacity(color) : 1;
-    const opacity = this.state === 'downplay' ? 0.1 : noneDownplayOpacity;
+    const opacity = this.isDownplay ? 0.1 : noneDownplayOpacity;
 
     ctx.beginPath();
     slice.moveTo(this.centerX, this.centerY);
@@ -120,7 +119,7 @@ class Pie {
     ctx.shadowOffsetY = 0;
     ctx.shadowBlur = 4;
 
-    const color = item.data.dataColor || this.color;
+    const color = item?.data?.dataColor || this.color;
     ctx.fillStyle = color;
     ctx.shadowColor = color;
 

--- a/src/components/chart/element/element.scatter.js
+++ b/src/components/chart/element/element.scatter.js
@@ -71,23 +71,16 @@ class Scatter {
 
     const getOpacity = (colorStr, dataIndex) => {
       const noneDownplayOpacity = colorStr.includes('rgba') ? Util.getOpacity(colorStr) : 1;
-      let resultOpacity = noneDownplayOpacity;
+      let isDownplay = false;
 
-      const { selectInfo } = param;
-      if (selectInfo) {
-        const isSelectedData = selectInfo?.seriesID === this.sId
-          && selectInfo?.dataIndex === dataIndex;
-
-        if (isSelectedData) {
-          resultOpacity = noneDownplayOpacity;
-        } else {
-          resultOpacity = 0.1;
-        }
-      } else {
-        resultOpacity = this.state === 'downplay' ? 0.1 : noneDownplayOpacity;
+      const { selectInfo, legendHitInfo } = param;
+      if (legendHitInfo) {
+        isDownplay = legendHitInfo.sId !== this.sId;
+      } else if (selectInfo) {
+        isDownplay = selectInfo?.seriesID !== this.sId || selectInfo?.dataIndex !== dataIndex;
       }
 
-      return resultOpacity;
+      return isDownplay ? 0.1 : noneDownplayOpacity;
     };
 
     this.data.forEach((curr, idx) => {

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -588,17 +588,6 @@ const modules = {
       if (!this.defaultSelectInfo) {
         this.defaultSelectInfo = { seriesId: [] };
       }
-
-      const selectedList = this.defaultSelectInfo.seriesId;
-      Object.values(this.seriesList).forEach((series) => {
-        if (!selectedList.length) {
-          series.state = 'normal';
-        } else if (selectedList.includes(series.sId)) {
-          series.state = 'highlight';
-        } else {
-          series.state = 'downplay';
-        }
-      });
     }
   },
 

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -214,24 +214,14 @@ const modules = {
       }
       const nameDOM = targetDOM.getElementsByClassName('ev-chart-legend-name')[0];
       const targetId = nameDOM.series.sId;
-      const selectSeriesOption = this.options.selectSeries;
-      const selectedList = this.defaultSelectInfo?.seriesId ?? [];
-
-      Object.values(this.seriesList).forEach((series) => {
-        series.state = series.sId === targetId
-        || (selectSeriesOption.use && selectedList.includes(targetId))
-          ? 'highlight' : 'downplay';
-      });
-
-      let hitInfo = null;
-      if (Util.isPieType(this.options.type)) {
-        hitInfo = { sId: targetId, type: this.options.type };
-      }
+      const legendHitInfo = { sId: targetId, type: this.options.type };
 
       this.update({
         updateSeries: false,
         updateSelTip: { update: false, keepDomain: false },
-        hitInfo,
+        hitInfo: {
+          legend: legendHitInfo,
+        },
       });
     };
 
@@ -241,20 +231,12 @@ const modules = {
      * @returns {undefined}
      */
     this.onLegendBoxLeave = () => {
-      const selectSeriesOption = this.options.selectSeries;
-      const selectedList = this.defaultSelectInfo?.seriesId ?? [];
-      Object.values(this.seriesList).forEach((series) => {
-        if (selectSeriesOption.use && selectedList.length) {
-          series.state = selectedList.includes(series.sId)
-            ? 'highlight' : 'downplay';
-        } else {
-          series.state = 'normal';
-        }
-      });
-
       this.update({
         updateSeries: false,
         updateSelTip: { update: false, keepDomain: false },
+        hitInfo: {
+          legend: null,
+        },
       });
     };
 

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -1,5 +1,3 @@
-import Util from '@/components/chart/helpers/helpers.util';
-
 const modules = {
   /**
    * Create legend DOM

--- a/src/components/chart/plugins/plugins.pie.js
+++ b/src/components/chart/plugins/plugins.pie.js
@@ -77,7 +77,9 @@ const modules = {
               ctx.stroke();
             }
 
-            series.isSelect = hitInfo?.sId === slice.id;
+            const { selectInfo, legendHitInfo } = hitInfo;
+            series.isSelect = selectInfo?.sId === slice.id;
+            series.isDownplay = (legendHitInfo && legendHitInfo.sId !== slice.id);
             series.type = isDoughnut ? 'doughnut' : 'pie';
             series.centerX = centerX;
             series.centerY = centerY;
@@ -175,7 +177,9 @@ const modules = {
               ctx.stroke();
             }
 
-            series.isSelect = hitInfo?.sId === slice.id;
+            const { selectInfo, legendHitInfo } = hitInfo;
+            series.isSelect = selectInfo?.sId === slice.id;
+            series.isDownplay = (legendHitInfo && legendHitInfo.sId !== slice.id);
             series.type = 'sunburst';
             series.centerX = centerX;
             series.centerY = centerY;


### PR DESCRIPTION
## 이슈 내용
- `selectSeries` , `selectLabel` 옵션을 사용중인 차트에서는 legend 영역에 mouseover를 하더라도 해당 series가 Highlight 되어 보이지 않음
- ![legend_highlight_before](https://user-images.githubusercontent.com/53548023/174253092-9072eceb-4cc1-48ae-ad74-d5c78bf9ed5f.gif)


## 작업내용
- `Bar`, `Line`, `Pie`, `Scatter` 차트 Highlight / Downplay 구분하여 Opacity 값 구하는 로직 전면 수정
- Legend 영역 `Mounseover` 이벤트 안에 들어있던 series의 state값 변경시키는 로직 삭제
- `SelectSeries` 옵션 관련 로직안에 들어있던 series의 state값 변경시키는 로직 삭제
- ![legend_highlight_after](https://user-images.githubusercontent.com/53548023/174253110-de41d02b-224e-4283-82d2-2c4083624e6b.gif)

