### PR TITLE
[#1341] Release 웹훅 적용

### DIFF
--- a/.github/actions/jandi-notify/action.yml
+++ b/.github/actions/jandi-notify/action.yml
@@ -25,6 +25,12 @@ runs:
           -H "Accept: application/vnd.tosslab.jandi-v2+json" \
           -H "Content-Type: application/json" \
           --data-binary '{"body":"📢 EVUI CI/CD Notification - ✅ Deployment succeeded", "connectColor":"#4285F6", "connectInfo":[{"title":"Commit message","description":"'"${COMMIT_MESSAGE}"'"},{"title":"EVUI document","description":"- [[EVUI]](https://ex-em.github.io/EVUI)"}]}'
+        elif [ "${{ inputs.status }}" = "release" ]; then          
+          curl \
+          -X POST "${{ inputs.jandi_incoming_url }}" \
+          -H "Accept: application/vnd.tosslab.jandi-v2+json" \
+          -H "Content-Type: application/json" \
+          --data-binary '{"body":"📢 EVUI CI/CD Notification -  🎉 Release succeeded", "connectColor":"#00FF7F", "connectInfo":[{"title":"[Release Note](${{ github.event.release.html_url }})","description":""},{"title":"Release Version: ${{ github.event.release.tag_name }}","description":""}]}'
         else
           curl \
           -X POST "${{ inputs.jandi_incoming_url }}" \

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,3 +18,8 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - name: Send Jandi
+        uses: ./.github/actions/jandi-notify
+        with:
+          status: release
+          jandi_incoming_url: ${{ secrets.JANDI_INCOMING_URL }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.48",
+  "version": "3.3.49",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",


### PR DESCRIPTION
### 개발 내용
- npm 배포 시 잔디 메시지 연동
### 예시
![image](https://user-images.githubusercontent.com/81760347/211259996-ff9572e0-e2be-47a6-8855-661b16f08492.png)
- Release Note: 패치 내역 링크를 제공합니다.
- Release Version: 태그 이름으로 추적하며, 배포된 EVUI 버전을 알려줍니다.

Close #1341 