### PR TITLE
[#1223] Chart > selectSeries 기능 사용시 선택 된 series 가 없을 때 모두 downplay 상태가 됨

### DIFF
--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -58,7 +58,7 @@ class Line {
     let extent;
     if (legendHitInfo) {
       extent = this.extent[legendHitInfo?.sId === this.sId ? 'highlight' : 'downplay'];
-    } else if (selectSeries?.option?.use) {
+    } else if (selectSeries?.option?.use && selectSeries?.selected?.seriesId?.length) {
       const isSelectedSeries = selectSeries?.selected?.seriesId?.includes(this.sId);
       extent = this.extent[isSelectedSeries ? 'highlight' : 'downplay'];
     } else if (useSelectLabel && selectedLabelIndexList.length) {


### PR DESCRIPTION
### 이슈 내용
- line chart 의 selectSeries 기능에서 선택된 시리즈가 없는 경우 모든 시리즈가 흐리게 보임

### 처리 내용
- downplay 로직에서 select 된 series 의 length 조건 추가