### PR TITLE
[#1286] Chart > Heatmap > legend > series 활성화 버그

### DIFF
--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -176,6 +176,7 @@ const modules = {
             cId: colorItem.id,
             color: colorItem.color,
             name,
+            show: true,
           });
         }
       }


### PR DESCRIPTION
### 이슈 내용
-  ![image](https://user-images.githubusercontent.com/53548023/191912958-259e82e4-f642-4e00-9ecf-bb6931a7d1b8.png)
- heatmap 의 legend영역에 series color가 inactive color로 표시 됨

### 이슈 원인
- https://github.com/ex-em/EVUI/pull/1226
  - series 별 show값이 false경우 inactive상태로 표시되도록 수정된 내용
  - heatmap은 사용자로부터 series별 show 여부를 받지 않아 기본이 undefined이기 때문에 inactive상태로 표시되는 현상 발생된 것 

### 처리 내용
- heatmap 의 series 정보에서 show: true 로 부여