### PR TITLE
 [#1245] Chart > Legend 관련 옵션 변경 시 DOM 을 못찾는 Error log 발생 및 select관련 예외처리 추가

### DIFF
--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -97,51 +97,59 @@ import { onMounted, onBeforeUnmount, watch, onDeactivated } from 'vue';
         }
       };
 
+      watch(() => props.options, (chartOpt) => {
+        const newOpt = getNormalizedOptions(chartOpt);
+
+        const isUpdateLegendType = !isEqual(newOpt.legend.table, evChart.options.legend.table);
+
+        evChart.options = cloneDeep(newOpt);
+
+        evChart.update({
+          updateSeries: false,
+          updateSelTip: { update: false, keepDomain: false },
+          updateLegend: isUpdateLegendType,
+        });
+      }, { deep: true });
+
+      watch(() => props.data, (chartData) => {
+        const newData = getNormalizedData(chartData);
+
+        const isUpdateSeries = !isEqual(newData.series, evChart.data.series)
+            || !isEqual(newData.groups, evChart.data.groups)
+            || props.options.type === 'heatMap';
+
+        const isUpdateData = !isEqual(newData.data, evChart.data);
+
+        evChart.data = cloneDeep(newData);
+
+        evChart.update({
+          updateSeries: isUpdateSeries,
+          updateSelTip: { update: true, keepDomain: false },
+          updateData: isUpdateData,
+        });
+      }, { deep: true });
+
+      watch(() => props.selectedItem, (newValue) => {
+        const chartType = props.options?.type;
+
+        evChart.selectItemByData(newValue, chartType);
+      }, { deep: true });
+
+      watch(() => props.selectedLabel, (newValue) => {
+        if (newValue.dataIndex) {
+          evChart.renderWithSelected(newValue.dataIndex);
+        }
+      }, { deep: true });
+
+      watch(() => props.selectedSeries, (newValue) => {
+        if (newValue.seriesId) {
+          evChart.renderWithSelected(newValue.seriesId);
+        }
+      }, { deep: true });
+
       onMounted(async () => {
         await createChart();
         await drawChart();
-
-        await watch(() => props.options, (chartOpt) => {
-          const newOpt = getNormalizedOptions(chartOpt);
-          const isUpdateLegend = !isEqual(newOpt.legend, evChart.options.legend);
-          evChart.options = cloneDeep(newOpt);
-          evChart.update({
-            updateSeries: false,
-            updateSelTip: { update: false, keepDomain: false },
-            updateLegend: isUpdateLegend,
-          });
-        }, { deep: true });
-
-        await watch(() => props.data, (chartData) => {
-          const newData = getNormalizedData(chartData);
-          const isUpdateSeries = !isEqual(newData.series, evChart.data.series)
-              || !isEqual(newData.groups, evChart.data.groups)
-              || props.options.type === 'heatMap';
-          const isUpdateData = !isEqual(newData.data, evChart.data);
-          evChart.data = cloneDeep(newData);
-          evChart.update({
-            updateSeries: isUpdateSeries,
-            updateSelTip: { update: true, keepDomain: false },
-            updateData: isUpdateData,
-          });
-        }, { deep: true });
-
-        await watch(() => props.selectedItem, (newValue) => {
-          const chartType = props.options?.type;
-          evChart.selectItemByData(newValue, chartType);
-        }, { deep: true });
-
-        await watch(() => props.selectedLabel, (newValue) => {
-          if (newValue.dataIndex) {
-            evChart.renderWithSelected(newValue.dataIndex);
-          }
-        }, { deep: true });
-
-        await watch(() => props.selectedSeries, (newValue) => {
-          if (newValue.seriesId) {
-            evChart.renderWithSelected(newValue.seriesId);
-          }
-        }, { deep: true });
       });
 
       onBeforeUnmount(() => {

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -792,9 +792,11 @@ class EvChart {
    * @returns {undefined}
    */
   render(hitInfo) {
-    this.clear();
-    this.chartRect = this.getChartRect();
-    this.drawChart(hitInfo);
+    if (this.isInit) {
+      this.clear();
+      this.chartRect = this.getChartRect();
+      this.drawChart(hitInfo);
+    }
   }
 
   /**


### PR DESCRIPTION
### 재현스텝
1. chart Option > legend > use: true <-> false 스왑
2. 동작 확인
3. v-if 등을 이용하여 ev-chart 컴포넌트 화면에서 제거
4. 제거 했던 ev-chart 다시 생성 
5. 1번과 같은 액션 수행
6. 동작 확인 

### 기대 결과 
2/ 에러 없이 정상 수행
6/ 에러 없이 정상 수행

### 실제 결과
2/ 에러 없이 정상 수행 (PASS)
6/ this.legendDOM 을 못찾는 에러로그 발생 (FAIL)

-------------

### 작업내용
1. watch 문이 mounted hook 안에 들어있어, mounted 될 때마다 동일한 객체를 바라보는 watch가 중복으로 생성되며 발생한 문제 픽스

### 추가 
1. 위 내용 테스트 도중 Chart의 init() 함수가 호출되기 전에 render() 함수가 먼저 호출되는 현상을 발경하여 예외 처리 추가