### PR TITLE
[#1350] DatePicker > dateRange, dateTimeRange 모드 > 사용자 입력 가능 옵션 추가

### DIFF
--- a/docs/views/calendar/example/Default.vue
+++ b/docs/views/calendar/example/Default.vue
@@ -133,7 +133,7 @@ export default {
     const calendar2 = ref('2020-09-15');
     const calendar3 = ref(null);
     const calendar4 = ref('2020-10-14 14:38:01');
-    const calendar5 = ref(['2020-10-21', '2020-11-01']);
+    const calendar5 = ref(['2020-10-21', '2020-11-02']);
     const calendar6 = ref([]);
     const calendar7 = ref([]);
     const calendar8 = ref(['2020-10-21', '2020-11-05']);

--- a/docs/views/datePicker/api/datePicker.md
+++ b/docs/views/datePicker/api/datePicker.md
@@ -16,6 +16,7 @@
 | --- | ---- | ----- | ---- | --- |
 | v-model | String, Array | '' | 컴포넌트 입력 값, String 타입인 경우는 'YYYY-MM-DD' 또는 'YYYY-MM-DD HH:MI:SS'의 형태로 작성해야하며, Array 타입인 경우는 배열 내에 'YYYY-MM-DD' 형식에 맞는 String 값을 넣어야한다.  | |
 | placeholder | String | '' | 인풋박스의 placeholder |  |
+| readonly | Boolean | true | <데이트피커> 읽기 전용 여부 |  |
 | disabled | Boolean | false | <데이트피커> 사용여부 |  |
 | clearable | Boolean | false | <데이트피커> 내 선택된 항목을 모두 clear할 수 있는 아이콘 사용 여부 |  |
 | mode | String | 'date' | 캘린더 모드 | 'date', 'dateTime', 'dateMulti', 'dateRange', 'dateTimeRange' |

--- a/docs/views/datePicker/api/datePicker.md
+++ b/docs/views/datePicker/api/datePicker.md
@@ -17,7 +17,7 @@
 | v-model | String, Array | '' | 컴포넌트 입력 값, String 타입인 경우는 'YYYY-MM-DD' 또는 'YYYY-MM-DD HH:MI:SS'의 형태로 작성해야하며, Array 타입인 경우는 배열 내에 'YYYY-MM-DD' 형식에 맞는 String 값을 넣어야한다.  | |
 | placeholder | String | '' | 인풋박스의 placeholder |  |
 | disabled | Boolean | false | <데이트피커> 사용여부 |  |
-| enableTextInput | Boolean | true | <데이트피커> 텍스트 입력 활성화  |  |
+| enableTextInput | Boolean | false | <데이트피커> 텍스트 입력 활성화  |  |
 | clearable | Boolean | false | <데이트피커> 내 선택된 항목을 모두 clear할 수 있는 아이콘 사용 여부 |  |
 | mode | String | 'date' | 캘린더 모드 | 'date', 'dateTime', 'dateMulti', 'dateRange', 'dateTimeRange' |
 |  |  | date(default) | 메인 캘린더에서 날짜를 선택(사용자가 인풋에 직접 입력 가능) | 'YYYY-MM-DD' |

--- a/docs/views/datePicker/api/datePicker.md
+++ b/docs/views/datePicker/api/datePicker.md
@@ -16,8 +16,8 @@
 | --- | ---- | ----- | ---- | --- |
 | v-model | String, Array | '' | 컴포넌트 입력 값, String 타입인 경우는 'YYYY-MM-DD' 또는 'YYYY-MM-DD HH:MI:SS'의 형태로 작성해야하며, Array 타입인 경우는 배열 내에 'YYYY-MM-DD' 형식에 맞는 String 값을 넣어야한다.  | |
 | placeholder | String | '' | 인풋박스의 placeholder |  |
-| readonly | Boolean | true | <데이트피커> 읽기 전용 여부 |  |
 | disabled | Boolean | false | <데이트피커> 사용여부 |  |
+| enableTextInput | Boolean | true | <데이트피커> 텍스트 입력 활성화  |  |
 | clearable | Boolean | false | <데이트피커> 내 선택된 항목을 모두 clear할 수 있는 아이콘 사용 여부 |  |
 | mode | String | 'date' | 캘린더 모드 | 'date', 'dateTime', 'dateMulti', 'dateRange', 'dateTimeRange' |
 |  |  | date(default) | 메인 캘린더에서 날짜를 선택(사용자가 인풋에 직접 입력 가능) | 'YYYY-MM-DD' |

--- a/docs/views/datePicker/example/Default.vue
+++ b/docs/views/datePicker/example/Default.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="case">
-    <p class="case-title">Calendar date mode (readonly: false)</p>
+    <p class="case-title">Calendar date mode (enable text input)</p>
     <ev-date-picker
       v-model="date1"
-      :readonly="false"
+      :enable-text-input="true"
       placeholder="Select a date."
       clearable
     />
@@ -41,7 +41,7 @@
       v-model="dateTime2"
       mode="dateTime"
       clearable
-      :readonly="false"
+      :enable-text-input="true"
       :options="{
         timeFormat: 'HH:00:ss'
       }"
@@ -116,11 +116,11 @@
     </div>
   </div>
   <div class="case ev-date-picker__date-range">
-    <p class="case-title">Calendar dateRange mode (readonly: false)</p>
+    <p class="case-title">Calendar dateRange mode (enable text input)</p>
     <ev-date-picker
         v-model="dateRange2"
         mode="dateRange"
-        :readonly="false"
+        :enable-text-input="true"
         clearable
     />
     <div class="description">
@@ -177,11 +177,11 @@
       {{ dateTimeRange2 }}
     </div>
     <div class="case ev-date-picker__date-time-range">
-      <p class="case-title">Calendar dateTimeRange mode (readonly: false)</p>
+      <p class="case-title">Calendar dateTimeRange mode (enable text input)</p>
       <ev-date-picker
           v-model="dateTimeRange3"
           mode="dateTimeRange"
-          :readonly="false"
+          :enable-text-input="true"
           clearable
       />
       <div class="description">

--- a/docs/views/datePicker/example/Default.vue
+++ b/docs/views/datePicker/example/Default.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="case">
-    <p class="case-title">Calendar date mode</p>
+    <p class="case-title">Calendar date mode (readonly: false)</p>
     <ev-date-picker
       v-model="date1"
+      :readonly="false"
       placeholder="Select a date."
       clearable
     />
@@ -37,13 +38,14 @@
   <div class="case">
     <p class="case-title">Calendar dateTime mode(shortcuts)</p>
     <ev-date-picker
-        v-model="dateTime2"
-        mode="dateTime"
-        clearable
-        :options="{
-          timeFormat: 'HH:00:ss'
-        }"
-        :shortcuts="dateTime2Shortcut"
+      v-model="dateTime2"
+      mode="dateTime"
+      clearable
+      :readonly="false"
+      :options="{
+        timeFormat: 'HH:00:ss'
+      }"
+      :shortcuts="dateTime2Shortcut"
     />
     <div class="description">
       <span class="badge">
