### PR TITLE
[#1298] BarChart > Horizontal Chart의 Brush 관련 에러 확인

### DIFF
--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -311,7 +311,7 @@ class Scale {
 
         if (this.type === 'x') {
           labelPoint = this.position === 'top' ? offsetPoint - 10 : offsetPoint + 10;
-          if (options?.brush?.showLabel || !options.brush) {
+          if (options?.brush?.showLabel || !options?.brush) {
             ctx.fillText(labelText, labelCenter, labelPoint);
           }
 
@@ -344,7 +344,7 @@ class Scale {
           }
         } else {
           labelPoint = this.position === 'left' ? offsetPoint - 10 : offsetPoint + 10;
-          if (options?.brush?.showLabel || !options.brush) {
+          if (options?.brush?.showLabel || !options?.brush) {
             ctx.fillText(labelText, labelPoint, labelCenter);
           }
 


### PR DESCRIPTION
#####################################################
[원인]   
 - Horizontal BarChart이 처음 마운트 될 때 LogarithmicScale에 의해 Scale이 정해지는데 이때 Scale로 전달되는 options의 값이 없어 (undefined) x, y축 라벨의 텍스트가 그려지는 부분에서 options에 brush 프로퍼티를 찾을 수 없으므로 에러가 발생하게 됨.    

[수정 내용]    
 - options.brush에서 options?.brush로 수정   