### PR TITLE
[#1324] Chart Legend > table type 일 때 차트에 값이 null이 들어올 경우 예외처리

### DIFF
--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -336,11 +336,14 @@ export default {
     });
   },
 
+  /**
+   * Check the value exceeds 9007199254740991 or less than -9007199254740991
+   * null =>  safe Integer
+   * string and undefined => Not Safe Integer
+   * @param {any} value
+   * @returns {boolean}
+   */
   checkSafeInteger(value) {
-    if (value === null || value === undefined) {
-      return false;
-    }
-
     return value <= Number.MAX_SAFE_INTEGER && value >= Number.MIN_SAFE_INTEGER;
   },
 };

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -993,7 +993,7 @@ const modules = {
         || !Util.checkSafeInteger(total)
         || !Util.checkSafeInteger(last)
       ) {
-        console.warn('[EVUI][Chart] The aggregated value exceeds 9007199254740991 or less then -9007199254740991.');
+        console.warn('[EVUI][Chart] The aggregated value exceeds 9007199254740991 or less than -9007199254740991.');
       }
 
       aggregationDataSet[sId] = { min, max, avg, total, last };


### PR DESCRIPTION
### 이슈 내용
![image](https://user-images.githubusercontent.com/53548023/202370365-6b8fc9d8-7c26-4d81-bdf8-659a6455c400.png)
- legend 타입이 'table'일 경우 차트의 값을 가지고 계산하는 로직이 있음
- 계산하는 로직에서 차트의 값이 MIN_SAFE_INTEGER~MAX_SAFE_INTEGER  사이인지 검사하는 로직 존재
- null 또는 undefine은 무조건 safe하지 않은 값으로 간주하여 warning log 발생

### 처리내용
- null은 차트 데이터에서 유의미한 데이터이기 때문에 warning log가 출력될 필요 없어 조건문 삭제함
- Util함수에 JS Docs 추가
- warning 메시지 오탈자 수정