### PR TITLE
[#1505] Line Chart > Fill > gradient 옵션 추가

### DIFF
--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -53,20 +53,20 @@ const selectedSeries = ref({
   | labels | Array  | [] | 축의 각 눈금에 해당하는 명칭, line Chart 에서는 time만 인정 |  |
 
 #### series
-  | 이름 | 타입 | 디폴트 | 설명                                                                    | 종류(예시) |
-  |------------ |-----------|-----------------------------------------------------------------------|-------------------------|---------------------------------------------------|
-  | show | Boolean |true | 표시 여부                                                                 |  |
-  | name | String | series-${index} | 특정 데이터에 대한 시리즈 옵션                                                     |  |
-  | lineWidth | Number | 2 | 선(line) 두께                                                            | |
-  | color | Hex, RGB, RGBA Code(String) | COLOR[index] | Line 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용               |  |
-  | fill | Boolean | false | 선(line) 아래 부분의 영역에 색상을 채울지의 여부. area chart 전환 여부                      |  |
-  | fillOpacity | Number | 0.4 | fill 영역의 투명도                                                          | |
-  | fillColor | Hex, RGB, RGBA Code(String) | COLOR[index] | Fill 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용               |  |
-  | point | Boolean | true | 선(line) 위에 값 위치 마다 점을 표시할지의 여부, 앞/뒤 값이 null인 경우 point 표시 여부에 상관없이 표시됨 |  |
-  | pointSize | Number | 3 | 점(Point)의 크기                                                          |  |
-  | pointFill | Hex, RGB, RGBA Code(String) | COLOR[index] | 점(Point) 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용           |  |
-  | pointStyle | String | 'circle' | 점(Point) 모양                                                           | 'triangle', 'rect', 'rectRounded', 'rectRot', 'cross', 'crossRot', 'star', 'line' |
-  | showLegend | Boolean | true | legend 표시 여부                                                          | |
+  | 이름 | 타입                          | 디폴트 | 설명                                                                  | 종류(예시)                                                                            |
+  |-----------------------------|-----------|---------------------------------------------------------------------|-----------------------------------------------------------------------------------|---------------------------------------------------|
+  | show | Boolean                     |true | 표시 여부                                                               |                                                                                   |
+  | name | String                      | series-${index} | 특정 데이터에 대한 시리즈 옵션                                                   |                                                                                   |
+  | lineWidth | Number                      | 2 | 선(line) 두께                                                          |                                                                                   |
+  | color | Hex, RGB, RGBA Code(String) | COLOR[index] | Line 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용             |                                                                                   |
+  | fill | Boolean / Object            | false | 선(line) 아래 부분의 영역에 색상을 채울지의 여부. area chart 전환 여부,                   | false / { gradient: true }                                                        |
+  | fillOpacity | Number                      | 0.4 | fill 영역의 투명도                                                        |                                                                                   |
+  | fillColor | Hex, RGB, RGBA Code(String) | COLOR[index] | Fill 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용             |                                                                                   |
+  | point | Boolean                     | true | 선(line) 위에 값 위치 마다 점을 표시할지의 여부, 앞/뒤 값이 null인 경우 point 표시 여부에 상관없이 표시됨 |                                                                                   |
+  | pointSize | Number                      | 3 | 점(Point)의 크기                                                        |                                                                                   |
+  | pointFill | Hex, RGB, RGBA Code(String) | COLOR[index] | 점(Point) 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용         |                                                                                   |
+  | pointStyle | String                      | 'circle' | 점(Point) 모양                                                         | 'triangle', 'rect', 'rectRounded', 'rectRot', 'cross', 'crossRot', 'star', 'line' |
+  | showLegend | Boolean                     | true | legend 표시 여부                                                        |                                                                                   |
   
 #### data example
 ```

--- a/docs/views/lineChart/example/Fill.vue
+++ b/docs/views/lineChart/example/Fill.vue
@@ -13,8 +13,7 @@
       const time = dayjs().format('YYYY-MM-DD HH:mm:ss');
       const chartData = {
         series: {
-          series1: { name: 'series#1', fill: true, point: false },
-          series2: { name: 'series#2', fill: true, point: false },
+          series1: { name: 'series#1', fill: { gradient: true }, point: false },
         },
         labels: [
           dayjs(time),
@@ -26,8 +25,7 @@
           dayjs(time).add(6, 'day'),
         ],
         data: {
-          series1: [100, 25, 36, 47, 0, 50, 80],
-          series2: [80, 36, 25, 47, 15, 100, 0],
+          series1: [50, 25, 36, 47, 50, 50, 50],
         },
       };
 
@@ -63,15 +61,6 @@
           startToZero: true,
           autoScaleRatio: 0.1,
         }],
-        maxTip: {
-          use: true,
-          showIndicator: true,
-          indicatorColor: '#FF0000',
-          tipStyle: {
-            background: '#000000',
-            textColor: '#FFFFFF',
-          },
-        },
       };
 
       return {

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -85,10 +85,6 @@ class Line {
     ctx.lineWidth = lineWidth;
     ctx.strokeStyle = Util.colorStringToRgba(mainColor, mainColorOpacity);
 
-    if (this.fill) {
-      ctx.fillStyle = Util.colorStringToRgba(mainColor, fillOpacity);
-    }
-
     let startFillIndex = 0;
     const endPoint = chartRect.y2 - labelOffset.bottom;
 

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -158,11 +158,10 @@ class Line {
             minValueYBottomPos = data.y;
           }
         });
-
         const gradient = ctx.createLinearGradient(0, chartRect.y2, 0, maxValueYPos);
-        gradient.addColorStop(0, Util.colorStringToRgba(mainColor, fillOpacity));
-        gradient.addColorStop(0.5, Util.colorStringToRgba(mainColor, fillOpacity));
-        gradient.addColorStop(1, mainColor);
+        gradient.addColorStop(0, fillColor);
+        gradient.addColorStop(0.5, fillColor);
+        gradient.addColorStop(1, (extent.opacity < 1 ? fillColor : mainColor));
 
         ctx.fillStyle = gradient;
       } else {

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -146,7 +146,28 @@ class Line {
     if (this.fill && this.data.length) {
       ctx.beginPath();
 
-      ctx.fillStyle = Util.colorStringToRgba(mainColor, fillOpacity);
+      const fillColor = Util.colorStringToRgba(mainColor, fillOpacity);
+
+      if (this.fill?.gradient) {
+        let maxValueYPos = this.data[0].yp;
+        let minValueYBottomPos = this.data[0].y;
+        this.data.forEach((data) => {
+          if (data.yp && data.yp <= maxValueYPos) {
+            maxValueYPos = data.yp;
+          } else if (data.y && data.y >= minValueYBottomPos) {
+            minValueYBottomPos = data.y;
+          }
+        });
+
+        const gradient = ctx.createLinearGradient(0, chartRect.y2, 0, maxValueYPos);
+        gradient.addColorStop(0, Util.colorStringToRgba(mainColor, fillOpacity));
+        gradient.addColorStop(0.5, Util.colorStringToRgba(mainColor, fillOpacity));
+        gradient.addColorStop(1, mainColor);
+
+        ctx.fillStyle = gradient;
+      } else {
+        ctx.fillStyle = fillColor;
+      }
 
       this.data.forEach((currData, ix) => {
         const isEmptyPoint = data => data?.x === null || data?.y === null


### PR DESCRIPTION
## 작업내용
- fill 옵션에 gradient 여부도 받을 수 있도록 로직 수정

## 결과

### Before
   - ![image](https://github.com/ex-em/EVUI/assets/53548023/4e8e3061-f239-464b-bc0e-5cd057d5248c)
```
        series: {
          series1: { name: 'series#1', fill: true, point: false },
        },
```


### After
   - ![image](https://github.com/ex-em/EVUI/assets/53548023/87c83691-c713-4d36-ae62-8ee4f07bccab)
```
        series: {
          series1: { name: 'series#1', fill: { gradient: true }, point: false },
        },
```

