### PR TITLE
[#1246] Chart > select 기능 > useClick 옵션 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -307,31 +307,33 @@ const chartOptions = {
 | tipTextColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상  | |
 
 #### selectItem
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| use | Boolean | false | 차트 아이템 선택 기능  | |
-| showTextTip | Boolean | false | 선택한 위치의 TextTip(text 포함 화살표, 흡사 말풍선) 생성 여부  | |
-| tipText | String | 'value' | 선택한 위치에 TextTip을 생성한다면 어떤 값  | 'value', 'label |
-| showTip | Boolean | false | 선택한 위치의 Tip(화살표) 생성 여부  | |
-| showIndicator | Boolean | false | 선택한 label의 indicator 표시  | |
-| fixedPosTop | Boolean | false | indicator 및 tip의 위치를 최대값으로 고정  | |
-| useApproximateValue | Boolean | false | 가까운 label을 선택  | |
-| indicatorColor | Hex, RGB, RGBA Code(String)| '#000000' | indicator 색상  | |
-| tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | tip 배경색상  | |
-| tipTextColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | tip 글자 색상  | |
+| 이름 | 타입 | 디폴트 | 설명                                                | 종류(예시) |
+| --- | ---- | ----- |---------------------------------------------------| ----------|
+| use | Boolean | false | 차트 아이템 선택 기능                                      | |
+| useClick            | Boolean | true      | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) | |
+| showTextTip | Boolean | false | 선택한 위치의 TextTip(text 포함 화살표, 흡사 말풍선) 생성 여부        | |
+| tipText | String | 'value' | 선택한 위치에 TextTip을 생성한다면 어떤 값                       | 'value', 'label |
+| showTip | Boolean | false | 선택한 위치의 Tip(화살표) 생성 여부                            | |
+| showIndicator | Boolean | false | 선택한 label의 indicator 표시                           | |
+| fixedPosTop | Boolean | false | indicator 및 tip의 위치를 최대값으로 고정                     | |
+| useApproximateValue | Boolean | false | 가까운 label을 선택                                     | |
+| indicatorColor | Hex, RGB, RGBA Code(String)| '#000000' | indicator 색상                                      | |
+| tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | tip 배경색상                                          | |
+| tipTextColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | tip 글자 색상                                         | |
 
 #### selectLabel
-| 이름                  | 타입                          | 디폴트       | 설명                                    | 종류(예시) |
-|---------------------|-----------------------------|-----------|---------------------------------------| ----------|
-| use                 | Boolean                     | false     | 차트 라벨 선택 기능                           | |
-| limit               | Number                      | 1         | 선택할 라벨의 최대 갯수                         | |
-| useDeselectOverflow | Boolean                     | false     | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부 | |
-| showTip             | Boolean                     | false     | 선택한 위치의 Tip(화살표) 생성 여부                | |
-| useSeriesOpacity    | Boolean                     | true      | 시리즈 opacity 변경 여부                     | |
-| useLabelOpacity     | Boolean                     | true      | Axes Label opacity 변경 여부              | |
-| fixedPosTop         | Boolean                     | false     | tip의 위치를 최대값으로 고정                     | |
-| useApproximateValue | Boolean                     | false     | 가까운 label을 선택                         | |
-| tipBackground       | Hex, RGB, RGBA Code(String) | '#000000' | tip 배경색상                              | |
+| 이름                  | 타입                          | 디폴트       | 설명                                                | 종류(예시) |
+|---------------------|-----------------------------|-----------|---------------------------------------------------| ----------|
+| use                 | Boolean                     | false     | 차트 라벨 선택 기능                                       | |
+| useClick            | Boolean | true      | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) | |
+| limit               | Number                      | 1         | 선택할 라벨의 최대 갯수                                     | |
+| useDeselectOverflow | Boolean                     | false     | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부             | |
+| showTip             | Boolean                     | false     | 선택한 위치의 Tip(화살표) 생성 여부                            | |
+| useSeriesOpacity    | Boolean                     | true      | 시리즈 opacity 변경 여부                                 | |
+| useLabelOpacity     | Boolean                     | true      | Axes Label opacity 변경 여부                          | |
+| fixedPosTop         | Boolean                     | false     | tip의 위치를 최대값으로 고정                                 | |
+| useApproximateValue | Boolean                     | false     | 가까운 label을 선택                                     | |
+| tipBackground       | Hex, RGB, RGBA Code(String) | '#000000' | tip 배경색상                                          | |
 
 ### 5. resize-timeout
 - Default : 0

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -275,38 +275,41 @@ const chartOptions = {
 | tipTextColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상  | |
 
 #### selectItem
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| use | Boolean | false | 차트 아이템 선택 기능  | |
-| showTextTip | Boolean | false | 선택한 위치의 TextTip(text 포함 화살표, 흡사 말풍선) 생성 여부  | |
-| tipText | String | 'value' | 선택한 위치에 TextTip을 생성한다면 어떤 값  | 'value', 'label |
-| showTip | Boolean | false | 선택한 위치의 Tip(화살표) 생성 여부  | |
-| showIndicator | Boolean | false | 선택한 label의 indicator 표시  | |
-| fixedPosTop | Boolean | false | indicator 및 tip의 위치를 최대값으로 고정  | |
-| useApproximateValue | Boolean | false | 가까운 label을 선택  | |
-| indicatorColor | Hex, RGB, RGBA Code(String) | '#000000' | indicator 색상  | |
-| tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | tip 배경색상  | |
-| tipTextColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | tip 글자 색상  | |
+| 이름                  | 타입 | 디폴트       | 설명                                                | 종류(예시) |
+|---------------------| ---- |-----------|---------------------------------------------------| ----------|
+| use                 | Boolean | false     | 차트 아이템 선택 기능                                      | |
+| useClick            | Boolean | true      | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) | |
+| showTextTip         | Boolean | false     | 선택한 위치의 TextTip(text 포함 화살표, 흡사 말풍선) 생성 여부        | |
+| tipText             | String | 'value'   | 선택한 위치에 TextTip을 생성한다면 어떤 값                       | 'value', 'label |
+| showTip             | Boolean | false     | 선택한 위치의 Tip(화살표) 생성 여부                            | |
+| showIndicator       | Boolean | false     | 선택한 label의 indicator 표시                           | |
+| fixedPosTop         | Boolean | false     | indicator 및 tip의 위치를 최대값으로 고정                     | |
+| useApproximateValue | Boolean | false     | 가까운 label을 선택                                     | |
+| indicatorColor      | Hex, RGB, RGBA Code(String) | '#000000' | indicator 색상                                      | |
+| tipBackground       | Hex, RGB, RGBA Code(String) | '#000000' | tip 배경색상                                          | |
+| tipTextColor        | Hex, RGB, RGBA Code(String) | '#FFFFFF' | tip 글자 색상                                         | |
 
 #### selectLabel
