### PR TITLE
[#1305] DatePicker > DateRange > Shortcut 버튼 클릭 시 calendar 반영되지 않음

### DIFF
--- a/docs/views/datePicker/example/Default.vue
+++ b/docs/views/datePicker/example/Default.vue
@@ -119,6 +119,7 @@
       v-model="dateRange1"
       mode="dateRange"
       clearable
+      :shortcuts="dateTimeRange2Shortcut"
     />
     <div class="description">
       <span class="badge">
@@ -196,7 +197,7 @@ export default {
           label: 'LastMonth',
           value: 'lastMonth',
           shortcutDate: () => [
-            new Date(dayjs(TODAY_0_O_CLOCK_DATE).subtract(1, 'month')),
+            new Date(dayjs(TODAY_0_O_CLOCK_DATE).subtract(30, 'd')),
             new Date(TODAY_0_O_CLOCK_DATE),
           ],
       },
@@ -204,7 +205,7 @@ export default {
         label: 'LastWeek',
         value: 'lastWeek',
         shortcutDate: () => [
-          new Date(dayjs(TODAY_0_O_CLOCK_DATE).subtract(1, 'week')),
+          new Date(dayjs(TODAY_0_O_CLOCK_DATE).subtract(6, 'day')),
           new Date(TODAY_0_O_CLOCK_DATE),
         ],
       },

--- a/src/components/calendar/uses.js
+++ b/src/components/calendar/uses.js
@@ -1246,7 +1246,9 @@ export const useEvent = (param) => {
     (curr) => {
       selectedValue.value = curr;
 
-      if (props.mode.includes('Time')) {
+      if (props.mode === 'dateRange') {
+        updateCalendarPage(selectedValue.value);
+      } else if (props.mode.includes('Time')) {
         let updateValue = [];
         if (props.mode === 'dateTime') {
           updateValue = [selectedValue.value];


### PR DESCRIPTION
이슈
-
date range 모드일 때, shortcut 버튼 클릭하면 model value는 변경되지만 calendar엔 바로 반영 되지 않음

![evui_date_picker_shortcut](https://user-images.githubusercontent.com/75718910/197710528-597ad413-fd2e-40c4-b291-208c62dbacc7.gif)


예상 원인
-
model value watch에서 dateRange 모드인 경우엔 업데이트 하지 않음

작업 내용
-
1. date range 모드인 경우에도 model value가 변경 감지되면 calendar 업데이트 하도록 수정
2. date range shortcut 추가
3. docs shortcut의 lastMonth, lastWeek 범위 수정

![evui_date_picker_shortcut_after](https://user-images.githubusercontent.com/75718910/197710918-d6f6ce26-9da4-4fa2-86d1-1c55a010b7d3.gif)
