### PR TITLE
[#1362] Chart > ev-chart-group 내 ev-chart, ev-chart-brush를 element로 감쌀 시 에러 발생

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.51",
+  "version": "3.3.52",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -79,6 +79,7 @@
       const injectBrushSeries = inject('brushSeries', { list: [], chartIdx: null });
       const injectGroupSelectedLabel = inject('groupSelectedLabel', null);
       const injectBrushIdx = inject('brushIdx', { start: 0, end: -1 });
+      const injectEvChartPropsInGroup = inject('evChartPropsInGroup', []);
 
       const {
         eventListeners,
@@ -114,6 +115,7 @@
         normalizedOptions,
         { wrapper, evChartGroupRef: null },
         props.selectedLabel ? selectedLabel : selectedItem,
+        injectEvChartPropsInGroup,
       );
 
       const createChart = () => {

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="zoomOptions.toolbar.show && !injectIsChartGroup"
+    v-if="zoomOptions.toolbar?.show && !injectIsChartGroup"
     ref="evChartToolbarRef"
   >
     <ev-chart-toolbar
@@ -111,7 +111,7 @@
         setDataForUseZoom,
         controlZoomIdx,
         onClickToolbar,
-      } = useZoomModel(
+      } = injectIsChartGroup ? {} : useZoomModel(
         normalizedOptions,
         { wrapper, evChartGroupRef: null },
         props.selectedLabel ? selectedLabel : selectedItem,
@@ -229,6 +229,10 @@
       }
 
       onMounted(async () => {
+        if (injectEvChartPropsInGroup?.value) {
+          injectEvChartPropsInGroup.value.push(props);
+        }
+
         await createChart();
         await drawChart();
       });
@@ -236,6 +240,10 @@
       onBeforeUnmount(() => {
         if (evChart && 'destroy' in evChart) {
           evChart.destroy();
+        }
+
+        if (injectEvChartPropsInGroup?.value?.length) {
+          injectEvChartPropsInGroup.value.length = 0;
         }
       });
 
@@ -270,7 +278,7 @@
         injectIsChartGroup,
         onClickToolbar,
         normalizedOptions,
-        zoomOptions: toRef(evChartZoomOptions, 'zoom'),
+        zoomOptions: toRef(evChartZoomOptions ?? { zoom: {} }, 'zoom'),
       };
     },
   };

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -6,8 +6,6 @@ import {
   getCurrentInstance,
   nextTick,
   onUpdated,
-  onMounted,
-  onBeforeUnmount,
 } from 'vue';
 import { cloneDeep, defaultsDeep, isEqual } from 'lodash-es';
 import { getQuantity } from '@/common/utils';
