### PR TITLE
[#1273] Grid, TreeGrid > title과 해당 column row 의 내용이 다를 때 마우스 우클릭 이상 동작 현상

### DIFF
--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -871,18 +871,13 @@ export const contextMenuEvent = (params) => {
    */
   const onContextMenu = (event) => {
     const target = event.target;
-    const tagName = target.tagName.toLowerCase();
-    let rowIndex;
+    const rowIndex = target.closest('.row').dataset.index;
 
-    if (tagName === 'td') {
-      rowIndex = target.parentElement.dataset.index;
-    } else {
-      rowIndex = target.parentElement.parentElement.dataset.index;
-    }
     let clickedRow;
     if (rowIndex) {
       clickedRow = stores.viewStore.find(row => row[ROW_INDEX] === +rowIndex)?.[ROW_DATA_INDEX];
     }
+
     if (clickedRow) {
       selectInfo.selectedRow = clickedRow;
       setContextMenu();

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -599,7 +599,7 @@ export const contextMenuEvent = (params) => {
    */
   const onContextMenu = (event) => {
     const target = event.target;
-    const rowIndex = target.parentElement.dataset.index;
+    const rowIndex = target.closest('.row').dataset.index;
 
     if (rowIndex) {
       const index = stores.viewStore.findIndex(v => v.index === Number(rowIndex));


### PR DESCRIPTION
## AS IS
![mouseRightClick](https://user-images.githubusercontent.com/76253952/186801974-631025f8-373a-4e43-a2b9-66b7549901fd.gif)


## 원인
![image](https://user-images.githubusercontent.com/76253952/186802176-717803c1-3453-45b1-ae6a-58afd154df5a.png)
해당 사진 처럼 ev-grid 템플릿 단 에서 데이터 값을 정제하려고 할 때 `div` 가 한번 더 쓰여져 tr의 data-index를 읽어오지 못하는 현상임을 확인 하였습니다.

## 해결
![image](https://user-images.githubusercontent.com/76253952/186802358-56602845-e646-4ca9-95b0-85b821079732.png)
tr의 공통된 특징은 `'.row'` 라는 클래스를 가지고 있는 것 이므로 이벤트가 일어난 target 에서 가장 가까우며 `'.row'` 라는 클래스를 가진 부모 (tr)을 찾기 위해 `closest` 를 사용 하였습니다.

해당 부분은 Tree-Grid 에서도 같은 현상이 있음을 확인하고 같이 수정 작업 하였습니다.

## TO BE
![toBeRightClick](https://user-images.githubusercontent.com/76253952/186802096-0664814d-cf4a-468e-acaa-a5d53245c662.gif)
