### PR TITLE
[#1236] Github Actions CI/CD 잔디 알람 적용

### DIFF
--- a/.github/actions/jandi-notify/action.yml
+++ b/.github/actions/jandi-notify/action.yml
@@ -1,0 +1,33 @@
+name: 'jandi-notify'
+
+inputs:
+  status:
+    required: false
+    description: CI/CD status
+    default: 'failure'
+  jandi_incoming_url:
+    description: jandi webhook URL
+    required: true
+
+description: jandi notify action
+runs:
+  using: 'composite'
+  steps:
+    - name: Send jandi
+      shell: bash
+      run: |
+        COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
+        
+        if [ "${{ inputs.status }}" = "success" ]; then
+          curl \
+          -X POST "${{ inputs.jandi_incoming_url }}" \
+          -H "Accept: application/vnd.tosslab.jandi-v2+json" \
+          -H "Content-Type: application/json" \
+          --data-binary '{"body":"📢 EVUI CI/CD Notification - ✅ Deployment succeeded", "connectColor":"#4285F6", "connectInfo":[{"title":"Commit message","description":"- '"${COMMIT_MESSAGE}"'"},{"title":"EVUI document","description":"- [[EVUI]](https://ex-em.github.io/EVUI)"}]}'
+        else
+          curl \
+          -X POST "${{ inputs.jandi_incoming_url }}" \
+          -H "Accept: application/vnd.tosslab.jandi-v2+json" \
+          -H "Content-Type: application/json" \
+          --data-binary '{"body":"📢 EVUI CI/CD Notification - ⛔ Deployment failed", "connectColor":"#FF4C15", "connectInfo":[{"title":"Commit message","description":"- '"${COMMIT_MESSAGE}"'"},{"title":"Error log","description":"- [[Workflow]](https://github.com/'"${GITHUB_REPOSITORY}"'/actions/runs/'"${GITHUB_RUN_ID}"')"}]}'
+        fi

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,12 +13,19 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
-          cache: 'npm'
+
+      - name: Cache node module
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: node_modules
+          key: npm-packages-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Build Docs
@@ -29,3 +36,16 @@ jobs:
         with:
           github_token: ${{ secrets.GH_ACTIONS_TOKEN }}
           publish_dir: ./dist
+
+      - name: Send jandi when failed
+        if: ${{ failure() }}
+        uses: ./.github/actions/jandi-notify
+        with:
+          jandi_incoming_url: ${{ secrets.JANDI_INCOMING_URL }}
+
+      - name: Send jandi if completed
+        if: ${{ success() }}
+        uses: ./.github/actions/jandi-notify
+        with:
+          status: success
+          jandi_incoming_url: ${{ secrets.JANDI_INCOMING_URL }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.1.38",
+  "version": "3.3.34",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.33",
+  "version": "3.3.34",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",


### PR DESCRIPTION
### 작업 내용
- 잔디 알람 액션 파일 추가
- npm 캐싱 방식 수정
#### CI/CD 성공 예시
![image](https://user-images.githubusercontent.com/81760347/178668264-0224e29c-4b3e-47e5-ab5a-8e1e7d4f35a8.png)
#### CI/CD 실패 예시
![image](https://user-images.githubusercontent.com/81760347/178668459-4f2e4b1a-cbb5-4ab5-a60b-e39a5f648e14.png)

