### PR TITLE
[#1444] Grid > sort 버튼 위치 변경

### DIFF
--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -251,7 +251,7 @@ export default {
         click: param => console.log(`[Menu1] Selected Row Data: ${param?.selectedRow}`),
       }, {
         text: 'Menu2',
-        click: () => console.log('[Menu2]', contextmenuInfo.value),
+        click: param => console.log('[Menu2]', param.contextMenuInfo),
       },
     ]);
     const highlightMV = ref(-1);

--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -3,7 +3,6 @@
     <ev-grid
       v-model:selected="selected"
       v-model:checked="checked"
-      v-model:contextmenuInfo="contextmenuInfo"
       :columns="columns"
       :rows="tableData"
       :width="widthMV"
@@ -227,7 +226,6 @@ export default {
   setup() {
     const tableData = ref([]);
     const selected = ref([]);
-    const contextmenuInfo = ref([]);
     const checked = ref([]);
     const widthMV = ref('100%');
     const heightMV = ref(300);
@@ -251,7 +249,7 @@ export default {
         click: param => console.log(`[Menu1] Selected Row Data: ${param?.selectedRow}`),
       }, {
         text: 'Menu2',
-        click: param => console.log('[Menu2]', param.contextMenuInfo),
+        click: param => console.log('[Menu2]', param.contextmenuInfo),
       },
     ]);
     const highlightMV = ref(-1);
