### PR TITLE
[#1431] Grid > 컬럼 show/hide 기능 버그 수정

### DIFF
--- a/docs/views/grid/example/Summary.vue
+++ b/docs/views/grid/example/Summary.vue
@@ -11,6 +11,7 @@
         adjust: true,
         rowHeight: 45,
         useFilter: false,
+        useColumnSetting: true,
         useCheckbox: {
           use: true,
           mode: 'multi',

--- a/src/components/checkbox/Checkbox.vue
+++ b/src/components/checkbox/Checkbox.vue
@@ -16,7 +16,7 @@
       :readonly="readonly"
       @change="changeMv"
     />
-    <span class="ev-checkbox-label">
+    <span class="ev-checkbox-label" :title="label">
       <template v-if="$slots.default">
         <slot />
       </template>

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -152,7 +152,7 @@
                       :style="{
                         height: `${rowHeight}px`,
                         'line-height': `${rowHeight}px`,
-                        visibility: !!sortOrder ? hidden : true,
+                        visibility: !!sortOrder ? column.hidden : true,
                       }"
                     />
                   </template>
@@ -667,8 +667,8 @@ export default {
       () => {
         sortInfo.isSorting = false;
         sortInfo.sortField = '';
-        initColumnSettingInfo();
         setSort();
+        initColumnSettingInfo();
       }, { deep: true },
     );
     watch(

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -327,7 +327,7 @@
   <!-- Summary -->
   <grid-summary
     v-if="useSummary"
-    :ordered-columns="orderedColumns"
+    :origin-columns="originColumns"
     :stores="stores"
     :use-checkbox="useCheckbox.use"
     :style-option="{
@@ -880,7 +880,6 @@ export default {
       onSearch,
       setColumnSetting,
       onApplyColumn,
-      setColumnHidden,
       onColumnContextMenu,
     };
   },

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -638,6 +638,7 @@ export default {
       stores,
       columnSettingInfo,
       onSearch,
+      onResize,
     });
 
     const {

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -327,7 +327,7 @@
   <!-- Summary -->
   <grid-summary
     v-if="useSummary"
-    :origin-columns="originColumns"
+    :ordered-columns="orderedColumns"
     :stores="stores"
     :use-checkbox="useCheckbox.use"
     :style-option="{

--- a/src/components/grid/grid.columnSetting.vue
+++ b/src/components/grid/grid.columnSetting.vue
@@ -90,7 +90,6 @@ export default {
     const columnList = computed(() => (isSearch.value
       ? searchColumnList.value : originColumnList.value));
     const isDisabled = computed(() => !columnList.value.length);
-
     let timer = null;
     let lastCheckedColumn = null;
 
@@ -158,8 +157,8 @@ export default {
           label: col.caption,
           text: col.field,
         }));
-
       checkColumnGroup.value = originColumnList.value?.map(col => col.label) || [];
