### PR TITLE
[#1299] Chart > Indicator 인디케이터의 dataIndex가 0일 때 위치가 정확하지 않음

### DIFF
--- a/docs/views/brushChart/example/SelectLabelGroup.vue
+++ b/docs/views/brushChart/example/SelectLabelGroup.vue
@@ -87,7 +87,7 @@ export default {
       selectLabel: {
         use: true,
         useClick: true,
-        limit: 3,
+        limit: 2,
         useDeselectOverflow: true,
         useApproximateValue: true,
         tipBackground: '#FF0000',
@@ -122,7 +122,7 @@ export default {
     });
 
     const defaultGroupSelectLabel = ref({
-      dataIndex: [1, 3, 7],
+      dataIndex: [0, 100],
     });
 
     const clickedLabel = ref("''");
@@ -152,7 +152,7 @@ export default {
     };
 
     onMounted(() => {
-      for (let ix = 0; ix < 10; ix++) {
+      for (let ix = 0; ix < 500; ix++) {
         addRandomChartData();
       }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.41",
+  "version": "3.3.42",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -246,12 +246,14 @@ class Line {
     let s = 0;
     let e = gdata.length - 1;
 
+    const xpInterval = gdata[1].xp - gdata[0].xp < 6 ? 1.5 : 6;
+
     while (s <= e) {
       const m = Math.floor((s + e) / 2);
       const x = gdata[m].xp;
       const y = gdata[m].yp;
 
-      if ((x - 6 <= xp) && (xp <= x + 6)) {
+      if ((x - xpInterval < xp) && (xp < x + xpInterval)) {
         item.data = gdata[m];
         item.index = m;
 
@@ -259,10 +261,10 @@ class Line {
           item.hit = true;
         }
         return item;
-      } else if (x + 6 < xp) {
-        s = m + 1;
-      } else {
+      } else if (x + xpInterval > xp) {
         e = m - 1;
+      } else {
+        s = m + 1;
       }
     }
 

--- a/src/components/chartGroup/ChartGroup.vue
+++ b/src/components/chartGroup/ChartGroup.vue
@@ -47,10 +47,11 @@ export default {
     },
   },
   emits: [
+    'update:groupSelectedLabel',
     'update:zoomStartIdx',
     'update:zoomEndIdx',
   ],
-  setup(props) {
+  setup(props, { emit }) {
     const {
       getNormalizedOptions,
       isExecuteZoom,
@@ -62,8 +63,10 @@ export default {
     provide('isExecuteZoom', isExecuteZoom);
     provide('isChartGroup', true);
     provide('brushSeries', brushSeries);
-
-    const groupSelectedLabel = computed(() => props.groupSelectedLabel);
+    const groupSelectedLabel = computed({
+      get: () => props.groupSelectedLabel,
+      set: val => emit('update:groupSelectedLabel', val),
+    });
     provide('groupSelectedLabel', groupSelectedLabel);
 
     const {


### PR DESCRIPTION
#####################################################
 [원인]
 - SelectedLabel 데이터 많을 때 정확하게 0번째 위치에 인디케이터가 생기지 않는데 데이터가 많아서 그래프의 포인트간 간격이 6 이하일 때 원하는 차트의 날짜에 클릭했을 때 정확하게 인디케이터가 생성 되지 않음.

[수정 내용]
 - 차트 포인트 간격이 6 미만일 때 데이터간 간격의 최소 값인 1.5로 계산하여 데이터 값의 x - 1.5 < 클릭한 차트의 xp 위치 && xp < x + 1.5로 오차 범위를 최소화 함.

[수정 범위]
 - line chart