### PR TITLE
[#1348] Bar Chart > 겹쳐지는(비율) 표현 방식 추가

### DIFF
--- a/docs/components/Example.vue
+++ b/docs/components/Example.vue
@@ -3,9 +3,9 @@
     <h3 class="article-title">
       {{ title }}
     </h3>
-    <p class="article-description">
-      {{ description }}
-    </p>
+    <p
+      class="article-description"
+      v-html="description" />
     <div
         :class="['article-example', { 'vertical-mode':verticalMode }]"
     >

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -39,7 +39,7 @@ const selectedLabel = ref({
   |------------ |-----------|---------|-------------------------|---------------------------------------------------|
   | series | Object | {} | 특정 데이터에 대한 시리즈 옵션 |  |
   | data   | Object | {} | 차트에 표시할 시리즈 별 데이터 |  |
-  | groups | Array  | [] | Stack 차트를 위한 시리즈 그룹을 지정 |  |
+  | groups | Array  | [] | Stack, Overlapping 차트를 위한 시리즈 그룹을 지정 |  |
   | labels | Array  | [] | 축의 각 눈금에 해당하는 명칭 |  |
 
 #### series
@@ -128,6 +128,7 @@ const chartData = {
   | gridLineColor | String | '#C9CFDC' | 그리드의 색상 | | 
   | range | Array | null | 축에 표시할 값의 min, max | [0, 100] |
   | horizontal | Boolean | null | horizontal Bar 차트 표시를 위한 속성 | true / false | 
+  | overlapping | Boolean | false | Overlapping Bar 차트 표시를 위한 속성<br/>data 속성의 groups 값을 같이 지정하여야 정상 표현됩니다. | true / false |     
   | interval | String | null | 축에 표시되는 값의 간격 단위 (축의 타입에 따라 달라짐)
   | labelStyle | Object | ([상세](#labelstyle)) | 라벨의 폰트 스타일을 설정 | |
   | plotLines | Array | ([상세](#plotline)) | plot line(임계선 표시 용도) 설정 | |

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -128,7 +128,7 @@ const chartData = {
   | gridLineColor | String | '#C9CFDC' | 그리드의 색상 | | 
   | range | Array | null | 축에 표시할 값의 min, max | [0, 100] |
   | horizontal | Boolean | null | horizontal Bar 차트 표시를 위한 속성 | true / false | 
-  | overlapping | Boolean | false | Overlapping Bar 차트 표시를 위한 속성<br/>data 속성의 groups 값을 같이 지정하여야 정상 표현됩니다. | true / false |     
+  | overlapping | Object | ([상세](#overlapping)) | Overlapping Bar 차트 표시를 위한 속성<br/>data 속성의 groups 값을 같이 지정하여야 정상 표현됩니다. |  |   
   | interval | String | null | 축에 표시되는 값의 간격 단위 (축의 타입에 따라 달라짐)
   | labelStyle | Object | ([상세](#labelstyle)) | 라벨의 폰트 스타일을 설정 | |
   | plotLines | Array | ([상세](#plotline)) | plot line(임계선 표시 용도) 설정 | |
@@ -165,6 +165,11 @@ const chartData = {
       - Step Axis를 Time 기반으로 변경, default: false
    - timeFormat
       - dayjs의 timeFormat 이용 [참고URL](https://day.js.org/docs/en/parse/string-format/)
+
+##### overlapping
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+|-----|------|-------|-----|-----|
+| use | Boolean | false | overlapping 사용 여부 | true / false |
 
 ##### labelStyle
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/barChart/example/Overlapping.vue
+++ b/docs/views/barChart/example/Overlapping.vue
@@ -1,0 +1,64 @@
+<template>
+  <ev-chart
+    :data="chartData"
+    :options="chartOptions"
+  />
+</template>
+
+<script>
+export default {
+  setup() {
+    const chartData = {
+      series: {
+        series1: { name: 'series#1', showValue: { use: true } },
+        series2: { name: 'series#2', showValue: { use: true } },
+      },
+      labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+      groups: [['series1', 'series2']],
+      data: {
+        series1: [null, 100, 58, 40, 50],
+        series2: [null, 200, 200, 60, 55],
+      },
+    };
+
+    const chartOptions = {
+      type: 'bar',
+      width: '100%',
+      height: '100%',
+      thickness: 1,
+      title: {
+        text: 'Chart Title',
+        show: true,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      horizontal: false,
+      overlapping: true,
+      axesX: [{
+        type: 'step',
+        showGrid: false,
+        labelStyle: {
+          fitWidth: true,
+          fitDir: 'left',
+        },
+      }],
+      axesY: [{
+        type: 'linear',
+        startToZero: true,
+        autoScaleRatio: 0.1,
+        showGrid: false,
+      }],
+    };
+
+    return {
+      chartData,
+      chartOptions,
+    };
+  },
+};
+</script>
+
+<style lang="scss">
+</style>

--- a/docs/views/barChart/example/Overlapping.vue
+++ b/docs/views/barChart/example/Overlapping.vue
@@ -35,7 +35,9 @@ export default {
         position: 'right',
       },
       horizontal: false,
-      overlapping: true,
+      overlapping: {
+        use: true,
+      },
       axesX: [{
         type: 'step',
         showGrid: false,

--- a/docs/views/barChart/props.js
+++ b/docs/views/barChart/props.js
@@ -18,6 +18,8 @@ import Gradient from './example/Gradient';
 import GradientRaw from '!!raw-loader!./example/Gradient';
 import PlotLine from './example/PlotLine';
 import PlotLineRaw from '!!raw-loader!./example/PlotLine';
+import Overlapping from './example/Overlapping';
+import OverlappingRaw from '!!raw-loader!./example/Overlapping';
 
 export default {
   mdText,
@@ -41,6 +43,13 @@ export default {
       description: '동일한 그룹으로 묶인 series들의 데이터를 한 막대에 누적하여 표현할 수 있습니다.',
       component: Stack,
       parsedData: parseComponent(StackRaw),
+    },
+    Overlapping: {
+      description: `동일한 그룹으로 묶인 series들의 데이터를 한 막대에 겹쳐서 표현할 수 있습니다.<br/>
+          2개의 시리즈에 한정해 사용하는 것을 권장하며, data 속성의 groups에서 지정한 시리즈 순서대로 이전 시리즈에 포함되는 값은 항상 다음 시리즈에 속하는 값보다 작거나 같아야 합니다.<br/>
+          초과의 값을 가지면 가려질 수 있습니다.`,
+      component: Overlapping,
+      parsedData: parseComponent(OverlappingRaw),
     },
     Time: {
       description: '실시간으로 데이터를 받아 표현할 수 있으며, 가장 큰 값에 해당하는 막대위에 Tip을 붙일 수 있습니다.',

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -100,7 +100,7 @@ class EvChart {
     const { series, data, labels, groups } = this.data;
     const { type, axesX, axesY, tooltip, horizontal } = this.options;
 
-    this.createSeriesSet(series, type, horizontal);
+    this.createSeriesSet(series, type, horizontal, groups);
     if (groups.length) {
       this.addGroupInfo(groups);
     }
@@ -702,7 +702,7 @@ class EvChart {
       this.seriesList = {};
       this.lastTip = { pos: null, value: null };
 
-      this.createSeriesSet(series, options.type, options.horizontal);
+      this.createSeriesSet(series, options.type, options.horizontal, groups);
 
       if (this.legendDOM) {
         this.updateLegend();

--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -292,7 +292,8 @@ const modules = {
 
       const seriesList = Object.keys(this.seriesList ?? {});
       const visibleSeries = seriesList.filter(sId => this.seriesList[sId].show);
-      const isExistGrp = seriesList.some(sId => this.seriesList[sId].isExistGrp);
+      const isExistGrp = seriesList
+          .some(sId => this.seriesList[sId].isExistGrp) && !this.options.overlapping;
       const groups = this.data.groups?.[0] ?? [];
 
       let gp;

--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -293,7 +293,7 @@ const modules = {
       const seriesList = Object.keys(this.seriesList ?? {});
       const visibleSeries = seriesList.filter(sId => this.seriesList[sId].show);
       const isExistGrp = seriesList
-          .some(sId => this.seriesList[sId].isExistGrp) && !this.options.overlapping;
+          .some(sId => this.seriesList[sId].isExistGrp && !this.seriesList[sId].isOverlapping);
       const groups = this.data.groups?.[0] ?? [];
 
       let gp;

--- a/src/components/chart/model/model.series.js
+++ b/src/components/chart/model/model.series.js
@@ -18,7 +18,7 @@ const modules = {
   createSeriesSet(series, defaultType, isHorizontal, groups) {
     let seriesKeys = Object.keys(series);
 
-    if (this.options.overlapping) {
+    if (this.options.overlapping.use) {
       seriesKeys = this.getOverlappingSeriesKeys(series, defaultType, groups);
     }
 
@@ -110,6 +110,7 @@ const modules = {
         series.isExistGrp = true;
         series.bsId = prev;
         series.bsIds = group.filter((item, idx) => item !== curr && sIdx > idx);
+        series.isOverlapping = this.options.overlapping.use;
 
         if (!series.show) {
           interpolation--;

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -48,7 +48,8 @@ const modules = {
             const sData = data[seriesID];
 
             if (series && sData) {
-              if (series.isExistGrp && series.stackIndex) {
+              const isOverlappingBar = typeKey === 'bar' && this.options.overlapping;
+              if (series.isExistGrp && series.stackIndex && !isOverlappingBar) {
                 series.data = this.addSeriesStackDS(sData, label, series.bsIds, series.stackIndex);
               } else {
                 series.data = this.addSeriesDS(sData, label);

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -48,8 +48,7 @@ const modules = {
             const sData = data[seriesID];
 
             if (series && sData) {
-              const isOverlappingBar = typeKey === 'bar' && this.options.overlapping;
-              if (series.isExistGrp && series.stackIndex && !isOverlappingBar) {
+              if (series.isExistGrp && series.stackIndex && !series.isOverlapping) {
                 series.data = this.addSeriesStackDS(sData, label, series.bsIds, series.stackIndex);
               } else {
                 series.data = this.addSeriesDS(sData, label);

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -70,6 +70,7 @@ const DEFAULT_OPTIONS = {
   },
   reverse: false,
   horizontal: false,
+  overlapping: false,
   width: '100%',
   height: '100%',
   thickness: 1,

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -70,7 +70,9 @@ const DEFAULT_OPTIONS = {
   },
   reverse: false,
   horizontal: false,
-  overlapping: false,
+  overlapping: {
+    use: false,
+  },
   width: '100%',
   height: '100%',
   thickness: 1,


### PR DESCRIPTION
### 이슈
[ 클릭업 ] https://app.clickup.com/t/25540965/DEV-8157
Stack Bar Chart와 유사하지만 값이 겹쳐지는 형태의 Overlapping Bar Chart 기능 구현

### 구현 내용
* **overlapping** 옵션 추가
  Stack Bar Chart와 유사하게 groups 설정해야 하며, 추가적으로 overlapping: true로 지정해야 정상 작동하게 됩니다.

![image](https://user-images.githubusercontent.com/92071892/218650032-474894c5-78fd-4290-9f17-ccb5dcf347b3.png)

