### PR TITLE
[2.0] Grid > Column 리사이즈 에러

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/grid.vue
+++ b/src/components/grid/grid.vue
@@ -1019,11 +1019,11 @@ export default {
 
       const nextColumnIndex = columnIndex + 1;
       const headerEl = this.$refs.header;
+      const bodyEl = this.$refs.body;
       const headerLeft = headerEl.getBoundingClientRect().left;
       const columnEl = headerEl.querySelector(`li[data-index="${columnIndex}"]`);
-      const nextColumnEl = headerEl.querySelector(`li[data-index="${nextColumnIndex}"]`);
       const columnRect = columnEl.getBoundingClientRect();
-      const maxRight = nextColumnEl.getBoundingClientRect().right - headerLeft - 40;
+      const maxRight = bodyEl.getBoundingClientRect().right - headerLeft;
       const resizeLineEl = this.$refs.resizeLine;
       const minLeft = columnRect.left - headerLeft + 40;
       const startLeft = columnRect.right - headerLeft;

--- a/src/components/grid/grid.vue
+++ b/src/components/grid/grid.vue
@@ -1017,13 +1017,16 @@ export default {
         return;
       }
 
-      const nextColumnIndex = columnIndex + 1;
+      let nextColumnIndex = columnIndex + 1;
       const headerEl = this.$refs.header;
-      const bodyEl = this.$refs.body;
       const headerLeft = headerEl.getBoundingClientRect().left;
       const columnEl = headerEl.querySelector(`li[data-index="${columnIndex}"]`);
+      while (this.orderedColumns[nextColumnIndex].hide) {
+        nextColumnIndex++;
+      }
+      const nextColumnEl = headerEl.querySelector(`li[data-index="${nextColumnIndex}"]`);
       const columnRect = columnEl.getBoundingClientRect();
-      const maxRight = bodyEl.getBoundingClientRect().right - headerLeft;
+      const maxRight = nextColumnEl.getBoundingClientRect().right - headerLeft - 40;
       const resizeLineEl = this.$refs.resizeLine;
       const minLeft = columnRect.left - headerLeft + 40;
       const startLeft = columnRect.right - headerLeft;


### PR DESCRIPTION
### 이슈내용
- 리사이즈 대상의 다음 컬럼이 hide: true 인 경우 에러 발생

### 처리내용
- hide 가 아닌 다음 대상을 찾도록 수정

[AS-IS]
![resize_before](https://user-images.githubusercontent.com/61657275/190364841-e9b298c0-0f9f-48fa-aad1-d45892873a2b.gif)

[TO-BE]
![resize_after](https://user-images.githubusercontent.com/61657275/190364881-03e6fd17-29c0-440f-8605-a4ff6cb11105.gif)
