### PR TITLE
[#1254] Chart > Bar Chart의 높이가 이상하게 그려짐

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.36",
+  "version": "3.3.37",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -120,7 +120,7 @@ class Scale {
       increase += interval;
     }
 
-    const graphMax = increase > maxValue ? maxValue : increase;
+    const graphMax = increase;
     const graphMin = minValue;
     const graphRange = graphMax - graphMin;
 


### PR DESCRIPTION
### 이슈 요약 
- Linear 타입의 축의 간격이 균일하게 배분되지 않는 현상 발생

### 처리 내용
- 균일한 간격으로 나눠 축을 그렸을때, 마지막 값이 maxValue보다 클 경우 maxValue로 대체되는 로직 제거

![image](https://user-images.githubusercontent.com/53548023/181684107-87364769-ccda-4616-92fe-e82f48323f49.png)

