### PR TITLE
[#1329]Line Chart > Select Label 차트 툴팁에서 날짜 확인 후 클릭해도 간헐적으로 다른 날짜가 선택 됨.

### DIFF
--- a/docs/views/brushChart/example/SelectLabelGroup.vue
+++ b/docs/views/brushChart/example/SelectLabelGroup.vue
@@ -89,7 +89,7 @@ export default {
         useClick: true,
         limit: 2,
         useDeselectOverflow: true,
-        useApproximateValue: true,
+        useApproximateValue: false,
         tipBackground: '#FF0000',
         useSeriesOpacity: false,
         useLabelOpacity: false,

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -237,35 +237,40 @@ class Line {
    *
    * @returns {object} graph item
    */
-  findGraphData(offset) {
+  findGraphData(offset, isHorizontal, dataIndex) {
     const xp = offset[0];
     const yp = offset[1];
     const item = { data: null, hit: false, color: this.color };
     const gdata = this.data;
 
     if (gdata?.length) {
-      let s = 0;
-      let e = gdata.length - 1;
+      if (typeof dataIndex === 'number' && this.show) {
+        item.data = gdata[dataIndex];
+        item.index = dataIndex;
+      } else {
+        let s = 0;
+        let e = gdata.length - 1;
 
-      const xpInterval = gdata[1]?.xp - gdata[0].xp < 6 ? 1.5 : 6;
+        const xpInterval = gdata[1]?.xp - gdata[0].xp < 6 ? 1.5 : 6;
 
-      while (s <= e) {
-        const m = Math.floor((s + e) / 2);
-        const x = gdata[m].xp;
-        const y = gdata[m].yp;
+        while (s <= e) {
+          const m = Math.floor((s + e) / 2);
+          const x = gdata[m].xp;
+          const y = gdata[m].yp;
 
-        if ((x - xpInterval < xp) && (xp < x + xpInterval)) {
-          item.data = gdata[m];
-          item.index = m;
+          if ((x - xpInterval < xp) && (xp < x + xpInterval)) {
+            item.data = gdata[m];
+            item.index = m;
 
-          if ((y - 6 <= yp) && (yp <= y + 6)) {
-            item.hit = true;
+            if ((y - 6 <= yp) && (yp <= y + 6)) {
+              item.hit = true;
+            }
+            return item;
+          } else if (x + xpInterval > xp) {
+            e = m - 1;
+          } else {
+            s = m + 1;
           }
-          return item;
-        } else if (x + xpInterval > xp) {
-          e = m - 1;
-        } else {
-          s = m + 1;
         }
       }
     }


### PR DESCRIPTION
[#1329]Line Chart > Select Label 차트 툴팁에서 날짜 확인 후 클릭해도 간헐적으로 다른 날짜가 선택 됨.
################################    
[원인]
 - 클릭한 데이터의 xp 좌표를 가지고 findGraphData 함수를 이용하여 (xp 간격과 각각 데이터의 x 좌표을 이용해서 이진 탐색 함) 전체 데이터에서 좌표에 맞는 데이터의 인덱스를 구하고 해당 값에 seletedLabel이 생성되는데 데이터가 너무 많을 경우 날짜는 다르지만 각각 데이터의 x 좌표가 같게 되고 이진 탐색시 간헐적으로 클릭한 날짜에 정확하게 selectedLabel이 생성되지 않음.
![image](https://user-images.githubusercontent.com/61274722/207523146-9624ac45-d7b5-41f3-b1e2-8137b5baa4d3.png)    

[수정 내용]
 - selectedLabel의 v-model 값으로 보내지는 dataIndex를 이용하여 정확하게 findGraphData를 하여 selectedLabel이 생성되도록 하고  tooltip과 같이 클릭 없이 마우스 위치의 값을 보여줘야 하는 경우 기존 xp 좌표를 이용하여findGraphData를 하도록 수정.
 - pointSize를 추가하여 차트의 끝 부분을 클릭 시 정확하게 0번째 날짜와 와 마지막 날짜가 선택되도록 수정

[확인 경로]
 - Line Chart > SelectedLabel