### PR TITLE
[#1391] Plot Line > x축, y 축 시작 또는 끝에 있을 때 라인이 생성 되지 않음

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.59",
+  "version": "3.3.60",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -370,9 +370,9 @@ class Scale {
       const xArea = chartRect.chartWidth - (labelOffset.left + labelOffset.right);
       const yArea = chartRect.chartHeight - (labelOffset.top + labelOffset.bottom);
       const padding = aliasPixel + 1;
-      const minX = aPos.x1 + padding;
-      const maxX = aPos.x2;
-      const minY = aPos.y1 + padding; // top
+      const minX = aPos.x1;
+      const maxX = aPos.x2 + padding;
+      const minY = aPos.y1; // top
       const maxY = aPos.y2; // bottom
 
       this.plotBands?.forEach((plotBand) => {
@@ -417,7 +417,7 @@ class Scale {
       });
 
       this.plotLines?.forEach((plotLine) => {
-        if (!plotLine.value) {
+        if (typeof +plotLine.value !== 'number') {
           return;
         }
 

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -372,7 +372,7 @@ class Scale {
       const padding = aliasPixel + 1;
       const minX = aPos.x1;
       const maxX = aPos.x2 + padding;
-      const minY = aPos.y1; // top
+      const minY = aPos.y1 - padding; // top
       const maxY = aPos.y2; // bottom
 
       this.plotBands?.forEach((plotBand) => {


### PR DESCRIPTION
##########################################   
[원인]
-  기존 padding (aliasPixel + 1) 만큼 x 축 시작 부분과, y 축 윗 부분에 더해졌는데 때문에 Plot Line의 x축이 잘려 보이고 y축이 그려지지 않음

[작업 내용]
 - Plot Line이 x, y축 시작 또는 끝에 있더라도 그려지도록 수정
 - Plot Line의 value가 0일 경우 !plotLine.value로 인해 return 되고 그려지지 않았음 아래 value 타입을 참고(bar, scatter, line 동일)하여 date, idx, value가 아닐 경우 retrun 되도록 수정.
![image](https://user-images.githubusercontent.com/61274722/228150560-53747a03-fc91-441e-9869-44500929f789.png)   

**<수정 후>**
![image](https://user-images.githubusercontent.com/61274722/228152199-265acfb5-c233-4c33-804f-4bf388a9561b.png) 
