### PR TITLE
[#1360] HeatMap Chart > SelectItem, SelectLabel 두가지 옵션을 동시에 사용할 수 있도록 로직 개선 및 신규 옵션 추가

### DIFF
--- a/docs/views/barChart/example/Event.vue
+++ b/docs/views/barChart/example/Event.vue
@@ -86,6 +86,7 @@
           tipStyle: {
             background: '#FF00FF',
           },
+          useDeselectItem: true,
         },
         maxTip: {
           use: true,

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -237,17 +237,18 @@ const chartOptions = {
 
 
 #### selectLabel
-| 이름                  | 타입                          | 디폴트       | 설명                                                          | 종류(예시) |
-|-----------------------|------------------------------|-------------|--------------------------------------------------------------|-----------|
-| use                 | Boolean                        | false     | 차트 라벨 선택 기능                                                  | |
+| 이름                  | 타입                          | 디폴트       | 설명                                                | 종류(예시) |
+|---------------------|------------------------------|-------------|---------------------------------------------------|-----------|
+| use                 | Boolean                        | false     | 차트 라벨 선택 기능                                       | |
 | useClick            | Boolean                        | true      | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) | |
-| limit               | Number                         | 1         | 선택할 라벨의 최대 갯수                                               | |
-| useDeselectOverflow | Boolean                        | false     | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부                    | |
-| showTip             | Boolean                        | false     | 선택한 label의 Tip(화살표) 생성 여부                                   | |
-| useSeriesOpacity    | Boolean                        | true      | 시리즈 opacity 변경 여부                                             | |
-| useLabelOpacity     | Boolean                        | true      | Axes Label opacity 변경 여부                                        | |
-| useApproximateValue | Boolean                        | false     | 가까운 label을 선택                                                  | |
-| tipBackground       | Hex, RGB, RGBA Code(String)    | '#000000' | tip 배경색상                                                        | |
+| limit               | Number                         | 1         | 선택할 라벨의 최대 갯수                                     | |
+| useDeselectOverflow | Boolean                        | false     | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부             | |
+| showTip             | Boolean                        | false     | 선택한 label의 Tip(화살표) 생성 여부                         | |
+| useSeriesOpacity    | Boolean                        | true      | 시리즈 opacity 변경 여부                                 | |
+| useLabelOpacity     | Boolean                        | true      | Axes Label opacity 변경 여부                          | |
+| useApproximateValue | Boolean                        | false     | 가까운 label을 선택                                     | |
+| useBothAxis         | Boolean                        | false     | X축, Y축 두개 모두 이벤트 적용할지의 여부                         | |
+| tipBackground       | Hex, RGB, RGBA Code(String)    | '#000000' | tip 배경색상                                          | |
 
 ### 3. resize-timeout
 - Default : 0

--- a/docs/views/heatMap/example/SelectBoth.vue
+++ b/docs/views/heatMap/example/SelectBoth.vue
@@ -58,7 +58,6 @@ import { reactive, ref } from 'vue';
           type: 'step',
           showGrid: false,
         }],
