### PR TITLE
[#1457] Grid > Fixes

### DIFF
--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -74,6 +74,7 @@
 | width | Number | 컬럼 넓이 | ex) 150 | N |
 | searchable | Boolean | 검색 대상 여부 | Boolean | N |
 | sortable | Boolean | 정렬 대상 여부 | Boolean | N |
+| filterable | Boolean | 필터 대상 여부 | Boolean | N |
 | align | String | 사용자 지정 정렬 | 'center', 'left', 'right' | N |
 | decimal | Number | 데이터 타입이 float 일 때 소수점 자리 표시 수 | ex) 0~20 (디폴트: 3 ) | N |
 | summaryType | String | 계산 타입 | 'sum', 'average', 'max', 'min', 'count' | N |

--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -256,7 +256,7 @@ export default {
       },
     ]);
     const columns = ref([
-      { caption: 'Name', field: 'userName', type: 'string', width: 80 },
+      { caption: 'Name', field: 'userName', type: 'string', width: 80, filterable: false },
       { caption: 'Role', field: 'role', type: 'string', width: 80 },
       { caption: 'number', field: 'number', type: 'number', width: 80 },
       { caption: 'Phone', field: 'phone', type: 'string', sortable: false },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/contextMenu/uses.js
+++ b/src/components/contextMenu/uses.js
@@ -35,6 +35,9 @@ export const usePosition = () => {
     top: null,
     left: null,
     right: null,
+    pageY: null,
+    pageX: null,
+    clientX: null,
   });
 
   /**
@@ -52,6 +55,9 @@ export const usePosition = () => {
       const docHeight = document.documentElement.clientHeight;
       const docWidth = document.documentElement.clientWidth;
       const RIGHT_BUFFER_PX = 20;
+      menuStyle.pageX = e.pageX;
+      menuStyle.pageY = e.pageY;
+      menuStyle.clientX = e.clientX;
       if (docHeight < e.clientY + menuListHeight) {
         // dropTop
         menuStyle.top = `${e.pageY - menuListHeight}px`;

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -50,10 +50,13 @@
             />
             <div
               class="filtering-items__item"
-              @click="onClickFilteringItem(field, filteringItemsByColumn[field])"
+              @click="onClickFilteringItem(
+                filteringItemsByColumn[field][0].caption,
+                filteringItemsByColumn[field]
+                )"
             >
               <span class="filtering-items__item--title">
-                {{ field }}
+                {{ filteringItemsByColumn[field][0].caption }}
               </span>
               <span
                 v-if="filteringItemsByColumn[field].length < 2"

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -55,20 +55,20 @@
             <div
               class="filtering-items__item"
               @click="onClickFilteringItem(
-                filteringItemsByColumn[field][0].caption,
+                filteringItemsByColumn[field]?.[0].caption,
                 filteringItemsByColumn[field]
                 )"
             >
               <span class="filtering-items__item--title">
-                {{ filteringItemsByColumn[field][0].caption }}
+                {{ filteringItemsByColumn[field]?.[0].caption }}
               </span>
               <span
                 v-if="filteringItemsByColumn[field].length < 2"
                 class="filtering-items__item--value"
                 :title="`${filteringItemsByColumn[field][0].value}`"
               >
-                {{ filteringItemsByColumn[field][0].comparison }}
-                {{ filteringItemsByColumn[field][0].value }}
+                {{ filteringItemsByColumn[field]?.[0].comparison }}
+                {{ filteringItemsByColumn[field]?.[0].value }}
               </span>
               <span
                 v-else

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -21,25 +21,29 @@
               ? '1px solid #CED4DA' : 'none',
           }"
         >
-          <ev-icon
-            class="filtering-items__item--remove"
-            icon="ev-icon-s-close"
-            :style="{
-              'margin-left': 0,
-            }"
-            @click="removeAllFiltering"
-          />
           <template
             v-for="(field, idx) in Object.keys(filteringItemsByColumn)"
             :key="idx"
           >
             <template v-if="idx === 0">
-              <ev-icon
-                icon="ev-icon-filter-list"
-                class="filtering-items-expand"
+              <div
+                class="filtering-items__item filtering-items__item--filter"
                 @click="onExpandFilteringItems"
-              />
-              Filter ({{ Object.keys(filteringItemsByColumn).length }})
+              >
+                <ev-icon
+                  icon="ev-icon-filter-list"
+                  class="filtering-items-expand"
+                />
+                <span class="filtering-items__item--title">
+                   Filter ({{ Object.keys(filteringItemsByColumn).length }})
+                </span>
+                <ev-icon
+                  class="filtering-items__item--remove"
+                  icon="ev-icon-s-close"
+                  style="margin-left: 0;"
+                  @click.stop="removeAllFiltering"
+                />
+              </div>
             </template>
             <ev-select
               v-if="idx === 1"

--- a/src/components/grid/grid.filterSetting.vue
+++ b/src/components/grid/grid.filterSetting.vue
@@ -21,6 +21,7 @@
             <ev-select
               v-model="item.operator"
               class="ev-grid-filter-setting__row--operator"
+              :title="getSelectTitle(items1, item.operator)"
               :items="items1"
               :disabled="idx > 1"
               :style="{
@@ -31,6 +32,7 @@
             <ev-select
               v-model="item.comparison"
               class="ev-grid-filter-setting__row--comparison"
+              :title="getSelectTitle(items2, item.comparison)"
               :items="items2"
               @change="changeComparison(item.comparison, idx)"
             />
@@ -204,6 +206,8 @@ export default {
       },
     );
 
+    const getSelectTitle = (items, title) => items.find(item => item.value === title)?.name || '';
+
     return {
       filteringItems,
       isShowFilterSetting,
@@ -214,6 +218,7 @@ export default {
       changeOperator,
       applyFiltering,
       changeComparison,
+      getSelectTitle,
     };
   },
 };

--- a/src/components/grid/grid.filterSetting.vue
+++ b/src/components/grid/grid.filterSetting.vue
@@ -104,7 +104,11 @@ export default {
   },
   setup(props, { emit }) {
     const filteringItems = ref([]);
-    const columnField = computed(() => props.column?.field);
+    const filteringColumn = computed(() => props.column);
+    // const columnField = computed(() => {
+    //   console.log(props.column);
+    //   return props.column?.field;
+    // });
     const items1 = [
       { name: 'AND', value: 'and' },
       { name: 'OR', value: 'or' },
@@ -173,7 +177,7 @@ export default {
     const applyFiltering = () => {
       emit(
         'apply-filtering',
-        columnField.value,
+        filteringColumn.value.field,
         filteringItems.value.filter(item => item.value
           || item.comparison === 'isEmpty' || item.comparison === 'isNotEmpty'),
       );
@@ -182,15 +186,16 @@ export default {
       () => props.isShow,
       (isShow) => {
         const rowList = [];
-        if (isShow && columnField.value) {
-          if (!props.items[columnField.value]?.length) {
+        if (isShow && filteringColumn.value.field) {
+          if (!props.items[filteringColumn.value.field]?.length) {
             rowList.push({
               comparison: '=',
               operator: 'and',
               value: '',
+              caption: filteringColumn.value.caption,
             });
           } else {
-            props.items[columnField.value].forEach((row) => {
+            props.items[filteringColumn.value.field].forEach((row) => {
               rowList.push(row);
             });
           }

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -278,6 +278,14 @@
       cursor: pointer;
       border: 1px solid #198FFF;
     }
+    &--filter {
+      font-weight: bold;
+      border: 1px solid #198FFF;
+      i {
+        color: #0077FF;
+        vertical-align: middle;
+      }
+    }
     &--title {
       color: #0077FF;
       margin-right: 6px;

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -666,10 +666,11 @@ export const filterEvent = (params) => {
     const comparison = condition.comparison;
     const conditionValue = condition.value;
     const value = item[ROW_DATA_INDEX][condition.index];
+    const comparisonValue = new RegExp(value, 'gi');
     let result;
 
     if (comparison === '=') {
-      result = value === conditionValue;
+      result = comparisonValue.test(conditionValue);
     } else if (comparison === '!=') {
       result = value !== conditionValue;
     } else if (comparison === '%s%') {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -756,7 +756,7 @@ export const filterEvent = (params) => {
 
       filters.forEach((filterItem) => {
         isApply = true;
-        if (!filterStore.length) {
+        if (!filterStore.length && Object.keys(filteringItemsByColumn).length < 2) {
           filterStore = getFilteringData(originStore, columnType, {
             ...filterItem,
             index,

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -665,14 +665,12 @@ export const filterEvent = (params) => {
   const stringFilter = (item, condition) => {
     const comparison = condition.comparison;
     const conditionValue = condition.value;
-    const value = item[ROW_DATA_INDEX][condition.index];
-    const comparisonValue = new RegExp(value, 'gi');
+    const value = `${item[ROW_DATA_INDEX][condition.index]}`;
     let result;
-
     if (comparison === '=') {
-      result = comparisonValue.test(conditionValue);
+      result = conditionValue.toLowerCase() === value.toLowerCase();
     } else if (comparison === '!=') {
-      result = !comparisonValue.test(conditionValue);
+      result = conditionValue.toLowerCase() !== value.toLowerCase();
     } else if (comparison === '%s%') {
       result = findLike(`%${conditionValue}%`, value);
     } else if (comparison === 'notLike') {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -672,7 +672,7 @@ export const filterEvent = (params) => {
     if (comparison === '=') {
       result = comparisonValue.test(conditionValue);
     } else if (comparison === '!=') {
-      result = value !== conditionValue;
+      result = !comparisonValue.test(conditionValue);
     } else if (comparison === '%s%') {
       result = findLike(`%${conditionValue}%`, value);
     } else if (comparison === 'notLike') {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -901,6 +901,14 @@ export const contextMenuEvent = (params) => {
           text: 'Filter',
           iconClass: 'ev-icon-filter-list',
           click: () => {
+            const docWidth = document.documentElement.clientWidth;
+            const clientX = contextInfo.columnMenu.menuStyle.clientX;
+            const pageX = contextInfo.columnMenu.menuStyle.pageX;
+            const MODAL_WIDTH = 350;
+            const isOver = docWidth < clientX + MODAL_WIDTH;
+            if (isOver) {
+              contextInfo.columnMenu.menuStyle.left = `${pageX - MODAL_WIDTH}px`;
+            }
             filterInfo.filterSettingPosition = {
               top: contextInfo.columnMenu.menuStyle.top,
               left: contextInfo.columnMenu.menuStyle.left,

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -885,6 +885,7 @@ export const contextMenuEvent = (params) => {
   const onColumnContextMenu = (event, column) => {
     if (event.target.className === 'column-name') {
       const sortable = column.sortable === undefined ? true : column.sortable;
+      const filterable = column.filterable === undefined ? true : column.filterable;
       contextInfo.columnMenuItems = [
         {
           text: 'Ascending',
@@ -917,7 +918,7 @@ export const contextMenuEvent = (params) => {
             filterInfo.isShowFilterSetting = true;
             filterInfo.filteringColumn = column;
           },
-          disabled: !filterInfo.isFiltering,
+          disabled: !filterable,
         },
         {
           text: 'Hide',


### PR DESCRIPTION
###############
- 컬럼명 field -> caption 표기
- 필터 설정창이 clientWidth를 넘어가면 계산 값으로 위치 조정
- 필터 버튼 변경
- 필터링이 2개 이상일 때, 이전 결과값이 없어도 연산 결과가 정상적으로 나오도록 수정
- comparison operator 셀렉트박스 title tooltip 노출
- string type 대소문자 구분 없이 필터링 되도록 수정
- stringNumber 타입 number값이어도 필터링 정상
- 컬럼 filterable 옵션 추가