### PR TITLE
[#1347][EXEM]Line Chart > Tooltip > 마우스 오버 시 일부 시점 포인트 안되는 현상

### DIFF
--- a/docs/views/brushChart/example/SelectLabelGroup.vue
+++ b/docs/views/brushChart/example/SelectLabelGroup.vue
@@ -144,7 +144,7 @@ export default {
       let val3;
       let val4;
 
-      if (ix >= 3) {
+      if (ix < 20 || ix > 40) {
         val = Math.floor(Math.random() * ((5000 - 5) + 1)) + 5;
         val2 = Math.floor(Math.random() * ((5000 - 5) + 1)) + 5;
         val3 = Math.floor(Math.random() * ((5000 - 5) + 1)) + 5;
@@ -161,7 +161,7 @@ export default {
     };
 
     onMounted(() => {
-      for (let ix = 0; ix < 10; ix++) {
+      for (let ix = 0; ix < 400; ix++) {
         addRandomChartLabel();
         addRandomChartData(ix);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.49",
+  "version": "3.3.50",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -28,6 +28,7 @@ class Line {
     };
     this.data = [];
     this.beforeMouseXp = 0;
+    this.beforeMouseYp = 0;
     this.beforeFindItemIndex = -1;
     this.size = {
       comboOffset: 0,
@@ -247,12 +248,13 @@ class Line {
     const yp = offset[1];
     const item = { data: null, hit: false, color: this.color };
     const gdata = this.data;
+    const SPARE_XP = 0.5;
 
     if (gdata?.length) {
       if (typeof dataIndex === 'number' && this.show) {
         item.data = gdata[dataIndex];
         item.index = dataIndex;
-      } else if (this.show && typeof this.beforeFindItemIndex === 'number' && useSelectLabelOrItem) {
+      } else if (typeof this.beforeFindItemIndex === 'number' && this.show && useSelectLabelOrItem) {
         item.data = gdata[this.beforeFindItemIndex];
         item.index = this.beforeFindItemIndex;
       } else {
@@ -274,15 +276,18 @@ class Line {
               const rightXp = gdata[m + 1].xp - xp;
 
               if (
-                Math.abs(this.beforeMouseXp - xp + 0.5) >= curXpInterval
+                Math.abs(this.beforeMouseXp - xp) >= curXpInterval - SPARE_XP
                 && (this.beforeFindItemIndex === m || midXp === rightXp || midXp === leftXp)
               ) {
                 if (this.beforeMouseXp - xp > 0) {
                   item.data = gdata[this.beforeFindItemIndex - 1];
                   item.index = this.beforeFindItemIndex - 1;
-                } else if (this.beforeMouseXp - xp <= 0) {
+                } else if (this.beforeMouseXp - xp < 0) {
                   item.data = gdata[this.beforeFindItemIndex + 1];
                   item.index = this.beforeFindItemIndex + 1;
+                } else if (this.beforeMouseYp !== yp) {
+                  item.data = gdata[this.beforeFindItemIndex];
+                  item.index = this.beforeFindItemIndex;
                 }
               } else {
                 const closeXp = Math.min(leftXp, midXp, rightXp);
@@ -319,6 +324,7 @@ class Line {
 
     if (!useSelectLabelOrItem) {
       this.beforeMouseXp = xp;
+      this.beforeMouseYp = yp;
 
       if (typeof item.index === 'number') {
         this.beforeFindItemIndex = item.index;

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -608,7 +608,12 @@ const modules = {
    * @param {number} dataIndex        selected data index
    * @returns {object} clicked item information
    */
-  getItemByPosition(offset, useApproximate = false, dataIndex) {
+  getItemByPosition(
+    offset,
+    useApproximate = false,
+    dataIndex,
+    isSelectLabel = false,
+  ) {
     const seriesIDs = Object.keys(this.seriesList);
     const isHorizontal = !!this.options.horizontal;
 
@@ -627,7 +632,7 @@ const modules = {
       const findFn = useApproximate ? series.findApproximateData : series.findGraphData;
 
       if (findFn) {
-        const item = findFn.call(series, offset, isHorizontal, dataIndex);
+        const item = findFn.call(series, offset, isHorizontal, dataIndex, isSelectLabel);
         const data = item.data;
         const index = item.index;
 
@@ -831,6 +836,7 @@ const modules = {
         [offsetX, y],
         selectLabel?.useApproximateValue,
         dataIndex,
+        true,
       );
       labelIndex = hitInfo.maxIndex ?? -1;
     }

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -554,6 +554,7 @@ const modules = {
         [dataInfo.xp, dataInfo.yp],
         useApproximate,
         dataIndex,
+        true,
       )];
     } else {
       const seriesList = Object.entries(this.seriesList);
@@ -579,6 +580,7 @@ const modules = {
           [dataInfo?.xp ?? 0, dataInfo?.yp ?? 0],
           useApproximate,
           idx,
+          true,
         );
       });
     }
@@ -606,13 +608,15 @@ const modules = {
    * @param {array}   offset          position x and y
    * @param {boolean} useApproximate  if it's true. it'll look for closed item on mouse position
    * @param {number} dataIndex        selected data index
+   * @param {boolean}  useSelectLabelOrItem   used to display select label/item at tooltip location
+   *
    * @returns {object} clicked item information
    */
   getItemByPosition(
     offset,
     useApproximate = false,
     dataIndex,
-    isSelectLabel = false,
+    useSelectLabelOrItem = false,
   ) {
     const seriesIDs = Object.keys(this.seriesList);
     const isHorizontal = !!this.options.horizontal;
@@ -632,7 +636,13 @@ const modules = {
       const findFn = useApproximate ? series.findApproximateData : series.findGraphData;
 
       if (findFn) {
-        const item = findFn.call(series, offset, isHorizontal, dataIndex, isSelectLabel);
+        const item = findFn.call(
+          series,
+          offset,
+          isHorizontal,
+          dataIndex,
+          useSelectLabelOrItem,
+        );
         const data = item.data;
         const index = item.index;
 


### PR DESCRIPTION
################################   
[수정 내용]      
**수정 전**   
![tooltip 수정 전](https://user-images.githubusercontent.com/61274722/217169925-3d7defbc-902e-4281-a313-4314e5c1b112.gif)   

**수정 후**
![tooltip 수정 후](https://user-images.githubusercontent.com/61274722/217169944-e5b9c62b-e0d4-4371-a3ac-ab2338a38ebf.gif)

1. 데이터 사이 간격이 존재 할 경우(데이터 간격 0 초과일 경우  (데이터 사이 간격은 0, 0.5, 1... 0.5 배수임 / 0일 경우는 차트의 가시성이 떨어지는 경우임. 아래 한계 참조.))
 - 마우스가 움직였지만 현재 툴팁과 이전 툴팁이 같거나 현재 마우스 포인트 기준 좌우 사이 간격이 같을 때 마우스가 우로 움직이고 있었다면 인덱스 +1, 좌로 움직이고 있었다면 인덱스 -1하여 1픽셀 움직일 때 tooltip에 다음 날의 값이 보여지도록 함.
 - 그외, 현재 마우스 위치와 가까운 값을 확인하여 tooltip에 보여줌   

2. Tooltip을 확인한 위치에 select label/item 이 생성 되도록 다시 반복문을 돌리지 않고 Tooltip 값 확인하면서 저장 한 index (this.beforeFindItemIndex)를 이용하여 select label/item 생성   
- useSelectLabelOrItem가 false 일 때(Tooltip 표시될 때) this.beforeFindItemIndex에 현재 툴팁의 item.index 저장.
- useSelectLabelOrItem이 true 일 때(select label/item 표시될 때) 이전 툴팁을 확인하면서 저장한 index을 가져다 사용.

3. this.beforeMouseYp !== yp 추가
 - 마우스가 Y 축으로만 움직였을 때 이전 Tooltip 그대로 보여줌

**this.beforeMouseYp !== yp 추가 안 하면**
![y축으로 움직일 떄](https://user-images.githubusercontent.com/61274722/217462897-81a09faa-8c1d-414c-b3d3-edfa6094e491.gif)   


4. SPARE_XP 추가
 - 마우스 이동(Math.abs(this.beforeMouseXp - xp))은 1 이상이고 데이터 사이 간격은 0, 0.5, 1, 1.5, 2...인데 간격이 1.5일때도 (1 이상 >= 1.5 - 0.5) 로직이 수행 되도록 수정. (ex. 데이터 사이 간격이 1.5일 때 우측으로 마우스를 1픽셀 움직였지만(1픽셀 움직이면 마우스와 좌측 포인트 사이 간격은 1,  마우스와 우측 포인트 사이 간격은 0.5임) 현재 툴팁이 이전 툴팁과 같을 때(this.beforeFindItemIndex === m) 마우스 움직임에 따라 인덱스 +1, -1함) 

**수정 전 마우스가 움직였지만 툴팁 내용이 같을 때**
![마우스가 움직였지만 툴팁 내용이 같을 떄](https://user-images.githubusercontent.com/61274722/217170478-53d9ef3a-a2d5-495c-9f4b-60694d5ee434.gif)   

5. 한계
 - 마우스의 x 포지션은 1 픽셀 씩 움직이기 때문에 가시성이 떨어질 정도로 데이터가 너무 많거나 화면이 좁을 경우 1픽셀 사이에 데이터를 감지할 수 없음. (이런 경우 인덱스 +1, -1로 임의로 조정 할 경우 tooltip이 마우스 커서를 따라오지 못 함. 따라서 이런 경우 기존 방식 그대로 보여줌)
 
**데이터가 너무 많을 경우 echart 예시** 
![echart 데이터 많을 때 tooltip](https://user-images.githubusercontent.com/61274722/217170115-208be217-498c-49b5-97d3-e1af9b423487.gif)   

**데이터 많을 경우 임의로 tooltip을 조정하면**
![임의로 조정 할 경우](https://user-images.githubusercontent.com/61274722/217170314-b5dcf5aa-fc7f-4872-b77c-3819cdb1f3b7.gif)


[확인 경로]    
 - Line Chart > tooltip