### PR TITLE
[#1446] Chart > Axis > PlotLine > anti alias pixel 적용

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -207,6 +207,7 @@ const chartData = {
 | value | Number(value), Date, Number(Index) | null | 선을 표시할 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
 | color | Hex, RGB, RGBA Code(String) | '#FF0000' | 선 색상 | |
 | segments | Array | null | dash 간격 | [6, 2] |
+| lineWidth | Number | 1 | 선 굵기 |  |
 | label | Object | null | 표시할 label의 스타일을 정의 | ([상세](#plotlabel)) |
 
 ##### plotBand

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -160,6 +160,7 @@ const chartData =
 | value | Number(value), Date, Number(Index) | null | 선을 표시할 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
 | color | Hex, RGB, RGBA Code(String) | '#FF0000' | 선 색상 | |
 | segments | Array | null | dash 간격 | [6, 2] |
+| lineWidth | Number | 1 | 선 굵기 |  |
 | label | Object | null | 표시할 label의 스타일을 정의 | ([상세](#plotlabel)) |
 
 ##### plotBand

--- a/docs/views/lineChart/example/PlotLine.vue
+++ b/docs/views/lineChart/example/PlotLine.vue
@@ -54,6 +54,7 @@ export default {
           color: '#FF0000',
           value: chartData.labels[5],
           segments: [6, 2],
+          lineWidth: 1,
           label: {
             show: true,
             text: 'X Plot Line',
@@ -80,6 +81,7 @@ export default {
           color: '#FF0000',
           value: 50,
           segments: [6, 2],
+          lineWidth: 1,
           label: {
             show: true,
             text: 'Y Plot Line',

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -129,6 +129,7 @@ const chartData =
 | value | Number(value), Date, Number(Index) | null | 선을 표시할 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
 | color | Hex, RGB, RGBA Code(String) | '#FF0000' | 선 색상 | |
 | segments | Array | null | dash 간격 | [6, 2] |
+| lineWidth | Number | 1 | 선 굵기 |  |
 | label | Object | null | 표시할 label의 스타일을 정의 | ([상세](#plotlabel)) |
 
 ##### plotBand

--- a/src/components/chart/helpers/helpers.constant.js
+++ b/src/components/chart/helpers/helpers.constant.js
@@ -127,11 +127,6 @@ export const AXIS_OPTION = {
   },
 };
 
-export const PLOT_LINE_OPTION = {
-  color: '#FF0000',
-  lineWidth: 1,
-};
-
 export const PLOT_LINE_LABEL_OPTION = {
   show: false,
   fontSize: 12,
@@ -145,6 +140,12 @@ export const PLOT_LINE_LABEL_OPTION = {
   textAlign: 'center',
   textOverflow: 'none', // 'none', 'ellipsis'
   maxWidth: null,
+};
+
+export const PLOT_LINE_OPTION = {
+  color: '#FF0000',
+  lineWidth: 1,
+  label: PLOT_LINE_LABEL_OPTION,
 };
 
 export const PLOT_BAND_OPTION = {

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -527,7 +527,7 @@ class Scale {
 
   /**
    * Draw X Plot line
-   * @param {object} dataX         Data's X Position
+   * @param {number} dataX         Data's X Position
    * @param {number} minX          Min X Position
    * @param {number} maxX          Max X Position
    * @param {number} minY          Min Y Position
@@ -544,8 +544,11 @@ class Scale {
       return;
     }
 
-    ctx.moveTo(dataX, maxY);
-    ctx.lineTo(dataX, minY);
+    let dataXPos = dataX;
+    dataXPos += Util.aliasPixel(ctx.lineWidth);
+
+    ctx.moveTo(dataXPos, maxY);
+    ctx.lineTo(dataXPos, minY);
 
     ctx.stroke();
     ctx.restore();
@@ -554,7 +557,7 @@ class Scale {
 
   /**
    * Draw Y Plot line
-   * @param {object} dataY         Data's Y Position
+   * @param {number} dataY         Data's Y Position
    * @param {number} minX          Min X Position
    * @param {number} maxX          Max X Position
    * @param {number} minY          Min Y Position
@@ -571,8 +574,11 @@ class Scale {
       return;
     }
 
-    ctx.moveTo(minX, dataY);
-    ctx.lineTo(maxX, dataY);
+    let dataYPos = dataY;
+    dataYPos += Util.aliasPixel(ctx.lineWidth);
+
+    ctx.moveTo(minX, dataYPos);
+    ctx.lineTo(maxX, dataYPos);
 
     ctx.stroke();
     ctx.restore();


### PR DESCRIPTION
### 이슈 개요 
- Axis > plotLine 기능에서 lineWidth 옵션을 1로 적용할때와 2로 적용할때 두께가 비슷하게 보이는 현상 발생
 - lineWidth: **1**
   -  ![image](https://github.com/ex-em/EVUI/assets/53548023/c6c8770a-5212-4d8f-bb6f-e41940003223)
- lineWidth: **2**
   - ![image](https://github.com/ex-em/EVUI/assets/53548023/dc9381d3-fb29-4a40-9a7c-2d0db8bd9fe7)

   
### 처리 내용
- plot Line 그리기전 안티앨리어싱 로직 추가
- md 파일에 lineWidth 설명 추가
- plotLine > label 옵션 기본값 추가

### 결과
- lineWidth: **1**
   - ![lineWidth1](https://github.com/ex-em/EVUI/assets/53548023/586e71de-d7bf-40f4-a827-96c511031459)
- lineWidth: **2**
   - ![lineWidth2](https://github.com/ex-em/EVUI/assets/53548023/04def913-3275-4712-b8f0-478a2f17c812)


### 기타 
- Anti Alias 관련 참고하면 좋은 링크 첨부합니다. 
   - https://usefulangle.com/post/17/html5-canvas-drawing-1px-crisp-straight-lines
   - https://ui.toast.com/posts/ko_20210526