-| 이름                 | 타입                          | 디폴트       | 설명                                    | 종류(예시) |
-|--------------------|-----------------------------|-----------|---------------------------------------| ----------|
-| use                | Boolean                     | false     | 차트 라벨 선택 기능                           | |
-| limit              | Number                      | 1         | 선택할 라벨의 최대 갯수                         | |
-| useDeselectOverflow | Boolean                     | false     | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부 | |
-| showTip            | Boolean                     | false     | 선택한 위치의 Tip(화살표) 생성 여부                | |
-| useSeriesOpacity   | Boolean                     | true      | 시리즈 opacity 변경 여부                     | |
-| useLabelOpacity   | Boolean                     | true      | Axes Label opacity 변경 여부              | |
-| fixedPosTop        | Boolean                     | false     | tip의 위치를 최대값으로 고정                     | |
-| useApproximateValue | Boolean                     | false     | 가까운 label을 선택                         | |
-| tipBackground      | Hex, RGB, RGBA Code(String) | '#000000' | tip 배경색상                              | |
+| 이름                 | 타입                          | 디폴트       | 설명                                                | 종류(예시) |
+|--------------------|-----------------------------|-----------|---------------------------------------------------| ----------|
+| use                | Boolean                     | false     | 차트 라벨 선택 기능                                       | |
+| useClick            | Boolean | true      | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) | |
+| limit              | Number                      | 1         | 선택할 라벨의 최대 갯수                                     | |
+| useDeselectOverflow | Boolean                     | false     | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부             | |
+| showTip            | Boolean                     | false     | 선택한 위치의 Tip(화살표) 생성 여부                            | |
+| useSeriesOpacity   | Boolean                     | true      | 시리즈 opacity 변경 여부                                 | |
+| useLabelOpacity   | Boolean                     | true      | Axes Label opacity 변경 여부                          | |
+| fixedPosTop        | Boolean                     | false     | tip의 위치를 최대값으로 고정                                 | |
+| useApproximateValue | Boolean                     | false     | 가까운 label을 선택                                     | |
+| tipBackground      | Hex, RGB, RGBA Code(String) | '#000000' | tip 배경색상                                          | |
 
 #### selectSeries
