### PR TITLE
[#1397] Chart > HeatMap > 차트 영역 외의 영역 클릭하면 전체 item 흐리게 처리되는 현상 수정

### DIFF
--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -241,13 +241,16 @@ const modules = {
             const { useBothAxis } = selectLabelOpt;
             const location = this.getClickedLocation(offset);
 
-            if (!useBothAxis && location !== 'chartBackground') {
+            if ((location === 'yAxis' || location === 'xAxis') && !useBothAxis) {
               const selectLabelAxis = isHorizontal ? 'yAxis' : 'xAxis';
               if (location !== selectLabelAxis) {
                 return;
               }
             }
-            setSelectedLabelInfo(useBothAxis ? location : null);
+
+            if (location !== 'canvas') {
+              setSelectedLabelInfo(useBothAxis ? location : null);
+            }
           }
           break;
         }
@@ -568,8 +571,7 @@ const modules = {
    * get formatted value for tooltip
    * @param seriesName
    * @param value
-   * @param x
-   * @param y
+   * @param itemData
    * @returns {string}
    */
   getFormattedTooltipValue({ seriesName, value, itemData }) {


### PR DESCRIPTION
이슈
-
HeatMap > 스크롤 우측 클릭하면 전체 item 흐리게 처리되는 현상 수정

재현 스텝
-
1. Select Label 옵션만 use: true로 변경 (SelectItem은 use: false)
2. 차트 외부 영역 클릭
3. item opacity 확인

예상 원인
-
차트 외 영역 클릭했을 때 예외 처리 없음

작업 내용
-
1. 차트 내부 영역만 클릭했을 때 SelectLabelItem 찾도록 예외처리

` AS-IS`

![heatmap_scroll_bug](https://user-images.githubusercontent.com/75718910/233521758-c0e34974-033d-44b7-801e-6523c24e5540.gif)

` TO-BE`

![heatmap_scroll_bug_fix](https://user-images.githubusercontent.com/75718910/233521743-825be58b-768e-4adc-8756-8e57159417f6.gif)

2. 함수 파라미터 warning 제거