### PR TITLE
[#1377] Chart > Bar > 차트 그리기 전 mouse move 이벤트 발생 시 오류 발생

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.56",
+  "version": "3.3.57",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -709,7 +709,7 @@ class EvChart {
       return;
     }
 
-    this.updateScrollbar?.();
+    this.updateScrollbar?.(updateData);
 
     this.resetProps();
 

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -305,7 +305,7 @@ class Bar {
     const gdata = this.data;
 
     let totalCount = gdata.length;
-    const [min, max] = this.range;
+    const [min, max] = this.range ?? [];
     if (truthyNumber(min) && truthyNumber(max)) {
       totalCount = (max - min) + 1;
     }
@@ -351,7 +351,7 @@ class Bar {
     const gdata = this.data;
 
     let totalCount = gdata.length;
-    const [min, max] = this.range;
+    const [min, max] = this.range ?? [];
     if (truthyNumber(min) && truthyNumber(max)) {
       totalCount = (max - min) + 1;
     }

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -213,6 +213,7 @@ const modules = {
         }
 
         case 'heatMap': {
+          const isHorizontal = !!this.options.horizontal;
           if (useSelectItem && useSelectLabel) {
             const { useBothAxis } = selectLabelOpt;
 
@@ -225,13 +226,27 @@ const modules = {
             } else if (location === 'yAxis' || location === 'xAxis') {
               this.clearSelectedItemInfo();
               args.deselected = { eventTarget: 'item' };
-              setSelectedLabelInfo(useBothAxis ? location : null);
+
+              if (!useBothAxis) {
+                const selectLabelAxis = isHorizontal ? 'yAxis' : 'xAxis';
+                if (location !== selectLabelAxis) {
+                  return;
+                }
+              }
+              setSelectedLabelInfo(location, useBothAxis);
             }
           } else if (useSelectItem) {
             setSelectedItemInfo();
           } else if (useSelectLabel) {
             const { useBothAxis } = selectLabelOpt;
             const location = this.getClickedLocation(offset);
+
+            if (!useBothAxis && location !== 'chartBackground') {
+              const selectLabelAxis = isHorizontal ? 'yAxis' : 'xAxis';
+              if (location !== selectLabelAxis) {
+                return;
+              }
+            }
             setSelectedLabelInfo(useBothAxis ? location : null);
           }
           break;
@@ -769,7 +784,7 @@ const modules = {
    */
   regulateSelectedLabelInfo(labelIndex, targetAxis) {
     const option = this.options?.selectLabel ?? {};
-    const before = this.defaultSelectInfo?.targetAxis === targetAxis
+    const before = targetAxis === null || this.defaultSelectInfo?.targetAxis === targetAxis
       ? { ...this.defaultSelectInfo, targetAxis }
       : { dataIndex: [], targetAxis };
 

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -71,16 +71,17 @@ const module = {
   /**
    * update scrollbar information
    */
-  updateScrollbar() {
-    this.updateScrollbarInfo('x');
-    this.updateScrollbarInfo('y');
+  updateScrollbar(updateData) {
+    this.updateScrollbarInfo('x', updateData);
+    this.updateScrollbarInfo('y', updateData);
   },
 
   /**
    * Updated scrollbar information with updated axis information
    * @param dir axis direction (x | y)
+   * @param updateData is update data
    */
-  updateScrollbarInfo(dir) {
+  updateScrollbarInfo(dir, updateData) {
     const { axesX, axesY } = this.options;
     const newOpt = dir === 'x' ? axesX : axesY;
     if (!this.scrollbar[dir].isInit && newOpt?.[0]?.scrollbar?.use && newOpt?.[0]?.range) {
@@ -93,7 +94,7 @@ const module = {
 
     const axisOpt = dir === 'x' ? this.axesX : this.axesY;
     const isUpdateAxesRange = !isEqual(newOpt?.[0]?.range, axisOpt?.[0]?.range);
-    if (isUpdateAxesRange) {
+    if (isUpdateAxesRange || updateData) {
       this.scrollbar[dir].range = newOpt?.[0]?.range || null;
     }
     this.scrollbar[dir].use = !!newOpt?.[0].scrollbar?.use;

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -33,13 +33,39 @@ const module = {
 
       scrollbarOpt.type = axisOpt?.[0]?.type;
       scrollbarOpt.range = axisOpt?.[0]?.range || null;
-      scrollbarOpt.interval = null;
 
       this.createScrollbarLayout(dir);
       this.createScrollbar(dir);
       this.createScrollEvent(dir);
       scrollbarOpt.isInit = true;
     }
+  },
+
+  checkValidRange(dir) {
+    const scrollbarOpt = this.scrollbar[dir];
+    const axesType = scrollbarOpt.type;
+
+    if (scrollbarOpt.range?.length) {
+      const [min, max] = scrollbarOpt.range;
+
+      if (!(truthyNumber(min) && truthyNumber(max))) {
+        return true;
+      }
+
+      if (axesType === 'step') {
+        const labels = this.options.type === 'heatMap' ? this.data.labels[dir] : this.data.labels;
+        if (min < 0 || max > labels.length - 1) {
+          return true;
+        }
+      } else {
+        const minMax = this.minMax[dir]?.[0];
+        if (+min < +minMax.min || +max > +minMax.max) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   },
 
   /**
@@ -78,10 +104,16 @@ const module = {
    */
   updateScrollbarPosition() {
     if (this.scrollbar.x?.use && this.scrollbar.x?.isInit) {
+      if (this.checkValidRange('x')) {
+        return;
+      }
       this.setScrollbarPosition('x');
     }
 
     if (this.scrollbar.y?.use && this.scrollbar.y?.isInit) {
+      if (this.checkValidRange('y')) {
+        return;
+      }
       this.setScrollbarPosition('y');
     }
   },
@@ -252,13 +284,13 @@ const module = {
     if (scrollbarOpt.showButton) {
       const upBtnDOM = scrollbarDOM.getElementsByClassName('ev-chart-scrollbar-button-up');
       const endPosition = Math.floor(trackSize - thumbSize.size);
-      const upBtnOpacity = Math.floor(thumbSize.position) === endPosition ? 0.5 : 1;
+      const upBtnOpacity = Math.floor(thumbSize.position) > endPosition ? 0.5 : 1;
       upBtnDOM[0].style.cssText = `background-color: ${scrollbarOpt.background};${upBtnStyle}`;
       upBtnDOM[0].style.opacity = upBtnOpacity;
       upBtnDOM[0].children[0].style.display = 'block';
       const downBtnDOM = scrollbarDOM.getElementsByClassName('ev-chart-scrollbar-button-down');
       downBtnDOM[0].style.cssText = `background-color: ${scrollbarOpt.background};${downBtnStyle}`;
-      downBtnDOM[0].style.opacity = Math.floor(thumbSize.position) === 0 ? 0.5 : 1;
+      downBtnDOM[0].style.opacity = Math.floor(thumbSize.position) < 0 ? 0.5 : 1;
       downBtnDOM[0].children[0].style.display = 'block';
     }
   },
@@ -287,16 +319,19 @@ const module = {
       thumbSize = intervalSize * range;
       thumbPosition = intervalSize * min;
     } else {
-      const minMax = this.minMax[dir];
-      const graphRange = (+minMax[0].max) - (+minMax[0].min);
+      const axisOpt = dir === 'x' ? this.axesX : this.axesY;
+      const minMax = this.minMax[dir]?.[0];
+      const graphRange = (+minMax.max) - (+minMax.min);
       const range = (+max) - (+min);
-      interval = this.axesX?.[0]?.getInterval({
-        min: minMax[0].min,
-        max: minMax[0].max,
-        maxSteps: this.labelRange[dir].max,
-      });
+      if (axesType === 'time') {
+        interval = axisOpt?.[0]?.getInterval({
+          minValue: minMax.min,
+          maxValue: minMax.max,
+          maxSteps: this.labelRange[dir]?.[0]?.max,
+        });
+      }
       steps = Math.ceil(graphRange / interval) + 1;
-      startValue = +minMax[0].min;
+      startValue = +minMax.min;
 
       const intervalSize = trackSize / steps;
       const count = (range / interval) + 1;
@@ -312,8 +347,6 @@ const module = {
     return {
       size: thumbSize,
       position: thumbPosition,
-      background: scrollbarOpt.background,
-      radius: scrollbarOpt.radius,
     };
   },
 
@@ -584,7 +617,10 @@ const module = {
     if (scrollbarXDOM) {
       scrollbarXDOM.remove();
       this.scrollbar[dir] = { isInit: false };
-      this.overlayCanvas?.removeEventListener('wheel', this.onScrollbarWheel, false);
+
+      if (dir === 'y') {
+        this.overlayCanvas?.removeEventListener('wheel', this.onScrollbarWheel, false);
+      }
     }
   },
 };

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -73,8 +73,8 @@ class Scale {
 
     const range = scrollbarOpt?.use ? scrollbarOpt?.range : this.range;
     if (range?.length === 2) {
-      maxValue = range[1];
-      minValue = range[0];
+      maxValue = range[1] > +minMax.max ? +minMax.max : range[1];
+      minValue = range[0] < +minMax.min ? +minMax.min : range[0];
     } else {
       maxValue = minMax.max;
       minValue = minMax.min;

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -2,6 +2,7 @@ import { defaultsDeep } from 'lodash-es';
 import { PLOT_BAND_OPTION, PLOT_LINE_OPTION } from '@/components/chart/helpers/helpers.constant';
 import Scale from './scale';
 import Util from '../helpers/helpers.util';
+import { truthyNumber } from '../../../common/utils';
 
 class StepScale extends Scale {
   constructor(type, axisOpt, ctx, labels, options) {
@@ -29,10 +30,14 @@ class StepScale extends Scale {
 
     const range = scrollbarOpt?.use ? scrollbarOpt?.range : this.range;
     if (range?.length) {
-      [minIndex, maxIndex] = range;
-      maxValue = this.labels[maxIndex];
-      minValue = this.labels[minIndex];
-      labelCount = maxIndex - minIndex + 1;
+      const [min, max] = range;
+      if (truthyNumber(min) && truthyNumber(max)) {
+        minIndex = min < minIndex ? minIndex : min;
+        maxIndex = max > maxIndex ? maxIndex : max;
+        maxValue = this.labels[maxIndex];
+        minValue = this.labels[minIndex];
+        labelCount = maxIndex - minIndex + 1;
+      }
     }
 
     const maxWidth = chartRect.chartWidth / (labelCount + 2);

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -180,7 +180,8 @@ class TimeCategoryScale extends Scale {
 
     let labelText;
     let labelPoint;
-    for (let ix = 0; ix < oriSteps; ix += count) {
+    let ix;
+    for (ix = 0; ix < oriSteps; ix += count) {
       ticks[ix] = axisMin + (ix * stepValue);
 
       labelCenter = Math.round(startPoint + (graphGap * ix));
@@ -246,13 +247,13 @@ class TimeCategoryScale extends Scale {
       ctx.stroke();
     }
 
-    if (this.categoryMode && alignToGridLine && (count * steps) === oriSteps) {
+    if (this.categoryMode && alignToGridLine && (ix * count) === oriSteps) {
       const diffTime = dayjs(labels[1]).diff(dayjs(labels[0]));
       const labelLastText = this.getLabelFormat(
-        dayjs(labels[labels.length - 1] + diffTime),
+        dayjs(ticks[oriSteps - 1] + diffTime),
       );
 
-      labelCenter = Math.round(startPoint + (graphGap * labels.length));
+      labelCenter = Math.round(startPoint + (graphGap * oriSteps));
       linePosition = labelCenter + aliasPixel;
 
       if (this.type === 'x') {


### PR DESCRIPTION
이슈
-
bar chart 그리기 전 mouse move 이벤트 발생시 오류 발생
![image_2023-03-21_11-17-12](https://user-images.githubusercontent.com/75718910/226523351-998d89c1-8f9d-4fdf-a52a-86dcbea1a29c.png)

원인
-
this.range 속성이 draw 함수 안에서 사용
draw 하기 전 mouse move 할 경우 findGraphData 함수를 호출하여 this.range 정의 되지 않아 오류 뱉어냄

작업 내용
-
1. findGraphData에서 this.range undefined인 경우 예외 처리
2. scrollbar 사용하는 경우 range 범위 확인하는 valid check 함수 추가
3. range의 min, max로 index 비교할 때 data의 min, max 값을 벗어나는지 체크 로직 추가
4. time categoryMode인 경우 마지막 라벨 출력 로직 수정
5. HeatMap 다른 이슈 추가 처리
    - horizontal: true, useBothAxis: false 인 경우 x축을 선택하면 선택된 label 해제 되는 버그 수정
    - selectLabe만 사용하는 경우 label 선택된 것을 재 선택하는 경우 해제 되지 않는 버그 수정
    - 데이터가 업데이트 되는 경우 scrollbar의 range 업데이트 로직 추가
