### PR TITLE
[#1448] Chart > Axis > 시간에 따라 x축이 움직이는 기능 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -139,7 +139,7 @@ const chartData = {
 ##### axesX
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 |-----|------|-------|-----|-----|
-| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부, categoryMode일 때는 작동하지 않음.  | |
+| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부, time type에서만 사용하길 권장.<br>categoryMode일 때는 작동하지 않음. | |
 
 ##### linear type
    - interval (Axis Label 표기를 위한 interval)

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -136,6 +136,11 @@ const chartData = {
   | formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (value) => value + '%' |
   | title | Object | ([상세](#title)) | 라벨의 폰트 스타일을 설정 | |  
 
+##### axesX
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+|-----|------|-------|-----|-----|
+| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부  | |
+
 ##### linear type
    - interval (Axis Label 표기를 위한 interval)
       - 미지정 시 Chart 내부에서 해당 Axis 데이터의 max/min value를 기반으로 interval을 구함

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -139,7 +139,7 @@ const chartData = {
 ##### axesX
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 |-----|------|-------|-----|-----|
-| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부  | |
+| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부, categoryMode일 때는 작동하지 않음.  | |
 
 ##### linear type
    - interval (Axis Label 표기를 위한 interval)
@@ -161,7 +161,10 @@ const chartData = {
       - 축에 표시할 시간 값을 `data`옵션의 `labels`속 값들로 표시할지의 여부
    - range
      - 축의 min 값, max 값을 array로 넘겨줌 ([0, 100])
-      
+   - flow
+     - 시간에 따라 x축 label이 움직일지의 여부
+     - categoryMode일 때는 작동하지 않음.
+
 ##### Logarithmic type
    - logarithmic Type Axis는 Axis의 min max를 로그로 계산하여 자동으로 추가 buffer값을 제공
    - Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -124,6 +124,11 @@ const chartData =
   | formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (value) => value + '%' |
   | title | Object | ([상세](#title)) | 라벨의 폰트 스타일을 설정 | |  
 
+##### axesX
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+|-----|------|-------|-----|-----|
+| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부  | |
+
 ##### time type
    - interval (Axis Label 표기를 위한 interval)
       - 'millisecond', 'second', 'minute', 'hour', 'day', 'week' ,'month', 'quarter', 'year'

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -127,7 +127,7 @@ const chartData =
 ##### axesX
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 |-----|------|-------|-----|-----|
-| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부  | |
+| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부, categoryMode일 때는 작동하지 않음.  | |
 
 ##### time type
    - interval (Axis Label 표기를 위한 interval)
@@ -136,6 +136,9 @@ const chartData =
       - dayjs의 timeFormat 이용 [참고URL](https://day.js.org/docs/en/parse/string-format)
    - categoryMode
       - 축에 표시할 시간 값을 `data`옵션의 `labels`속 값들로 표시할지의 여부
+   - flow
+      - 시간에 따라 x축 label이 움직일지의 여부
+      - categoryMode일 때는 작동하지 않음.
 
 ##### labelStyle
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -127,7 +127,7 @@ const chartData =
 ##### axesX
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 |-----|------|-------|-----|-----|
-| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부, categoryMode일 때는 작동하지 않음.  | |
+| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부, time type에서만 사용하길 권장.<br>categoryMode일 때는 작동하지 않음. | |
 
 ##### time type
    - interval (Axis Label 표기를 위한 interval)

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -92,7 +92,7 @@ const chartData =
 ##### axesX
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 |-----|------|-------|-----|-----|
-| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부, categoryMode일 때는 작동하지 않음.  | |
+| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부, time type에서만 사용하길 권장.<br>categoryMode일 때는 작동하지 않음. | |
 
 ##### time type
    - interval (Axis Label 표기를 위한 interval)

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -89,6 +89,11 @@ const chartData =
   | formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (value) => value + '%' |
   | title | Object | ([상세](#title)) | 라벨의 폰트 스타일을 설정 | |  
 
+##### axesX
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+|-----|------|-------|-----|-----|
+| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부  | |
+
 ##### time type
    - interval (Axis Label 표기를 위한 interval)
       - 'millisecond', 'second', 'minute', 'hour', 'day', 'week' ,'month', 'quarter', 'year'

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -92,13 +92,16 @@ const chartData =
 ##### axesX
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 |-----|------|-------|-----|-----|
-| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부  | |
+| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부, categoryMode일 때는 작동하지 않음.  | |
 
 ##### time type
    - interval (Axis Label 표기를 위한 interval)
       - 'millisecond', 'second', 'minute', 'hour', 'day', 'week' ,'month', 'quarter', 'year'
    - timeFormat
       - dayjs의 timeFormat 이용 [참고URL](https://day.js.org/docs/en/parse/string-format)
+   - flow
+      - 시간에 따라 x축 label이 움직일지의 여부
+      - categoryMode일 때는 작동하지 않음.
 
 ##### linear type
 - interval (Axis Label 표기를 위한 interval)

--- a/docs/views/scatterChart/example/RealTimeScatter.vue
+++ b/docs/views/scatterChart/example/RealTimeScatter.vue
@@ -50,7 +50,7 @@ export default {
       },
     });
 
-    const chartOptions = ref({
+    const chartOptions = {
       type: 'scatter',
       width: '100%',
       height: '100%',
@@ -69,6 +69,7 @@ export default {
           fontFamily: 'Roboto',
           fitDir: 'right',
         },
+        flow: true,
       }],
       axesY: [{
         type: 'linear',
@@ -94,7 +95,7 @@ export default {
         use: true,
         range: 300, // 총 5분, 초 단위
       },
-    });
+    };
 
     let timeoutId;
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -379,12 +379,12 @@ class EvChart {
     return axes.map((axis) => {
       switch (axis.type) {
         case 'linear':
-          return new LinearScale(dir, axis, ctx, options);
+          return new LinearScale(dir, axis, ctx, labels, options);
         case 'time':
           if (axis.categoryMode) {
             return new TimeCategoryScale(dir, axis, ctx, labels, options);
           }
-          return new TimeScale(dir, axis, ctx, options);
+          return new TimeScale(dir, axis, ctx, labels, options);
         case 'log':
           return new LogarithmicScale(dir, axis, ctx);
         case 'step':

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -5,11 +5,6 @@ import Util from '../helpers/helpers.util';
 import { truthyNumber } from '../../../common/utils';
 
 class StepScale extends Scale {
-  constructor(type, axisOpt, ctx, labels, options) {
-    super(type, axisOpt, ctx, options);
-    this.labels = labels;
-  }
-
   /**
    * Calculate min/max value, label and size information for step scale
    * @param {object} minMax       min/max information (unused on step scale)

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -4,12 +4,6 @@ import Scale from './scale';
 import Util from '../helpers/helpers.util';
 
 class TimeCategoryScale extends Scale {
-  constructor(type, axisOpt, ctx, labels, options) {
-    super(type, axisOpt, ctx);
-    this.labels = labels;
-    this.options = options;
-  }
-
   /**
    * Transforming label by designated format
    * @param {number} value       label value


### PR DESCRIPTION
###############

- RTM 차트에서 시간 흐름에 따라 Label 위치가 데이터 위치에 맞게 이동하는 기능 추가.
- RealTimeScatter.vue에 적용.
- axis.categoryMode는 고려하지 않았습니다.
- 만약 x축의 labels.length와 구간을 나누는 steps + 1이 같다면 flow 기능이 적용 안되게 하였습니다.
- options.axesX[0].flow로 설정.

다른 의견 환영 합니다.

예시
![chart_x_flow](https://github.com/ex-em/EVUI/assets/22311883/d9cc27d5-7978-43fc-88ce-fdadf75fb26d)
![chart_x_flow2](https://github.com/ex-em/EVUI/assets/22311883/e6846737-3b3d-4802-9a43-900e8997ff4a)
![chart_x_flow3](https://github.com/ex-em/EVUI/assets/22311883/0fcccc5b-926e-452c-9194-031f3f1d16e2)

Closes #1448 