### PR TITLE
[#1321] grid > sort 이벤트 영역 개선

### DIFF
--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -82,6 +82,7 @@
                 'margin-right': (orderedColumns.length - 1 === index
                 && hasVerticalScrollBar && hasHorizontalScrollBar) ? `${scrollWidth}px` : '0px',
               }"
+              @click.stop="onSort(column)"
             >
               <!-- Filter Status -->
               <span
@@ -94,7 +95,6 @@
               <span
                 :title="column.caption"
                 class="column-name"
-                @click.stop="onSort(column)"
               >
                 {{ column.caption }}
               </span>
@@ -113,7 +113,7 @@
               <span
                 v-if="isFiltering"
                 class="column-filter"
-                @click.capture="onClickFilter(column)"
+                @click.stop="onClickFilter(column)"
               >
                 <ev-icon icon="ev-icon-hamburger2"/>
               </span>


### PR DESCRIPTION
### 변경 내용
- sort 클릭 이벤트 관련 이벤트 위치 이동
- 위 변경사항으로 인해 filtering 관련 클릭 이벤트 capture -> stop으로 변경

### Before
![evui_grid_sort](https://user-images.githubusercontent.com/53548023/201814338-f4f0496d-7365-4cad-a45f-0e4499186288.gif)

### After
![evui_grid_sort_fix](https://user-images.githubusercontent.com/53548023/201814368-ff02a06f-e5c6-4699-9dad-cc0ed5fcce3f.gif)

