### PR TITLE
[#1499] Grid > 스크롤 시 contextmenu 자동 닫힘 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.18",
+  "version": "3.4.19",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -237,7 +237,18 @@
 </template>
 
 <script>
-import { reactive, toRefs, computed, watch, onMounted, onActivated, nextTick, ref, provide } from 'vue';
+import {
+  reactive,
+  toRefs,
+  computed,
+  watch,
+  onActivated,
+  nextTick,
+  ref,
+  provide,
+  onMounted,
+  onUnmounted,
+} from 'vue';
 import treeGridNode from './TreeGridNode';
 import Toolbar from './treeGrid.toolbar';
 import GridPagination from '../grid/grid.pagination';
@@ -545,9 +556,28 @@ export default {
 
     provide('toolbarWrapper', toolbarWrapper);
 
+    const onMouseWheel = (e) => {
+      if (e.type === 'wheel') {
+        contextInfo.menu?.hide(e);
+      }
+      if (e.type === 'scroll' && !e.target.classList?.contains('table-body')
+        && !e.target.offsetParent?.classList?.contains('ev-grid-column-setting')) {
+        contextInfo.columnMenu?.hide(e);
+        columnSettingInfo.isShowColumnSetting = false;
+      }
+    };
+
     onMounted(() => {
       stores.treeStore = setTreeNodeStore();
+      document.addEventListener('wheel', onMouseWheel, { capture: false });
+      document.addEventListener('scroll', onMouseWheel, { capture: true });
     });
+
+    onUnmounted(() => {
+      document.removeEventListener('wheel', onMouseWheel);
+      document.removeEventListener('scroll', onMouseWheel);
+    });
+
     onActivated(() => {
       onResize();
     });


### PR DESCRIPTION
###################
- Column List 옵션창을 비롯하여 Column, Row Contextmenu 창들은 다른 영역을 클릭하면 닫히도록 되어있기 때문에 마우스 좌클릭으로 스크롤바를 클릭하여 스크롤하여도 닫히는 기존 동작과 휠을 이용한 스크롤 시에도 통일된 스펙으로 결정
- 단, 그리드 내의 스크롤인 경우에는 닫히는 경우 불편성을 야기시킬 수 있으므로 제외