### PR TITLE
[#1491] 차트 Resize > DrawChart > DrawImage 할 때 BufferCanvas의 width 또는 …

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -189,7 +189,11 @@ class EvChart {
 
     this.drawTip();
 
-    if (this.bufferCanvas) {
+    if (
+      this.bufferCanvas
+      && this.bufferCanvas?.width > 1
+      && this.bufferCanvas?.height > 1
+    ) {
       this.displayCtx.drawImage(this.bufferCanvas, 0, 0);
     }
   }


### PR DESCRIPTION
…th 또는 height가 1 보다 작으면 발생하는 에러

############################   
[원인]
 - 창 사이즈를 조절할 때 차트 Resize가 되면서 간헐적으로 아래와 같은 에러가 발생함.
![image](https://github.com/ex-em/EVUI/assets/61274722/84f2dd31-7f85-4905-8cad-aff873440b8e)    

 - drawImage의 argument인 with또는 height가  1보다 작으면 에러가 발생한다고 함.(https://github.com/niklasvh/html2canvas/pull/2982)   
![image](https://github.com/ex-em/EVUI/assets/61274722/404d4277-aa1a-4eff-affb-9989a62cbeed)     

[작업 내용]
 - BufferCanvas의 width 또는 height가 1보다 클 때 drawImage가 가능하도록 수정