### PR TITLE
[#1395] Chart > heatMap > redraw 호출 시 Scrollbar에 변경된 옵션으로 적용 되지 않는 현상 발생

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.61",
+  "version": "3.3.62",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -182,6 +182,7 @@ class EvChart {
     this.drawSeries(hitInfo);
 
     if (this.scrollbar?.x?.use || this.scrollbar?.y?.use) {
+      this.initScrollbar();
       this.updateScrollbarPosition();
     }
 

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -24,13 +24,12 @@ const module = {
    */
   initScrollbarInfo(axisOpt, dir) {
     const scrollbarOpt = this.scrollbar[dir];
+    const merged = defaultsDeep({}, axisOpt?.[0]?.scrollbar, AXIS_OPTION.scrollbar);
+    Object.keys(merged).forEach((key) => {
+      scrollbarOpt[key] = merged[key];
+    });
 
     if (!scrollbarOpt.isInit) {
-      const merged = defaultsDeep({}, axisOpt?.[0]?.scrollbar, AXIS_OPTION.scrollbar);
-      Object.keys(merged).forEach((key) => {
-        scrollbarOpt[key] = merged[key];
-      });
-
       scrollbarOpt.type = axisOpt?.[0]?.type;
       scrollbarOpt.range = axisOpt?.[0]?.range || null;
 
@@ -505,7 +504,7 @@ const module = {
       scrollbarYDOM.addEventListener('click', this.onScrollbarClick);
       scrollbarYDOM.addEventListener('mousedown', this.onScrollbarDown);
       scrollbarYDOM.addEventListener('mouseleave', this.onScrollbarLeave);
-      this.overlayCanvas?.addEventListener('wheel', this.onScrollbarWheel);
+      this.overlayCanvas?.addEventListener('wheel', this.onScrollbarWheel, { passive: false });
     }
   },
 
@@ -620,7 +619,7 @@ const module = {
       this.scrollbar[dir] = { isInit: false };
 
       if (dir === 'y') {
-        this.overlayCanvas?.removeEventListener('wheel', this.onScrollbarWheel, false);
+        this.overlayCanvas?.removeEventListener('wheel', this.onScrollbarWheel, { passive: false });
       }
     }
   },


### PR DESCRIPTION
## 이슈 개요
- chart.redraw 호출 시 변경 된 옵션으로 scrollbar가 그려지지 않음
- (이슈 상세) https://github.com/ex-em/EVUI/issues/1395

## 처리 내용
- chart draw시 호출되는 scrollbar 관련 로직에서 Scrollbar의 스타일을 적용하는데, 
이전에 새로운 차트 옵션으로 적용될 수 있도록 로직 개선
- wheel 이벤트 관련 warning 픽스
   - ![image](https://user-images.githubusercontent.com/53548023/232001537-df023429-8fac-471d-9608-5fd1f9d4f5bd.png)
- **`Version Update (3.3.61 -> 3.3.62)`**

## Before / After
- Before
   - ![scrollbar_bug](https://user-images.githubusercontent.com/53548023/232001623-af2df70e-d0ba-428c-bd76-1070e4ba8118.gif)

- After
   - ![scrollbar_bug_fix](https://user-images.githubusercontent.com/53548023/232001590-53c61883-eee6-4877-937d-8334f8f69252.gif)