### PR TITLE
[#1487] Chart > Axis > flow기능이 추가되면서 select label의 위치가 의도치 않은 곳에 그려지는 버그 수정

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -374,12 +374,12 @@ class EvChart {
     return axes.map((axis) => {
       switch (axis.type) {
         case 'linear':
-          return new LinearScale(dir, axis, ctx, labels, options);
+          return new LinearScale(dir, axis, ctx, options);
         case 'time':
           if (axis.categoryMode) {
             return new TimeCategoryScale(dir, axis, ctx, labels, options);
           }
-          return new TimeScale(dir, axis, ctx, labels, options);
+          return new TimeScale(dir, axis, ctx, options);
         case 'log':
           return new LogarithmicScale(dir, axis, ctx);
         case 'step':
@@ -416,7 +416,8 @@ class EvChart {
         this.labelOffset,
         this.axesSteps.x[index],
         hitInfo,
-        this.defaultSelectInfo);
+        this.defaultSelectInfo,
+        this.data.labels);
     });
 
     this.axesY.forEach((axis, index) => {

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -10,7 +10,7 @@ import {
 import Util from '../helpers/helpers.util';
 
 class Scale {
-  constructor(type, axisOpt, ctx, labels, options) {
+  constructor(type, axisOpt, ctx, options) {
     const merged = defaultsDeep({}, axisOpt, AXIS_OPTION);
     Object.keys(merged).forEach((key) => {
       this[key] = merged[key];
@@ -19,7 +19,6 @@ class Scale {
     this.type = type;
     this.ctx = ctx;
     this.units = AXIS_UNITS[this.type];
-    this.labels = labels;
     this.options = options;
 
     if (!this.position) {
@@ -219,10 +218,13 @@ class Scale {
    * @param {object} chartRect      min/max information
    * @param {object} labelOffset    label offset information
    * @param {object} stepInfo       label steps information
+   * @param {object} hitInfo        hit information
+   * @param {object} selectLabelInfo selected label information
+   * @param {object} dataLabels     data label information, x axis only
    *
    * @returns {undefined}
    */
-  draw(chartRect, labelOffset, stepInfo, hitInfo, selectLabelInfo) {
+  draw(chartRect, labelOffset, stepInfo, hitInfo, selectLabelInfo, dataLabels) {
     const ctx = this.ctx;
     const options = this.options;
     const aPos = {
@@ -290,7 +292,7 @@ class Scale {
       let offsetStartPoint = startPoint;
       let axisMinForLabel = axisMin;
 
-      if (this.type === 'x' && options?.axesX[0].flow && this.labels.length !== steps + 1) {
+      if (this.type === 'x' && options?.axesX[0].flow && dataLabels.length !== steps + 1) {
         const axisMinByMinutes = Math.floor(axisMin / size) * size;
         if (axisMinByMinutes !== +axisMin) {
           axisMinForLabel = axisMinByMinutes + size;
@@ -306,7 +308,7 @@ class Scale {
       for (let ix = 0; ix <= steps; ix++) {
         labelCenter = Math.round(offsetStartPoint + (labelGap * ix));
 
-        if (labelCenter <= endPoint || this.type !== 'x' || !options?.axesX[0].flow || this.labels.length === steps + 1) {
+        if (labelCenter <= endPoint || this.type !== 'x' || !options?.axesX[0].flow || dataLabels.length === steps + 1) {
           ctx.beginPath();
           ticks[ix] = axisMinForLabel + (ix * stepValue);
 

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -5,6 +5,11 @@ import Util from '../helpers/helpers.util';
 import { truthyNumber } from '../../../common/utils';
 
 class StepScale extends Scale {
+  constructor(type, axisOpt, ctx, labels, options) {
+    super(type, axisOpt, ctx, options);
+    this.labels = labels;
+  }
+
   /**
    * Calculate min/max value, label and size information for step scale
    * @param {object} minMax       min/max information (unused on step scale)

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -4,6 +4,12 @@ import Scale from './scale';
 import Util from '../helpers/helpers.util';
 
 class TimeCategoryScale extends Scale {
+  constructor(type, axisOpt, ctx, labels, options) {
+    super(type, axisOpt, ctx);
+    this.labels = labels;
+    this.options = options;
+  }
+
   /**
    * Transforming label by designated format
    * @param {number} value       label value


### PR DESCRIPTION
# 원인
- scale.js의 constructor에 labels가 들어가면 생기는 문제
![image](https://github.com/ex-em/EVUI/assets/22311883/cca3780a-0789-44e5-95c3-2c0128c5d6cc)


# 해결
- 이전처럼 labels를 필요한 곳 마다 받고, draw하는 곳에 labels를 따로 받아서 처리.
![image](https://github.com/ex-em/EVUI/assets/22311883/482b91a5-16ae-4d67-8f80-54ee572870c8)