@@ -113,8 +115,23 @@
       {{ dateMulti3 }}
     </div>
   </div>
+  <div class="case ev-date-picker__date-range">
+    <p class="case-title">Calendar dateRange mode (readonly: false)</p>
+    <ev-date-picker
+        v-model="dateRange2"
+        mode="dateRange"
+        :readonly="false"
+        clearable
+    />
+    <div class="description">
+      <span class="badge">
+        Value
+      </span>
+      {{ dateRange2 }}
+    </div>
+  </div>
   <div class="case">
-    <p class="case-title">Calendar dateRange mode</p>
+    <p class="case-title">Calendar dateRange mode (shortcut)</p>
     <ev-date-picker
       v-model="dateRange1"
       mode="dateRange"
@@ -147,7 +164,6 @@
     <ev-date-picker
         v-model="dateTimeRange2"
         mode="dateTimeRange"
-        clearable
         :options="{
           timeFormat: ['HH:mm:00', 'HH:mm:00'],
           disabledDate: disabledDateTime,
@@ -159,6 +175,21 @@
         Value
       </span>
       {{ dateTimeRange2 }}
+    </div>
+    <div class="case ev-date-picker__date-time-range">
+      <p class="case-title">Calendar dateTimeRange mode (readonly: false)</p>
+      <ev-date-picker
+          v-model="dateTimeRange3"
+          mode="dateTimeRange"
+          :readonly="false"
+          clearable
+      />
+      <div class="description">
+      <span class="badge">
+        Value
+      </span>
+        {{ dateTimeRange3 }}
+      </div>
     </div>
   </div>
 </template>
@@ -176,8 +207,10 @@ export default {
     const dateMulti2 = ref([]);
     const dateMulti3 = ref([]);
     const dateRange1 = ref([]);
+    const dateRange2 = ref(['2023-02-12', '2023-02-13']);
     const dateTimeRange1 = ref([]);
     const dateTimeRange2 = ref(['2022-06-07 16:01:01', '2022-06-08 17:10:15']);
+    const dateTimeRange3 = ref(['2023-02-14 10:00:00', '2023-02-14 11:00:00']);
 
     const TODAY_0_O_CLOCK_DATE = new Date(dayjs()
         .format('YYYY-MM-DD 00:00:00'));
@@ -244,11 +277,28 @@ export default {
       dateMulti2,
       dateMulti3,
       dateRange1,
+      dateRange2,
       dateTimeRange1,
       dateTimeRange2,
       dateTimeRange2Shortcut,
+      dateTimeRange3,
       disabledDateTime,
     };
   },
 };
 </script>
