### PR TITLE
[#1467] Chart > Tooltip 사용하지 않는 경우에도 item highlight 되는 버그 픽스

### DIFF
--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -33,11 +33,9 @@ const modules = {
       this.overlayClear();
 
       if (Object.keys(hitInfo.items).length) {
-        if ((type !== 'scatter' && type !== 'heatMap') || tooltip.use) {
-          this.drawItemsHighlight(hitInfo, ctx);
-        }
-
         if (tooltip.use) {
+          this.drawItemsHighlight(hitInfo, ctx);
+
           if (tooltip?.formatter?.html) {
             this.drawCustomTooltip(hitInfo?.items);
             this.setCustomTooltipLayoutPosition(hitInfo, e);


### PR DESCRIPTION
이슈
-
chart type이 scatter & heatmap이 아닌 경우 chart option의 tooltip use: false로 해도 item highlight 됨

작업 내용
-
1. item highlight 그리는 if문 조건 변경
   ->  tooltip.use 가 true일 때만 그리도록 변경
   
   - before (tooltip use: false이지만 highlight됨)
   
    ![image](https://github.com/ex-em/EVUI/assets/75718910/694d9eff-dfe9-4507-8f64-aa1efbe689c9)
    
    - after (highlight 되지 않음)
    
   ![image](https://github.com/ex-em/EVUI/assets/75718910/f22d8402-11d2-4713-8acc-3cae7a4e4b64)

