### PR TITLE
[#1404] Select > filterable 기능 개선

### DIFF
--- a/docs/views/select/example/Default.vue
+++ b/docs/views/select/example/Default.vue
@@ -192,6 +192,26 @@ export default {
         name: 'name33',
         value: 'value33',
       },
+      {
+        name: '인스턴스 A',
+        value: 'instance A',
+      },
+      {
+        name: '인스턴스 B',
+        value: 'instance B',
+      },
+      {
+        name: '인스턴트 식품',
+        value: 'instant grocery',
+      },
+      {
+        name: 'A 인스턴스',
+        value: 'A instance',
+      },
+      {
+        name: 'B 인스턴스',
+        value: 'B instance',
+      },
     ]);
     const isDisabled = ref(true);
     const disableSelect = () => { isDisabled.value = !isDisabled.value; };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "core-js": "^3.6.5",
     "dayjs": "^1.10.4",
+    "korean-regexp": "^1.0.10",
     "vue": "^3.0.0",
     "vue-resize-observer": "^2.0.15",
     "vue3-observe-visibility": "^0.1.2",

--- a/src/components/select/uses.js
+++ b/src/components/select/uses.js
@@ -2,6 +2,11 @@ import {
   ref, reactive, computed, watch,
   nextTick, getCurrentInstance,
 } from 'vue';
+import {
+  getRegExp,
+  engToKor,
+  korToEng,
+} from 'korean-regexp';
 
 export const useModel = () => {
   const { props, emit } = getCurrentInstance();
@@ -124,7 +129,14 @@ export const useDropdown = (param) => {
       return props.items;
     }
     const trimText = filterTextRef.value?.trim();
-    return props.items.filter(v => v.name.toUpperCase().includes(trimText.toUpperCase())) || [];
+    const korean = engToKor(trimText);
+    const eng = korToEng(trimText);
+
+    return props.items.filter(({ name }) => (
+      name.search(getRegExp(trimText)) > -1
+        || name.search(getRegExp(korean)) > -1
+        || name.search(getRegExp(eng)) > -1
+        ));
   });
 
   /**


### PR DESCRIPTION
도입 배경
-
네이버 FE 뉴스에 나온 항목 중에 EVUI 에 적용하면 괜찮겠다 싶은 라이브러리가 있어서 적용해보았습니다.
https://github.com/naver/fe-news/blob/master/issues/2023-05.md#%ED%95%9C%EA%B8%80-%EC%9E%90%EB%8F%99%EC%99%84%EC%84%B1%EC%9D%84-%EC%9C%84%ED%95%9C-%EC%A0%95%EA%B7%9C%EC%8B%9D

기대 효과
-
한글 입력시 자음만 입력되거나 입력이 완료되지 않은 글자에도 자동완성 비슷하게 검색되어 필터 리스트에 추가됨
한글로 된 내용을 검색하는 중에 올바른 내용을 조회하는 중에, 필터된 목록에서 사라지는 현상 개선됨
한/영 키를 잘못 누른 상태에서 입력된 텍스트에 대해서도 검색이 됨

작업 내용
-
1. `korean-regexp` 를 dependencies 에 추가
2. 입력된 텍스트를 필터링 하는 곳에 동적으로 regex 를 생성하여 한글이 필터링 되도록 함.
3. 영문과 한글로 오입력된 텍스트도 검색이 되도록 조건 추가.

**Before**
![before](https://github.com/ex-em/EVUI/assets/46586573/4b834a8d-761e-45c2-89a4-32a867e81db1)

**After**
![dynamic regex](https://github.com/ex-em/EVUI/assets/46586573/e4c524cf-2461-4fc5-8fd9-7d4948c4ed69)
![invalid language convert](https://github.com/ex-em/EVUI/assets/46586573/ac584853-1752-492a-856c-495955e1b166)