-        itemHighlight: false,
         heatMapColor: {
           colorsByRange: [
             { color: '#EAE2B7', label: 'Normal' },

--- a/docs/views/heatMap/example/SelectBoth.vue
+++ b/docs/views/heatMap/example/SelectBoth.vue
@@ -61,8 +61,8 @@ import { reactive, ref } from 'vue';
         heatMapColor: {
           colorsByRange: [
             { color: '#EAE2B7', label: 'Normal' },
-            { color: '#fcbf49', label: 'Caution' },
-            { color: '#d62828', label: 'Crush' },
+            { color: '#FCBF49', label: 'Caution' },
+            { color: '#D62828', label: 'Crush' },
           ],
           decimalPoint: 1,
           stroke: {

--- a/docs/views/heatMap/example/SelectBoth.vue
+++ b/docs/views/heatMap/example/SelectBoth.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="case">
+    <ev-chart
+      v-model:selectedItem="selectedItem"
+      v-model:selectedLabel="selectedLabel"
+      :data="chartData"
+      :options="chartOptions"
+    />
+    <div class="description">
+      <label class="badge yellow"> v-model:selectedItem </label>
+      <span>{{ selectedItem }}</span>
+      <br>
+      <br>
+      <label class="badge yellow"> v-model:selectedLabel</label>
+      <span>{{ selectedLabel }}</span>
+    </div>
+  </div>
+</template>
+
+<script>
+import { reactive, ref } from 'vue';
+
+  export default {
+    setup() {
+      const chartData = reactive({
+        series: {
+          series1: {
+            name: 'series#1',
+          },
+        },
+        labels: {
+          x: [
+            '00', '01', '02', '03', '04', '05',
+            '06', '07', '08', '09', '10', '11',
+            '12', '13', '14', '15', '16', '17',
+            '18', '19', '20', '21', '22', '23',
+          ],
+          y: ['02-01', '02-02', '02-03', '02-04', '02-05', '02-06', '02-07'],
+        },
+        data: {
+          series1: [],
+        },
+      });
+
+      const chartOptions = reactive({
+        type: 'heatMap',
+        width: '100%',
+        height: '300px',
+        title: {
+          text: 'Chart Title',
+          show: true,
+        },
+        axesX: [{
+          type: 'step',
+          showGrid: false,
+        }],
+        axesY: [{
+          type: 'step',
+          showGrid: false,
+        }],
+        itemHighlight: false,
+        heatMapColor: {
+          colorsByRange: [
+            { color: '#EAE2B7', label: 'Normal' },
+            { color: '#fcbf49', label: 'Caution' },
+            { color: '#d62828', label: 'Crush' },
+          ],
+          decimalPoint: 1,
+          stroke: {
+            show: true,
+            lineWidth: 1,
+            color: '#FFFFFF',
+          },
+        },
+        tooltip: {
+          use: true,
+          formatter: {
+            title: ({ x }) => `${x}:00`,
+          },
+        },
+        selectItem: {
+          use: true,
+          useSeriesOpacity: true,
+          useClick: true,
+          showBorder: true,
+          useDeselectItem: true,
+        },
+        selectLabel: {
+          use: true,
+          useClick: true,
+          limit: 1,
+          useDeselectOverflow: true,
+          useSeriesOpacity: true,
+          useLabelOpacity: true,
+          useBothAxis: true,
+        },
+      });
+
+      const selectedItem = ref();
+
+      const selectedLabel = ref({
+        dataIndex: [],
+      });
+
+      const createChartData = () => {
+        const labelX = chartData.labels.x;
+        const labelY = chartData.labels.y;
+        for (let ix = 0; ix < labelX.length; ix++) {
+          for (let iy = 0; iy < labelY.length; iy++) {
+            const randomCount = Math.floor(Math.random() * 3) + 1;
+            chartData.data.series1.push({
+              x: labelX[ix],
+              y: labelY[iy],
+              value: randomCount,
+            });
+          }
+        }
+      };
+      createChartData();
+
+      return {
+        chartData,
+        chartOptions,
+        selectedItem,
+        selectedLabel,
+      };
+    },
+  };
+</script>

--- a/docs/views/heatMap/example/SelectBoth.vue
+++ b/docs/views/heatMap/example/SelectBoth.vue
@@ -87,7 +87,7 @@ import { reactive, ref } from 'vue';
         selectLabel: {
           use: true,
           useClick: true,
-          limit: 1,
+          limit: 3,
           useDeselectOverflow: true,
           useSeriesOpacity: true,
           useLabelOpacity: true,

--- a/docs/views/heatMap/props.js
+++ b/docs/views/heatMap/props.js
@@ -14,6 +14,8 @@ import SelectLabel from './example/SelectLabel';
 import SelectLabelRaw from '!!raw-loader!./example/SelectLabel';
 import SelectItem from './example/SelectItem';
 import SelectItemRaw from '!!raw-loader!./example/SelectItem';
+import SelectBoth from './example/SelectBoth';
+import SelectBothRaw from '!!raw-loader!./example/SelectBoth';
 
 export default {
   mdText,
@@ -52,6 +54,11 @@ export default {
       description: '차트 전체에서 선택한 라벨 내 모든 아이템이 하이라이트 되는 기능입니다.',
       component: SelectLabel,
       parsedData: parseComponent(SelectLabelRaw),
+    },
+    SelectBoth: {
+      description: '아이템을 선택 기능과 라벨 선택 기능을 동시에 사용할 수 있습니다.',
+      component: SelectBoth,
+      parsedData: parseComponent(SelectBothRaw),
     },
   },
 };

--- a/docs/views/lineChart/example/Event.vue
+++ b/docs/views/lineChart/example/Event.vue
@@ -89,11 +89,6 @@
             background: '#FF00FF',
           },
         },
-        zoom: {
-          toolbar: {
-            show: true,
-          },
-        },
       });
 
       const clickedLabel = ref("''");

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -209,9 +209,8 @@
       }, { deep: true, flush: 'post' });
 
       watch(() => (injectGroupSelectedLabel?.value ?? selectedLabel.value), (newValue) => {
-        if (newValue.dataIndex) {
-          const isHorizontal = !!normalizedOptions?.horizontal;
-          evChart.selectLabelByData(newValue.dataIndex, newValue.targetAxis ?? (isHorizontal ? 'yAxis' : 'xAxis'));
+        if (newValue?.dataIndex) {
+          evChart.selectLabelByData(newValue.dataIndex, newValue?.targetAxis);
         }
       }, { deep: true, flush: 'post' });
 

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -210,13 +210,14 @@
 
       watch(() => (injectGroupSelectedLabel?.value ?? selectedLabel.value), (newValue) => {
         if (newValue.dataIndex) {
-          evChart.renderWithSelected(newValue.dataIndex);
+          const isHorizontal = !!normalizedOptions?.horizontal;
+          evChart.selectLabelByData(newValue.dataIndex, newValue.targetAxis ?? (isHorizontal ? 'yAxis' : 'xAxis'));
         }
       }, { deep: true, flush: 'post' });
 
       watch(() => props.selectedSeries, (newValue) => {
         if (newValue.seriesId) {
-          evChart.renderWithSelected(newValue.seriesId);
+          evChart.selectSeriesByData(newValue.seriesId);
         }
       }, { deep: true, flush: 'post' });
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -943,8 +943,8 @@ class EvChart {
       }
 
       this.defaultSelectInfo = !this.defaultSelectInfo?.dataIndex
-        ? { dataIndex: [] }
-        : this.getSelectedLabelInfo(this.defaultSelectInfo.dataIndex, targetAxis);
+        ? { dataIndex: [], label: [], data: [] }
+        : this.getSelectedLabelInfoWithLabelData(this.defaultSelectInfo.dataIndex, targetAxis);
     }
 
     if (selectSeries.use && !this.defaultSelectInfo) {

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -116,7 +116,7 @@ class EvChart {
     this.axesRange = this.getAxesRange();
     this.labelOffset = this.getLabelOffset();
 
-    this.initSelectedInfo?.();
+    this.initDefaultSelectInfo();
 
     this.drawChart();
 
@@ -161,7 +161,7 @@ class EvChart {
 
   /**
    * To draw canvas chart, it processes several sequential jobs
-   * @param {any} [hitInfo=undefined]    from mousemove callback (object or undefined)
+   * @param {any} [hitInfo=undefined]    from mousemove callback (object or object[] of undefined)
    *
    * @returns {undefined}
    */
@@ -186,7 +186,14 @@ class EvChart {
    * @returns {undefined}
    */
   drawSeries(hitInfo) {
-    const { maxTip, selectLabel, selectItem, selectSeries, brush, displayOverflow } = this.options;
+    const {
+      maxTip,
+      selectLabel,
+      selectItem,
+      selectSeries,
+      brush,
+      displayOverflow,
+    } = this.options;
 
     const opt = {
       ctx: this.bufferCtx,
@@ -196,6 +203,7 @@ class EvChart {
       maxTipOpt: { background: maxTip.background, color: maxTip.color },
       selectLabel: { option: selectLabel, selected: this.defaultSelectInfo },
       selectSeries: { option: selectSeries, selected: this.defaultSelectInfo },
+      selectItem: { option: selectItem, selected: this.defaultSelectItemInfo },
       overlayCtx: this.overlayCtx,
       isBrush: !!brush,
       displayOverflow,
@@ -231,21 +239,8 @@ class EvChart {
           case 'heatMap': {
             const legendHitInfo = hitInfo?.legend;
 
-            let selectInfo;
-            const defaultSelectInfo = this.defaultSelectItemInfo;
-            if (defaultSelectInfo?.dataIndex || defaultSelectInfo?.dataIndex === 0) {
-              selectInfo = { ...defaultSelectInfo };
-            } else {
-              selectInfo = null;
-            }
-
             series.draw({
               legendHitInfo,
-              selectInfo,
-              selectItem: {
-                option: selectItem,
-                selected: selectInfo,
-              },
               ...opt,
             });
             break;
@@ -766,7 +761,7 @@ class EvChart {
     this.axesRange = this.getAxesRange();
     this.labelOffset = this.getLabelOffset();
 
-    this.initSelectedInfo?.();
+    this.initDefaultSelectInfo();
 
     this.render(updateInfo?.hitInfo);
 
@@ -928,6 +923,32 @@ class EvChart {
   hideTooltip() {
     if (this.options.tooltip.use && this.tooltipDOM?.style) {
       this.tooltipDOM.style.display = 'none';
+    }
+  }
+
+  /**
+   * init defaultSelectInfo (for selectLabel, selectSeries options)
+   */
+  initDefaultSelectInfo() {
+    const {
+      type: chartType,
+      selectLabel,
+      selectSeries,
+    } = this.options;
+
+    if (selectLabel.use) {
+      let targetAxis = null;
+      if (chartType === 'heatMap' && selectLabel?.useBothAxis) {
+        targetAxis = this.defaultSelectInfo?.targetAxis;
+      }
+
+      this.defaultSelectInfo = !this.defaultSelectInfo?.dataIndex
+        ? { dataIndex: [] }
+        : this.getSelectedLabelInfo(this.defaultSelectInfo.dataIndex, targetAxis);
+    }
+
+    if (selectSeries.use && !this.defaultSelectInfo) {
+      this.defaultSelectInfo = { seriesId: [] };
     }
   }
 }

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -569,7 +569,7 @@ const modules = {
         }
       }
 
-      itemPosition = dataIndex.map((idx) => {
+      itemPosition = dataIndex?.map((idx) => {
         const dataInfo = this.getDataByValues(firShowSeriesID, idx);
 
         if (!dataInfo) {
@@ -700,7 +700,7 @@ const modules = {
    *
    * @returns {object} clicked series id
    */
-  getSeriesIdByPosition(offset) {
+  getSeriesInfoByPosition(offset) {
     const [clickedX, clickedY] = offset;
     const chartRect = this.chartRect;
     const labelOffset = this.labelOffset;
@@ -802,10 +802,11 @@ const modules = {
   /**
    * Find label info by position x and y
    * @param {array}   offset          position x and y
+   * @param {string | null}  targetAxis    target Axis Location ('xAxis', 'yAxis' , null)
    *
    * @returns {object} clicked label information
    */
-  getLabelInfoByPosition(offset) {
+  getLabelInfoByPosition(offset, targetAxis) {
     const [x, y] = offset;
     const aPos = {
       x1: this.chartRect.x1 + this.labelOffset.left,
@@ -814,12 +815,21 @@ const modules = {
       y2: this.chartRect.y2 - this.labelOffset.bottom,
     };
 
-    const seiresList = this.data.series;
-    const pointSize = Object.values(seiresList).sort(
+    const seriesList = this.data.series;
+    const pointSize = Object.values(seriesList).sort(
       (a, b) => b.pointSize ?? 0 - a.pointSize ?? 0,
     )[0]?.pointSize ?? 3; // default pointSize 3
     const { horizontal, selectLabel } = this.options;
-    const scale = horizontal ? this.axesY[0] : this.axesX[0];
+
+    let scale;
+    if (targetAxis === 'xAxis') {
+      scale = this.axesX[0];
+    } else if (targetAxis === 'yAxis') {
+      scale = this.axesY[0];
+    } else {
+      scale = horizontal ? this.axesY[0] : this.axesX[0];
+    }
+
     const startPoint = aPos[scale.units.rectStart];
     const endPoint = aPos[scale.units.rectEnd];
 
@@ -827,7 +837,8 @@ const modules = {
     let hitInfo;
     if (scale?.labels?.length) {
       const labelGap = (endPoint - startPoint) / scale.labels.length;
-      const index = Math.floor(((horizontal ? y : x) - startPoint) / labelGap);
+      const isYAxis = targetAxis === 'yAxis' || horizontal;
+      const index = Math.floor(((isYAxis ? y : x) - startPoint) / labelGap);
       labelIndex = scale.labels.length > index ? index : -1;
     } else {
       let offsetX;

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -149,13 +149,13 @@ const modules = {
         };
       };
 
-      const setSelectedLabelInfo = (axisDirection) => {
-        const hitInfo = this.getLabelInfoByPosition(offset, axisDirection);
-        const allSelectedList = this.updateSelectedLabelInfo(hitInfo.labelIndex, axisDirection);
+      const setSelectedLabelInfo = (targetAxis) => {
+        const hitInfo = this.getLabelInfoByPosition(offset, targetAxis);
+        const allSelectedList = this.updateSelectedLabelInfo(hitInfo.labelIndex, targetAxis);
         this.defaultSelectInfo.dataIndex = allSelectedList.dataIndex;
 
-        if (axisDirection) {
-          this.defaultSelectInfo.targetAxis = axisDirection;
+        if (targetAxis) {
+          this.defaultSelectInfo.targetAxis = allSelectedList.dataIndex?.length ? targetAxis : null;
         }
 
         args.selected = {

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -69,13 +69,15 @@ class StepScale extends Scale {
 
   /**
    * Draw axis
-   * @param {object} chartRect      min/max information
-   * @param {object} labelOffset    label offset information
-   * @param {object} stepInfo       label steps information
+   * @param {object} chartRect  min/max information
+   * @param {object} labelOffset  label offset information
+   * @param {object} stepInfo  label steps information
+   * @param {object} hitInfo  legend Hit Info
+   * @param {object} selectedLabelInfo Selected Label Info
    *
    * @returns {undefined}
    */
-  draw(chartRect, labelOffset, stepInfo, hitInfo, selectLabelInfo) {
+  draw(chartRect, labelOffset, stepInfo, hitInfo, selectedLabelInfo) {
     const ctx = this.ctx;
     const labels = this.labels;
     const aPos = {
@@ -146,11 +148,24 @@ class StepScale extends Scale {
         linePosition = labelCenter + aliasPixel;
         labelText = this.getLabelFormat(item, maxWidth);
 
-        const isBlurredLabel = this.options?.selectLabel?.use
-          && this.options?.selectLabel?.useLabelOpacity
-          && (this.options.horizontal === (this.type === 'y'))
-          && selectLabelInfo?.dataIndex?.length
-          && !selectLabelInfo?.dataIndex?.includes(index);
+        const {
+          selectLabel: selectLabelOpt,
+          selectItem: selectItemOpt,
+          horizontal,
+        } = this.options;
+
+        let targetAxis;
+        if (selectedLabelInfo?.targetAxis) {
+          targetAxis = selectedLabelInfo?.targetAxis === 'yAxis' ? 'y' : 'x';
+        } else {
+          targetAxis = horizontal ? 'y' : 'x';
+        }
+
+        const isBlurredLabel = selectLabelOpt?.use
+          && selectLabelOpt?.useLabelOpacity
+          && targetAxis === this.type
+          && selectedLabelInfo?.dataIndex?.length
+          && !selectedLabelInfo?.dataIndex?.includes(index);
 
         const labelColor = this.labelStyle.color;
         let defaultOpacity = 1;
@@ -167,9 +182,9 @@ class StepScale extends Scale {
           ctx.fillText(labelText, xPoint, labelPoint);
 
           if (!isBlurredLabel
-            && this.options?.selectItem?.showLabelTip
+            && selectItemOpt?.showLabelTip
             && hitInfo?.label
-            && !this.options?.horizontal) {
+            && !horizontal) {
             const selectedLabel = hitInfo.label;
             if (selectedLabel === labelText) {
               const height = Math.round(ctx.measureText(this.labelStyle?.fontSize).width);
@@ -182,8 +197,8 @@ class StepScale extends Scale {
                 borderRadius: 2,
                 arrowSize: 3,
                 text: labelText,
-                backgroundColor: this.options?.selectItem?.labelTipStyle?.backgroundColor,
-                textColor: this.options?.selectItem?.labelTipStyle?.textColor,
+                backgroundColor: selectItemOpt?.labelTipStyle?.backgroundColor,
+                textColor: selectItemOpt?.labelTipStyle?.textColor,
               });
             }
           }


### PR DESCRIPTION
## 개요 
- HeatMap Chart에서 `selectLabel` 옵션과 `selectItem` 옵션을 동시에 사용할 수 없음. 
- 화면 기획의 요구사항에 따라 두개의 옵션을 동시에 사용할 필요 있음

## Before
- `v-model:selectItem` 혹은 `v-model:selectLabel` 둘 중 하나만 사용 가능 

## After
- `v-model:selectItem`, `v-model:selectLabel` 두개 동시에 사용 가능하도록 구조 변경 
- 이럴경우 Item 클릭시 Item 만 클릭된것으로 인식하며, **Label (Axis text)을 클릭했을 경우에만 `selectLabel`로 인식되도록 함** 
   _- 기존에는 `selectLabel`을 사용중일 경우, **item을 클릭해도** `selectLabel`로 인식되었음_

## 추가 개선 
1.  `chartOption > selectLabel > useBothAxis` 옵션을 true 로 설정할 경우, 두 가지 축 모두에 이벤트가 동작하도록 개선
   - 기존에는 X축 Y축 둘중 한쪽으로만 동작함
2. .Chart > click 이벤트 관련 로직 전체적으로 리팩토링 
   - 차트 타입별로 이벤트 처리 방안이 다름에도 불구하고, 옵션명의 유무로 차트의 타입을 유추해야하는 점이 직관적이지 않아 switch 문으로 분리 
3. `selectItem`, `selectLabel` 둘다 사용중인 Example Code 추가
    - ![select_label_after](https://user-images.githubusercontent.com/53548023/221526799-fbc3ad2a-2082-4f14-a606-21c26c2d0717.gif)