### PR TITLE
[#1334] Chart > HeatMap > 범주별 색상, 라벨 지정 옵션 추가

### DIFF
--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -77,7 +77,7 @@ const chartData =
   | dragSelection | Object | ([상세](#dragselection)) | drag-select의 사용 여부 | |
   | padding | Object | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값 |
   | tooltip | Object | ([상세](#tooltip)) | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성 | |
-  | heatMapColor | Object | ([상세](#heatMapColor)) | color 옵션 | |
+  | heatMapColor | Object | ([상세](#heatmap-color)) | color 옵션 | |
   
 #### axesX axesY
 ##### type 공통
@@ -90,10 +90,10 @@ const chartData =
   | showGrid | Boolean | true | 차트 내부 그리드 표시 여부 | true / false |
   | axisLineColor | String | '#C9CFDC' | 축의 색상 | | 
   | gridLineColor | String | '#C9CFDC' | 그리드의 색상 | | 
-  | interval | String/number | | 축에 표시되는 값의 간격 단위 ( time: string / linear: number) |  [time](#time-type), [linear](#linear-type) |
-  | labelStyle | Object | ([상세](#labelstyle)) | 라벨의 폰트 스타일을 설정 | |
+  | interval | String/number | | 축에 표시되는 값의 간격 단위 ( time: string / linear: number) |  [time](#time-type), [linear](#step-type) |
+  | labelStyle | Object | ([상세](#label-style)) | 라벨의 폰트 스타일을 설정 | |
   | formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (value) => value + '%' |
-  | title | Object | ([상세](#title)) | 라벨의 폰트 스타일을 설정 | |  
+  | title | Object | ([상세](#axes-title)) | 라벨의 폰트 스타일을 설정 | |  
 
 ##### time type
    - interval (Axis Label 표기를 위한 interval)
@@ -107,7 +107,7 @@ const chartData =
 
 ##### step type
 
-##### labelStyle
+##### label style
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 |-----|------|-------|-----|-----|
 | show | Boolean | true | label 표시 여부 | true / false |
@@ -118,7 +118,7 @@ const chartData =
 | fitDir | String | 'right' | Ellipsis 방향 | ( right => 'aaa...', left => '...aaa') |
 | alignToGridLine | Boolean | false | 축 line에 표시할지의 여부 | |
 
-##### title
+##### axes title
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 |-----|------|-------|-----|-----|
 | use | Boolean | false | Chart 축(Axis) Title 표시 여부 | true / false |
@@ -194,14 +194,14 @@ const chartOptions = {
     },
 }
 ```
-
-#### heatMapColor
+#### heatmap color
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
   |------------ |-----------|---------|-------------------------|---------------------------------------------------|
 | min | Hex, RGB, RGBA Code(String) | '#FFFFFF' | min color |  |
 | max | Hex, RGB, RGBA Code(String) | '#5586EB' | max color |  | 
-| categoryCnt | number | 5 | color min - max 그라데이션 분류 개수 | |
-| stroke | object | ([상세](#stroke)) | series stroke 지정 |  |
+| categoryCnt | number | 5 | color min - max 그라데이션 범주 개수 | |
+| categoryColors | Array | [] | 범주별 color, label 지정 | [{ color: '#FFFFFF', label: 'A' }] |
+| stroke | Object | ([상세](#stroke)) | series stroke 지정 |  |
 | error | Hex, RGB, RGBA Code(String) | '#FFFFFF' | series error color (value가 -1인 경우 error로 인식) |  |
 | decimalPoint | number | 0 | 범주 표현 소숫값 처리 | |
 

--- a/docs/views/heatMap/example/Category.vue
+++ b/docs/views/heatMap/example/Category.vue
@@ -1,7 +1,7 @@
 <template>
   <ev-chart
-      :data="chartData"
-      :options="chartOptions"
+    :data="chartData"
+    :options="chartOptions"
   />
 </template>
 
@@ -24,7 +24,6 @@ import { onMounted, reactive } from 'vue';
           series1: [],
         },
       });
-
 
       const chartOptions = {
         type: 'heatMap',

--- a/docs/views/heatMap/example/Custom.vue
+++ b/docs/views/heatMap/example/Custom.vue
@@ -1,0 +1,102 @@
+<template>
+  <ev-chart
+      :data="chartData"
+      :options="chartOptions"
+  />
+</template>
+
+<script>
+import { onMounted, reactive } from 'vue';
+
+  export default {
+    setup() {
+      const chartData = reactive({
+        series: {
+          series1: {
+            name: 'series#1',
+          },
+        },
+        labels: {
+          x: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+          y: [],
+        },
+        data: {
+          series1: [],
+        },
+      });
+
+
+      const chartOptions = {
+        type: 'heatMap',
+        width: '100%',
+        title: {
+          text: 'Chart Title',
+          show: true,
+        },
+        indicator: {
+          use: true,
+        },
+        axesX: [{
+          type: 'step',
+          showGrid: false,
+        }],
+        axesY: [{
+          type: 'step',
+          showGrid: false,
+        }],
+        heatMapColor: {
+          categoryColors: [
+            { color: '#4FD4B6', label: 'Low' },
+            { color: '#6DB9E3', label: 'Medium' },
+            { color: '#5A4BE1', label: 'High' },
+          ],
+          error: '#D46C4F',
+          stroke: {
+            show: true,
+            color: '#FFFFFF',
+            lineWidth: 2,
+            radius: 3,
+          },
+        },
+        tooltip: {
+          use: true,
+        },
+      };
+
+      const crateYAxisLabels = () => {
+        const currentYear = new Date().getFullYear();
+        for (let i = 0; i < 7; i++) {
+          chartData.labels.y.push(currentYear - i);
+        }
+      };
+
+      const createChartData = () => {
+        const labelX = chartData.labels.x;
+        const labelY = chartData.labels.y;
+        for (let ix = 0; ix < labelX.length; ix++) {
+          for (let iy = 0; iy < labelY.length; iy++) {
+            let randomCount = Math.floor(Math.random() * 100) + 1;
+            if (randomCount > 90) {
+              randomCount = -1;
+            }
+            chartData.data.series1.push({
+              x: labelX[ix],
+              y: labelY[iy],
+              value: randomCount,
+            });
+          }
+        }
+      };
+
+      onMounted(() => {
+        crateYAxisLabels();
+        createChartData();
+      });
+
+      return {
+        chartData,
+        chartOptions,
+      };
+    },
+  };
+</script>

--- a/docs/views/heatMap/props.js
+++ b/docs/views/heatMap/props.js
@@ -8,6 +8,8 @@ import Time from './example/Time';
 import TimeRaw from '!!raw-loader!./example/Time';
 import Gradient from './example/Gradient';
 import GradientRaw from '!!raw-loader!./example/Gradient';
+import Custom from './example/Custom';
+import CustomRaw from '!!raw-loader!./example/Custom';
 
 export default {
   mdText,
@@ -27,10 +29,15 @@ export default {
       component: Event,
       parsedData: parseComponent(EventRaw),
     },
-    Gradient: {
+    'Gradient Legend': {
       description: 'gradient 범주로 표현 가능합니다.',
       component: Gradient,
       parsedData: parseComponent(GradientRaw),
+    },
+    'Custom Legend': {
+      description: '범주의 색상, label을 지정할 수 있습니다.',
+      component: Custom,
+      parsedData: parseComponent(CustomRaw),
     },
   },
 };

--- a/docs/views/heatMap/props.js
+++ b/docs/views/heatMap/props.js
@@ -8,8 +8,8 @@ import Time from './example/Time';
 import TimeRaw from '!!raw-loader!./example/Time';
 import Gradient from './example/Gradient';
 import GradientRaw from '!!raw-loader!./example/Gradient';
-import Custom from './example/Custom';
-import CustomRaw from '!!raw-loader!./example/Custom';
+import Category from './example/Category';
+import CategoryRaw from '!!raw-loader!./example/Category';
 
 export default {
   mdText,
@@ -34,10 +34,10 @@ export default {
       component: Gradient,
       parsedData: parseComponent(GradientRaw),
     },
-    'Custom Legend': {
+    'Category Legend': {
       description: '범주의 색상, label을 지정할 수 있습니다.',
-      component: Custom,
-      parsedData: parseComponent(CustomRaw),
+      component: Category,
+      parsedData: parseComponent(CategoryRaw),
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.47",
+  "version": "3.3.48",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -35,7 +35,7 @@ class HeatMap {
   createColorState(colorOpt) {
     const colorState = [];
     const regex = /[^0-9]&[^,]/g;
-    const { min, max, categoryCnt, error, stroke } = colorOpt;
+    const { min, max, categoryCnt, categoryColors, error, stroke } = colorOpt;
 
     const minColor = min.includes('#') ? Util.hexToRgb(min) : min.replace(regex, '');
     const maxColor = max.includes('#') ? Util.hexToRgb(max) : max.replace(regex, '');
@@ -51,6 +51,17 @@ class HeatMap {
         start: 0,
         end: 100,
         selectedValue: null,
+      });
+    } else if (categoryColors.length) {
+      colorOpt.categoryCnt = categoryColors.length;
+      categoryColors.forEach(({ color, label }, ix) => {
+        colorState.push({
+          id: `color#${ix}`,
+          color,
+          label,
+          state: 'normal',
+          show: true,
+        });
       });
     } else {
       const unitR = Math.floor((minR - maxR) / (categoryCnt - 1));

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -450,6 +450,7 @@ const modules = {
         id: `color#${categoryCnt}`,
         color: colorOpt.error,
         state: 'normal',
+        label: 'Error',
         show: true,
       });
     }

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -147,8 +147,9 @@ const modules = {
         const { min, max, interval, existError, decimalPoint } = valueOpt;
         const length = colorState.length;
         const endIndex = existError ? length - 2 : length - 1;
+
         for (let index = 0; index < length; index++) {
-          const colorItem = colorState[index];
+          const { id, color, label = '' } = colorState[index];
           const minValue = min + (interval * index);
           let maxValue = minValue + interval;
           if (index < endIndex) {
@@ -157,24 +158,25 @@ const modules = {
             maxValue = max + (0.1 ** decimalPoint);
           }
 
-          let name = `${minValue.toFixed(decimalPoint)} - ${maxValue.toFixed(decimalPoint)}`;
-          if (min === undefined || max === undefined) {
-            if (index === 0) {
-              name = '0';
-            } else {
+          let name = label;
+          if (!name) {
+            name = `${minValue.toFixed(decimalPoint)} - ${maxValue.toFixed(decimalPoint)}`;
+            if (min === undefined || max === undefined) {
+              if (index === 0) {
+                name = '0';
+              } else {
+                break;
+              }
+            } else if (minValue > max) {
               break;
+            } else if (interval <= 1 && decimalPoint === 0) {
+              name = minValue;
             }
-          } else if (existError && index === endIndex + 1) {
-            name = 'error';
-          } else if (minValue > max) {
-            break;
-          } else if (interval <= 1 && decimalPoint === 0) {
-            name = minValue;
           }
 
           this.addLegend({
-            cId: colorItem.id,
-            color: colorItem.color,
+            cId: id,
+            color,
             name,
             show: true,
           });

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -349,6 +349,7 @@ const modules = {
     const series = Object.values(this.seriesList)[0];
 
     let isShow = false;
+    let valueText = hitItem.formatted;
     const { colorState, isGradient } = series;
     if (isGradient) {
       const { min, max } = series.valueOpt;
@@ -356,7 +357,9 @@ const modules = {
       const { start, end } = colorState[0];
       isShow = (start <= ratio && ratio <= end) || hitItem.o === -1;
     } else {
-      isShow = colorState.find(({ id }) => id === hitItem.cId)?.show;
+      const colorItem = colorState.find(({ id }) => id === hitItem.cId);
+      isShow = colorItem?.show;
+      valueText = colorItem?.label ?? valueText;
     }
 
     if (!isShow) {
@@ -392,7 +395,6 @@ const modules = {
 
     const itemX = boxPadding.l + 2;
     const itemY = boxPadding.t + TEXT_HEIGHT + 2;
-    const valueText = hitItem.formatted;
 
     ctx.font = fontStyle;
 

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -197,6 +197,7 @@ const DEFAULT_OPTIONS = {
     min: '#FFFFFF',
     max: '#0052FF',
     categoryCnt: 1,
+    categoryColors: [],
     stroke: {
       show: false,
       color: '#FFFFFF',


### PR DESCRIPTION
작업 내용
-
1.  categoryColors 옵션 추가
    - List 순서대로 범주의 label 변경
    - categoryColors length가 있는 경우 min, max, categoryCnt 옵션 무시
    - 속성
      1. color: 범주 색상
      3. label: 범주명

`Before`
min, max color내에서 범주 개수에 따라 그라데이션 색상 생성

![image](https://user-images.githubusercontent.com/75718910/209084901-19e31d9d-405e-4f0e-b59b-0de051028520.png)


`After`
사용자 지정 옵션 추가(categoryColors)

![image](https://user-images.githubusercontent.com/75718910/209085239-db6e33e9-a8fa-456a-8be8-debd611fb5ec.png)

    

