### PR TITLE
[#1380] Line Chart > Point: false 이고, 앞뒤 데이터가 null일 경우, 차트에 표시되지않는 문제 발생

### DIFF
--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -53,20 +53,20 @@ const selectedSeries = ref({
   | labels | Array  | [] | 축의 각 눈금에 해당하는 명칭, line Chart 에서는 time만 인정 |  |
 
 #### series
-  | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-  |------------ |-----------|---------|-------------------------|---------------------------------------------------|
-  | show | Boolean |true | 표시 여부 |  |
-  | name | String | series-${index} | 특정 데이터에 대한 시리즈 옵션 |  |
-  | lineWidth | Number | 2 | 선(line) 두께  | |
-  | color | Hex, RGB, RGBA Code(String) | COLOR[index] | Line 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용 |  |
-  | fill | Boolean | false | 선(line) 아래 부분의 영역에 색상을 채울지의 여부. area chart 전환 여부 |  |
-  | fillOpacity | Number | 0.4 | fill 영역의 투명도 | |
-  | fillColor | Hex, RGB, RGBA Code(String) | COLOR[index] | Fill 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용 |  |
-  | point | Boolean | true | 선(line) 위에 값 위치 마다 점을 표시할지의 여부 |  |
-  | pointSize | Number | 3 | 점(Point)의 크기 |  |
-  | pointFill | Hex, RGB, RGBA Code(String) | COLOR[index] | 점(Point) 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용 |  |
-  | pointStyle | String | 'circle' | 점(Point) 모양 | 'triangle', 'rect', 'rectRounded', 'rectRot', 'cross', 'crossRot', 'star', 'line' |
-  | showLegend | Boolean | true | legend 표시 여부 | |
+  | 이름 | 타입 | 디폴트 | 설명                                                                    | 종류(예시) |
+  |------------ |-----------|-----------------------------------------------------------------------|-------------------------|---------------------------------------------------|
+  | show | Boolean |true | 표시 여부                                                                 |  |
+  | name | String | series-${index} | 특정 데이터에 대한 시리즈 옵션                                                     |  |
+  | lineWidth | Number | 2 | 선(line) 두께                                                            | |
+  | color | Hex, RGB, RGBA Code(String) | COLOR[index] | Line 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용               |  |
+  | fill | Boolean | false | 선(line) 아래 부분의 영역에 색상을 채울지의 여부. area chart 전환 여부                      |  |
+  | fillOpacity | Number | 0.4 | fill 영역의 투명도                                                          | |
+  | fillColor | Hex, RGB, RGBA Code(String) | COLOR[index] | Fill 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용               |  |
+  | point | Boolean | true | 선(line) 위에 값 위치 마다 점을 표시할지의 여부, 앞/뒤 값이 null인 경우 point 표시 여부에 상관없이 표시됨 |  |
+  | pointSize | Number | 3 | 점(Point)의 크기                                                          |  |
+  | pointFill | Hex, RGB, RGBA Code(String) | COLOR[index] | 점(Point) 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용           |  |
+  | pointStyle | String | 'circle' | 점(Point) 모양                                                           | 'triangle', 'rect', 'rectRounded', 'rectRot', 'cross', 'crossRot', 'star', 'line' |
+  | showLegend | Boolean | true | legend 표시 여부                                                          | |
   
 #### data example
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.57",
+  "version": "3.3.58",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -182,18 +182,19 @@ class Line {
     }
 
     // Draw points
-    if (!isBrush && (this.point || useSelectLabel)) {
+    if (!isBrush) {
       ctx.strokeStyle = Util.colorStringToRgba(mainColor, mainColorOpacity);
       const focusStyle = Util.colorStringToRgba(pointFillColor, 1);
       const blurStyle = Util.colorStringToRgba(pointFillColor, pointFillColorOpacity);
 
       this.data.forEach((curr, ix) => {
-        const isSelectedLabel = selectedLabelIndexList.includes(ix);
         if (curr.xp === null || curr.yp === null) {
           return;
         }
 
-        if (this.point || isSelectedLabel) {
+        const isSingle = this.data[ix - 1]?.o === null && this.data[ix + 1]?.o === null;
+        const isSelectedLabel = selectedLabelIndexList.includes(ix);
+        if (this.point || isSingle || isSelectedLabel) {
           ctx.fillStyle = isSelectedLabel && !legendHitInfo ? focusStyle : blurStyle;
           Canvas.drawPoint(ctx, this.pointStyle, this.pointSize, curr.xp, curr.yp);
         }


### PR DESCRIPTION
## 이슈 요약
-  Line Chart > Point: false 이고, 앞뒤 데이터가 null일 경우, 차트에 표시되지않는 문제 발생
![linechart-point](https://user-images.githubusercontent.com/53548023/227145319-e4ea8e27-1ce1-4a7b-8b1c-fe2f30c51bd6.gif)
  
## 수정내용
- point를 그릴 때 앞/뒤 데이터가 null인지 체크하는 로직 추가
- docs에 관련 설명 추가
![linechart-point-after](https://user-images.githubusercontent.com/53548023/227145369-0d46aa53-6e05-4a21-9d57-826db809f5c9.png)