+<style lang="scss">
+.ev-date-picker__date-range {
+  .ev-date-picker-range-input {
+    width: 100px;
+    flex: none;
+  }
+}
+.ev-date-picker__date-time-range {
+  .ev-date-picker-range-input {
+    width: 155px;
+    flex: none;
+    text-align: center;
+  }
+}
+</style>

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -10,10 +10,7 @@
         <span class="ev-calendar-year">{{ mainCalendarPageInfo.year }}</span>
         <span class="ev-calendar-month">{{ mainCalendarMonth }}</span>
         <div
-          :class="[
-            'move-month-arrow',
-            { disabled: isContinuousMonths }
-          ]"
+          class="move-month-arrow"
           @click="clickPrevNextBtn('main', 'next')">
           <i class="ev-icon-s-arrow-right move-month-arrow-icon"
           />
@@ -138,10 +135,7 @@
     >
       <div class="ev-calendar-header">
         <div
-            :class="[
-              'move-month-arrow',
-              { disabled: isContinuousMonths }
-            ]"
+            class="move-month-arrow"
             @click="clickPrevNextBtn('expanded', 'prev')"
         >
           <i class="ev-icon-s-arrow-left move-month-arrow-icon"/>
@@ -338,7 +332,6 @@ export default {
       mainCalendarMonth,
       expandedCalendarMonth,
       dayOfTheWeekList,
-      isContinuousMonths,
     } = useModel();
 
     const {
@@ -391,7 +384,6 @@ export default {
       mainCalendarMonth,
       expandedCalendarMonth,
       dayOfTheWeekList,
-      isContinuousMonths,
 
       mainCalendarTableInfo,
       expandedCalendarTableInfo,

--- a/src/components/datePicker/DatePicker.vue
+++ b/src/components/datePicker/DatePicker.vue
@@ -18,16 +18,16 @@
         <input
           v-model.trim="currentValue"
           type="text"
-          :class="['ev-input', {readonly : $props.readonly}]"
+          :class="['ev-input', {readonly : !$props.enableTextInput}]"
           :placeholder="$props.placeholder"
-          :readonly="$props.readonly"
+          :readonly="!$props.enableTextInput"
           :disabled="$props.disabled"
           @click="clickSelectInput"
           @keydown.enter.prevent="validateValue(currentValue)"
           @change="validateValue(currentValue)"
         />
       </template>
-      <template v-else-if="$props.mode === 'dateMulti' || $props.readonly">
+      <template v-else-if="$props.mode === 'dateMulti' || !$props.enableTextInput">
         <div
           class="ev-date-picker-tag-wrapper"
           @click="clickSelectInput"
@@ -204,11 +204,11 @@ export default {
       type: Boolean,
       default: false,
     },
-    readonly: {
-      type: Boolean,
-      default: true,
-    },
     clearable: {
+      type: Boolean,
+      default: false,
+    },
+    enableTextInput: {
       type: Boolean,
       default: false,
     },

--- a/src/components/datePicker/DatePicker.vue
+++ b/src/components/datePicker/DatePicker.vue
@@ -18,15 +18,16 @@
         <input
           v-model.trim="currentValue"
           type="text"
-          class="ev-input"
+          :class="['ev-input', {readonly : $props.readonly}]"
           :placeholder="$props.placeholder"
+          :readonly="$props.readonly"
           :disabled="$props.disabled"
           @click="clickSelectInput"
           @keydown.enter.prevent="validateValue(currentValue)"
           @change="validateValue(currentValue)"
         />
       </template>
-      <template v-else>
+      <template v-else-if="$props.mode === 'dateMulti' || $props.readonly">
         <div
           class="ev-date-picker-tag-wrapper"
           @click="clickSelectInput"
@@ -76,6 +77,35 @@
                 <span class="ev-tag-name"> {{ mv[mv.length - 1] }} </span>
               </div>
             </template>
+          </template>
+        </div>
+      </template>
+      <template v-else>
+        <div
+          class="ev-date-picker-input-wrapper"
+          @click="clickSelectInput"
+        >
+          <span class="ev-date-picker-prefix-icon">
+            <i class="ev-icon-calendar" />
+          </span>
+          <input
+            v-model.trim="currentValue[0]"
+            type="text"
+            class="ev-date-picker-range-input"
+            @keydown.enter.prevent="validateValue(currentValue)"
+            @change="validateValue(currentValue)"
+          />
+          <template v-if="currentValue[currentValue.length - 1]">
+            <div class="ev-date-picker-range-separator">
+              <span class="ev-tag-name"> ~ </span>
+            </div>
+            <input
+              v-model.trim="currentValue[currentValue.length - 1]"
+              type="text"
+              class="ev-date-picker-range-input"
+              @keydown.enter.prevent="validateValue(currentValue)"
+              @change="validateValue(currentValue)"
+            />
           </template>
         </div>
       </template>
@@ -173,6 +203,10 @@ export default {
     disabled: {
       type: Boolean,
       default: false,
+    },
+    readonly: {
+      type: Boolean,
+      default: true,
     },
     clearable: {
       type: Boolean,
@@ -330,6 +364,19 @@ export default {
     }
   }
 
+  &-range-input {
+    position: relative;
+    width: 100%;
+    outline: 0;
+    padding: 0 $input-default-padding 0 $input-default-padding;
+    border: none;
+    flex: 1;
+  }
+
+  &-range-separator {
+    border: none;
+  }
+
   .ev-input-suffix {
     display: flex;
     position: absolute;
@@ -343,7 +390,8 @@ export default {
     }
   }
 
-  .ev-date-picker-tag-wrapper {
+  .ev-date-picker-tag-wrapper,
+  .ev-date-picker-input-wrapper {
     display: flex;
     width: 100%;
     height: 100%;
@@ -351,6 +399,25 @@ export default {
     padding: 3px 30px 3px 30px;
     flex-wrap: wrap;
     align-items: center;
+  }
+
+  .ev-date-picker-input-wrapper {
+    transition: border $animate-base;
+    outline: 0;
+    background-color: transparent;
+    border-radius: $default-radius;
+
+    @include evThemify() {
+      border: 1px solid evThemed('border-base');
+      color: evThemed('font-base');
+    }
+
+    &:focus,
+    &:hover {
+      @include evThemify() {
+        border: 1px solid evThemed('primary');
+      }
+    }
   }
 }
 

--- a/src/components/datePicker/uses.js
+++ b/src/components/datePicker/uses.js
@@ -187,7 +187,7 @@ export const useDropdown = () => {
    */
   const clickSelectInput = async () => {
     if (!props.disabled) {
-      isDropbox.value = props.readonly ? !isDropbox.value : true;
+      isDropbox.value = props.enableTextInput ? true : !isDropbox.value;
       if (isDropbox.value) {
         await changeDropboxPosition();
       }


### PR DESCRIPTION
이슈
-
date, dateTime 모드에선 input에서 바로 입력하여 변경 가능하지만 dateRange, dateTimeRange 모드에선 입력할 수 없음   
range 모드에서도 입력 가능할 수 있도록 개선 필요

기대 효과
-
range 모드도 calendar를 클릭하지 않고 input태그에 입력하여 변경할 수 있음

작업 내용
-
1. enableTextInput (텍스트 입력 활성화) 옵션 추가 
   - 현재 프로젝트에 적용된 datepicker가 있으므로 적용된 프로젝트의 수정 범위가 적도록 하기 위해 옵션 추가
   - 기본값: false
   - enableTextInput : true일 경우 입력 할 수 없도록 적용(date, dateTime 모드도 포함)
   - enableTextInput : false일 경우 입력 가능
   - **참고** dateMulti 는 항상 readonly: true
   - 입력할 때 disabledDate 함수에 포함되거나 invalid한 날짜 입력했을 때 변경되기 전의 날짜로 변경됨 
   
   ![datepicker_readonly](https://user-images.githubusercontent.com/75718910/218626077-466c5a06-e486-495c-8cd9-f3e56d551585.gif)

2. 그 외 이슈 또는 개선
     - 함수 안에서만 사용하는 변수들 computed 제거
     - range모드에서 clickDate했을 경우 클릭한 calendar의 page만 업데이트
     - from 달력의 년,월 페이지가 to 달력의 페이지를 넘어서지 못하는 제한 제거(반대도 동일)
       - 이전 from날짜에서 to날짜로 연속된 날짜 표시할 때 사용되었지만 현재 이 기능이 삭제되어 제거
       - 추후 다시 기능을 넣을 때 사용 예정
       - AS-IS
         ![calendar_bug](https://user-images.githubusercontent.com/75718910/218625372-fcb933fa-b8e4-4d0d-86cc-de1a2cfd27d6.gif)
       - TO-BE 
         ![calendar_bug_fix](https://user-images.githubusercontent.com/75718910/218625425-285151ca-a75b-468e-9228-2829b740b8c0.gif)

     - range 모드에서 현재 달력에서 이전 달력의 날짜가 선택되었을 때 표시되지 않는 버그 수정
        - AS-IS
          ![datepicker_bug](https://user-images.githubusercontent.com/75718910/218625829-b8869c99-2f57-4ef7-adf6-3a05461be1bf.gif)          
        - TO-BE
          ![datepicker_bug_fix](https://user-images.githubusercontent.com/75718910/218625848-9cbe48de-5ac7-455c-8539-bfce6e443414.gif)


