### PR TITLE
[#1382] Chart > Heatmap > Item Highlight 시 shadow 안쪽으로 그려지는 현상 수정

### DIFF
--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -469,10 +469,10 @@ class HeatMap {
     const gdata = item.data;
     const ctx = context;
 
-    let x = gdata.xp;
-    let y = gdata.yp;
-    let w = gdata.w;
-    let h = gdata.h;
+    const x = gdata.xp;
+    const y = gdata.yp;
+    const w = gdata.w;
+    const h = gdata.h;
     const cId = gdata.cId;
 
     let isShow;
@@ -484,7 +484,6 @@ class HeatMap {
     } else {
       isShow = this.colorState.find(({ id }) => id === cId)?.show;
     }
-
     ctx.save();
     ctx.shadowOffsetX = 0;
     ctx.shadowOffsetY = 0;
@@ -495,17 +494,6 @@ class HeatMap {
       ctx.shadowColor = Util.colorStringToRgba('#959494');
       ctx.strokeStyle = color;
       ctx.fillStyle = color;
-
-      if (this.stroke.show) {
-        const { lineWidth } = this.stroke;
-        if (lineWidth < w && lineWidth < h) {
-          ctx.lineWidth = lineWidth;
-          x += (lineWidth * 0.5);
-          y += (lineWidth * 0.5);
-          w -= (lineWidth);
-          h -= (lineWidth);
-        }
-      }
 
       this.drawItem(ctx, x - 0.5, y - 0.5, w + 1, h + 1, this.stroke);
 


### PR DESCRIPTION
이슈
-
1. Item Highlight 시 기존 item 크기보다 작게 그려지는 현상
   ![image](https://user-images.githubusercontent.com/75718910/227819081-f694f66c-6ccf-4317-9b4d-19edcd6edca7.png)

재현 방법
-
1.  Heatmap 예제 중 stroke 옵션의 use: true, lineWidth: 10 이상 으로 할 경우 확인 가능

예상 원인
-
1. itemHightlight 로직에서 stroke를 사용할 경우 x, y point에서 lineWidth만큼 빼서 계산하는 로직

작업 내용
- 
1. itemHighlight 함수에서 lineWidth 계산하는 로직 제거