### PR TITLE
[#1243] Grid, Tree Grid > 컬럼 너비 변경 기능

### DIFF
--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -8,7 +8,7 @@
       :width="widthMV"
       :height="heightMV"
       :option="{
-        adjust: adjustMV,
+        adjust: true,
         showHeader: showHeaderMV,
         rowHeight: rowHeightMV,
         columnWidth: columnWidthMV,
@@ -46,12 +46,6 @@
         </span>
         <ev-toggle
           v-model="showHeaderMV"
-        />
-        <span class="badge yellow">
-          Adjust
-        </span>
-        <ev-toggle
-          v-model="adjustMV"
         />
         <span class="badge yellow">
           Use Filter
@@ -229,7 +223,6 @@ export default {
     const checked = ref([]);
     const widthMV = ref('100%');
     const heightMV = ref(300);
-    const adjustMV = ref(true);
     const showHeaderMV = ref(true);
     const stripeMV = ref(false);
     const rowHeightMV = ref(45);
@@ -347,7 +340,6 @@ export default {
       checked,
       widthMV,
       heightMV,
-      adjustMV,
       showHeaderMV,
       stripeMV,
       rowHeightMV,

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -9,7 +9,7 @@
       :width="widthMV"
       :height="heightMV"
       :option="{
-        adjust: adjustMV,
+        adjust: true,
         showHeader: showHeaderMV,
         rowHeight: rowHeightMV,
         columnWidth: columnWidthMV,
@@ -46,12 +46,6 @@
         </span>
         <ev-toggle
           v-model="showHeaderMV"
-        />
-        <span class="badge yellow">
-          Adjust
-        </span>
-        <ev-toggle
-          v-model="adjustMV"
         />
         <span class="badge yellow">
           Use Checkbox
@@ -270,7 +264,6 @@ export default {
     const checked = ref([]);
     const widthMV = ref('100%');
     const heightMV = ref(300);
-    const adjustMV = ref(true);
     const showHeaderMV = ref(true);
     const stripeMV = ref(false);
     const rowHeightMV = ref(35);
@@ -492,7 +485,6 @@ export default {
       checked,
       widthMV,
       heightMV,
-      adjustMV,
       showHeaderMV,
       stripeMV,
       rowHeightMV,

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -79,6 +79,8 @@
               :style="{
                 width: `${column.width}px`,
                 'min-width': `${isRenderer(column) ? rendererMinWidth : minWidth}px`,
+                'margin-right': (orderedColumns.length - 1 === index
+                && hasVerticalScrollBar && hasHorizontalScrollBar) ? `${scrollWidth}px` : '0px',
               }"
             >
               <!-- Filter Status -->
@@ -417,6 +419,7 @@ export default {
       vScrollTopHeight: 0,
       vScrollBottomHeight: 0,
       hasVerticalScrollBar: false,
+      hasHorizontalScrollBar: false,
     });
     const selectInfo = reactive({
       selectedRow: props.selected,
@@ -443,7 +446,7 @@ export default {
       rendererMinWidth: 80,
       iconWidth: 42,
       showResizeLine: false,
-      adjust: computed(() => (props.option.adjust || false)),
+      adjust: props.option.adjust || false,
       columnWidth: props.option.columnWidth || 80,
       scrollWidth: props.option.scrollWidth || 17,
       rowHeight: computed(() =>
@@ -552,6 +555,7 @@ export default {
       filterInfo,
       isRenderer,
       updateVScroll,
+      updateHScroll,
     });
 
     const {
@@ -692,7 +696,7 @@ export default {
       },
     );
     watch(
-      () => [resizeInfo.adjust, props.option.columnWidth, resizeInfo.gridWidth],
+      () => [props.option.columnWidth, resizeInfo.gridWidth],
       () => {
         resizeInfo.columnWidth = props.option.columnWidth;
         const gridWrapper = elementInfo['grid-wrapper'];

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -144,7 +144,7 @@
           :style="`height: ${vScrollTopHeight}px;`"
           class="vscroll-spacer"
         />
-        <table>
+        <table ref="grid-table">
           <tbody>
             <!-- Row List -->
             <tr
@@ -363,6 +363,7 @@ export default {
       header: null,
       resizeLine: null,
       'grid-wrapper': null,
+      'grid-table': null,
     });
     const filterInfo = reactive({
       filterList: {},

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -144,7 +144,7 @@
           :style="`height: ${vScrollTopHeight}px;`"
           class="vscroll-spacer"
         />
-        <table ref="grid-table">
+        <table ref="table">
           <tbody>
             <!-- Row List -->
             <tr
@@ -361,9 +361,9 @@ export default {
     const elementInfo = reactive({
       body: null,
       header: null,
+      table: null,
       resizeLine: null,
       'grid-wrapper': null,
-      'grid-table': null,
     });
     const filterInfo = reactive({
       filterList: {},

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -59,9 +59,6 @@
   }
   &:nth-last-child(1) {
     border-right: 0;
-    .column-resize {
-      cursor: default !important;
-    }
   }
   .sort-icon {
     display: inline-block;

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -59,6 +59,7 @@
   }
   &:nth-last-child(1) {
     border-right: 0;
+    margin-right: 17px;
   }
   .sort-icon {
     display: inline-block;

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -59,7 +59,6 @@
   }
   &:nth-last-child(1) {
     border-right: 0;
-    margin-right: 17px;
   }
   .sort-icon {
     display: inline-block;

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -102,7 +102,7 @@ export const scrollEvent = (params) => {
       const lastVisibleIndex = firstVisibleIndex + rowCount + 1;
       const firstIndex = Math.max(firstVisibleIndex, 0);
       const lastIndex = lastVisibleIndex;
-      const tableEl = elementInfo['grid-table'];
+      const tableEl = elementInfo.table;
 
       stores.viewStore = store.slice(firstIndex, lastIndex);
       scrollInfo.hasVerticalScrollBar = rowCount < store.length
@@ -124,7 +124,7 @@ export const scrollEvent = (params) => {
   const updateHScroll = () => {
     const headerEl = elementInfo.header;
     const bodyEl = elementInfo.body;
-    const tableEl = elementInfo['grid-table'];
+    const tableEl = elementInfo.table;
 
     headerEl.scrollLeft = bodyEl.scrollLeft;
     summaryScroll.value = bodyEl.scrollLeft;

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -156,25 +156,6 @@ export const resizeEvent = (params) => {
   const { props } = getCurrentInstance();
   const { resizeInfo, elementInfo, checkInfo, stores, isRenderer, updateVScroll } = params;
   /**
-   * 해당 컬럼 인덱스가 마지막인지 확인한다.
-   *
-   * @param {number} index - 컬럼 인덱스
-   * @returns {boolean} 마지막 컬럼 유무
-   */
-  const isLastColumn = (index) => {
-    const columns = stores.orderedColumns;
-    let lastIndex = -1;
-
-    for (let ix = columns.length - 1; ix >= 0; ix--) {
-      if (!columns[ix].hide) {
-        lastIndex = ix;
-        break;
-      }
-    }
-
-    return lastIndex === index;
-  };
-  /**
    * 고정 너비, 스크롤 유무 등에 따른 컬럼 너비를 계산한다.
    */
   const calculatedColumn = () => {
@@ -280,22 +261,15 @@ export const resizeEvent = (params) => {
    * @param {object} event - 이벤트 객체
    */
   const onColumnResize = (columnIndex, event) => {
-    let nextColumnIndex = columnIndex + 1;
     const headerEl = elementInfo.header;
+    const bodyEl = elementInfo.body;
     const headerLeft = headerEl.getBoundingClientRect().left;
     const columnEl = headerEl.querySelector(`li[data-index="${columnIndex}"]`);
-    if (!isLastColumn(columnIndex) && !columnEl.className.includes('db-icon')
-      && !columnEl.className.includes('user-icon')) {
-      while (stores.orderedColumns[nextColumnIndex].hide) {
-        nextColumnIndex++;
-      }
+    if (!columnEl.className.includes('db-icon') && !columnEl.className.includes('user-icon')) {
       const minWidth = isRenderer(stores.orderedColumns[columnIndex])
         ? resizeInfo.rendererMinWidth : resizeInfo.minWidth;
-      const nextMinWidth = isRenderer(stores.orderedColumns[nextColumnIndex])
-        ? resizeInfo.rendererMinWidth : resizeInfo.minWidth;
-      const nextColumnEl = headerEl.querySelector(`li[data-index="${nextColumnIndex}"]`);
       const columnRect = columnEl.getBoundingClientRect();
-      const maxRight = nextColumnEl.getBoundingClientRect().right - headerLeft - nextMinWidth;
+      const maxRight = bodyEl.getBoundingClientRect().right - headerLeft;
       const resizeLineEl = elementInfo.resizeLine;
       const minLeft = columnRect.left - headerLeft + minWidth;
       const startLeft = columnRect.right - headerLeft;
@@ -321,11 +295,12 @@ export const resizeEvent = (params) => {
         const changedWidth = destLeft - startColumnLeft;
 
         if (stores.orderedColumns[columnIndex]) {
-          const columnWidth = stores.orderedColumns[columnIndex].width;
           stores.orderedColumns[columnIndex].width = changedWidth;
-          stores.orderedColumns[columnIndex].resized = true;
-          stores.orderedColumns[nextColumnIndex].width += (columnWidth - changedWidth);
-          stores.orderedColumns[nextColumnIndex].resized = true;
+          stores.orderedColumns.map((column) => {
+            const item = column;
+            item.resized = true;
+            return item;
+          });
         }
 
         resizeInfo.showResizeLine = false;

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -126,14 +126,9 @@ export const scrollEvent = (params) => {
     const bodyEl = elementInfo.body;
     const tableEl = bodyEl.children[1];
 
-    if (bodyEl.clientWidth < tableEl.clientWidth) {
-      scrollInfo.hasHorizontalScrollBar = true;
-    } else {
-      scrollInfo.hasHorizontalScrollBar = false;
-    }
-
     headerEl.scrollLeft = bodyEl.scrollLeft;
     summaryScroll.value = bodyEl.scrollLeft;
+    scrollInfo.hasHorizontalScrollBar = bodyEl.clientWidth < tableEl.clientWidth;
   };
   /**
    * scroll 이벤트를 처리한다.

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -102,9 +102,11 @@ export const scrollEvent = (params) => {
       const lastVisibleIndex = firstVisibleIndex + rowCount + 1;
       const firstIndex = Math.max(firstVisibleIndex, 0);
       const lastIndex = lastVisibleIndex;
+      const tableEl = bodyEl.children[1];
 
       stores.viewStore = store.slice(firstIndex, lastIndex);
-      scrollInfo.hasVerticalScrollBar = rowCount < store.length;
+      scrollInfo.hasVerticalScrollBar = rowCount < store.length
+        || bodyEl.clientHeight < tableEl.clientHeight;
       scrollInfo.vScrollTopHeight = firstIndex * rowHeight;
       scrollInfo.vScrollBottomHeight = totalScrollHeight - (stores.viewStore.length * rowHeight)
         - scrollInfo.vScrollTopHeight;
@@ -122,6 +124,13 @@ export const scrollEvent = (params) => {
   const updateHScroll = () => {
     const headerEl = elementInfo.header;
     const bodyEl = elementInfo.body;
+    const tableEl = bodyEl.children[1];
+
+    if (bodyEl.clientWidth < tableEl.clientWidth) {
+      scrollInfo.hasHorizontalScrollBar = true;
+    } else {
+      scrollInfo.hasHorizontalScrollBar = false;
+    }
 
     headerEl.scrollLeft = bodyEl.scrollLeft;
     summaryScroll.value = bodyEl.scrollLeft;
@@ -154,7 +163,15 @@ export const scrollEvent = (params) => {
 
 export const resizeEvent = (params) => {
   const { props } = getCurrentInstance();
-  const { resizeInfo, elementInfo, checkInfo, stores, isRenderer, updateVScroll } = params;
+  const {
+    resizeInfo,
+    elementInfo,
+    checkInfo,
+    stores,
+    isRenderer,
+    updateVScroll,
+    updateHScroll,
+  } = params;
   /**
    * 고정 너비, 스크롤 유무 등에 따른 컬럼 너비를 계산한다.
    */
@@ -244,6 +261,9 @@ export const resizeEvent = (params) => {
       calculatedColumn();
       if (elementInfo.body?.clientHeight) {
         updateVScroll();
+      }
+      if (elementInfo.body?.clientWidth) {
+        updateHScroll();
       }
     });
   };

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -102,7 +102,7 @@ export const scrollEvent = (params) => {
       const lastVisibleIndex = firstVisibleIndex + rowCount + 1;
       const firstIndex = Math.max(firstVisibleIndex, 0);
       const lastIndex = lastVisibleIndex;
-      const tableEl = bodyEl.children[1];
+      const tableEl = elementInfo['grid-table'];
 
       stores.viewStore = store.slice(firstIndex, lastIndex);
       scrollInfo.hasVerticalScrollBar = rowCount < store.length
@@ -124,7 +124,7 @@ export const scrollEvent = (params) => {
   const updateHScroll = () => {
     const headerEl = elementInfo.header;
     const bodyEl = elementInfo.body;
-    const tableEl = bodyEl.children[1];
+    const tableEl = elementInfo['grid-table'];
 
     headerEl.scrollLeft = bodyEl.scrollLeft;
     summaryScroll.value = bodyEl.scrollLeft;

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -265,52 +265,50 @@ export const resizeEvent = (params) => {
     const bodyEl = elementInfo.body;
     const headerLeft = headerEl.getBoundingClientRect().left;
     const columnEl = headerEl.querySelector(`li[data-index="${columnIndex}"]`);
-    if (!columnEl.className.includes('db-icon') && !columnEl.className.includes('user-icon')) {
-      const minWidth = isRenderer(stores.orderedColumns[columnIndex])
-        ? resizeInfo.rendererMinWidth : resizeInfo.minWidth;
-      const columnRect = columnEl.getBoundingClientRect();
-      const maxRight = bodyEl.getBoundingClientRect().right - headerLeft;
-      const resizeLineEl = elementInfo.resizeLine;
-      const minLeft = columnRect.left - headerLeft + minWidth;
-      const startLeft = columnRect.right - headerLeft;
-      const startMouseLeft = event.clientX;
-      const startColumnLeft = columnRect.left - headerLeft;
+    const minWidth = isRenderer(stores.orderedColumns[columnIndex])
+      ? resizeInfo.rendererMinWidth : resizeInfo.minWidth;
+    const columnRect = columnEl.getBoundingClientRect();
+    const maxRight = bodyEl.getBoundingClientRect().right - headerLeft;
+    const resizeLineEl = elementInfo.resizeLine;
+    const minLeft = columnRect.left - headerLeft + minWidth;
+    const startLeft = columnRect.right - headerLeft;
+    const startMouseLeft = event.clientX;
+    const startColumnLeft = columnRect.left - headerLeft;
 
-      resizeLineEl.style.left = `${startLeft}px`;
+    resizeLineEl.style.left = `${startLeft}px`;
 
-      resizeInfo.showResizeLine = true;
+    resizeInfo.showResizeLine = true;
 
-      const handleMouseMove = (evt) => {
-        const deltaLeft = evt.clientX - startMouseLeft;
-        const proxyLeft = startLeft + deltaLeft;
-        let resizeWidth = Math.max(minLeft, proxyLeft);
+    const handleMouseMove = (evt) => {
+      const deltaLeft = evt.clientX - startMouseLeft;
+      const proxyLeft = startLeft + deltaLeft;
+      let resizeWidth = Math.max(minLeft, proxyLeft);
 
-        resizeWidth = Math.min(maxRight, resizeWidth);
+      resizeWidth = Math.min(maxRight, resizeWidth);
 
-        resizeLineEl.style.left = `${resizeWidth}px`;
-      };
+      resizeLineEl.style.left = `${resizeWidth}px`;
+    };
 
-      const handleMouseUp = () => {
-        const destLeft = parseInt(resizeLineEl.style.left, 10);
-        const changedWidth = destLeft - startColumnLeft;
+    const handleMouseUp = () => {
+      const destLeft = parseInt(resizeLineEl.style.left, 10);
+      const changedWidth = destLeft - startColumnLeft;
 
-        if (stores.orderedColumns[columnIndex]) {
-          stores.orderedColumns[columnIndex].width = changedWidth;
-          stores.orderedColumns.map((column) => {
-            const item = column;
-            item.resized = true;
-            return item;
-          });
-        }
+      if (stores.orderedColumns[columnIndex]) {
+        stores.orderedColumns[columnIndex].width = changedWidth;
+        stores.orderedColumns.map((column) => {
+          const item = column;
+          item.resized = true;
+          return item;
+        });
+      }
 
-        resizeInfo.showResizeLine = false;
-        document.removeEventListener('mousemove', handleMouseMove);
-        onResize();
-      };
+      resizeInfo.showResizeLine = false;
+      document.removeEventListener('mousemove', handleMouseMove);
+      onResize();
+    };
 
-      document.addEventListener('mousemove', handleMouseMove);
-      document.addEventListener('mouseup', handleMouseUp, { once: true });
-    }
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp, { once: true });
   };
   return { calculatedColumn, onResize, onShow, onColumnResize };
 };

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -59,7 +59,7 @@
               v-if="!column.hide"
               :data-index="index"
               :class="getColumnClass(column)"
-              :style="getColumnStyle(column)"
+              :style="getColumnStyle(column, index)"
             >
               <!-- Column Name -->
               <span
@@ -322,6 +322,7 @@ export default {
       vScrollTopHeight: 0,
       vScrollBottomHeight: 0,
       hasVerticalScrollBar: false,
+      hasHorizontalScrollBar: false,
     });
     const selectInfo = reactive({
       selectedRow: props.selected,
@@ -342,7 +343,7 @@ export default {
       minWidth: 40,
       rendererMinWidth: 80,
       showResizeLine: false,
-      adjust: computed(() => props.option.adjust || false),
+      adjust: props.option.adjust || false,
       columnWidth: props.option.columnWidth || 80,
       scrollWidth: props.option.scrollWidth || 17,
       rowHeight: computed(() => props.option.rowHeight || 35),
@@ -426,6 +427,7 @@ export default {
       stores,
       isRenderer,
       updateVScroll,
+      updateHScroll,
     });
 
     const {
@@ -595,7 +597,7 @@ export default {
       },
     );
     watch(
-      () => [props.width, props.height, resizeInfo.adjust, props.option.columnWidth],
+      () => [props.width, props.height, props.option.columnWidth],
       (value) => {
         resizeInfo.columnWidth = value[3];
         stores.orderedColumns.map((column) => {
@@ -690,11 +692,14 @@ export default {
         'non-border': !!styleInfo.borderStyle,
       };
     };
-    const getColumnStyle = (column) => {
+    const getColumnStyle = (column, index) => {
       const render = isRenderer(column);
       return {
         width: `${column.width}px`,
         'min-width': render ? `${resizeInfo.rendererMinWidth}px;` : `${resizeInfo.minWidth}px`,
+        'margin-right': (stores.orderedColumns.length - 1 === index
+          && scrollInfo.hasVerticalScrollBar
+          && scrollInfo.hasHorizontalScrollBar) ? `${resizeInfo.scrollWidth}px` : '0px',
       };
     };
     const getSlotName = column => `${column}Node`;

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -90,7 +90,7 @@
           :style="`height: ${vScrollTopHeight}px;`"
           class="vscroll-spacer"
         />
-        <table>
+        <table ref="grid-table">
           <tbody>
             <tree-grid-node
               v-for="(node, idx) in viewStore"
@@ -266,6 +266,7 @@ export default {
       header: null,
       resizeLine: null,
       'grid-wrapper': null,
+      'grid-table': null,
     });
     const filterInfo = reactive({
       isSearch: false,

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -90,7 +90,7 @@
           :style="`height: ${vScrollTopHeight}px;`"
           class="vscroll-spacer"
         />
-        <table ref="grid-table">
+        <table ref="table">
           <tbody>
             <tree-grid-node
               v-for="(node, idx) in viewStore"
@@ -264,9 +264,9 @@ export default {
     const elementInfo = reactive({
       body: null,
       header: null,
+      table: null,
       resizeLine: null,
       'grid-wrapper': null,
-      'grid-table': null,
     });
     const filterInfo = reactive({
       isSearch: false,

--- a/src/components/treeGrid/style/treeGrid.scss
+++ b/src/components/treeGrid/style/treeGrid.scss
@@ -55,9 +55,6 @@
   }
   &:nth-last-child(1) {
     border-right: 0;
-    .column-resize {
-      cursor: default !important;
-    }
   }
   .sort-icon {
     display: inline-block;

--- a/src/components/treeGrid/style/treeGrid.scss
+++ b/src/components/treeGrid/style/treeGrid.scss
@@ -55,7 +55,6 @@
   }
   &:nth-last-child(1) {
     border-right: 0;
-    margin-right: 17px;
   }
   .sort-icon {
     display: inline-block;

--- a/src/components/treeGrid/style/treeGrid.scss
+++ b/src/components/treeGrid/style/treeGrid.scss
@@ -55,6 +55,7 @@
   }
   &:nth-last-child(1) {
     border-right: 0;
+    margin-right: 17px;
   }
   .sort-icon {
     display: inline-block;

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -138,14 +138,9 @@ export const scrollEvent = (params) => {
     const bodyEl = elementInfo.body;
     const tableEl = bodyEl.children[1];
 
-    if (bodyEl.clientWidth < tableEl.clientWidth) {
-      scrollInfo.hasHorizontalScrollBar = true;
-    } else {
-      scrollInfo.hasHorizontalScrollBar = false;
-    }
-
     headerEl.scrollLeft = bodyEl.scrollLeft;
     summaryScroll.value = bodyEl.scrollLeft;
+    scrollInfo.hasHorizontalScrollBar = bodyEl.clientWidth < tableEl.clientWidth;
   };
   /**
    * scroll 이벤트를 처리한다.

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -114,9 +114,11 @@ export const scrollEvent = (params) => {
       const lastVisibleIndex = firstVisibleIndex + rowCount + 1;
       const firstIndex = Math.max(firstVisibleIndex, 0);
       const lastIndex = lastVisibleIndex;
+      const tableEl = bodyEl.children[1];
 
       stores.viewStore = store.slice(firstIndex, lastIndex);
-      scrollInfo.hasVerticalScrollBar = rowCount < store.length;
+      scrollInfo.hasVerticalScrollBar = rowCount < store.length
+        || bodyEl.clientHeight < tableEl.clientHeight;
       scrollInfo.vScrollTopHeight = firstIndex * rowHeight;
       scrollInfo.vScrollBottomHeight = totalScrollHeight - (stores.viewStore.length * rowHeight)
         - scrollInfo.vScrollTopHeight;
@@ -134,6 +136,13 @@ export const scrollEvent = (params) => {
   const updateHScroll = () => {
     const headerEl = elementInfo.header;
     const bodyEl = elementInfo.body;
+    const tableEl = bodyEl.children[1];
+
+    if (bodyEl.clientWidth < tableEl.clientWidth) {
+      scrollInfo.hasHorizontalScrollBar = true;
+    } else {
+      scrollInfo.hasHorizontalScrollBar = false;
+    }
 
     headerEl.scrollLeft = bodyEl.scrollLeft;
     summaryScroll.value = bodyEl.scrollLeft;
@@ -166,7 +175,15 @@ export const scrollEvent = (params) => {
 
 export const resizeEvent = (params) => {
   const { props } = getCurrentInstance();
-  const { resizeInfo, elementInfo, checkInfo, stores, isRenderer, updateVScroll } = params;
+  const {
+    resizeInfo,
+    elementInfo,
+    checkInfo,
+    stores,
+    isRenderer,
+    updateVScroll,
+    updateHScroll,
+  } = params;
   /**
    * 고정 너비, 스크롤 유무 등에 따른 컬럼 너비를 계산한다.
    */
@@ -261,6 +278,9 @@ export const resizeEvent = (params) => {
       calculatedColumn();
       if (elementInfo.body?.clientHeight) {
         updateVScroll();
+      }
+      if (elementInfo.body?.clientWidth) {
+        updateHScroll();
       }
     });
   };

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -114,7 +114,7 @@ export const scrollEvent = (params) => {
       const lastVisibleIndex = firstVisibleIndex + rowCount + 1;
       const firstIndex = Math.max(firstVisibleIndex, 0);
       const lastIndex = lastVisibleIndex;
-      const tableEl = bodyEl.children[1];
+      const tableEl = elementInfo['grid-table'];
 
       stores.viewStore = store.slice(firstIndex, lastIndex);
       scrollInfo.hasVerticalScrollBar = rowCount < store.length
@@ -136,7 +136,7 @@ export const scrollEvent = (params) => {
   const updateHScroll = () => {
     const headerEl = elementInfo.header;
     const bodyEl = elementInfo.body;
-    const tableEl = bodyEl.children[1];
+    const tableEl = elementInfo['grid-table'];
 
     headerEl.scrollLeft = bodyEl.scrollLeft;
     summaryScroll.value = bodyEl.scrollLeft;

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -338,15 +338,15 @@ export const clickEvent = (params) => {
       if (tagName === 'td') {
         cellInfo = event.target.dataset;
       } else {
-        cellInfo = event.target.closest('td')?.dataset;
+        cellInfo = event.target.closest('td')?.dataset ?? {};
       }
     }
     return {
       event,
       rowData: row,
       rowIndex: row.index,
-      cellName: cellInfo?.name,
-      cellIndex: cellInfo?.index,
+      cellName: cellInfo.name,
+      cellIndex: cellInfo.index,
     };
   };
   /**

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -114,7 +114,7 @@ export const scrollEvent = (params) => {
       const lastVisibleIndex = firstVisibleIndex + rowCount + 1;
       const firstIndex = Math.max(firstVisibleIndex, 0);
       const lastIndex = lastVisibleIndex;
-      const tableEl = elementInfo['grid-table'];
+      const tableEl = elementInfo.table;
 
       stores.viewStore = store.slice(firstIndex, lastIndex);
       scrollInfo.hasVerticalScrollBar = rowCount < store.length
@@ -136,7 +136,7 @@ export const scrollEvent = (params) => {
   const updateHScroll = () => {
     const headerEl = elementInfo.header;
     const bodyEl = elementInfo.body;
-    const tableEl = elementInfo['grid-table'];
+    const tableEl = elementInfo.table;
 
     headerEl.scrollLeft = bodyEl.scrollLeft;
     summaryScroll.value = bodyEl.scrollLeft;


### PR DESCRIPTION
### 이슈 사항
- 컬럼 데이터의 내용이 긴 경우, 사용자가 컬럼 크기를 확장하더라도 컬럼 크기의 확장 제한이 있어 데이터 확인이 어려우며 가독성이 좋지 않음.
- 특정 컬럼을 확대 할 경우, 다음 컬럼도 데이터도 확인하기 어려움
- 특정 컬럼을 리사이즈 시, 데이터 확인이 가능하도록 개선 필요

### 작업 내용
**[AS-IS]**
- 컬럼 확장 시, 다음 컬럼의 크기 만큼만 확장이 가능하여 확장 제한이 있음. 
- 해당 컬럼을 확대 및 축소 시, 다음 컬럼만 크기의 영향을 받음.
![Animation-asis](https://user-images.githubusercontent.com/79958259/180133883-51fd72f4-02a3-4a55-bc52-2dbe8cc5a12b.gif)


**[TO-BE]**
- 컬럼 변경 시, 다른 컬럼에 영향받지 않고 해당 컬럼의 크기가 변경되어 변경된 컬럼의 크기만큼 전체 그리드 크기가 변경되도록 수정
- 컬럼 크기 확장 시, 확장 제약없이 전체 너비 만큼 드래그하여 확장 되도록 수정
- 컬럼들이 축소되었을 때, 컬럼들이 전체 그리드에서 공간이 채워지지 않는 경우가 생겨 마지막 컬럼도 리사이즈 되도록 변경 및 수정
![Animation-tobe](https://user-images.githubusercontent.com/79958259/180134336-3c70a11a-885d-41b7-bdca-57cb413489d1.gif)
