### PR TITLE
[#1280][2.0] TextField > disabled 상태 color 조정

### DIFF
--- a/src/components/textfield/textfield.vue
+++ b/src/components/textfield/textfield.vue
@@ -154,7 +154,7 @@
           `${prefixCls}`,
           { [`${prefixCls}-disabled`]: this.disabled },
           { focus: this.focus },
-          { error: this.cssError },
+          { error: this.cssError || this.customErrorMsg },
         ];
       },
       wrapStyle() {


### PR DESCRIPTION
## 이슈 내용
2.0 버전의  컴포넌트에서 custom-error-msg prop 값 넘겨주었을 때 오류 상태를 표현하는 색상으로 변경되지 않습니다.

## 처리 내용
custom-error-msg prop가 truthy한 값인 경우, 오류 상태 표현하는 색상으로 변경

## Before
ID 항목에 custom-error-msg 설정하였지만 border-color가 변경되지 않는 모습
![image](https://user-images.githubusercontent.com/92071892/190298168-c2cae6f3-d6c2-43e8-9d2d-ca155050d2e9.png)

## After
![image](https://user-images.githubusercontent.com/92071892/190298177-7ad9b577-f25a-4b92-b3ca-40b50cefa1e4.png)
