### PR TITLE
[#1477] Chart > bar 차트의 height가 일정 크기 이상 줄어들때 label 목록 요약 & HeatMap update되지 않는 이슈 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.64",
+  "version": "3.3.65",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -31,7 +31,7 @@ const module = {
 
     if (!scrollbarOpt.isInit) {
       scrollbarOpt.type = axisOpt?.[0]?.type;
-      scrollbarOpt.range = axisOpt?.[0]?.range || null;
+      scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...axisOpt?.[0]?.range] : null;
 
       this.initScrollbarRange(dir);
       this.createScrollbarLayout(dir);
@@ -44,15 +44,15 @@ const module = {
   initScrollbarRange(dir) {
     const scrollbarOpt = this.scrollbar[dir];
     const axesType = scrollbarOpt.type;
+    const labels = this.options.type === 'heatMap' ? this.data.labels[dir] : this.data.labels;
 
-    if (scrollbarOpt.range?.length) {
+    if (scrollbarOpt.range?.length && labels.length) {
       const [min, max] = scrollbarOpt.range;
       let limitMin;
       let limitMax;
 
       if ((truthyNumber(min) && truthyNumber(max))) {
         if (axesType === 'step') {
-          const labels = this.options.type === 'heatMap' ? this.data.labels[dir] : this.data.labels;
           limitMin = 0;
           limitMax = labels.length - 1;
         } else {
@@ -93,7 +93,7 @@ const module = {
     const axisOpt = dir === 'x' ? this.axesX : this.axesY;
     const isUpdateAxesRange = !isEqual(newOpt?.[0]?.range, axisOpt?.[0]?.range);
     if (isUpdateAxesRange || updateData) {
-      this.scrollbar[dir].range = newOpt?.[0]?.range || null;
+      this.scrollbar[dir].range = newOpt?.[0]?.range?.length ? [...newOpt?.[0]?.range] : null;
       this.initScrollbarRange(dir);
     }
     this.scrollbar[dir].use = !!newOpt?.[0].scrollbar?.use;

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -85,8 +85,6 @@ class StepScale extends Scale {
       } else {
         interval = oriSteps;
       }
-    } else if (numberOfSteps > maxSteps * 2) {
-      interval *= 2;
     }
 
     return {


### PR DESCRIPTION
이슈
-
1. Chart > bar 차트의 height가 일정 크기 이상 줄어들때 label 목록 요약됨
   
![image_2023-07-10_15-45-25](https://github.com/ex-em/EVUI/assets/75718910/646ef618-680e-4e96-b967-8406bfb54d63)

2. HeatMap 초기 draw 시 데이터 update되지 않는 이슈 수정

작업 내용
-
1. step 타입일 경우도 height에 따라 label 겹치는 경우가 있어서 수정했던 코드로 사이드 이펙트가 있어 number인 경우만 적용되도록 로직 삭제
2. heatmap range valid 체크할 때 축의 옵션도 수정되어 해당 로직 수정
