### PR TITLE
[#1337] Chart > HeatMap > label 선택 기능 추가

### DIFF
--- a/docs/views/barChart/example/SelectLabel.vue
+++ b/docs/views/barChart/example/SelectLabel.vue
@@ -332,7 +332,10 @@ export default {
 
     const toggleSelectData = () => {
       const arr = defaultSelectLabel.value.dataIndex;
-      arr.push((arr.pop() + 1) % 5);
+      const newIndex = (arr.pop() + 1) % 9;
+      if (!arr.includes(newIndex)) {
+        arr.push(newIndex);
+      }
     };
 
     const toggleOverflow = () => {

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -78,6 +78,7 @@ const chartData =
   | padding | Object | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값 |
   | tooltip | Object | ([상세](#tooltip)) | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성 | |
   | heatMapColor | Object | ([상세](#heatmap-color)) | color 옵션 | |
+  | selectLabel  | Object | ([상세](#selectlabel)) | 차트 라벨 선택 기능 활성화 여부 및 속성 | | 
   
 #### axesX axesY
 ##### type 공통
@@ -213,6 +214,19 @@ const chartOptions = {
 | lineWidth | number | 1 | stroke 선 굵기 지정 | |
 | opacity | number | 1 | stroke opacity 지정 | 0.1 ~ 1 |
 | radius | number | 0 | border radius 조정 | |
+
+#### selectLabel
+| 이름                  | 타입                          | 디폴트       | 설명                                                          | 종류(예시) |
+|-----------------------|------------------------------|-------------|--------------------------------------------------------------|-----------|
+| use                 | Boolean                        | false     | 차트 라벨 선택 기능                                                  | |
+| useClick            | Boolean                        | true      | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) | |
+| limit               | Number                         | 1         | 선택할 라벨의 최대 갯수                                               | |
+| useDeselectOverflow | Boolean                        | false     | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부                    | |
+| showTip             | Boolean                        | false     | 선택한 label의 Tip(화살표) 생성 여부                                   | |
+| useSeriesOpacity    | Boolean                        | true      | 시리즈 opacity 변경 여부                                             | |
+| useLabelOpacity     | Boolean                        | true      | Axes Label opacity 변경 여부                                        | |
+| useApproximateValue | Boolean                        | false     | 가까운 label을 선택                                                  | |
+| tipBackground       | Hex, RGB, RGBA Code(String)    | '#000000' | tip 배경색상                                                        | |
 
 ### 3. resize-timeout
 - Default : 0

--- a/docs/views/heatMap/example/SelectLabel.vue
+++ b/docs/views/heatMap/example/SelectLabel.vue
@@ -75,10 +75,8 @@
 
 <script>
 import { reactive, ref, watch } from 'vue';
-import EvInputNumber from '../../../../src/components/inputNumber/InputNumber';
 
   export default {
-    components: { EvInputNumber },
     setup() {
       const timeList = ['04-06', '06-09', '09-11', '11-14', '14-16', '16-18', '18-21', '21-24', '24-04'];
       const dayList = ['Weekday', 'Saturday', 'Sunday'];
@@ -229,7 +227,6 @@ import EvInputNumber from '../../../../src/components/inputNumber/InputNumber';
         },
       });
 
-
       const chartOptions2 = reactive({
         type: 'heatMap',
         width: '100%',
@@ -325,14 +322,13 @@ import EvInputNumber from '../../../../src/components/inputNumber/InputNumber';
       };
 
       watch(isLive, (newVal) => {
-          if (newVal) {
-            addRandomChartData();
-            liveInterval = setInterval(addRandomChartData, 2000);
-          } else {
-            clearInterval(liveInterval);
-          }
-        },
-      );
+        if (newVal) {
+          addRandomChartData();
+          liveInterval = setInterval(addRandomChartData, 2000);
+        } else {
+          clearInterval(liveInterval);
+        }
+      });
 
       return {
         chartData1,

--- a/docs/views/heatMap/example/SelectLabel.vue
+++ b/docs/views/heatMap/example/SelectLabel.vue
@@ -1,0 +1,378 @@
+<template>
+  <div class="case">
+    <ev-chart
+        v-model:selectedLabel="defaultSelectLabel"
+        :data="chartData1"
+        :options="chartOptions1"
+        @click="onClick"
+    />
+    <ev-chart
+        v-model:selectedLabel="defaultSelectLabel"
+        :data="chartData2"
+        :options="chartOptions2"
+        @click="onClick"
+    />
+    <div class="description">
+      <div class="option">
+        <ev-toggle v-model="isLive" />
+        <span>데이터 자동 업데이트</span>
+      </div>
+      <div class="option">
+        <ev-toggle v-model="isUseClick" />
+        <span>클릭 기능 enable ( false 일때는 v-model 값으로만 변경 )</span>
+      </div>
+      <div class="option">
+        <ev-button @click="updateSelectedLabel">
+          select by v-model
+        </ev-button>
+        <span>
+          차트 클릭이 아닌 v-model:selectedLabel 에 바인딩한 dataIndex 배열을 변경해서 라벨 선택
+        </span>
+      </div>
+      <div class="option">
+        <ev-toggle v-model="isDeselctOverflow" />
+        <span>
+          DeselectOverflow: 설정한 limit 를 넘어서 클릭했을때 선입선출로 deselect 를 할지를 옵션으로 선택 가능
+        </span>
+      </div>
+      <div class="option">
+        <ev-toggle v-model="useSeriesOpacity" />
+        <span>
+        useSeriesOpacity: 시리즈 opacity 변경 여부
+      </span>
+      </div>
+      <div class="option">
+        <ev-toggle v-model="useLabelOpacity" />
+        <span>
+        useLabelOpacity:  Axes Label opacity 변경 여부
+        </span>
+      </div>
+      <div class="option">
+        <ev-input-number
+            v-model="limit"
+            :min="1"
+            :max="7"
+        />
+        <span>
+          limit: 선택할 라벨의 최대 갯수
+        </span>
+      </div>
+      <div>
+        <div class="badge yellow">
+          v-model:selectedLabel
+        </div>
+        {{ defaultSelectLabel }}
+        <br>
+        <br>
+        <div class="badge yellow">
+          클릭 이벤트 데이터 (selected)
+        </div>
+        {{ clickedLabel }}
+      </div>
+    </div>
+</div>
+</template>
+
+<script>
+import { reactive, ref, watch } from 'vue';
+import EvInputNumber from '../../../../src/components/inputNumber/InputNumber';
+
+  export default {
+    components: { EvInputNumber },
+    setup() {
+      const timeList = ['04-06', '06-09', '09-11', '11-14', '14-16', '16-18', '18-21', '21-24', '24-04'];
+      const dayList = ['Weekday', 'Saturday', 'Sunday'];
+      const chartData1 = reactive({
+        series: {
+          series1: {
+            name: 'series#1',
+            showValue: {
+              use: true,
+            },
+          },
+        },
+        labels: {
+          x: [...timeList],
+          y: [...dayList],
+        },
+        data: {
+          series1: [
+            { x: '04-06', y: 'Weekday', value: 0 },
+            { x: '04-06', y: 'Saturday', value: 2 },
+            { x: '04-06', y: 'Sunday', value: 1 },
+            { x: '06-09', y: 'Weekday', value: 22 },
+            { x: '06-09', y: 'Saturday', value: 1 },
+            { x: '06-09', y: 'Sunday', value: 22 },
+            { x: '09-11', y: 'Weekday', value: 55 },
+            { x: '09-11', y: 'Saturday', value: 43 },
+            { x: '09-11', y: 'Sunday', value: 85 },
+            { x: '11-14', y: 'Weekday', value: 51 },
+            { x: '11-14', y: 'Saturday', value: 87 },
+            { x: '11-14', y: 'Sunday', value: 100 },
+            { x: '14-16', y: 'Weekday', value: 38 },
+            { x: '14-16', y: 'Saturday', value: 93 },
+            { x: '14-16', y: 'Sunday', value: 58 },
+            { x: '16-18', y: 'Weekday', value: 22 },
+            { x: '16-18', y: 'Saturday', value: 71 },
+            { x: '16-18', y: 'Sunday', value: 26 },
+            { x: '18-21', y: 'Weekday', value: 17 },
+            { x: '18-21', y: 'Saturday', value: 31 },
+            { x: '18-21', y: 'Sunday', value: 10 },
+            { x: '21-24', y: 'Weekday', value: 8 },
+            { x: '21-24', y: 'Saturday', value: 24 },
+            { x: '21-24', y: 'Sunday', value: 12 },
+            { x: '24-04', y: 'Weekday', value: 2 },
+            { x: '24-04', y: 'Saturday', value: 15 },
+            { x: '24-04', y: 'Sunday', value: 3 },
+          ],
+        },
+      });
+      const chartData2 = reactive({
+        series: {
+          series1: {
+            name: 'series#1',
+            showValue: {
+              use: true,
+            },
+          },
+        },
+        labels: {
+          x: [...dayList],
+          y: [...timeList],
+        },
+        data: {
+          series1: [
+            { x: 'Weekday', y: '04-06', value: 0 },
+            { x: 'Saturday', y: '04-06', value: 2 },
+            { x: 'Sunday', y: '04-06', value: 1 },
+            { x: 'Weekday', y: '06-09', value: 22 },
+            { x: 'Saturday', y: '06-09', value: 1 },
+            { x: 'Sunday', y: '06-09', value: 22 },
+            { x: 'Weekday', y: '09-11', value: 55 },
+            { x: 'Saturday', y: '09-11', value: 43 },
+            { x: 'Sunday', y: '09-11', value: 85 },
+            { x: 'Weekday', y: '11-14', value: 51 },
+            { x: 'Saturday', y: '11-14', value: 87 },
+            { x: 'Sunday', y: '11-14', value: 100 },
+            { x: 'Weekday', y: '14-16', value: 38 },
+            { x: 'Saturday', y: '14-16', value: 93 },
+            { x: 'Sunday', y: '14-16', value: 58 },
+            { x: 'Weekday', y: '16-18', value: 22 },
+            { x: 'Saturday', y: '16-18', value: 71 },
+            { x: 'Sunday', y: '16-18', value: 26 },
+            { x: 'Weekday', y: '18-21', value: 17 },
+            { x: 'Saturday', y: '18-21', value: 31 },
+            { x: 'Sunday', y: '18-21', value: 10 },
+            { x: 'Weekday', y: '21-24', value: 8 },
+            { x: 'Saturday', y: '21-24', value: 24 },
+            { x: 'Sunday', y: '21-24', value: 12 },
+            { x: 'Weekday', y: '24-04', value: 2 },
+            { x: 'Saturday', y: '24-04', value: 15 },
+            { x: 'Sunday', y: '24-04', value: 3 },
+          ],
+        },
+      });
+
+      const isUseClick = ref(true);
+      const isDeselctOverflow = ref(true);
+      const useSeriesOpacity = ref(true);
+      const useLabelOpacity = ref(true);
+      const limit = ref(2);
+
+      const chartOptions1 = reactive({
+        type: 'heatMap',
+        width: '100%',
+        height: '300px',
+        title: {
+          text: 'Chart Title',
+          show: true,
+        },
+        indicator: {
+          use: true,
+        },
+        axesX: [{
+          type: 'step',
+          showGrid: false,
+        }],
+        axesY: [{
+          type: 'step',
+          showGrid: false,
+        }],
+        heatMapColor: {
+          categoryColors: [
+            { color: '#F2F2F2', label: '< 20' },
+            { color: '#C4DBD1', label: '20 - 39' },
+            { color: '#96C4B0', label: '40 - 59' },
+            { color: '#68AD8F', label: '60 - 79' },
+            { color: '#3A946C', label: '80 <=' },
+          ],
+          stroke: {
+            show: true,
+            color: '#FFFFFF',
+            lineWidth: 2,
+            radius: 8,
+          },
+        },
+        tooltip: {
+          use: true,
+        },
+        selectLabel: {
+          use: true,
+          showTip: true,
+          useApproximateValue: true,
+          tipBackground: '#E76F51',
+          useClick: isUseClick,
+          useDeselectOverflow: isDeselctOverflow,
+          limit,
+          useSeriesOpacity,
+          useLabelOpacity,
+        },
+      });
+
+
+      const chartOptions2 = reactive({
+        type: 'heatMap',
+        width: '100%',
+        height: '300px',
+        horizontal: true,
+        title: {
+          text: 'Chart Title',
+          show: true,
+        },
+        indicator: {
+          use: true,
+        },
+        axesX: [{
+          type: 'step',
+          showGrid: false,
+        }],
+        axesY: [{
+          type: 'step',
+          showGrid: false,
+        }],
+        heatMapColor: {
+          categoryColors: [
+            { color: '#F2F2F2', label: '< 20' },
+            { color: '#C4DBD1', label: '20 - 39' },
+            { color: '#96C4B0', label: '40 - 59' },
+            { color: '#68AD8F', label: '60 - 79' },
+            { color: '#3A946C', label: '80 <=' },
+          ],
+          stroke: {
+            show: true,
+            color: '#FFFFFF',
+            lineWidth: 2,
+            radius: 8,
+          },
+        },
+        tooltip: {
+          use: true,
+        },
+        selectLabel: {
+          use: true,
+          showTip: true,
+          useApproximateValue: true,
+          tipBackground: '#E76F51',
+          useClick: isUseClick,
+          useDeselectOverflow: isDeselctOverflow,
+          limit,
+          useSeriesOpacity,
+          useLabelOpacity,
+        },
+      });
+
+      const clickedLabel = ref('');
+      const defaultSelectLabel = ref({
+        dataIndex: [2],
+      });
+      const onClick = ({ selected }) => {
+        clickedLabel.value = selected;
+      };
+
+      const updateSelectedLabel = () => {
+        const arr = defaultSelectLabel.value.dataIndex;
+        const newIndex = (arr.pop() + 1) % 9;
+        if (!arr.includes(newIndex)) {
+          arr.push(newIndex);
+        }
+      };
+
+      const isLive = ref(false);
+      let liveInterval;
+      let timeIndex = 0;
+
+      const addRandomChartData = () => {
+        if (timeIndex > 8) {
+          timeIndex = 0;
+        }
+        const targetTime = timeList[timeIndex];
+        chartData1.labels.x.shift();
+        chartData2.labels.y.shift();
+        chartData1.labels.x.push(targetTime);
+        chartData2.labels.y.push(targetTime);
+
+        const dataByChart1 = chartData1.data.series1;
+        const dataByChart2 = chartData2.data.series1;
+        dataByChart1.splice(0, 3);
+        dataByChart2.splice(0, 3);
+        dayList.forEach((day) => {
+          const randomValue = Math.ceil(Math.random() * 100);
+          dataByChart1.push({ x: targetTime, y: day, value: randomValue });
+          dataByChart2.push({ x: day, y: targetTime, value: randomValue });
+        });
+
+        timeIndex++;
+      };
+
+      watch(isLive, (newVal) => {
+          if (newVal) {
+            addRandomChartData();
+            liveInterval = setInterval(addRandomChartData, 2000);
+          } else {
+            clearInterval(liveInterval);
+          }
+        },
+      );
+
+      return {
+        chartData1,
+        chartData2,
+        chartOptions1,
+        chartOptions2,
+        isLive,
+        isUseClick,
+        isDeselctOverflow,
+        useSeriesOpacity,
+        useLabelOpacity,
+        limit,
+        defaultSelectLabel,
+        clickedLabel,
+        onClick,
+        updateSelectedLabel,
+      };
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+.description {
+  position: relative;
+
+  .option {
+    display: flex;
+    gap: 10px;
+    height: 30px;
+    line-height: 20px;
+    margin: 10px 0;
+  }
+
+  .ev-input-number + span {
+    line-height: 35px;
+  }
+
+  .ev-button {
+    height: 20px;
+    line-height: 20px !important;
+  }
+}
+</style>

--- a/docs/views/heatMap/example/Time.vue
+++ b/docs/views/heatMap/example/Time.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import { onBeforeUnmount, reactive, ref, watch } from 'vue';
+import { onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
   import dayjs from 'dayjs';
 
   export default {
@@ -43,28 +43,7 @@ import { onBeforeUnmount, reactive, ref, watch } from 'vue';
           y: [0, 1, 2, 3, 4, 5],
         },
         data: {
-          series1: [
-            { x: dayjs(timeValue), y: 0, value: 0 },
-            { x: dayjs(timeValue), y: 1, value: 22 },
-            { x: dayjs(timeValue), y: 3, value: 15 },
-            { x: dayjs(timeValue), y: 4, value: 8 },
-            { x: dayjs(timeValue), y: 5, value: 10 },
-            { x: dayjs(timeValue).add(2, 'second'), y: 0, value: 42 },
-            { x: dayjs(timeValue).add(2, 'second'), y: 2, value: 11 },
-            { x: dayjs(timeValue).add(2, 'second'), y: 3, value: 22 },
-            { x: dayjs(timeValue).add(2, 'second'), y: 5, value: 15 },
-            { x: dayjs(timeValue).add(4, 'second'), y: 0, value: 36 },
-            { x: dayjs(timeValue).add(4, 'second'), y: 1, value: 25 },
-            { x: dayjs(timeValue).add(4, 'second'), y: 3, value: 13 },
-            { x: dayjs(timeValue).add(4, 'second'), y: 4, value: 9 },
-            { x: dayjs(timeValue).add(6, 'second'), y: 0, value: 45 },
-            { x: dayjs(timeValue).add(6, 'second'), y: 2, value: 39 },
-            { x: dayjs(timeValue).add(6, 'second'), y: 3, value: 3 },
-            { x: dayjs(timeValue).add(8, 'second'), y: 0, value: 50 },
-            { x: dayjs(timeValue).add(8, 'second'), y: 1, value: 44 },
-            { x: dayjs(timeValue).add(8, 'second'), y: 4, value: 2 },
-            { x: dayjs(timeValue).add(8, 'second'), y: 5, value: 8 },
-          ],
+          series1: [],
         },
       });
 
@@ -134,32 +113,43 @@ import { onBeforeUnmount, reactive, ref, watch } from 'vue';
         timeValue = dayjs(timeValue).add(2, 'second');
         chartData.labels.x.push(timeValue);
 
-        for (let iv = 0; iv <= 5; iv++) {
-          const yRandomIndex = Math.floor(Math.random() * 6);
-          const yValue = chartData.labels.y[yRandomIndex];
-          const randomValue = Math.floor(Math.random() * 50);
-          const item = {
+        const labelY = chartData.labels.y;
+        for (let iy = 0; iy < labelY.length; iy++) {
+          const randomCount = Math.floor(Math.random() * 50) + 1;
+          chartData.data.series1.push({
             x: timeValue,
-            y: yValue,
-            value: randomValue,
-          };
-
-          // eslint-disable-next-line no-loop-func
-          const targetIndex = seriesData.findIndex(({ x, y }) =>
-              new Date(x).getTime() === new Date(timeValue).getTime() && y === yValue);
-          if (targetIndex === -1) {
-            seriesData.push(item);
-          }
+            y: labelY[iy],
+            value: randomCount,
+          });
         }
       };
 
       watch(isLive, (newValue) => {
         if (newValue) {
           addRandomChartData();
-          liveInterval.value = setInterval(addRandomChartData, 2000);
+          liveInterval.value = setInterval(addRandomChartData, 1000);
         } else {
           clearInterval(liveInterval.value);
         }
+      });
+
+      const createChartData = () => {
+        const labelX = chartData.labels.x;
+        const labelY = chartData.labels.y;
+        for (let ix = 0; ix < labelX.length; ix++) {
+          for (let iy = 0; iy < labelY.length; iy++) {
+            const randomCount = Math.floor(Math.random() * 50) + 1;
+            chartData.data.series1.push({
+              x: dayjs(labelX[ix]),
+              y: labelY[iy],
+              value: randomCount,
+            });
+          }
+        }
+      };
+
+      onMounted(() => {
+        createChartData();
       });
 
       onBeforeUnmount(() => {

--- a/docs/views/heatMap/props.js
+++ b/docs/views/heatMap/props.js
@@ -42,7 +42,7 @@ export default {
       parsedData: parseComponent(CategoryRaw),
     },
     SelectLabel: {
-      description: '범주의 색상, label을 지정할 수 있습니다.',
+      description: '차트 전체에서 선택한 라벨 내 모든 아이템이 하이라이트 되는 기능입니다.',
       component: SelectLabel,
       parsedData: parseComponent(SelectLabelRaw),
     },

--- a/docs/views/heatMap/props.js
+++ b/docs/views/heatMap/props.js
@@ -16,11 +16,6 @@ import SelectLabelRaw from '!!raw-loader!./example/SelectLabel';
 export default {
   mdText,
   components: {
-    SelectLabel: {
-      description: '범주의 색상, label을 지정할 수 있습니다.',
-      component: SelectLabel,
-      parsedData: parseComponent(SelectLabelRaw),
-    },
     Default: {
       description: 'HeatMap은 데이터의 분포를 색상에 따라 시각적으로 인지하도록 합니다',
       component: Default,
@@ -45,6 +40,11 @@ export default {
       description: '범주의 색상, label을 지정할 수 있습니다.',
       component: Category,
       parsedData: parseComponent(CategoryRaw),
+    },
+    SelectLabel: {
+      description: '범주의 색상, label을 지정할 수 있습니다.',
+      component: SelectLabel,
+      parsedData: parseComponent(SelectLabelRaw),
     },
   },
 };

--- a/docs/views/heatMap/props.js
+++ b/docs/views/heatMap/props.js
@@ -10,6 +10,8 @@ import Gradient from './example/Gradient';
 import GradientRaw from '!!raw-loader!./example/Gradient';
 import Category from './example/Category';
 import CategoryRaw from '!!raw-loader!./example/Category';
+import SelectLabel from './example/SelectLabel';
+import SelectLabelRaw from '!!raw-loader!./example/SelectLabel';
 
 export default {
   mdText,
@@ -38,6 +40,11 @@ export default {
       description: '범주의 색상, label을 지정할 수 있습니다.',
       component: Category,
       parsedData: parseComponent(CategoryRaw),
+    },
+    SelectLabel: {
+      description: '범주의 색상, label을 지정할 수 있습니다.',
+      component: SelectLabel,
+      parsedData: parseComponent(SelectLabelRaw),
     },
   },
 };

--- a/docs/views/heatMap/props.js
+++ b/docs/views/heatMap/props.js
@@ -16,6 +16,11 @@ import SelectLabelRaw from '!!raw-loader!./example/SelectLabel';
 export default {
   mdText,
   components: {
+    SelectLabel: {
+      description: '범주의 색상, label을 지정할 수 있습니다.',
+      component: SelectLabel,
+      parsedData: parseComponent(SelectLabelRaw),
+    },
     Default: {
       description: 'HeatMap은 데이터의 분포를 색상에 따라 시각적으로 인지하도록 합니다',
       component: Default,
@@ -40,11 +45,6 @@ export default {
       description: '범주의 색상, label을 지정할 수 있습니다.',
       component: Category,
       parsedData: parseComponent(CategoryRaw),
-    },
-    SelectLabel: {
-      description: '범주의 색상, label을 지정할 수 있습니다.',
-      component: SelectLabel,
-      parsedData: parseComponent(SelectLabelRaw),
     },
   },
 };

--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -398,10 +398,9 @@ const modules = {
       const offset = 6 * (isHorizontal ? 1 : -1);
       const gp = aPos[valueAxes.units.rectEnd] + offset;
 
-      let dp;
       dataIndex?.forEach((index) => {
         const labelCenter = Math.round(labelStartPoint + (labelGap * index));
-        dp = labelCenter + (labelGap / 2);
+        const dp = labelCenter + (labelGap / 2);
 
         this.showTip({
           context: this.bufferCtx,

--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -19,7 +19,8 @@ const modules = {
     let isExistSelectedLabel;
 
     if (labelTipOpt.use && labelTipOpt.showTip) {
-      isExistSelectedLabel = this.drawLabelTip();
+      const isHeatMap = opt.type === 'heatMap';
+      isExistSelectedLabel = isHeatMap ? this.drawLabelTipForHeatMap() : this.drawLabelTip();
     }
 
     const executeDrawIndicator = (tipOpt) => {
@@ -365,6 +366,56 @@ const modules = {
 
     return drawTip;
   },
+
+  /**
+   * Draw Selected Label Tip
+   * @returns {boolean} Whether drew at least one tip
+   */
+  drawLabelTipForHeatMap() {
+    const opt = this.options;
+    const isHorizontal = !!opt.horizontal;
+    const labelTipOpt = opt.selectLabel;
+    const { dataIndex } = this.defaultSelectInfo;
+    let drawTip = false;
+
+    if (dataIndex) {
+      drawTip = true;
+
+      const chartRect = this.chartRect;
+      const labelOffset = this.labelOffset;
+      const aPos = {
+        x1: chartRect.x1 + labelOffset.left,
+        x2: chartRect.x2 - labelOffset.right,
+        y1: chartRect.y1 + labelOffset.top,
+        y2: chartRect.y2 - labelOffset.bottom,
+      };
+      const labelAxes = isHorizontal ? this.axesY[0] : this.axesX[0];
+      const labelStartPoint = aPos[labelAxes.units.rectStart];
+      const labelEndPoint = aPos[labelAxes.units.rectEnd];
+      const labelGap = (labelEndPoint - labelStartPoint) / labelAxes.labels.length;
+
+      const valueAxes = isHorizontal ? this.axesX[0] : this.axesY[0];
+      const offset = 6 * (isHorizontal ? 1 : -1);
+      const gp = aPos[valueAxes.units.rectEnd] + offset;
+
+      let dp;
+      dataIndex?.forEach((index) => {
+        const labelCenter = Math.round(labelStartPoint + (labelGap * index));
+        dp = labelCenter + (labelGap / 2);
+
+        this.showTip({
+          context: this.bufferCtx,
+          x: isHorizontal ? gp : dp,
+          y: isHorizontal ? dp : gp,
+          opt: labelTipOpt,
+          isSamePos: false,
+        });
+      });
+    }
+
+    return drawTip;
+  },
+
   /**
    * Calculate x, y position to draw text tip
    * @param {object} param     object for drawing text tip

--- a/src/components/chart/model/model.series.js
+++ b/src/components/chart/model/model.series.js
@@ -56,7 +56,7 @@ const modules = {
       this.seriesInfo.charts.heatMap.push(id);
       const { heatMapColor, legend } = this.options;
       const isGradient = legend.type === 'gradient';
-      return new HeatMap(id, opt, heatMapColor, isGradient);
+      return new HeatMap(id, opt, heatMapColor, isHorizontal, isGradient);
     }
 
     return false;

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -420,7 +420,7 @@ const modules = {
   getSeriesValueOptForHeatMap(series) {
     const { data, colorState, isGradient } = series;
     const colorOpt = this.options.heatMapColor;
-    const categoryCnt = colorOpt.categoryCnt;
+    const categoryCnt = colorOpt.categoryColors.length || colorOpt.categoryCnt;
     const decimalPoint = colorOpt.decimalPoint;
 
     let minValue;

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -619,10 +619,16 @@ const modules = {
    */
   initSelectedInfo() {
     if (this.options.selectLabel.use) {
-      const { limit } = this.options.selectLabel;
       if (!this.defaultSelectInfo) {
         this.defaultSelectInfo = { dataIndex: [] };
       }
+
+      if (this.options.type === 'heatMap') {
+        this.initSelectedInfoForHeatMap();
+        return;
+      }
+
+      const { limit } = this.options.selectLabel;
       const infoObj = this.defaultSelectInfo;
       infoObj.dataIndex.splice(limit);
       infoObj.label = infoObj.dataIndex.map(i => this.data.labels[i]);
@@ -634,6 +640,26 @@ const modules = {
         this.defaultSelectInfo = { seriesId: [] };
       }
     }
+  },
+
+  /**
+   * init defaultSelectInfo object for HeatMap.
+   * - at selectLabel using: set each series data and label text
+   */
+  initSelectedInfoForHeatMap() {
+    const { limit } = this.options.selectLabel;
+    const isHorizontal = this.options.horizontal;
+
+    const infoObj = this.defaultSelectInfo;
+    infoObj.dataIndex.splice(limit);
+
+    const targetLabel = isHorizontal ? 'y' : 'x';
+    infoObj.label = infoObj.dataIndex.map(i => this.data.labels[targetLabel][i]);
+
+    const dataValues = Object.values(this.data.data)[0];
+    infoObj.data = dataValues.filter(({ x, y }) =>
+      (infoObj.label.includes(isHorizontal ? y : x)),
+    );
   },
 
   /**

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -427,6 +427,7 @@ const modules = {
       }
 
       const targetId = targetDOM?.series?.cId;
+      const legendHitInfo = { sId: targetId, type: this.options.type };
 
       series.colorState.forEach((colorItem) => {
         colorItem.state = colorItem.id === targetId ? 'highlight' : 'downplay';
@@ -435,6 +436,9 @@ const modules = {
       this.update({
         updateSeries: false,
         updateSelTip: { update: false, keepDomain: false },
+        hitInfo: {
+          legend: legendHitInfo,
+        },
       });
     };
 


### PR DESCRIPTION
이슈
-
https://app.clickup.com/t/25540965/DEV-6485

작업 내용
-
1. label 선택 기능 추가
2. heatmp용 label tip 그리는 로직 추가
3. selectLabel 관련 description 추가
4. Time 예제 초기 data 함수로 생성하도록 변경
5. 옵션이 업데이트 되는 경우 categoryCnt가 categoryColors length가 아닌 option에 설정된 categoryCnt로 적용되는 이슈 수정

![image](https://user-images.githubusercontent.com/75718910/209771635-eb2448f1-4c97-4a97-91ba-9f4772cbb3b4.png)

HeatMap SelectLabel  스펙
- 
1. label 선택하는 경우 선택된 label에 해당되는 데이터만 반환
   기존 Chart
   -  [{ series명: value}, {series명: value}]
   
   HeatMap Chart (series명 반환 x)
   - [{x: label, y: label, value: value}, {x: label, y: label, value: value}]
6. fixedPosTop 옵션 사용x (항상 tip이 top에 위치)
