### PR TITLE
[#1269] Chart > Legend 영역 통계 > null 처리

### DIFF
--- a/docs/views/comboChart/example/TableTypeLegend.vue
+++ b/docs/views/comboChart/example/TableTypeLegend.vue
@@ -201,15 +201,16 @@ import { onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
               avg: {
                 use: useAvg,
                 decimalPoint: 4,
+                formatter: value => `${value.toFixed(0)}`,
               },
               total: {
                 use: useTotal,
                 decimalPoint: 4,
+                formatter: value => `${value.toFixed(0)}`,
               },
               last: {
                 use: useLast,
                 title: 'CURRENT',
-                formatter: value => `${value.toFixed(0)}`,
                 style: {
                   color: '#219EBC',
                 },
@@ -223,7 +224,7 @@ import { onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
       const liveInterval = ref();
       let timeValue = dayjs().format('YYYY-MM-DD HH:mm:ss');
 
-      const addRandomChartData = () => {
+      const addRandomChartData = (ix) => {
         if (isLive.value) {
           chartData.labels.shift();
         }
@@ -236,13 +237,13 @@ import { onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
             seriesData.shift();
           }
 
-          seriesData.push(Math.random() * (100 - 1) + 1);
+          seriesData.push(ix > 6 ? null : Math.random() * (100 - 1) + 1);
         });
       };
 
       onMounted(() => {
         for (let ix = 0; ix < 10; ix++) {
-          addRandomChartData();
+          addRandomChartData(ix);
         }
       });
 

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -335,4 +335,12 @@ export default {
       targetDOM.style[key] = styleObject[key];
     });
   },
+
+  checkSafeInteger(value) {
+    if (value === null || value === undefined) {
+      return false;
+    }
+
+    return value <= Number.MAX_SAFE_INTEGER && value >= Number.MIN_SAFE_INTEGER;
+  },
 };

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -949,13 +949,23 @@ const modules = {
     const seriesIds = Object.keys(series);
 
     seriesIds?.forEach((sId) => {
-      const dataList = allData[sId].map(data => (data.value ? data.value : data));
-
-      const min = (Math.min(...dataList));
-      const max = (Math.max(...dataList));
-      const total = (dataList.reduce((a, b) => a + b, 0));
-      const avg = (total / dataList.length || 0);
+      const dataList = allData[sId].map(data => (data?.value ? data.value : data));
       const last = (dataList[dataList.length - 1]);
+
+      const dataListExcludedNull = dataList.filter(value => value !== undefined && value !== null);
+      const min = (Math.min(...dataListExcludedNull));
+      const max = (Math.max(...dataListExcludedNull));
+      const total = (dataListExcludedNull.reduce((a, b) => a + b, 0));
+      const avg = (total / dataListExcludedNull.length || 0);
+
+      if (!Util.checkSafeInteger(min)
+        || !Util.checkSafeInteger(max)
+        || !Util.checkSafeInteger(avg)
+        || !Util.checkSafeInteger(total)
+        || !Util.checkSafeInteger(last)
+      ) {
+        console.warn('[EVUI][Chart] The aggregated value exceeds 9007199254740991 or less then -9007199254740991.');
+      }
 
       aggregationDataSet[sId] = { min, max, avg, total, last };
     });

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -533,7 +533,7 @@ const modules = {
         }
 
         const seriesId = row.series.sId;
-        const value = +aggregations?.[seriesId]?.[key];
+        const value = aggregations?.[seriesId]?.[key];
         dom.textContent = this.getFormattedValue(columns[key], value);
       });
     });
@@ -756,7 +756,7 @@ const modules = {
       }
 
       if (columns[key].use) {
-        const formattedTxt = this.getFormattedValue(columns[key], +aggregations[key]);
+        const formattedTxt = this.getFormattedValue(columns[key], aggregations[key]);
         const valueDOM = document.createElement('td');
         valueDOM.className = 'ev-chart-legend--table__value';
         valueDOM.style.color = series.show ? opt.color : opt.inactive;
@@ -1134,13 +1134,17 @@ const modules = {
    * @returns {string}
    */
   getFormattedValue({ formatter, decimalPoint }, value) {
+    if (value === undefined || value === null) {
+      return 'Null';
+    }
+
     let formattedTxt;
     if (formatter) {
-      formattedTxt = formatter(value);
+      formattedTxt = formatter(+value);
     }
 
     if (!formatter || typeof formattedTxt !== 'string') {
-      formattedTxt = Util.labelSignFormat(value, decimalPoint);
+      formattedTxt = Util.labelSignFormat(+value, decimalPoint);
     }
 
     return formattedTxt;


### PR DESCRIPTION
### 처리 내용 
- 합계, 최솟값, 최댓값, 평균 계산시 null과 undefined는 제외하도록 함
- 마지막값 계산 시 null과 undefined는 'Null'로 표시되도록함
- 계산된 값이 javascript기준 MAX_SAFE_INTEGER을 초과했거나 MIN_SAFE_INTEGER 미만일 경우 console warning이 출력되도록함 


### 예시
![legend_aggregation_table_null](https://user-images.githubusercontent.com/53548023/186049201-3353a08e-9602-49ea-83ef-2cdf403886bb.gif)
