### PR TITLE
[#1470] Chart > Scatter Chart > Range 사용할 때 Max Value가 그대로 적용되지 않는 이슈 수정 (version 3.3.64)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.63",
+  "version": "3.3.64",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -73,8 +73,13 @@ class Scale {
 
     const range = scrollbarOpt?.use ? scrollbarOpt?.range : this.range;
     if (range?.length === 2) {
-      maxValue = range[1] > +minMax.max ? +minMax.max : range[1];
-      minValue = range[0] < +minMax.min ? +minMax.min : range[0];
+      if (this.options.type === 'heatMap') {
+        maxValue = range[1] > +minMax.max ? +minMax.max : range[1];
+        minValue = range[0] < +minMax.min ? +minMax.min : range[0];
+      } else {
+        maxValue = range[1];
+        minValue = range[0];
+      }
     } else {
       maxValue = minMax.max;
       minValue = minMax.min;


### PR DESCRIPTION
이슈
-
scatter chart에서 range 사용하는 경우 제대로 반영되지 않는 이슈

![image](https://github.com/ex-em/EVUI/assets/75718910/34545183-a55c-48a4-8a86-1753259bd5c0)


원인
-
heatmap에서 scrollbar 사용하는 경우 min, max를 넘어갈 때 스크롤 바가 영역을 벗어나는 오류가 있어 넣었었던 유효성 체크 로직 때문

해결
-
heatmap인 경우만 min, max 값을 넘어가지 않도록 분기 처리 로직 추가

![image](https://github.com/ex-em/EVUI/assets/75718910/be7203da-1700-4872-967e-e35fabed24fb)
