### PR TITLE
[#1402] Grid > 브라우저 배율 변경 시, adjust 상태에서 스크롤 생기는 이슈

### DIFF
--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -178,6 +178,7 @@ export const resizeEvent = (params) => {
       let elWidth = bodyEl.offsetWidth;
       const elHeight = bodyEl.offsetHeight;
       const rowHeight = bodyEl.querySelector('tr')?.offsetHeight || resizeInfo.rowHeight;
+      const scrollWidth = elWidth - bodyEl.clientWidth;
 
       const result = stores.orderedColumns.reduce((acc, cur) => {
         if (cur.hide) {
@@ -196,7 +197,7 @@ export const resizeEvent = (params) => {
       }, { totalWidth: 0, emptyCount: 0 });
 
       if (rowHeight * props.rows.length > elHeight) {
-        elWidth -= resizeInfo.scrollWidth;
+        elWidth -= scrollWidth;
       }
 
       if (checkInfo.useCheckbox.use) {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -193,7 +193,8 @@ export const resizeEvent = (params) => {
         return acc;
       }, { totalWidth: 0, emptyCount: 0 });
 
-      if (resizeInfo.rowHeight * props.rows.length > elHeight) {
+      const rowHeight = bodyEl.querySelector('tr')?.offsetHeight || resizeInfo.rowHeight;
+      if (rowHeight * props.rows.length > elHeight) {
         elWidth -= resizeInfo.scrollWidth;
       }
 

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -177,6 +177,8 @@ export const resizeEvent = (params) => {
       const bodyEl = elementInfo.body;
       let elWidth = bodyEl.offsetWidth;
       const elHeight = bodyEl.offsetHeight;
+      const rowHeight = bodyEl.querySelector('tr')?.offsetHeight || resizeInfo.rowHeight;
+
       const result = stores.orderedColumns.reduce((acc, cur) => {
         if (cur.hide) {
           return acc;
@@ -193,7 +195,6 @@ export const resizeEvent = (params) => {
         return acc;
       }, { totalWidth: 0, emptyCount: 0 });
 
-      const rowHeight = bodyEl.querySelector('tr')?.offsetHeight || resizeInfo.rowHeight;
       if (rowHeight * props.rows.length > elHeight) {
         elWidth -= resizeInfo.scrollWidth;
       }


### PR DESCRIPTION
### 이슈 내용
브라우저 배율 변경 시 그리드 row(=`<tr>`)의 width와 height가 같이 변경됩니다.

칼럼(=`<td>`) 너비 조정을 위해(옵션 adjust: true)
스크롤 여부를 확인하는 로직에서 row의 height를 고정 값(=옵션에서 설정한 값)으로 가지고 있어,
스크롤이 있는데 없다고 판별하여
칼럼 너비 계산에 오차가 생기는 이슈 발생하였습니다.

### 수정 내용
row(=`<tr>`)의 실제 height 가져오도록 수정