### PR TITLE
[#1416] MarkdownView > heading 태그에 링크 연결 시 header에 가려지는 현상 수정

### DIFF
--- a/docs/components/MarkdownView.vue
+++ b/docs/components/MarkdownView.vue
@@ -346,6 +346,7 @@ export default {
 .markdown h6 {
   margin-bottom: 0;
   margin-top: 0;
+  scroll-margin-top: 80px;
 }
 
 .markdown h1 {


### PR DESCRIPTION
##########

- MarkdownView.vue > .markdown h1 ~ h6에 scroll-margin-top: 80px; 추가