### PR TITLE
[#1384] Grid > 컬럼 리사이즈 시 Sort가 동시에 되는 현상

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.58",
+  "version": "3.3.59",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -82,7 +82,6 @@
                 'margin-right': (orderedColumns.length - 1 === index
                 && hasVerticalScrollBar && hasHorizontalScrollBar) ? `${scrollWidth}px` : '0px',
               }"
-              @click.stop="onSort(column)"
             >
               <!-- Filter Status -->
               <span
@@ -95,20 +94,21 @@
               <span
                 :title="column.caption"
                 class="column-name"
+                @click.stop="onSort(column)"
               >
                 {{ column.caption }}
+                <!-- Sort Icon -->
+                <template v-if="sortField === column.field">
+                  <ev-icon
+                    v-if="sortOrder === 'desc'"
+                    icon="ev-icon-triangle-down"
+                  />
+                  <ev-icon
+                    v-if="sortOrder === 'asc'"
+                    icon="ev-icon-triangle-up"
+                  />
+                </template>
               </span>
-              <!-- Sort Icon -->
-              <template v-if="sortField === column.field">
-                <ev-icon
-                  v-if="sortOrder === 'desc'"
-                  icon="ev-icon-triangle-down"
-                />
-                <ev-icon
-                  v-if="sortOrder === 'asc'"
-                  icon="ev-icon-triangle-up"
-                />
-              </template>
               <!-- Filter Button -->
               <span
                 v-if="isFiltering"

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -79,6 +79,7 @@
 .column-name {
   display: inline-block;
   float: left;
+  width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: bold;


### PR DESCRIPTION
##################
- 컬럼의 클릭 이벤트 태그 변경 (li -> span)
- 대신 span 의 영역의 넓혀 이벤트 동작되도록

[ as-is ]
![sort_22](https://user-images.githubusercontent.com/61657275/227822347-ef9bc13d-02fc-43dd-9b9e-e5e8040338c4.gif)

[ to-be ]
![sort_11](https://user-images.githubusercontent.com/61657275/227822360-52995515-dbf4-43ab-9f46-f1b5adb6b985.gif)
