### PR TITLE
[#1296] Chart > Brush, Zoom, Title 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.40",
+  "version": "3.3.41",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -78,7 +78,7 @@
       const injectIsChartGroup = inject('isChartGroup', false);
       const injectBrushSeries = inject('brushSeries', { list: [], chartIdx: null });
       const injectGroupSelectedLabel = inject('groupSelectedLabel', null);
-      const injectBrushIdx = inject('brushIdx', { start: 0, end: 0 });
+      const injectBrushIdx = inject('brushIdx', { start: 0, end: -1 });
 
       const {
         eventListeners,

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -705,7 +705,12 @@ class EvChart {
 
     // title update
     if (options.title.show) {
-      this.initTitle();
+      if (!this.isInitTitle) {
+        this.initTitle();
+      } else {
+        this.updateTitle();
+      }
+
       this.showTitle();
     } else if (this.isInitTitle) {
       this.hideTitle();

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -705,10 +705,7 @@ class EvChart {
 
     // title update
     if (options.title.show) {
-      if (!this.isInitTitle) {
-        this.initTitle();
-      }
-
+      this.initTitle();
       this.showTitle();
     } else if (this.isInitTitle) {
       this.hideTitle();

--- a/src/components/chart/chartZoom.core.js
+++ b/src/components/chart/chartZoom.core.js
@@ -438,7 +438,7 @@ export default class EvChartZoom {
       }
     };
 
-    if (isUseZoomMode) {
+    if (isUseZoomMode && this.dragZoomIcon.classList.contains('active')) {
       const { previous, latest } = this.zoomAreaMemory;
 
       toggleIconStyle(this.previousIcon, previous.length);

--- a/src/components/chart/plugins/plugins.title.js
+++ b/src/components/chart/plugins/plugins.title.js
@@ -20,19 +20,7 @@ const modules = {
       this.createTitle();
     }
 
-    const opt = this.options.title;
-
-    if (this.titleDOM.textContent === opt.text) {
-      return;
-    }
-
-    Object.keys(opt.style).forEach((key) => {
-      this.titleDOM.style[key] = opt.style[key];
-    });
-
-    this.titleDOM.textContent = opt.text;
-    this.titleDOM.style.height = `${opt.height}px`;
-    this.titleDOM.style.lineHeight = `${opt.height}px`;
+    this.updateTitle();
 
     this.isInitTitle = true;
   },
@@ -55,6 +43,18 @@ const modules = {
   hideTitle() {
     this.titleDOM.style.display = 'none';
     this.wrapperDOM.style.paddingTop = '0px';
+  },
+
+  updateTitle() {
+    const opt = this.options.title;
+
+    Object.keys(opt.style).forEach((key) => {
+      this.titleDOM.style[key] = opt.style[key];
+    });
+
+    this.titleDOM.textContent = opt.text;
+    this.titleDOM.style.height = `${opt.height}px`;
+    this.titleDOM.style.lineHeight = `${opt.height}px`;
   },
 };
 

--- a/src/components/chart/plugins/plugins.title.js
+++ b/src/components/chart/plugins/plugins.title.js
@@ -21,6 +21,11 @@ const modules = {
     }
 
     const opt = this.options.title;
+
+    if (this.titleDOM.textContent === opt.text) {
+      return;
+    }
+
     Object.keys(opt.style).forEach((key) => {
       this.titleDOM.style[key] = opt.style[key];
     });

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -232,7 +232,7 @@ export const useModel = (selectedLabel) => {
         left: 2,
         bottom: 4,
       };
-}
+    }
 
     return normalizedOptions;
   };
@@ -308,7 +308,6 @@ export const useWrapper = (options) => {
   };
 };
 
-
 export const useZoomModel = (
   evChartNormalizedOptions,
   { wrapper: evChartWrapper, evChartGroupRef },
@@ -323,7 +322,7 @@ export const useZoomModel = (
   const evChartZoomOptions = reactive({ zoom: evChartNormalizedOptions.zoom });
   const brushIdx = reactive({
     start: 0,
-    end: 0,
+    end: -1,
     isUseButton: false,
     isUseScroll: false,
   });
@@ -337,6 +336,7 @@ export const useZoomModel = (
     },
   });
   const evChartClone = reactive({ data: null, options: null });
+  const brushChartIdx = ref([]);
 
   const getRangeInfo = (zoomInfo) => {
     if (zoomInfo.data.length && zoomInfo.range && isUseZoomMode.value) {
@@ -387,6 +387,8 @@ export const useZoomModel = (
 
             evChartInfo.props.data.push(data);
             evChartInfo.props.options.push(options);
+          } else if (type?.name === 'EvChartBrush') {
+            brushChartIdx.value.push(evChartProps?.options?.chartIdx ?? 0);
           }
         });
       }
@@ -490,8 +492,15 @@ export const useZoomModel = (
 
       setEvChartOptions();
 
-      brushIdx.start = 0;
-      brushIdx.end = evChartClone.data[0].labels.length - 1;
+      brushIdx.end = -1;
+      for (let i = 0; i < brushChartIdx.value.length; i++) {
+        const data = evChartClone.data[brushChartIdx.value[i]];
+
+        if (data.labels.length) {
+          brushIdx.start = 0;
+          brushIdx.end = data.labels.length - 1;
+        }
+      }
 
       if (evChartZoom) {
         evChartZoom.updateEvChartCloneData(evChartClone, isUseZoomMode.value);

--- a/src/components/chartBrush/ChartBrush.vue
+++ b/src/components/chartBrush/ChartBrush.vue
@@ -32,7 +32,7 @@ export default {
     const injectEvChartInfo = inject('evChartInfo', { props: { options: [] } });
     const injectBrushIdx = inject('brushIdx', {
       start: 0,
-      end: 0,
+      end: -1,
       isUseButton: false,
       isUseScroll: false,
     });

--- a/src/components/chartBrush/chartBrush.core.js
+++ b/src/components/chartBrush/chartBrush.core.js
@@ -15,6 +15,8 @@ export default class EvChartBrush {
 
   init(isResize) {
     if (this.brushIdx.start > this.brushIdx.end) {
+      this.initEventState();
+      this.removeBrushCanvas();
       return;
     }
 
@@ -72,52 +74,55 @@ export default class EvChartBrush {
     const brushIdx = this.debounceBrushIdx ?? this.brushIdx;
 
     const labelEndIdx = this.evChartData.value.labels.length - 1;
-    this.labelEndIdx = labelEndIdx;
-    const axesXInterval = (evChartRange.x2 - evChartRange.x1) / labelEndIdx;
-    const brushRectX = brushIdx.start * axesXInterval * pixelRatio;
-    const brushRectWidth = (
-      brushCanvasWidth - (
-        labelEndIdx - (brushIdx.end - brushIdx.start)
-      ) * axesXInterval
-    ) * pixelRatio;
-    const brushRectHeight = this.evChartBrushOptions.value.height - evChartRange.y1;
-    const brushButtonLeftXPos = brushRectX;
-    const brushButtonRightXPos = brushRectX + brushRectWidth;
 
-    if (!brushCanvas.style.position) {
-      brushCanvas.style.position = 'absolute';
-      brushCanvas.style.top = `${evChartRange.y1}px`;
-      brushCanvas.style.left = `${evChartRange.x1 - (brushButtonWidth / 2)}px`;
+    if (labelEndIdx >= 0) {
+      this.labelEndIdx = labelEndIdx;
+      const axesXInterval = (evChartRange.x2 - evChartRange.x1) / labelEndIdx;
+      const brushRectX = brushIdx.start * axesXInterval * pixelRatio;
+      const brushRectWidth = (
+        brushCanvasWidth - (
+          labelEndIdx - (brushIdx.end - brushIdx.start)
+        ) * axesXInterval
+      ) * pixelRatio;
+      const brushRectHeight = this.evChartBrushOptions.value.height - evChartRange.y1;
+      const brushButtonLeftXPos = brushRectX;
+      const brushButtonRightXPos = brushRectX + brushRectWidth;
+
+      if (!brushCanvas.style.position) {
+        brushCanvas.style.position = 'absolute';
+        brushCanvas.style.top = `${evChartRange.y1}px`;
+        brushCanvas.style.left = `${evChartRange.x1 - (brushButtonWidth / 2)}px`;
+      }
+
+      if (!isEqualWidth) {
+        brushCanvas.width = (brushCanvasWidth * pixelRatio);
+        brushCanvas.style.width = `${brushCanvasWidth}px`;
+        brushCanvas.height = brushCanvasHeight * pixelRatio;
+        brushCanvas.style.height = `${brushCanvasHeight}px`;
+      }
+
+      const ctx = brushCanvas.getContext('2d');
+
+      ctx.clearRect(
+        0,
+        0,
+        brushCanvasWidth * pixelRatio,
+        brushCanvasHeight * pixelRatio,
+      );
+
+      ctx.fillStyle = this.evChartBrushOptions.value.selection.fillColor;
+      ctx.globalAlpha = this.evChartBrushOptions.value.selection.opacity;
+      ctx.fillRect(brushRectX, 0, brushRectWidth, brushRectHeight);
+      ctx.fillRect(brushButtonLeftXPos, 0, brushButtonWidth, brushRectHeight);
+      ctx.fillRect(brushButtonRightXPos - brushButtonWidth, 0, brushButtonWidth, brushRectHeight);
+
+      this.evChartBrushPos = {
+        leftX: brushButtonLeftXPos / pixelRatio,
+        rightX: brushButtonRightXPos / pixelRatio,
+        buttonWidth: brushButtonWidth,
+        axesXInterval,
+      };
     }
-
-    if (!isEqualWidth) {
-      brushCanvas.width = (brushCanvasWidth * pixelRatio);
-      brushCanvas.style.width = `${brushCanvasWidth}px`;
-      brushCanvas.height = brushCanvasHeight * pixelRatio;
-      brushCanvas.style.height = `${brushCanvasHeight}px`;
-    }
-
-    const ctx = brushCanvas.getContext('2d');
-
-    ctx.clearRect(
-      0,
-      0,
-      brushCanvasWidth * pixelRatio,
-      brushCanvasHeight * pixelRatio,
-    );
-
-    ctx.fillStyle = this.evChartBrushOptions.value.selection.fillColor;
-    ctx.globalAlpha = this.evChartBrushOptions.value.selection.opacity;
-    ctx.fillRect(brushRectX, 0, brushRectWidth, brushRectHeight);
-    ctx.fillRect(brushButtonLeftXPos, 0, brushButtonWidth, brushRectHeight);
-    ctx.fillRect(brushButtonRightXPos - brushButtonWidth, 0, brushButtonWidth, brushRectHeight);
-
-    this.evChartBrushPos = {
-      leftX: brushButtonLeftXPos / pixelRatio,
-      rightX: brushButtonRightXPos / pixelRatio,
-      buttonWidth: brushButtonWidth,
-      axesXInterval,
-    };
   }
 
   addEvent() {


### PR DESCRIPTION
###########################################
[이슈 내용]
 - Chart Options의 title 변경 시 evChart.update를 타고 initTile로 타이틀이 변경 되어야 하지만 초반 차트를 그리며 this.isInitTitle = true; 된 값 때문에 initTitle 함수를 타지 않게 되고 변경 된 타이틀이 적용되지 않게 됨.   
 - zoom 아이콘이 활성화 된 상태에서 데이터를 다시 업데이트 한 후 브러시 영역을 움직였을 경우 줌 아이콘은 비활성화 되어 있지만 나머지 아이콘은 활성화 됨.   
 - brush에 사용하는 차트의 데이터가 없지만 브러시가 그려지게 됨
![image](https://user-images.githubusercontent.com/61274722/196085452-474f143f-1141-462e-bca3-b86473646632.png)


[수정 내용]
 - title 변경 시 initTile 함수를 타고 titleDOM.textContent에 바뀐 title이 적용되도록 수정.   
 - 데이터를 다시 업데이트하고 브러시 영역을 움직이더라도 zoom 아이콘들은 zoom 아이콘이 활성화 되어야 사용 가능하도록 수정.   
 - brush에 사용하는 차트의 데이터가 없을 경우 브러시가 그려지지 않도록 수정   
![image](https://user-images.githubusercontent.com/61274722/196084908-1551d969-e9f8-43f0-b801-648f67c81f91.png)
