### PR TITLE
[#1345] Grid, TreeGrid > customContextMenu 옵션 > click event parameter 개선

### DIFF
--- a/docs/views/grid/example/CellRenderer.vue
+++ b/docs/views/grid/example/CellRenderer.vue
@@ -126,10 +126,10 @@ export default {
     const menuItems = ref([
       {
         text: 'Menu1',
-        click: () => console.log(`[Menu1] Selected Row Data: ${selected.value}`),
+        click: param => console.log(`[Menu1] Selected Row Data: ${param?.selectedRow}`),
       }, {
         text: 'Menu2',
-        click: () => console.log('[Menu2]'),
+        click: param => console.log('[Menu2]', param),
       },
     ]);
     const borderMV = ref('');

--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -239,10 +239,10 @@ export default {
     const menuItems = ref([
       {
         text: 'Menu1',
-        click: () => console.log(`[Menu1] Selected Row Data: ${selected.value}`),
+        click: param => console.log(`[Menu1] Selected Row Data: ${param?.selectedRow}`),
       }, {
         text: 'Menu2',
-        click: () => console.log('[Menu2]'),
+        click: param => console.log('[Menu2]', param),
       },
     ]);
     const highlightMV = ref(-1);

--- a/docs/views/grid/example/Toolbar.vue
+++ b/docs/views/grid/example/Toolbar.vue
@@ -163,15 +163,6 @@ export default {
     const clickedRowMV = ref();
     const DbClickedRowsMV = ref();
     const highlightMV = ref(-1);
-    const menuItems = ref([
-      {
-        text: 'Menu1',
-        click: () => console.log(`[Menu1] Selected Row Data: ${selected.value}`),
-      }, {
-        text: 'Menu2',
-        click: () => console.log('[Menu2]'),
-      },
-    ]);
     const borderMV = ref('none');
     const searchVm = ref('');
     const columns = ref([
@@ -265,7 +256,6 @@ export default {
       checkedRowsMV,
       clickedRowMV,
       DbClickedRowsMV,
-      menuItems,
       borderMV,
       searchVm,
       orderItems,

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -290,18 +290,19 @@ export default {
     const clickedRowMV = ref();
     const DbClickedRowsMV = ref();
     const expandColumnMV = ref(0);
-    const menuItems = ref([{
+    const menuItems = ref([
+      {
         text: 'Menu1',
-        click: () => {
-          console.log(`[Menu1] Selected Row Data: ${JSON.stringify(selected.value[0].data)}`);
+        click: (param) => {
+          console.log(`[Menu1] Selected Row Data: ${JSON.stringify(param?.selectedRow?.[0]?.data)}`);
         },
       }, {
         text: 'Menu2',
-        click: () => console.log('[Menu2]'),
+        click: param => console.log('[Menu2]', param),
       },
     ]);
     const highlightMV = ref(-1);
-    const borderMV = ref('');
+    const borderMV =menuItems ref('');
     const iconMV = ref('');
     const dataIconMV = ref('');
     const borderItems = ref([

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -302,7 +302,7 @@ export default {
       },
     ]);
     const highlightMV = ref(-1);
-    const borderMV =menuItems ref('');
+    const borderMV = ref('');
     const iconMV = ref('');
     const dataIconMV = ref('');
     const borderItems = ref([

--- a/docs/views/treeGrid/example/Toolbar.vue
+++ b/docs/views/treeGrid/example/Toolbar.vue
@@ -81,10 +81,12 @@ export default {
     const menuItems = ref([
       {
         text: 'Menu1',
-        click: () => console.log(`[Menu1] Selected Row Data: ${selected.value[0].data}`),
+        click: (param) => {
+          console.log(`[Menu1] Selected Row Data: ${JSON.stringify(param?.selectedRow?.[0]?.data)}`);
+        },
       }, {
         text: 'Menu2',
-        click: () => console.log('[Menu2]'),
+        click: param => console.log('[Menu2]', param),
       },
     ]);
     const borderMV = ref('');

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -845,6 +845,8 @@ export const contextMenuEvent = (params) => {
             menuItem.disabled = !menuItem.validate(menuItem.itemId, row);
           }
 
+          menuItem.selectedRow = row ?? [];
+
           return menuItem;
         });
 

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -585,6 +585,8 @@ export const contextMenuEvent = (params) => {
             menuItem.disabled = !menuItem.validate(menuItem.itemId, row);
           }
 
+          menuItem.selectedRow = row ?? [];
+
           return menuItem;
         });
 


### PR DESCRIPTION
## 이슈 개요 
- 그리드 타입 (Grid, TreeGrid) 의 컴포넌트 사용시 `customContextMenu` 기능을 사용 할 수 있으나, Context Menu를 오픈하게 된(클릭 된) Row의 정보를 가져오려면 `v-model:selected`와 같은 양방향 바인딩 모델을 활용 해야 함
- context menu 기능 특성 상 context Menu를 오픈하게된 Row에 대한 정보가 대부분 필요하니 click이벤트에 parameter 로 전달하고자 함

### 기대 효과 
- 양반향 바인딩 모델을 사용하지 않고 Context Menu 기능을 좀 더 편리하게 사용할 수 있음 
- 여러개의 화면에서 공통적으로 GridOption을 선언하여 사용중일 때, context Menu를 사용하기 위해 그리드 별로 Option을 분리할 필요가 없어짐 

## 처리내용
- selectedRow에 대한 정보도 넘기도록 로직 개선
- 예제 코드 수정

## Example Code
### Before
```
const selectedRowRef = ref([]);
const customContextMenu = [{
  {
    text: 'Copy Row',
    click: () => copyRow(selectedRowRef.value),
  },
}];

<ev-grid
  v-model:selected="selectedRowRef"
  :option="{
    customContextMenu="customContextMenu"
    ...
  }"
  ...
/>  
```

###  After
```
const customContextMenu = [{
  {
    text: 'Copy Row',
    click: (param) => copyRow(param.selectedRow),
  },
}];


<ev-grid
  :option="{
    customContextMenu="customContextMenu"
    ...
  }"
  ...
/> 
```


## 기타 
`docs/views/grid/example/Toolbar.vue` 속 customContextMenu는 변수만 있고 component에 Binding하지 않고 있어 예제 코드에서 삭제함