### PR TITLE
[#1221] Chart > showAllValueInRange, formatter 동시 설정 시 콘솔 오류

### DIFF
--- a/docs/views/barChart/example/Column.vue
+++ b/docs/views/barChart/example/Column.vue
@@ -21,8 +21,8 @@
           'value5',
         ],
         data: {
-          series1: [100, 150, 51, 150, { value: 350, color: '#FF0000' }],
-          series2: [150.0, 100.2, 151.433, 50.221, 250.123],
+          series1: [null, 150, 0, 150, { value: 350, color: '#FF0000' }],
+          series2: [null, 100.2, 0, 50.221, 250.123],
         },
       };
 
@@ -57,6 +57,7 @@
         }],
         tooltip: {
           showAllValueInRange: true,
+          formatter: ({ y }) => `${y}`,
         },
       };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.30",
+  "version": "3.3.31",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -469,7 +469,7 @@ const modules = {
     }
 
     if (value && (!tooltipValueFormatter || typeof formattedTxt !== 'string')) {
-      if (this.options.type === 'heatMap') {
+      if (opt.type === 'heatMap') {
         formattedTxt = value < 0 ? 'error' : numberWithComma(value);
       } else {
         formattedTxt = numberWithComma(value);

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -438,29 +438,31 @@ const modules = {
    * @returns {string}
    */
   getFormattedTooltipValue({ seriesName, value, itemData }) {
-    const tooltipOpt = this.options.tooltip;
-    const tooltipValueFormatter = typeof tooltipOpt.formatter === 'function'
-      ? tooltipOpt.formatter
-      : tooltipOpt.formatter?.value;
+    const opt = this.options;
+    const isHorizontal = !!opt.horizontal;
+    const tooltipOpt = opt.tooltip;
+    const tooltipValueFormatter = typeof tooltipOpt?.formatter === 'function'
+      ? tooltipOpt?.formatter
+      : tooltipOpt?.formatter?.value;
 
     let formattedTxt = value;
     if (tooltipValueFormatter) {
-      if (this.options.type === 'pie') {
+      if (opt.type === 'pie') {
         formattedTxt = tooltipValueFormatter({
           value,
           name: seriesName,
-          percentage: itemData.percentage,
+          percentage: itemData?.percentage,
         });
-      } else if (this.options.type === 'heatMap') {
+      } else if (opt.type === 'heatMap') {
         formattedTxt = tooltipValueFormatter({
-          x: itemData.x,
-          y: itemData.y,
+          x: itemData?.x,
+          y: itemData?.y,
           value: value > -1 ? value : 'error',
         });
       } else {
         formattedTxt = tooltipValueFormatter({
-          x: this.options.horizontal ? value : itemData.x,
-          y: this.options.horizontal ? itemData.y : value,
+          x: isHorizontal ? value : itemData?.x,
+          y: isHorizontal ? itemData?.y : value,
           name: seriesName,
         });
       }


### PR DESCRIPTION
### 이슈 내용
- `tooltip`의 `showAllValueInRange` 옵션과 `formatter`를 동시 사용한 상태에서 `NULL` 로 표시된 공간에 마우스 오버시 참조 에러 발생

### 작업내용
- EVUI Version Update (3.3.30 -> 3.3.31)
- Optional chaining 추가