@@ -332,7 +330,6 @@ export default {
 
     tableData.value = getData(50, 0);
     return {
-      contextmenuInfo,
       columns,
       tableData,
       selected,

--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -3,6 +3,7 @@
     <ev-grid
       v-model:selected="selected"
       v-model:checked="checked"
+      v-model:contextmenuInfo="contextmenuInfo"
       :columns="columns"
       :rows="tableData"
       :width="widthMV"
@@ -226,6 +227,7 @@ export default {
   setup() {
     const tableData = ref([]);
     const selected = ref([]);
+    const contextmenuInfo = ref([]);
     const checked = ref([]);
     const widthMV = ref('100%');
     const heightMV = ref(300);
@@ -249,7 +251,7 @@ export default {
         click: param => console.log(`[Menu1] Selected Row Data: ${param?.selectedRow}`),
       }, {
         text: 'Menu2',
-        click: param => console.log('[Menu2]', param),
+        click: () => console.log('[Menu2]', contextmenuInfo.value),
       },
     ]);
     const highlightMV = ref(-1);
@@ -330,6 +332,7 @@ export default {
 
     tableData.value = getData(50, 0);
     return {
+      contextmenuInfo,
       columns,
       tableData,
       selected,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -526,7 +526,7 @@ export default {
       hasHorizontalScrollBar: false,
     });
     const selectInfo = reactive({
-      contextMenuInfo: props.contextmenuInfo,
+      contextmenuInfo: props.contextmenuInfo,
       selectedRow: props.selected,
       useSelect: computed(() => props.option?.useSelection?.use ?? true),
       multiple: computed(() => props.option?.useSelection?.multiple ?? false),

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -426,12 +426,17 @@ export default {
       type: [Array],
       default: () => [],
     },
+    contextmenuInfo: {
+      type: [Array],
+      default: () => [],
+    },
     option: {
       type: Object,
       default: () => ({}),
     },
   },
   emits: {
+    'update:contextmenuInfo': null,
     'update:selected': null,
     'click-row': null,
     'dblclick-row': null,

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -436,7 +436,6 @@ export default {
     },
   },
   emits: {
-    'update:contextmenuInfo': null,
     'update:selected': null,
     'click-row': null,
     'dblclick-row': null,
@@ -527,6 +526,7 @@ export default {
       hasHorizontalScrollBar: false,
     });
     const selectInfo = reactive({
+      contextMenuInfo: props.contextmenuInfo,
       selectedRow: props.selected,
       useSelect: computed(() => props.option?.useSelection?.use ?? true),
       multiple: computed(() => props.option?.useSelection?.multiple ?? false),

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -426,10 +426,6 @@ export default {
       type: [Array],
       default: () => [],
     },
-    contextmenuInfo: {
-      type: [Array],
-      default: () => [],
-    },
     option: {
       type: Object,
       default: () => ({}),

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -68,6 +68,7 @@
   .column-sort__icon {
     position: absolute;
     top: 50%;
+    right: 0;
     width: 24px;
     height: 24px;
     background-size: contain;

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -760,24 +760,13 @@ export const contextMenuEvent = (params) => {
   const onContextMenu = (event) => {
     const target = event.target;
     const rowIndex = target.closest('.row')?.dataset?.index;
-    let clickedRow;
+    let clickedRow = null;
     if (rowIndex) {
       clickedRow = stores.viewStore.find(row => row[ROW_INDEX] === +rowIndex)?.[ROW_DATA_INDEX];
     }
-
-    if (event.target.closest('td')?.classList?.contains('row-contextmenu')) {
+    if (clickedRow) {
       setContextMenu();
       emit('update:contextmenuInfo', [clickedRow]);
-      return;
-    }
-    if (clickedRow) {
-      selectInfo.selectedRow = clickedRow;
-      setContextMenu();
-      emit('update:selected', [clickedRow]);
-    } else {
-      selectInfo.selectedRow = [];
-      setContextMenu(false);
-      emit('update:selected', []);
     }
   };
   return {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -765,7 +765,7 @@ export const contextMenuEvent = (params) => {
       clickedRow = stores.viewStore.find(row => row[ROW_INDEX] === +rowIndex)?.[ROW_DATA_INDEX];
     }
     if (clickedRow) {
-      selectInfo.contextmenuInfo = [clickedRow];
+      selectInfo.contextmenuInfo = clickedRow;
       setContextMenu();
     }
   };

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -357,7 +357,7 @@ export const clickEvent = (params) => {
   let lastIndex = -1;
   const onRowClick = (event, row) => {
     if (event.target.parentElement.classList?.contains('row-checkbox-input')
-      || event.target.closest('td').classList?.contains('row-contextmenu')) {
+      || event.target.closest('td')?.classList?.contains('row-contextmenu')) {
       return false;
     }
     const onMultiSelectByKey = (keyType, selected, selectedRow) => {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -717,7 +717,7 @@ export const contextMenuEvent = (params) => {
           }
 
           menuItem.selectedRow = row ?? [];
-          menuItem.contextMenuInfo = [selectInfo.contextMenuInfo];
+          menuItem.contextmenuInfo = [selectInfo.contextmenuInfo];
 
           return menuItem;
         });
@@ -765,7 +765,7 @@ export const contextMenuEvent = (params) => {
       clickedRow = stores.viewStore.find(row => row[ROW_INDEX] === +rowIndex)?.[ROW_DATA_INDEX];
     }
     if (clickedRow) {
-      selectInfo.contextMenuInfo = [clickedRow];
+      selectInfo.contextmenuInfo = [clickedRow];
       setContextMenu();
     }
   };

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -765,6 +765,11 @@ export const contextMenuEvent = (params) => {
       clickedRow = stores.viewStore.find(row => row[ROW_INDEX] === +rowIndex)?.[ROW_DATA_INDEX];
     }
 
+    if (event.target.closest('td')?.classList?.contains('row-contextmenu')) {
+      setContextMenu();
+      emit('update:contextmenuInfo', [clickedRow]);
+      return;
+    }
     if (clickedRow) {
       selectInfo.selectedRow = clickedRow;
       setContextMenu();

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -691,7 +691,6 @@ export const filterEvent = (params) => {
 };
 
 export const contextMenuEvent = (params) => {
-  const { emit } = getCurrentInstance();
   const {
     contextInfo,
     stores,
@@ -718,6 +717,7 @@ export const contextMenuEvent = (params) => {
           }
 
           menuItem.selectedRow = row ?? [];
+          menuItem.contextMenuInfo = [selectInfo.contextMenuInfo];
 
           return menuItem;
         });
@@ -765,8 +765,8 @@ export const contextMenuEvent = (params) => {
       clickedRow = stores.viewStore.find(row => row[ROW_INDEX] === +rowIndex)?.[ROW_DATA_INDEX];
     }
     if (clickedRow) {
+      selectInfo.contextMenuInfo = [clickedRow];
       setContextMenu();
-      emit('update:contextmenuInfo', [clickedRow]);
     }
   };
   return {


### PR DESCRIPTION
###############
- label 우측이 아닌 컬럼영역의 우측으로 변경
- Row Contextmenu 클릭 시 로우 선택과 무관하게 옵션 클릭 버튼 동작하도록 변경 필요
- revision update