### PR TITLE
[#1225] Chart > Legend 영역 > 스크롤바 생성되지 않음

### DIFF
--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -26,6 +26,9 @@ const modules = {
       this.setLegendColumnHeader();
       this.legendBoxDOM.appendChild(this.legendTableDOM);
       this.legendDOM.style.overflow = 'auto';
+    } else {
+      this.legendBoxDOM.style.overflowX = 'hidden';
+      this.legendBoxDOM.style.overflowY = 'auto';
     }
 
     this.legendDOM.appendChild(this.legendBoxDOM);


### PR DESCRIPTION
### 이슈 원인
- #1225  이슈에 수정한 내용 중 legend 영역의 overflow 스타일이 제거되어 발생한 문제

### 작업 내용
- table 타입이 아닐 경우 legend 영역의 overflow 스타일을 다음과 같이 적용되도록 함 
   - overflowX : 'hidden' 
   - overflowY: 'auto'


### 결과 이미지
[Before]
![image](https://user-images.githubusercontent.com/53548023/179129373-1ab2c95d-c8e8-41f9-a8df-34605ffa57ca.png)

[After]
![image](https://user-images.githubusercontent.com/53548023/179129342-689a3502-be19-4367-b8ea-8fef59b25ca6.png)

