### PR TITLE
[#1420] Chart > Scatter > drag가 불가능한 mobile을 위한 selection 기능 추가

### DIFF
--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -183,8 +183,10 @@ const chartData =
 | --- | ---- | ----- | --- | ----------|
 | use | Boolean | false | drag-select 사용 여부 | true / false |
 | keepDisplay | Boolean | true | 드래그 후 선택영역 유지 여부  | true / false  |
+| size | number | 50 | 모바일에서 선택 영역 크기 | only mobile |
 | fillColor | Hex, RGB, RGBA Code(String) | '#38ACEC' | 선택 영역 색상 | |
 | opacity | Number | 0.65 | 선택 영역 불투명도 | 0 ~ 1 |
+* PC버전에서는 drag, Mobile에서는 touch로 선택 영역을 지정할 수 있습니다.
 
 #### tooltip
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/scatterChart/example/Event.vue
+++ b/docs/views/scatterChart/example/Event.vue
@@ -61,7 +61,7 @@
 </template>
 
 <script>
-  import { ref, reactive } from 'vue';
+  import { ref } from 'vue';
   import dayjs from 'dayjs';
 
   export default {
@@ -97,7 +97,7 @@
         },
       };
 
-      const chartOptions = reactive({
+      const chartOptions = {
         type: 'scatter',
         width: '100%',
         title: {
@@ -128,7 +128,7 @@
         tooltip: {
           use: true,
         },
-      });
+      };
 
       const selectionItems = ref([]);
       const selectionRange = ref({});

--- a/docs/views/scatterChart/example/Event.vue
+++ b/docs/views/scatterChart/example/Event.vue
@@ -61,7 +61,7 @@
 </template>
 
 <script>
-  import { ref } from 'vue';
+  import { ref, reactive, onMounted } from 'vue';
   import dayjs from 'dayjs';
 
   export default {
@@ -97,7 +97,7 @@
         },
       };
 
-      const chartOptions = {
+      const chartOptions = reactive({
         type: 'scatter',
         width: '100%',
         title: {
@@ -128,7 +128,7 @@
         tooltip: {
           use: true,
         },
-      };
+      });
 
       const selectionItems = ref([]);
       const selectionRange = ref({});
@@ -137,7 +137,6 @@
         selectionItems.value = data;
         selectionRange.value = range;
       };
-
 
       const dblClickedInfo = ref(null);
       const onDblClick = ({ e, label, value, sId }) => {
@@ -149,11 +148,27 @@
         clickedInfo.value = { e, label, value, sId };
 
         // Clear drag selection info
-        selectionItems.value = [];
-        selectionRange.value = {};
+        if (e.pointerType === 'mouse') {
+          selectionItems.value = [];
+          selectionRange.value = {};
+        }
       };
 
       const getDateString = x => dayjs(x).format('HH:mm:ss');
