### PR TITLE
[#1353] evChartZoom 변수 valid 로직 추가

### DIFF
--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -479,7 +479,7 @@ export const useZoomModel = (
   };
 
   onUpdated(() => {
-    if (evChartToolbarRef.value) {
+    if (evChartZoom && evChartToolbarRef.value) {
       evChartZoom.setIcon(evChartToolbarRef.value);
     }
   });


### PR DESCRIPTION
### 이슈
- ev-chart-group 사용 시 다음과 같은 에러가 발생합니다.
- ![image_2023-02-14_17-01-12](https://user-images.githubusercontent.com/10824092/218679158-690f6289-3c57-4e62-ac23-72ccb09fb62f.png)


### 구현 내용
- 컴포넌트가 업데이트되었지만 evChartZoom 변수가 없는 경우가 발생하여 valid 로직을 추가하였습니다.

Close #1353 