### PR TITLE
[#1459] Chart > Tooltip > throttledMove 옵션 버그

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -1,4 +1,3 @@
-import throttle from '@/common/utils.throttle';
 import { mobileCheck } from '@/common/utils';
 import Model from './model';
 import TimeScale from './scale/scale.time';
@@ -134,10 +133,6 @@ class EvChart {
 
     if (tooltip.use) {
       this.createTooltipDOM();
-
-      if (tooltip.throttledMove) {
-        this.onMouseMove = throttle(this.onMouseMove, 30);
-      }
     }
 
     this.createEventFunctions?.();

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1,4 +1,5 @@
 import { numberWithComma } from '@/common/utils';
+import throttle from '@/common/utils.throttle';
 import { cloneDeep, defaultsDeep, inRange } from 'lodash-es';
 import dayjs from 'dayjs';
 
@@ -348,6 +349,9 @@ const modules = {
 
     if (this.options?.tooltip?.useScrollbar) {
       this.overlayCanvas.addEventListener('wheel', this.onWheel, { passive: false });
+    }
+    if (this.options?.tooltip?.throttledMove) {
+      this.onMouseMove = throttle(this.onMouseMove, 30);
     }
 
     this.overlayCanvas.addEventListener('mousemove', this.onMouseMove);


### PR DESCRIPTION
![image](https://github.com/ex-em/EVUI/assets/46586573/c940d8df-968d-44f9-ae27-e986a9cec80d)
- throttledMove 옵션을 설정하면 mouseleave 이벤트에서 에러가 발생
- throttledMove 가 설정된 경우 onMouseMove 를 throttle 된 함수로 변경해야하는데, 이벤트 등록 순서의 문제로 의도대로 동작하지 않아 발생한 문제