### PR TITLE
[#1224] Chart > bar Chart size 가 0 이 되는 문제

### DIFF
--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -84,7 +84,7 @@ class Bar {
     bArea = cArea > (cPad * 2) ? (cArea - (cPad * 2)) : cArea;
     bArea = this.isExistGrp ? bArea : bArea / showSeriesCount;
 
-    const size = Math.round(bArea * thickness);
+    const size = Math.ceil(bArea * thickness);
 
     w = isHorizontal ? null : size;
     h = isHorizontal ? size : null;

--- a/src/components/chart/element/element.bar.time.js
+++ b/src/components/chart/element/element.bar.time.js
@@ -46,9 +46,12 @@ class TimeBar extends Bar {
     } else {
       bArea = (cArea - (cPad * 2)) / showSeriesCount;
     }
-    let w = isHorizontal ? null : Math.round(bArea * thickness);
-    let subW = isHorizontal ? null : Math.round(bArea * thickness);
-    let h = isHorizontal ? Math.round(bArea * thickness) : null;
+
+    const size = Math.ceil(bArea * thickness);
+
+    let w = isHorizontal ? null : size;
+    let subW = isHorizontal ? null : size;
+    let h = isHorizontal ? size : null;
 
     const bPad = isHorizontal ? (bArea - h) / 2 : (bArea - w) / 2;
     const barSeriesX = this.isExistGrp ? 1 : showIndex + 1;


### PR DESCRIPTION
### 이슈 내용
- bar 의 갯수가 많아지는 경우 크기가 0 이 되어 차트가 그려지지 않음

### 처리 내용
 - 크기 계산 방식을 반올림에서 올림으로 변경하여 최소 1을 보장

### Before
![image](https://user-images.githubusercontent.com/46586573/175456222-22cfffda-44fc-40b1-af97-eff976fcb903.png)
### After
![image](https://user-images.githubusercontent.com/46586573/175456069-bce1b1d6-dccb-4a2f-a128-78da1aef8315.png)