### PR TITLE
[#1497] EVUI 사용 장비를 모바일과 PC로 구분하는 로직 수정

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -147,6 +147,5 @@ export function mobileCheck() {
       navigator.userAgent,
     )
     || 'ontouchstart' in window
-    || navigator.maxTouchPoints
   );
 }


### PR DESCRIPTION
#############################    
[원인]    
 - navigator.maxTouchPoints 경우 단순 터치 수를 반환하기 때문에 모바일 뿐만 아니라 터치가 가능한 노트북 또는 테블릿을 연결해서 사용하는 데스크탑 경우 1이상의 값을 반환하게 되면서 마우스무브 이벤트가 발생하지 않게 됨   

[수정 내용]   
 - navigator.maxTouchPoints 제거