+
+      const mobileCheck = () => (
+          /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+            navigator.userAgent,
+          )
+          || 'ontouchstart' in window
+          || navigator.maxTouchPoints
+        );
+
+      onMounted(() => {
+        if (mobileCheck()) {
+          chartOptions.dragSelection.keepDisplay = false;
+        }
+      });
 
       return {
         chartData,

--- a/docs/views/scatterChart/example/Event.vue
+++ b/docs/views/scatterChart/example/Event.vue
@@ -61,7 +61,7 @@
 </template>
 
 <script>
-  import { ref, reactive, onMounted } from 'vue';
+  import { ref, reactive } from 'vue';
   import dayjs from 'dayjs';
 
   export default {
@@ -155,20 +155,6 @@
       };
 
       const getDateString = x => dayjs(x).format('HH:mm:ss');
-
-      const mobileCheck = () => (
-          /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-            navigator.userAgent,
-          )
-          || 'ontouchstart' in window
-          || navigator.maxTouchPoints
-        );
-
-      onMounted(() => {
-        if (mobileCheck()) {
-          chartOptions.dragSelection.keepDisplay = false;
-        }
-      });
 
       return {
         chartData,

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -136,3 +136,17 @@ export function getPrecision(v) {
 export function checkNullAndUndefined(value) {
   return value === null || value === undefined;
 }
+
+/**
+ * Check if the device is mobile
+ * @returns {boolean}
+ */
+export function mobileCheck() {
+  return (
+    /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+      navigator.userAgent,
+    )
+    || 'ontouchstart' in window
+    || navigator.maxTouchPoints
+  );
+}

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -846,7 +846,7 @@ class EvChart {
   overlayClear() {
     this.clearRectRatio = (this.pixelRatio < 1) ? this.pixelRatio : 1;
 
-    this.overlayCtx.clearRect(0, 0, this.overlayCanvas?.width / this.clearRectRatio,
+    this.overlayCtx.clearRect(0, 0, this.overlayCanvas.width / this.clearRectRatio,
       this.overlayCanvas?.height / this.clearRectRatio);
   }
 
@@ -941,6 +941,7 @@ class EvChart {
       this.overlayCanvas.removeEventListener('click', this.onClick);
       this.overlayCanvas.removeEventListener('mousedown', this.onMouseDown);
       this.overlayCanvas.removeEventListener('wheel', this.onWheel);
+      window.removeEventListener('click', this.dragTouchSelectionEvent);
     }
 
     if (this.options.tooltip.use) {

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -879,7 +879,6 @@ class EvChart {
    * @returns {undefined}
    */
   resize(promiseRes) {
-    this.isMobile = mobileCheck();
     this.clear();
     this.bufferCtx.restore();
     this.bufferCtx.save();

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -847,7 +847,7 @@ class EvChart {
     this.clearRectRatio = (this.pixelRatio < 1) ? this.pixelRatio : 1;
 
     this.overlayCtx.clearRect(0, 0, this.overlayCanvas.width / this.clearRectRatio,
-      this.overlayCanvas?.height / this.clearRectRatio);
+      this.overlayCanvas.height / this.clearRectRatio);
   }
 
   /**

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -1,4 +1,5 @@
 import throttle from '@/common/utils.throttle';
+import { mobileCheck } from '@/common/utils';
 import Model from './model';
 import TimeScale from './scale/scale.time';
 import LinearScale from './scale/scale.linear';
@@ -40,6 +41,7 @@ class EvChart {
       Object.assign(this, GradientLegend);
     }
 
+    this.isMobile = mobileCheck();
     this.brushSeries = brushSeries;
     this.target = target;
     this.data = data;
@@ -844,8 +846,8 @@ class EvChart {
   overlayClear() {
     this.clearRectRatio = (this.pixelRatio < 1) ? this.pixelRatio : 1;
 
-    this.overlayCtx.clearRect(0, 0, this.overlayCanvas.width / this.clearRectRatio,
-      this.overlayCanvas.height / this.clearRectRatio);
+    this.overlayCtx.clearRect(0, 0, this.overlayCanvas?.width / this.clearRectRatio,
+      this.overlayCanvas?.height / this.clearRectRatio);
   }
 
   /**
@@ -877,6 +879,7 @@ class EvChart {
    * @returns {undefined}
    */
   resize(promiseRes) {
+    this.isMobile = mobileCheck();
     this.clear();
     this.bufferCtx.restore();
     this.bufferCtx.save();

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -288,16 +288,16 @@ const modules = {
               || e.layerY < touchInfo.range.y1
               || e.layerX > touchInfo.range.x2
               || e.layerY > touchInfo.range.y2)) {
-              this.isOverlay = false;
+              this.isTouchOverlay = false;
             } else {
               touchInfo = this.setTouchBoxDimensions(touchInfo);
-              this.isOverlay = true;
+              this.isTouchOverlay = true;
               this.drawSelectionArea(touchInfo);
             }
 
             if (!this.options.dragSelection.keepDisplay) {
               setTimeout(() => {
-                this.isOverlay = false;
+                this.isTouchOverlay = false;
                 this.overlayClear();
               }, 100);
             }
@@ -356,7 +356,8 @@ const modules = {
     this.overlayCanvas.addEventListener('click', this.onClick);
     this.overlayCanvas.addEventListener('mousedown', this.onMouseDown);
 
-    window.addEventListener('click', e => this.dragTouchSelectionDestroy(e));
+    this.dragTouchSelectionEvent = e => this.dragTouchSelectionDestroy(e);
+    window.addEventListener('click', this.dragTouchSelectionEvent);
   },
 
   /**
@@ -681,9 +682,9 @@ const modules = {
     if (
       this.options.dragSelection?.use
       && e.target !== this.overlayCanvas
-      && this.isOverlay
+      && this.isTouchOverlay
     ) {
-      this.isOverlay = false;
+      this.isTouchOverlay = false;
       this.overlayClear();
     }
   },

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -15,7 +15,7 @@ const modules = {
      * @returns {undefined}
      */
     this.onMouseMove = (e) => {
-      if (this.dragInfo?.isMove) {
+      if (this.dragInfo?.isMove || this.isMobile) {
         return;
       }
 
@@ -265,11 +265,46 @@ const modules = {
           break;
         }
 
-        case 'pie':
+        case 'pie': {
+          if (useSelectItem) {
+            setSelectedItemInfo();
+          }
+
+          break;
+        }
+
         case 'scatter': {
           if (useSelectItem) {
             setSelectedItemInfo();
           }
+
+          // 모바일용 dragSelection
+          if (this.options.dragSelection?.use && this.isMobile) {
+            let touchInfo = this.setTouchInfo(e);
+            this.overlayClear();
+
+            if (!this.options.dragSelection.keepDisplay
+              && (e.layerX < touchInfo.range.x1
+              || e.layerY < touchInfo.range.y1
+              || e.layerX > touchInfo.range.x2
+              || e.layerY > touchInfo.range.y2)) {
+              this.isOverlay = false;
+            } else {
+              touchInfo = this.setTouchBoxDimensions(touchInfo);
+              this.isOverlay = true;
+              this.drawSelectionArea(touchInfo);
+            }
+
+            args.e = e;
+            args.touchInfo = touchInfo;
+            args.data = this.findSelectedItems(touchInfo);
+            args.range = this.getSelectionRange(touchInfo);
+
+            if (typeof this.listeners['drag-select'] === 'function') {
+              this.listeners['drag-select'](args);
+            }
+          }
+
           break;
         }
       }
@@ -313,6 +348,8 @@ const modules = {
     this.overlayCanvas.addEventListener('dblclick', this.onDblClick);
     this.overlayCanvas.addEventListener('click', this.onClick);
     this.overlayCanvas.addEventListener('mousedown', this.onMouseDown);
+
+    window.addEventListener('click', e => this.dragTouchSelectionDestroy(e));
   },
 
   /**
@@ -549,6 +586,100 @@ const modules = {
     }
 
     return curMouseTargetVal;
+  },
+
+  /**
+   * Processes touch event to determine touch position within the chart.
+   *
+   * @param {TouchEvent} event - the touch event to process
+   * @returns {object} - the processed touch information
+   */
+  setTouchInfo(event) {
+    let [offsetX, offsetY] = this.getMousePosition(event);
+    const chartRect = this.chartRect;
+    const labelOffset = this.labelOffset;
+    const range = {
+      x1: chartRect.x1 + labelOffset.left,
+      x2: chartRect.x2 - labelOffset.right,
+      y1: chartRect.y1 + labelOffset.top,
+      y2: chartRect.y2 - labelOffset.bottom,
+    };
+
+    offsetX = Math.max(range.x1, Math.min(offsetX, range.x2));
+    offsetY = Math.max(range.y1, Math.min(offsetY, range.y2));
+
+    return {
+      xcp: offsetX,
+      ycp: offsetY,
+      range,
+    };
+  },
+
+  /**
+   * Adjusts the touch box dimensions based on the provided touch information.
+   *
+   * @param {object} touchInfo - The touch information including touch position and plotting range
+   * @returns {object} - The adjusted touch information
+   */
+  setTouchBoxDimensions(touchInfo) {
+    const boxSize = this.options.dragSelection?.size || 50;
+    const halfBoxSize = boxSize / 2;
+    const { xcp, ycp, range } = touchInfo;
+    let xsp = xcp - halfBoxSize;
+    let ysp = ycp - halfBoxSize;
+    let width = boxSize;
+    let height = boxSize;
+
+    this.boxOverflow = {
+      x1: false,
+      x2: false,
+      y1: false,
+      y2: false,
+    };
+
+    if (xcp < range.x1 + halfBoxSize) {
+      xsp = range.x1;
+      width = halfBoxSize - (range.x1 - xcp);
+      this.boxOverflow.x1 = true;
+    }
+    if (xcp > range.x2 - halfBoxSize) {
+      width = halfBoxSize - (xcp - range.x2);
+      this.boxOverflow.x2 = true;
+    }
+    if (ycp < range.y1 + halfBoxSize) {
+      ysp = range.y1;
+      height = halfBoxSize - (range.y1 - ycp);
+      this.boxOverflow.y1 = true;
+    }
+    if (ycp > range.y2 - halfBoxSize) {
+      height = halfBoxSize - (ycp - range.y2);
+      this.boxOverflow.y2 = true;
+    }
+
+    touchInfo.xsp = xsp;
+    touchInfo.ysp = ysp;
+    touchInfo.width = width;
+    touchInfo.height = height;
+
+    return touchInfo;
+  },
+
+  /**
+   * Handles the termination of a touch selection.
+   *
+   * @param {TouchEvent} e - the touch event to process
+   * @returns {undefined}
+   */
+  dragTouchSelectionDestroy(e) {
+    if (
+      this.options.dragSelection?.use
+      && e.target !== this.overlayCanvas
+      && this.isOverlay
+      && !this.options.dragSelection?.keepDisplay
+    ) {
+      this.isOverlay = false;
+      this.overlayClear();
+    }
   },
 
   /**
@@ -952,16 +1083,24 @@ const modules = {
     const yMinRatio = this.getRatioInRange(range.y1, range.y2, yep);
     const yMaxRatio = this.getRatioInRange(range.y1, range.y2, ysp);
 
-    const xMin = dataRangeX.graphMin + graphWidth * xMinRatio;
-    const xMax = dataRangeX.graphMin + graphWidth * xMaxRatio;
-    const yMin = dataRangeY.graphMin + graphHeight * (1 - yMinRatio);
-    const yMax = dataRangeY.graphMin + graphHeight * (1 - yMaxRatio);
+    const xMin = this.isMobile && this.boxOverflow?.x1
+      ? Math.min(this.minMax.x[0].min, dataRangeX.graphMin)
+      : Math.max(dataRangeX.graphMin + graphWidth * xMinRatio, dataRangeX.graphMin);
+    const xMax = this.isMobile && this.boxOverflow?.x2
+      ? Math.max(this.minMax.x[0].max, dataRangeX.graphMax)
+      : Math.min(dataRangeX.graphMin + graphWidth * xMaxRatio, dataRangeX.graphMax);
+    const yMin = this.isMobile && this.boxOverflow?.y2
+      ? Math.min(this.minMax.y[0].min, dataRangeY.graphMin)
+      : Math.max(dataRangeY.graphMin + graphHeight * (1 - yMinRatio), dataRangeY.graphMin);
+    const yMax = this.isMobile && this.boxOverflow?.y1
+      ? Math.max(this.minMax.y[0].max, dataRangeY.graphMax)
+      : Math.min(dataRangeY.graphMin + graphHeight * (1 - yMaxRatio), dataRangeY.graphMax);
 
     return {
-      xMin: Math.max(+parseFloat(xMin).toFixed(3), dataRangeX.graphMin),
-      xMax: Math.min(+parseFloat(xMax).toFixed(3), dataRangeX.graphMax),
-      yMin: Math.max(+parseFloat(yMin).toFixed(3), dataRangeY.graphMin),
-      yMax: Math.min(+parseFloat(yMax).toFixed(3), dataRangeY.graphMax),
+      xMin: +xMin.toFixed(3),
+      xMax: +xMax.toFixed(3),
+      yMin: +yMin.toFixed(3),
+      yMax: +yMax.toFixed(3),
     };
   },
 

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -283,7 +283,7 @@ const modules = {
             let touchInfo = this.setTouchInfo(e);
             this.overlayClear();
 
-            if (!this.options.dragSelection.keepDisplay
+            if (this.options.dragSelection.keepDisplay
               && (e.layerX < touchInfo.range.x1
               || e.layerY < touchInfo.range.y1
               || e.layerX > touchInfo.range.x2
@@ -293,6 +293,13 @@ const modules = {
               touchInfo = this.setTouchBoxDimensions(touchInfo);
               this.isOverlay = true;
               this.drawSelectionArea(touchInfo);
+            }
+
+            if (!this.options.dragSelection.keepDisplay) {
+              setTimeout(() => {
+                this.isOverlay = false;
+                this.overlayClear();
+              }, 100);
             }
 
             args.e = e;
@@ -665,7 +672,7 @@ const modules = {
   },
 
   /**
-   * Handles the termination of a touch selection.
+   * Remove a touch selection.
    *
    * @param {TouchEvent} e - the touch event to process
    * @returns {undefined}
@@ -675,7 +682,6 @@ const modules = {
       this.options.dragSelection?.use
       && e.target !== this.overlayCanvas
       && this.isOverlay
-      && !this.options.dragSelection?.keepDisplay
     ) {
       this.isOverlay = false;
       this.overlayClear();

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -181,6 +181,7 @@ const DEFAULT_OPTIONS = {
   dragSelection: {
     use: false,
     keepDisplay: true,
+    size: 50,
     fillColor: '#38ACEC',
     opacity: 0.65,
   },


### PR DESCRIPTION
###############

- mobile에서 drag가 UX적으로 좋지 않기에 기존 dragSelection에 내부 로직을 통해 mobile인지 감지하고, mobile일 경우 click했을 때 특정 범위만큼 박스로 선택되는 기능 추가