### PR TITLE
[#1288][2.0] Tab > 'change-tab' emit 위치 변경

### DIFF
--- a/src/components/tabs/tabs.vue
+++ b/src/components/tabs/tabs.vue
@@ -149,8 +149,10 @@
           const addValue = value[value.length - 1].value;
 
           this.tabList = value.slice();
-          this.$emit('change-tab', this.activeTab, addValue);
+
+          const prevActiveTab = this.activeTab;
           this.activeTab = addValue;
+          this.$emit('change-tab', prevActiveTab, this.activeTab);
         } else {
           this.tabList = value.slice();
         }
@@ -361,8 +363,9 @@
          * @property {string} oldTab - 이전 탭 키값
          * @property {string} newTab - 현재 탭 키값
          */
-        this.$emit('change-tab', this.activeTab, value);
+        const prevActiveTab = this.activeTab;
         this.activeTab = value;
+        this.$emit('change-tab', prevActiveTab, this.activeTab);
       },
       /**
        * 탭 제거에 대해서 처리한다.


### PR DESCRIPTION
### 이슈 내용
2.0 버전의 Tab 컴포넌트에서 탭 변경 시 'change-tab' 이벤트를 먼저 emit하고, activeTab(현재 활성화된 탭을 가리키는 변수)의 값을 변경하도록 되어 있습니다.

'change-tab' 이벤트를 사용하는 외부 컴포넌트에서 실제 탭 내용이 변경되기 전에 이벤트 핸들러가 실행되어, 변경된 탭 화면과 관련된 이벤트 핸들러 코드가 정상 작동하지 않는 이슈가 발생하였습니다.

---
### 처리 내용
activeTab 값을 변경 후 'change-tab' 이벤트 emit하도록 변경