### PR TITLE
[#1465] Grid > Filtering Functions Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.11",
+  "version": "3.4.12",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -87,7 +87,7 @@
               <ev-icon
                 class="filtering-items__item--remove"
                 icon="ev-icon-s-close"
-                @click="removeColumnFiltering(field)"
+                @click="onApplyFilter(field, [])"
               />
             </div>
           </template>
@@ -1091,21 +1091,22 @@ export default {
 
     const setColumnFilteringItems = () => {
       isExpandColumnFilteringItems.value = true;
-      const conditionItems = filteringItemsRef.value
-        .getElementsByClassName('filtering-items__item');
       let hasHiddenElement = false;
+      const conditionItems = filteringItemsRef.value
+        ?.getElementsByClassName('filtering-items__item');
+      if (conditionItems) {
+        for (let i = 0; i < conditionItems.length; i++) {
+          const itemEl = conditionItems[i];
+          itemEl.classList.remove('non-display');
+          const filteringBoxTop = filteringItemsRef.value.getBoundingClientRect()?.top;
+          const { top } = itemEl.getBoundingClientRect(); // rect height: 27
+          if (isShowColumnFilteringItems.value && (top - filteringBoxTop > 27)) {
+            isExpandColumnFilteringItems.value = false;
+            hasHiddenElement = true;
+          }
 
-      for (let i = 0; i < conditionItems.length; i++) {
-        const itemEl = conditionItems[i];
-        itemEl.classList.remove('non-display');
-        const filteringBoxTop = filteringItemsRef.value.getBoundingClientRect()?.top;
-        const { top } = itemEl.getBoundingClientRect(); // rect height: 27
-        if (isShowColumnFilteringItems.value && (top - filteringBoxTop > 27)) {
-          isExpandColumnFilteringItems.value = false;
-          hasHiddenElement = true;
+          itemEl.classList.toggle('non-display', hasHiddenElement);
         }
-
-        itemEl.classList.toggle('non-display', hasHiddenElement);
       }
     };
 
@@ -1115,9 +1116,9 @@ export default {
       } else {
         filterInfo.filteringItemsByColumn[field] = list;
         isShowColumnFilteringItems.value = true;
-        await nextTick();
-        setColumnFilteringItems();
       }
+      await nextTick();
+      setColumnFilteringItems();
       filterInfo.isShowFilterSetting = false; // filter setting close
       stores.filterStore = [];
       setStore([], false);
@@ -1128,11 +1129,6 @@ export default {
       setColumnFilteringItems();
     };
 
-    const removeColumnFiltering = (field) => {
-      delete filterInfo.filteringItemsByColumn[field];
-      stores.filterStore = [];
-      setStore([], false);
-    };
     const removeFiltering = ({ field, idx }) => {
       filterInfo.filteringItemsByColumn[field]?.splice(idx, 1);
       if (!filterInfo.filteringItemsByColumn[field].length) {
@@ -1219,7 +1215,6 @@ export default {
       isShowFilteringItemsBox,
       ...toRefs(filteringItemsBoxPosition),
       removeFiltering,
-      removeColumnFiltering,
       removeAllFiltering,
       onExpandFilteringItems,
       setColumnFilteringItems,

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -792,12 +792,12 @@ export const filterEvent = (params) => {
             ...item,
             index,
           }));
-        } else if (item.operator === 'or') {
+        } else if (ix !== 0 && item.operator === 'or') {
           filterStore.push(...getFilteringData(originStore, columnType, {
             ...item,
             index,
           }));
-        } else {
+        } else { // (ix === 0 && filterInfo.columnOperator === 'and') || item.operator === 'and'
           filterStore = getFilteringData(filterStore, columnType, {
             ...item,
             index,

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -334,7 +334,7 @@ export const clickEvent = (params) => {
   const { emit } = getCurrentInstance();
   const { selectInfo, stores } = params;
   const getClickedRowData = (event, row) => {
-    const tagName = event.target.tagName.toLowerCase();
+    const tagName = event.target.tagName?.toLowerCase();
     let cellInfo = {};
     if (tagName === 'td') {
       cellInfo = event.target.dataset;
@@ -654,8 +654,8 @@ export const filterEvent = (params) => {
     if (typeof conditionValue !== 'string' || value === null) {
       return false;
     }
-    const baseValueLower = value.toLowerCase();
-    const conditionValueLower = conditionValue.toLowerCase();
+    const baseValueLower = value?.toLowerCase();
+    const conditionValueLower = conditionValue?.toLowerCase();
     let result = baseValueLower.includes(conditionValueLower);
     if (pos) {
       if (pos === 'start') {
@@ -682,9 +682,9 @@ export const filterEvent = (params) => {
     }
     let result;
     if (comparison === '=') {
-      result = conditionValue.toLowerCase() === value.toLowerCase();
+      result = conditionValue?.toLowerCase() === value?.toLowerCase();
     } else if (comparison === '!=') {
-      result = conditionValue.toLowerCase() !== value.toLowerCase();
+      result = conditionValue?.toLowerCase() !== value?.toLowerCase();
     } else if (comparison === '%s%') {
       result = findLike(conditionValue, value);
     } else if (comparison === 'notLike') {


### PR DESCRIPTION
#################################
- 컬럼에 대한 필터링 전체 삭제 시 removeColumnFiltering() -> onApplyFilter() 메서드 호출
- column 사이의 operator 가 and 이지만, 다음 컬럼 필터의 oprator 가 or 이어서 or 연산으로 되었음, 다음 컬럼 필터의 0번째 인덱스 일 땐 column 사이의 operator 로 정상 분기되도록 수정
- sting 타입 값 undefined 시 toLowerCase 값 체크