@@ -344,19 +342,7 @@ export const useZoomModel = (
   selectedLabelOrItem,
   evChartPropsInGroup,
 ) => {
-  const { props, emit, type } = getCurrentInstance();
-
-  onMounted(() => {
-    if (evChartPropsInGroup?.value && type?.name === 'EvChart') {
-      evChartPropsInGroup.value.push(props);
-    }
-  });
-
-  onBeforeUnmount(() => {
-    if (evChartPropsInGroup?.value?.length) {
-      evChartPropsInGroup.value.length = 0;
-    }
-  });
+  const { props, emit } = getCurrentInstance();
 
   const isExecuteZoom = ref(false);
   const isUseZoomMode = ref(false);

--- a/src/components/chartBrush/chartBrush.core.js
+++ b/src/components/chartBrush/chartBrush.core.js
@@ -39,26 +39,28 @@ export default class EvChartBrush {
       return;
     }
 
-    const existedBrushCanvas = this.evChartBrushRef.value.querySelector('.brush-canvas');
+    if (this.evChartBrushRef?.value) {
+      const existedBrushCanvas = this.evChartBrushRef.value.querySelector('.brush-canvas');
 
-    if (!existedBrushCanvas) {
-      const brushCanvas = document.createElement('canvas');
+      if (!existedBrushCanvas) {
+        const brushCanvas = document.createElement('canvas');
 
-      brushCanvas.setAttribute('class', 'brush-canvas');
-      brushCanvas.setAttribute('style', 'display: block; z-index: 1;');
+        brushCanvas.setAttribute('class', 'brush-canvas');
+        brushCanvas.setAttribute('style', 'display: block; z-index: 1;');
 
-      const evChartBrushContainer = this.evChartBrushRef.value.querySelector('.ev-chart-brush-container');
+        const evChartBrushContainer = this.evChartBrushRef.value.querySelector('.ev-chart-brush-container');
 
-      if (evChartBrushContainer) {
-        this.brushCanvas = brushCanvas;
-        evChartBrushContainer.appendChild(brushCanvas);
-        this.evChartBrushContainer = evChartBrushContainer;
+        if (evChartBrushContainer) {
+          this.brushCanvas = brushCanvas;
+          evChartBrushContainer.appendChild(brushCanvas);
+          this.evChartBrushContainer = evChartBrushContainer;
 
-        this.drawBrushRect({ brushCanvas });
-        this.addEvent(brushCanvas);
+          this.drawBrushRect({ brushCanvas });
+          this.addEvent(brushCanvas);
+        }
+      } else {
+        this.drawBrushRect({ brushCanvas: existedBrushCanvas, isResize });
       }
-    } else {
-      this.drawBrushRect({ brushCanvas: existedBrushCanvas, isResize });
     }
   }
 

--- a/src/components/chartGroup/ChartGroup.vue
+++ b/src/components/chartGroup/ChartGroup.vue
@@ -57,12 +57,14 @@ export default {
       isExecuteZoom,
       brushSeries,
       evChartGroupRef,
+      evChartPropsInGroup,
     } = useGroupModel();
 
     const normalizedOptions = getNormalizedOptions(props.options);
     provide('isExecuteZoom', isExecuteZoom);
     provide('isChartGroup', true);
     provide('brushSeries', brushSeries);
+    provide('evChartPropsInGroup', evChartPropsInGroup);
     const groupSelectedLabel = computed({
       get: () => props.groupSelectedLabel,
       set: val => emit('update:groupSelectedLabel', val),
@@ -85,6 +87,7 @@ export default {
       normalizedOptions,
       { wrapper: null, evChartGroupRef },
       groupSelectedLabel,
+      evChartPropsInGroup,
     );
 
     provide('evChartClone', evChartClone);

--- a/src/components/chartGroup/uses.js
+++ b/src/components/chartGroup/uses.js
@@ -37,6 +37,7 @@ const DEFAULT_OPTIONS = {
 export const useGroupModel = () => {
   const isExecuteZoom = ref(false);
   const evChartGroupRef = ref();
+  const evChartPropsInGroup = ref([]);
   const brushSeries = reactive({ list: [], chartIdx: null });
   const getNormalizedOptions = options => defaultsDeep({}, options, DEFAULT_OPTIONS);
 
@@ -45,5 +46,6 @@ export const useGroupModel = () => {
     isExecuteZoom,
     brushSeries,
     evChartGroupRef,
+    evChartPropsInGroup,
   };
 };


### PR DESCRIPTION
Click Up: https://app.clickup.com/t/25540965/DEV-8567   
################################   
[원인]
 - ev-chart-group 내에 있는 ev-chart의 props(data, options)를 가지고 전체 줌과 ev-chart-brush에 사용해야 하는데 slot의 정보로 props(data, options)를 찾을 경우 element로 감쌀 시 children에 들어있거나 컴포넌트의 경우 null이어서 찾지 못하게 되고 에러가 발생하게 됨.

[수정 내용]
 - ev-chart-group에 'evChartPropsInGroup' 반응형 변수를 두고 group 내부에 있는 ev-chart가 생성될 때 ev-chart의 props(data, options)를 evChartPropsInGroup에 넣어 slot 으로 값을 찾지 않고 변수에 담긴 값을 이용하여 그룹에서 줌을 사용 시 brush와 함께 전체적으로 동작하도록 수정.

[확인 경로]
 Chart > BrushChart