+      applyColumnList.value.length = 0;
     };
 
     const hideColumnSetting = () => {
@@ -181,7 +180,7 @@ export default {
 
     watch(() => props.columns, () => {
       setColumns();
-    }, { immediate: true });
+    }, { immediate: true, deep: true });
 
     watch(() => isShowColumnSetting.value, async () => {
       if (!isShowColumnSetting.value) {
@@ -228,7 +227,6 @@ export default {
 </script>
 
 <style lang="scss">
-@import 'style/grid.scss';
 .ev-grid-column-setting {
   position: absolute;
   width: 180px;
@@ -256,7 +254,6 @@ export default {
       padding: 10px 0;
 
       .ev-checkbox-label {
-        display: inline-block;
         width: 120px;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/src/components/grid/grid.columnSetting.vue
+++ b/src/components/grid/grid.columnSetting.vue
@@ -260,6 +260,10 @@ export default {
         white-space: nowrap;
       }
     }
+    .is-empty {
+      height: 30px;
+      text-align: center;
+    }
   }
 
   &__footer {

--- a/src/components/grid/grid.summary.vue
+++ b/src/components/grid/grid.summary.vue
@@ -79,7 +79,7 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    orderedColumns: {
+    originColumns: {
       type: Object,
       default: () => ({}),
     },
@@ -104,7 +104,7 @@ export default {
     const summaryRef = ref();
     const ROW_DATA_INDEX = 2;
     const stores = computed(() => props.stores);
-    const columns = computed(() => props.orderedColumns);
+    const columns = computed(() => props.originColumns);
     const showCheckbox = computed(() => props.useCheckbox);
     const styleInfo = computed(() => props.styleOption);
     const getConvertValue = (column, value) => {
@@ -180,7 +180,7 @@ export default {
         const columnIndex = getColumnIndex(name);
         if (columnIndex >= 0) {
           const value = getSummaryValue(
-            stores.value.orderedColumns[columnIndex],
+            stores.value.originColumns[columnIndex],
             column.summaryType,
           );
           result = result.replace(`{${idx}}`, value);

--- a/src/components/grid/grid.summary.vue
+++ b/src/components/grid/grid.summary.vue
@@ -79,7 +79,7 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    originColumns: {
+    orderedColumns: {
       type: Object,
       default: () => ({}),
     },
@@ -104,7 +104,7 @@ export default {
     const summaryRef = ref();
     const ROW_DATA_INDEX = 2;
     const stores = computed(() => props.stores);
-    const columns = computed(() => props.originColumns);
+    const columns = computed(() => props.orderedColumns);
     const showCheckbox = computed(() => props.useCheckbox);
     const styleInfo = computed(() => props.styleOption);
     const getConvertValue = (column, value) => {
@@ -180,7 +180,7 @@ export default {
         const columnIndex = getColumnIndex(name);
         if (columnIndex >= 0) {
           const value = getSummaryValue(
-            stores.value.originColumns[columnIndex],
+            stores.value.orderedColumns[columnIndex],
             column.summaryType,
           );
           result = result.replace(`{${idx}}`, value);

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -96,6 +96,7 @@
   -webkit-line-clamp: 1;
   font-weight: bold;
   font-size: 14px;
+  cursor: pointer;
 
   @include evThemify() {
     color: evThemed('font-color-base');

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -566,15 +566,15 @@ export const sortEvent = (params) => {
       return;
     }
     const index = getColumnIndex(sortInfo.sortField);
-    const type = stores.orderedColumns[index]?.type || 'string';
+    const type = stores.originColumns[index]?.type || 'string';
     const sortFn = sortInfo.sortOrder === 'desc' ? setDesc : setAsc;
     const numberSortFn = sortInfo.sortOrder === 'desc' ? numberSetDesc : numberSetAsc;
     const getColumnValue = (a, b) => {
       let aCol = a[ROW_DATA_INDEX][index];
       let bCol = b[ROW_DATA_INDEX][index];
       if (a[ROW_DATA_INDEX][index] && typeof a[ROW_DATA_INDEX][index] === 'object') {
-        aCol = a[ROW_DATA_INDEX][index][stores.orderedColumns[index]?.field];
-        bCol = b[ROW_DATA_INDEX][index][stores.orderedColumns[index]?.field];
+        aCol = a[ROW_DATA_INDEX][index][stores.originColumns[index]?.field];
+        bCol = b[ROW_DATA_INDEX][index][stores.originColumns[index]?.field];
       }
       return { aCol, bCol };
     };
@@ -745,7 +745,7 @@ export const contextMenuEvent = (params) => {
         {
           text: 'Hide',
           iconClass: 'ev-icon-visibility-off',
-          disabled: !useColumnSetting.value,
+          disabled: !useColumnSetting.value || stores.orderedColumns.length === 1,
           click: () => setColumnHidden(column.field),
         },
       ];
@@ -920,6 +920,7 @@ export const columnSettingEvent = (params) => {
     }
   };
   const onApplyColumn = (columns) => {
+    columnSettingInfo.hiddenColumn = '';
     stores.filteredColumns = stores.originColumns.filter(cur => columns.includes(cur.field));
     setFilteringColumn();
   };

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -896,6 +896,7 @@ export const columnSettingEvent = (params) => {
     stores,
     columnSettingInfo,
     onSearch,
+    onResize,
   } = params;
   const setColumnSetting = () => {
     columnSettingInfo.isShowColumnSetting = true;
@@ -918,6 +919,7 @@ export const columnSettingEvent = (params) => {
     if (props.option.searchValue) {
       onSearch(props.option.searchValue);
     }
+    onResize();
   };
   const onApplyColumn = (columns) => {
     columnSettingInfo.hiddenColumn = '';

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -923,7 +923,8 @@ export const columnSettingEvent = (params) => {
   };
   const onApplyColumn = (columns) => {
     columnSettingInfo.hiddenColumn = '';
-    stores.filteredColumns = stores.originColumns.filter(cur => columns.includes(cur.field));
+    stores.filteredColumns = stores.originColumns
+      .filter(cur => columns.includes(cur.field) || !cur.caption);
     setFilteringColumn();
   };
   const setColumnHidden = (val) => {


### PR DESCRIPTION
이슈사항
-
1. 컬럼 한개만 있는 경우에도 컬럼명 클릭 시, hide 클릭이 가능함 -> Hide 비활성화 되도록 개선 필요
2. 컬럼 값을 다시 받아오는 경우, 컬럼 목록 설정과 그리드 컬럼과 싱크가 맞지 않는 현상 발생
3. 컬럼 목록 설정 > 컬럼명이 긴 경우 어떤 컬럼명인지 인지하기 어려워 마우스 오버 시, 전체 컬럼명이 보이도록 개선 필요
4. 컬럼명을 클릭하였을 때, 정렬 옵션이 나오므로 컬럼명은 마우스 포인터로 변경 필요
5. 컬럼 숨김한 경우, 일부 컬럼이 정렬이 안되는 현상 발생
6. 단일 컬럼 hide 설정 후, 컬럼 목록 설정에서 설정 시, 단일 컬럼 hide 하였던 컬럼이 컬럼 목록에 반영하지 않는 버그 발생 

수정사항
-
- 컬럼이 1개만 있는 경우, 컬럼 클릭 시, Hide가 비활성화 되도록 수정
- 컬럼값을 새로 받아오는 경우에도 컬럼 목록 설정에 대한 체크 여부를 다시 초기화 시켜주도록 수정
- 컬럼 목록 설정 > 컬럼명 마우스 오버 시, 컬럼명 텍스트 문구가 보여지도록 CheckBox 컴포넌트의 span 태그에 title 속성 추가
- 그리드 헤더 -> 마우스 포인터로 변경
- 정렬 시, show/hide로 필터링된 컬럼이 아닌 기존 컬럼들값을 사용하여 정렬이 되도록 수정
- 컬럼 목록 설정에서 적용 시, 단일 컬럼으로 받아왔던 값을 초기화 시켜주도록 수정