### PR TITLE
[#1382] Chart > Heatmap > Item Highlight 시 기존 item보다 작게 그려지는 현상 수정

### DIFF
--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -115,7 +115,7 @@ class Bar {
     this.chartRect = chartRect;
     this.labelOffset = labelOffset;
     this.borderRadius = param.borderRadius;
-    this.range = [minIndex, maxIndex];
+    this.filteredCount = totalCount;
 
     let categoryPoint = null;
 
@@ -304,11 +304,7 @@ class Bar {
     const item = { data: null, hit: false, color: this.color };
     const gdata = this.data;
 
-    let totalCount = gdata.length;
-    const [min, max] = this.range ?? [];
-    if (truthyNumber(min) && truthyNumber(max)) {
-      totalCount = (max - min) + 1;
-    }
+    const totalCount = this.filteredCount ?? gdata.length;
 
     let s = 0;
     let e = totalCount - 1;
@@ -350,11 +346,7 @@ class Bar {
     const item = { data: null, hit: false, color: this.color };
     const gdata = this.data;
 
-    let totalCount = gdata.length;
-    const [min, max] = this.range ?? [];
-    if (truthyNumber(min) && truthyNumber(max)) {
-      totalCount = (max - min) + 1;
-    }
+    const totalCount = this.filteredCount ?? gdata.length;
 
     let s = 0;
     let e = totalCount - 1;


### PR DESCRIPTION
이슈
-
1. Item Highlight 시 기존 item 크기보다 작게 그려지는 현상
   ![image](https://user-images.githubusercontent.com/75718910/227819081-f694f66c-6ccf-4317-9b4d-19edcd6edca7.png)

재현 방법
-
1.  Heatmap 예제 중 stroke 옵션의 use: true, lineWidth: 10 이상 으로 할 경우 확인 가능

예상 원인
-
1. itemHightlight 로직에서 stroke를 사용할 경우 x, y point에서 lineWidth만큼 빼서 계산하는 로직

작업 내용
- 
1. itemHighlight 함수에서 lineWidth 계산하는 로직 제거
2. bar, heatmap findItem 함수에서 this.range -> this.filteredCount 로 변경
3. 그 외 이슈 사항 수정
    - drag 할 경우 drag한 item을 제대로 찾지 못하는 버그 수정
      **Before**
      ![drag_error](https://user-images.githubusercontent.com/75718910/227820014-c1c6dafb-874d-49b1-b204-795fc674c2f2.gif)
      
      **After**
![scrollbar_drag_bug_fix2](https://user-images.githubusercontent.com/75718910/227820797-e3f2768d-37c3-4557-aff6-13f86678a43a.gif)

         
    - scroll 사용 시 drag 할 때 block 단위로 되지 않는 현상 수정
      **Before**
![scrollbar_drag_bug_fix](https://user-images.githubusercontent.com/75718910/227820406-793cf56f-81df-4f36-9b31-6ffcda3cd8f6.gif)
    **After**
![scrollbar_drag_bug_fix23](https://user-images.githubusercontent.com/75718910/227820788-400a8acb-7cbe-40fa-98a0-caeed78505f0.gif)


