### PR TITLE
[#1229] Grid, TreeGrid > 데이터 없을 경우 scrollbar 생기는 현상

### DIFF
--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -59,7 +59,6 @@
   }
   &:nth-last-child(1) {
     border-right: 0;
-    margin-right: 20px;
     .column-resize {
       cursor: default !important;
     }

--- a/src/components/treeGrid/style/treeGrid.scss
+++ b/src/components/treeGrid/style/treeGrid.scss
@@ -55,7 +55,6 @@
   }
   &:nth-last-child(1) {
     border-right: 0;
-    margin-right: 20px;
     .column-resize {
       cursor: default !important;
     }


### PR DESCRIPTION
####################
- 데이터가 있을 땐 body 에 row 의 width 에 따라 overflow 적용됨
- 데이터가 없을 때 전체 컬럼을 볼 수 있도록 `display: table`를 주어 header 의 width 에 따라 overflow 적용됨
- 이때 header 의 마지막 컬럼 margin 값으로 인해 scroll 이 생기는데 데이터가 있을 때는 scroll 이 사라지는 문제 -> margin 값을 제거

#데이터 있을 때
![image](https://user-images.githubusercontent.com/61657275/176598861-a6f09f8b-e80a-4800-b87e-b132a857ef81.png)

#데이터 없을 때
[AS-IS]

![image](https://user-images.githubusercontent.com/61657275/176598812-f97db1b2-9a0b-4634-9a8d-c9eb04fa2fa6.png)

[TO-BE]

![image](https://user-images.githubusercontent.com/61657275/176598838-71aa20af-bc4d-4c66-9a79-1be06778cc39.png)