-| 이름                 | 타입                          | 디폴트       | 설명                                    | 종류(예시) |
-|--------------------|-----------------------------|-----------|---------------------------------------| ----------|
-| use                | Boolean                     | false     | 차트 라벨 선택 기능                           | |
-| limit              | Number                      | 1         | 선택할 라벨의 최대 갯수                         | |
-| useDeselectOverflow | Boolean                     | false     | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부 | |
+| 이름                 | 타입                          | 디폴트       | 설명                                                | 종류(예시) |
+|--------------------|-----------------------------|-----------|---------------------------------------------------| ----------|
+| use                | Boolean                     | false     | 차트 라벨 선택 기능                                       | |
+| useClick            | Boolean | true      | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) | |
+| limit              | Number                      | 1         | 선택할 라벨의 최대 갯수                                     | |
+| useDeselectOverflow | Boolean                     | false     | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부             | |
 
 #### dragSelection
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/lineChart/example/SelectLabel.vue
+++ b/docs/views/lineChart/example/SelectLabel.vue
@@ -14,6 +14,12 @@
       @click="onClick"
     />
     <div class="description">
+      <ev-toggle v-model="isUseClick" />
+      <span>
+        클릭 기능 enable ( false 일때는 v-model 값으로 변경 )
+      </span>
+      <br>
+      <br>
       <ev-toggle v-model="isFixedPosTop" />
       <span>
         tip 위치를 최상단에 고정
@@ -89,6 +95,7 @@ export default {
         series5: [],
       },
     });
+    const isUseClick = ref(true);
     const isFixedPosTop = ref(false);
 
     const chartOptions1 = ref({
@@ -115,6 +122,7 @@ export default {
       }],
       selectLabel: {
         use: true,
+        useClick: isUseClick,
         limit: 2,
         useDeselectOverflow: true,
         showTip: true,
@@ -149,6 +157,7 @@ export default {
       }],
       selectLabel: {
         use: true,
+        useClick: isUseClick,
         limit: 2,
         useDeselectOverflow: true,
         showTip: true,
@@ -224,6 +233,7 @@ export default {
       chartOptions2,
       clickedLabel,
       defaultSelectLabel,
+      isUseClick,
       isFixedPosTop,
       isLive,
       onClick,

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -112,7 +112,7 @@ const modules = {
      */
     this.onClick = (e) => {
       const args = { e };
-      if (this.options.selectItem.use) {
+      if (this.options.selectItem.use && this.options.selectItem.useClick) {
         const offset = this.getMousePosition(e);
         const hitInfo = this.getItemByPosition(offset, false);
 
@@ -127,14 +127,14 @@ const modules = {
           maxIndex: args.dataIndex,
           acc: args.acc,
         } = hitInfo);
-      } else if (this.options.selectLabel.use) {
+      } else if (this.options.selectLabel.use && this.options.selectLabel.useClick) {
         const offset = this.getMousePosition(e);
         const clickedLabelInfo = this.getLabelInfoByPosition(offset);
         const selected = this.selectLabel(clickedLabelInfo.labelIndex);
         this.renderWithSelected(selected.dataIndex);
 
         args.selected = cloneDeep(this.defaultSelectInfo);
-      } else if (this.options.selectSeries.use) {
+      } else if (this.options.selectSeries.use && this.options.selectSeries.useClick) {
         const offset = this.getMousePosition(e);
         const hitInfo = this.getSeriesIdByPosition(offset);
         if (hitInfo.sId !== null) {

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -103,6 +103,7 @@ const DEFAULT_OPTIONS = {
   },
   selectItem: {
     use: false,
+    useClick: true,
     showTextTip: false,
     tipText: 'value',
     showTip: false,
@@ -116,6 +117,7 @@ const DEFAULT_OPTIONS = {
   },
   selectLabel: {
     use: false,
+    useClick: true,
     limit: 1,
     useDeselectOverflow: false,
     showTip: false,
@@ -127,6 +129,7 @@ const DEFAULT_OPTIONS = {
   },
   selectSeries: {
     use: false,
+    useClick: true,
     limit: 1,
     useDeselectOverflow: false,
   },


### PR DESCRIPTION
### 이슈 내용
- selectSeries 의 선택된 시리즈를 고정하고 싶다는 요구사항

### 처리 내용
 - selectItem, selectLabel, selectSeries 옵션에 useClick 을 추가 (default: true)
 - 클릭 이벤트에서 useClick 이 true 인 경우에만 클릭 이벤트로 select 기능이 동작

### Before
![fixed before](https://user-images.githubusercontent.com/46586573/180343438-bd2cc9db-fca6-47e7-bd10-b73e3965d3ab.gif)

### After
![fixed after](https://user-images.githubusercontent.com/46586573/180343454-90b46027-8107-465b-bf92-8f88a9b66395.gif)

