### PR TITLE
[#1323]Line Chart > Zoom 메모리 초기화

### DIFF
--- a/docs/views/brushChart/example/Default.vue
+++ b/docs/views/brushChart/example/Default.vue
@@ -48,6 +48,7 @@ export default {
 
     const chartGroupOptions = reactive({
       zoom: {
+        useResetZoomMemory: false,
         toolbar: {
           show: isShowToolbar,
         },
@@ -109,7 +110,7 @@ export default {
     };
 
     onMounted(() => {
-      for (let ix = 0; ix < Math.ceil(Math.random() * 1000); ix++) {
+      for (let ix = 0; ix < 100; ix++) {
         addRandomChartData();
       }
     });
@@ -128,7 +129,7 @@ export default {
 
       init(chartData);
 
-      for (let ix = 0; ix < Math.ceil(Math.random() * 1000); ix++) {
+      for (let ix = 0; ix < 100; ix++) {
         addRandomChartData();
       }
     };

--- a/docs/views/zoomChart/api/zoomChart.md
+++ b/docs/views/zoomChart/api/zoomChart.md
@@ -72,10 +72,11 @@ const zoomEndIdx = ref(0);
 | zoom            | Object | ([상세](#zoom)) | 차트 줌 설정 |                              |
 
 #### zoom
-| 이름              | 타입 | 디폴트              | 설명                     | 종류(예시)                       | 
-|-----------------|------------------|--------------------|------------------------|---------------------------------------------------|
-| toolbar         | Object | ([상세](#toolbar)) | 차트 줌을 제어할 수 있는 toolbar |                              |
-| bufferMemoryCnt | Number | 100             | 차트 줌 버퍼 메모리 제한 설정      | 100이면 최신 100개의 zoom 기록만 저장 됨 |
+| 이름                 | 타입 | 디폴트              | 설명                         | 종류(예시)                       | 
+|--------------------|------------------|--------------------|----------------------------|---------------------------------------------------|
+| toolbar            | Object | ([상세](#toolbar)) | 차트 줌을 제어할 수 있는 toolbar     |                              |
+| bufferMemoryCnt    | Number | 100             | 차트 줌 버퍼 메모리 제한 설정          | 100이면 최신 100개의 zoom 기록만 저장 됨 |
+| useResetZoomMemory | Boolean | true             | 데이트 업데이트시 줌 메모리를 초기화 할지 설정 |  |
 
 #### toolbar
 | 이름    | 타입      | 디폴트            | 설명                                         | 종류(예시) |
@@ -104,6 +105,7 @@ const zoomEndIdx = ref(0);
 const options = {
     zoom: {
     bufferMemoryCnt: 100,
+    useResetZoomMemory: true,
     toolbar: {
       show: true,
       items: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.45",
+  "version": "3.3.46",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/chartZoom.core.js
+++ b/src/components/chart/chartZoom.core.js
@@ -286,7 +286,24 @@ export default class EvChartZoom {
     }
   }
 
-  updateEvChartCloneData(evChartClone, isUseZoomMode, isResetZoomMemory) {
+  setBrushIdx(evChartClone, brushChartIdx) {
+    this.brushIdx.end = -1;
+    for (let i = 0; i < brushChartIdx.value.length; i++) {
+      const data = evChartClone.data[brushChartIdx.value[i]];
+
+      if (data.labels.length) {
+        this.brushIdx.start = 0;
+        this.brushIdx.end = data.labels.length - 1;
+      }
+    }
+  }
+
+  updateEvChartCloneData(
+    evChartClone,
+    brushChartIdx,
+    isUseZoomMode,
+    isResetZoomMemory,
+  ) {
     const cloneLabelsLastIdx = evChartClone.data[0].labels.length - 1;
     this.cloneLabelsLastIdx = cloneLabelsLastIdx;
     this.evChartCloneData = evChartClone.data;
@@ -308,7 +325,11 @@ export default class EvChartZoom {
       }
 
       this.setIconStyle(isUseZoomMode);
+    } else if (this.brushIdx.end !== -1) {
+      this.setZoomAreaMemory(0, cloneLabelsLastIdx);
     }
+
+    this.setBrushIdx(evChartClone, brushChartIdx);
   }
 
   setZoomAreaMemory(zoomStartIdx, zoomEndIdx, direction) {
@@ -327,7 +348,11 @@ export default class EvChartZoom {
 
       this.zoomAreaMemory[direction].push(currentZoomArea);
     } else if (zoomStartIdx !== currentZoomArea[0] || zoomEndIdx !== currentZoomArea[1]) {
-      previous.push(currentZoomArea);
+      if (currentZoomArea[0] === 0 && currentZoomArea[1] === -1) {
+        previous.push([0, this.cloneLabelsLastIdx]);
+      } else {
+        previous.push(currentZoomArea);
+      }
       latest.length = 0;
     }
 

--- a/src/components/chart/chartZoom.core.js
+++ b/src/components/chart/chartZoom.core.js
@@ -286,30 +286,36 @@ export default class EvChartZoom {
     }
   }
 
-  updateEvChartCloneData(evChartClone, isUseZoomMode) {
+  updateEvChartCloneData(evChartClone, isUseZoomMode, isResetZoomMemory) {
     const cloneLabelsLastIdx = evChartClone.data[0].labels.length - 1;
     this.cloneLabelsLastIdx = cloneLabelsLastIdx;
     this.evChartCloneData = evChartClone.data;
 
-    if (this.dragZoomIcon) {
-      this.dragZoomIcon.classList.remove('active');
+    if (isResetZoomMemory) {
+      if (this.dragZoomIcon) {
+        this.dragZoomIcon.classList.remove('active');
+      }
+
+      this.zoomAreaMemory = {
+        previous: [],
+        current: [[0, cloneLabelsLastIdx]],
+        latest: [],
+      };
+
+      if (this.emitFunc) {
+        this.emitFunc.updateZoomStartIdx(0);
+        this.emitFunc.updateZoomEndIdx(cloneLabelsLastIdx);
+      }
+
+      this.setIconStyle(isUseZoomMode);
     }
-
-    this.zoomAreaMemory = {
-      previous: [],
-      current: [[0, cloneLabelsLastIdx]],
-      latest: [],
-    };
-
-    if (this.emitFunc) {
-      this.emitFunc.updateZoomStartIdx(0);
-      this.emitFunc.updateZoomEndIdx(cloneLabelsLastIdx);
-    }
-
-    this.setIconStyle(isUseZoomMode);
   }
 
   setZoomAreaMemory(zoomStartIdx, zoomEndIdx, direction) {
+    if (zoomStartIdx < 0 || zoomEndIdx <= 0) {
+      return;
+    }
+
     const { previous, current, latest } = this.zoomAreaMemory;
     const currentZoomArea = current.pop();
     const { bufferMemoryCnt } = this.evChartZoomOptions.zoom;
@@ -320,7 +326,7 @@ export default class EvChartZoom {
       }
 
       this.zoomAreaMemory[direction].push(currentZoomArea);
-    } else {
+    } else if (zoomStartIdx !== currentZoomArea[0] || zoomEndIdx !== currentZoomArea[1]) {
       previous.push(currentZoomArea);
       latest.length = 0;
     }

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -166,6 +166,7 @@ const DEFAULT_OPTIONS = {
   },
   zoom: {
     bufferMemoryCnt: 100,
+    useResetZoomMemory: true,
     toolbar: {
       show: false,
       items: {
@@ -488,22 +489,29 @@ export const useZoomModel = (
   const setDataForUseZoom = (newData) => {
     if (!isExecuteZoom.value) {
       evChartClone.data = evChartGroupRef ? cloneDeep(newData) : [cloneDeep(newData)];
-      isUseZoomMode.value = false;
 
-      setEvChartOptions();
+      if (evChartZoomOptions.zoom.useResetZoomMemory) {
+        isUseZoomMode.value = false;
 
-      brushIdx.end = -1;
-      for (let i = 0; i < brushChartIdx.value.length; i++) {
-        const data = evChartClone.data[brushChartIdx.value[i]];
+        setEvChartOptions();
 
-        if (data.labels.length) {
-          brushIdx.start = 0;
-          brushIdx.end = data.labels.length - 1;
+        brushIdx.end = -1;
+        for (let i = 0; i < brushChartIdx.value.length; i++) {
+          const data = evChartClone.data[brushChartIdx.value[i]];
+
+          if (data.labels.length) {
+            brushIdx.start = 0;
+            brushIdx.end = data.labels.length - 1;
+          }
         }
       }
 
       if (evChartZoom) {
-        evChartZoom.updateEvChartCloneData(evChartClone, isUseZoomMode.value);
+        evChartZoom.updateEvChartCloneData(
+          evChartClone,
+          isUseZoomMode.value,
+          evChartZoomOptions.zoom.useResetZoomMemory,
+        );
       }
     }
 

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -494,21 +494,12 @@ export const useZoomModel = (
         isUseZoomMode.value = false;
 
         setEvChartOptions();
-
-        brushIdx.end = -1;
-        for (let i = 0; i < brushChartIdx.value.length; i++) {
-          const data = evChartClone.data[brushChartIdx.value[i]];
-
-          if (data.labels.length) {
-            brushIdx.start = 0;
-            brushIdx.end = data.labels.length - 1;
-          }
-        }
       }
 
       if (evChartZoom) {
         evChartZoom.updateEvChartCloneData(
           evChartClone,
+          brushChartIdx,
           isUseZoomMode.value,
           evChartZoomOptions.zoom.useResetZoomMemory,
         );

--- a/src/components/chartBrush/ChartBrush.vue
+++ b/src/components/chartBrush/ChartBrush.vue
@@ -162,7 +162,9 @@ export default {
 
           if (seriesList) {
             Object.keys(data.series).forEach((series) => {
-              data.series[series].show = seriesList[series].show;
+              if (!('show' in data.series[series])) {
+                data.series[series].show = seriesList[series]?.show ?? true;
+              }
             });
           }
 
@@ -242,7 +244,9 @@ export default {
 
           if (seriesList) {
             Object.keys(evChartData.value.series).forEach((series) => {
-              evChartData.value.series[series].show = seriesList[series].show;
+              if (!('show' in evChartData.value.series[series])) {
+                evChartData.value.series[series].show = seriesList[series]?.show ?? true;
+              }
             });
           }
 

--- a/src/components/chartBrush/ChartBrush.vue
+++ b/src/components/chartBrush/ChartBrush.vue
@@ -160,7 +160,7 @@ export default {
 
           const seriesList = injectBrushSeries.list[evChartBrushOptions.value.chartIdx];
 
-          if (seriesList) {
+          if (typeof seriesList === 'object' && Object.keys(seriesList).length) {
             Object.keys(data.series).forEach((series) => {
               if (!('show' in data.series[series])) {
                 data.series[series].show = seriesList[series]?.show ?? true;
@@ -242,7 +242,7 @@ export default {
         if (evChartBrushOptions.value.chartIdx <= injectEvChartClone.data?.length - 1) {
           const seriesList = injectBrushSeries.list[evChartBrushOptions.value.chartIdx];
 
-          if (seriesList) {
+          if (typeof seriesList === 'object' && Object.keys(seriesList).length) {
             Object.keys(evChartData.value.series).forEach((series) => {
               if (!('show' in evChartData.value.series[series])) {
                 evChartData.value.series[series].show = seriesList[series]?.show ?? true;

--- a/src/components/chartGroup/uses.js
+++ b/src/components/chartGroup/uses.js
@@ -4,6 +4,7 @@ import { defaultsDeep } from 'lodash-es';
 const DEFAULT_OPTIONS = {
   zoom: {
     bufferMemoryCnt: 100,
+    useResetZoomMemory: true,
     toolbar: {
       show: false,
       items: {


### PR DESCRIPTION
################################
[수정내역]
 - 차트에 사용하는 chartData가 업데이트 시 기존에 메모리와, 브러시 선택 영역이 자동으로 초기화 되던 부분을 useResetZoomMemory(default true) 옵션으로 상황에 따라 차트 데이터가 업데이트 되더라도 줌 메모리와 브러시 선택 영역은 초기화가 되지 않도록 수정.