### PR TITLE
[#1234] Calendar > disabledDate 함수가 있는 경우 fromDate > toDate 비교하지 않도록 변경

### DIFF
--- a/docs/views/datePicker/example/Default.vue
+++ b/docs/views/datePicker/example/Default.vue
@@ -226,10 +226,10 @@ export default {
       },
     ];
 
+    // toDate - fromDate 최소 선택 시간: 30분, 최대 선택 날짜: 한달
     const disabledDateTime = computed(() => [
-      time => (+time < +new Date(dayjs(TODAY_0_O_CLOCK_DATE).subtract(1, 'month')))
-            || (+time > +new Date(dateTimeRange2.value[1]) - (1000 * 60 * 30)
-             && +time <= +new Date(dateTimeRange2.value[1])),
+      time => +time > +new Date(dateTimeRange2.value[1]) - (1000 * 60 * 30)
+            || +time < +new Date(dayjs(dateTimeRange2.value[1]).subtract(1, 'month')),
       time => (+time < +new Date(dateTimeRange2.value[0]) + (1000 * 60 * 30))
             || (+time >= +new Date(dayjs(TODAY_0_O_CLOCK_DATE).add(2, 'day'))),
     ]);
@@ -251,9 +251,3 @@ export default {
   },
 };
 </script>
-
-<style>
-.case-block {
-  border: 1px solid black;
-}
-</style>

--- a/src/components/calendar/uses.js
+++ b/src/components/calendar/uses.js
@@ -532,7 +532,8 @@ export const useCalendarDate = (param) => {
       // time 모드인 경우 현재 값의 시간을 가지고 테스트
       const timeValue = modelValue?.split(' ')[1] ?? '';
 
-      const isDisabled = disabledDate && disabledDate(new Date(`${currDate} ${timeValue}`));
+      const isDisabled = disabledDate
+        ? disabledDate(new Date(`${currDate} ${timeValue}`)) : isInvalidDate;
 
       const index = +(calendarType !== 'main');
       const isRangeSelected = isRangeMode && selectedValue.value.length > index
@@ -543,7 +544,7 @@ export const useCalendarDate = (param) => {
 
       // mode가 dateRange일 때는 이전, 다음달에 selected 를 하지 않는다.
       calendarTableInfo[i][j] = {
-        monthType: `${monthType}${isDisabled || isInvalidDate ? ' disabled' : ''}`,
+        monthType: `${monthType}${isDisabled ? ' disabled' : ''}`,
         isToday: TODAY_YMD === currDate,
         isSelected,
         year,
@@ -632,7 +633,7 @@ export const useCalendarDate = (param) => {
         return true;
       }
 
-      return compareFromAndToDateTime(
+      return !disabledDateFunc && compareFromAndToDateTime(
           props.mode,
           calendarType,
           targetDateTimeValue,
@@ -887,7 +888,8 @@ export const useEvent = (param) => {
     };
 
     const setRangeModeDateByIndex = (currIndex, currDate) => {
-      if (compareFromAndToDateTime(props.mode, calendarType, currDate, selectedValue.value)) {
+      if (!disabledDate
+        && compareFromAndToDateTime(props.mode, calendarType, currDate, selectedValue.value)) {
         return;
       }
 
@@ -1156,13 +1158,6 @@ export const useEvent = (param) => {
               timeFormat[index],
               currDateTime,
           );
-        }
-
-        const fromDate = index ? selectedValue.value[0] : currDateTime;
-        const toDate = index ? currDateTime : selectedValue.value[1];
-
-        if (new Date(fromDate).getTime() > new Date(toDate).getTime()) {
-          return;
         }
 
         selectedValue.value[index] = currDateTime;


### PR DESCRIPTION
이슈 사항
-
disabledDate로 최소 범위를 변경하고 싶은데 기존 SPEC으로 인해 최소 범위가 1일로 잡힘

작업 내용
-
**AS-IS**
기존 SPEC 
rangeMode(fromDate, toDate가 있는 경우)일 때 fromDate 시간이 toDate를 넘으면 disabled처리

**TO-BE**
사용자가 작성한 disabledDate가 있는 경우 기존 SPEC 무시
disabledDate가 없는 경우 기존대로 비교하여 disabled 처리

