### PR TITLE
[#1219] Chart > Tooltip > showAllValueInRange 옵션 사용중일때, 마우스 위치에 따라 동일한 툴팁의 너비가 다르게 보이는 현상 발생

### DIFF
--- a/docs/views/barChart/example/Column.vue
+++ b/docs/views/barChart/example/Column.vue
@@ -55,6 +55,9 @@
           autoScaleRatio: 0.1,
           showGrid: false,
         }],
+        tooltip: {
+          showAllValueInRange: true,
+        },
       };
 
       return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.29",
+  "version": "3.3.30",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",


### PR DESCRIPTION
### 이슈 내용
- **tooltip > showAllValueInRange 옵션을 true로 설정하였을 때, 어떤 막대를 선택했느냐에 따라 Tooltip의 너비가 다르게 보임**
- ![image](https://user-images.githubusercontent.com/53548023/174696432-7cfb7409-0df4-41d0-ba0c-c91b8cb15b8d.png)


### 작업내용
- **showAllValueInRange 옵션이 켜져있을 경우 show상태인 sereis를 대상으로 가장 길이가 긴 name과 value를 구하도록 로직 수정**
- ![image](https://user-images.githubusercontent.com/53548023/174696465-38d983e0-7264-497d-969c-0f6a5a3cd463.png)
- ![image](https://user-images.githubusercontent.com/53548023/174696483-1902b376-7daa-4246-b562-b2a518b98251.png)
