### PR TITLE
[#1319] Line Chart > Select Label > 축을 벗어나는 라벨을 클릭하면 동작하지 않음

### DIFF
--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -797,7 +797,7 @@ const modules = {
 
     let labelIndex;
     let hitInfo;
-    if (scale.labels) {
+    if (scale?.labels?.length) {
       const labelGap = (endPoint - startPoint) / scale.labels.length;
       const index = Math.floor(((horizontal ? y : x) - startPoint) / labelGap);
       labelIndex = scale.labels.length > index ? index : -1;

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -790,7 +790,8 @@ const modules = {
       y2: this.chartRect.y2 - this.labelOffset.bottom,
     };
 
-    const scale = this.options.horizontal ? this.axesY[0] : this.axesX[0];
+    const { horizontal, selectLabel } = this.options;
+    const scale = horizontal ? this.axesY[0] : this.axesX[0];
     const startPoint = aPos[scale.units.rectStart];
     const endPoint = aPos[scale.units.rectEnd];
 
@@ -798,10 +799,19 @@ const modules = {
     let hitInfo;
     if (scale.labels) {
       const labelGap = (endPoint - startPoint) / scale.labels.length;
-      const index = Math.floor(((this.options.horizontal ? y : x) - startPoint) / labelGap);
+      const index = Math.floor(((horizontal ? y : x) - startPoint) / labelGap);
       labelIndex = scale.labels.length > index ? index : -1;
     } else {
-      hitInfo = this.getItemByPosition(offset, this.options.selectLabel.useApproximateValue);
+      let offsetX;
+      if (x < startPoint) {
+        offsetX = startPoint;
+      } else if (x > endPoint) {
+        offsetX = endPoint;
+      } else {
+        offsetX = x;
+      }
+
+      hitInfo = this.getItemByPosition([offsetX, y], selectLabel?.useApproximateValue);
       labelIndex = hitInfo.maxIndex ?? -1;
     }
 


### PR DESCRIPTION
## 이슈 내용
![bug_select_label](https://user-images.githubusercontent.com/53548023/200463999-02c57ac0-e0c6-4502-8cf0-734db60f6244.gif)


## 처리 내용
![fix_select_label](https://user-images.githubusercontent.com/53548023/200464025-fba636ca-b9d6-4960-a624-dce613099525.gif)
- click 이벤트로 받은 mouse offset의 위치가 X축 시작과 끝 지점보다 크거나 작을 경우 조정하는 로직추가