### PR TITLE
[#1520] Chart, ChartBrush > 다른 메뉴 이동 후 다시 기존 메뉴로 왔을 때 차트 깨지거나 리사이즈 안 …

### DIFF
--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -18,7 +18,17 @@
 </template>
 
 <script>
-  import { onMounted, onBeforeUnmount, watch, onDeactivated, inject, toRef, computed } from 'vue';
+  import {
+    onMounted,
+    onBeforeUnmount,
+    onActivated,
+    onDeactivated,
+    inject,
+    watch,
+    ref,
+    toRef,
+    computed,
+  } from 'vue';
   import { cloneDeep, isEqual, debounce } from 'lodash-es';
   import EvChart from './chart.core';
   import EvChartToolbar from './ChartToolbar';
@@ -76,6 +86,7 @@
     ],
     setup(props) {
       let evChart = null;
+      const isMounted = ref(false);
       const injectIsChartGroup = inject('isChartGroup', false);
       const injectBrushSeries = inject('brushSeries', { list: [], chartIdx: null });
       const injectGroupSelectedLabel = inject('groupSelectedLabel', null);
@@ -242,6 +253,8 @@
 
         await createChart();
         await drawChart();
+
+        isMounted.value = true;
       });
 
       onBeforeUnmount(() => {
@@ -252,6 +265,8 @@
         if (injectEvChartPropsInGroup?.value?.length) {
           injectEvChartPropsInGroup.value.length = 0;
         }
+
+        isMounted.value = false;
       });
 
       onDeactivated(() => {
@@ -274,6 +289,12 @@
           evChart.resize();
         }
       }, props.resizeTimeout);
+
+      onActivated(() => {
+        if (isMounted.value) {
+          onResize();
+        }
+      });
 
       return {
         wrapper,

--- a/src/components/chartBrush/ChartBrush.vue
+++ b/src/components/chartBrush/ChartBrush.vue
@@ -9,7 +9,17 @@
 </template>
 
 <script>
-import { inject, watch, computed, onMounted, onBeforeUnmount, onDeactivated, onUpdated } from 'vue';
+import {
+  inject,
+  watch,
+  ref,
+  computed,
+  onMounted,
+  onBeforeUnmount,
+  onDeactivated,
+  onActivated,
+  onUpdated,
+} from 'vue';
 import { cloneDeep, debounce, isEqual } from 'lodash-es';
 import EvChart from '../chart/chart.core';
 import { useModel, useWrapper } from '../chart/uses';
@@ -28,6 +38,7 @@ export default {
     let evChart = null;
     let evChartBrush = null;
 
+    const isMounted = ref(false);
     const injectEvChartClone = inject('evChartClone', { data: [] });
     const injectEvChartInfo = inject('evChartInfo', { props: { options: [] } });
     const injectBrushIdx = inject('brushIdx', {
@@ -235,6 +246,8 @@ export default {
         createChartBrush();
         drawChartBrush();
       }
+
+      isMounted.value = true;
     });
 
     onUpdated(async () => {
@@ -266,6 +279,8 @@ export default {
       if (evChartBrush) {
         evChartBrush.destroy();
       }
+
+      isMounted.value = false;
     });
 
     onDeactivated(() => {
@@ -290,6 +305,12 @@ export default {
         });
       }
     }, 0);
+
+    onActivated(() => {
+      if (isMounted.value) {
+        onResize();
+      }
+    });
 
     return {
       evChartBrushOptions,


### PR DESCRIPTION
…되는 현상

#############################    
![차트 다른 메뉴 이동 후 리사이즈 안 됨](https://github.com/ex-em/EVUI/assets/61274722/0bc27a7f-d28b-40dd-87a1-ba3bcb61b2cb)    

[원인]
 - 기존 메뉴에서 창을 리사이즈 하고 다른 메뉴로 이동 후 다시 리사이즈 하고 기존 메뉴로 왔을 경우 차트가 리사이즈 되지 않아 처음에 리사이즈한 차트 그대로 남아있음.

[수정 내용]
 - 새로 고침 또는 처음 메뉴 접근으로 차트가 그려지고 난 이후 해당 메뉴에 다시 접근 시 차트가 리사이즈 되도록 수정.
 - 로직 타는 순서 1 -> 2 -> 3
![image](https://github.com/ex-em/EVUI/assets/61274722/080f0ab3-f095-4df0-97c8-dccde124fe9f)   
![image](https://github.com/ex-em/EVUI/assets/61274722/d8513b56-2d71-43d7-80ca-36cacf067d98)   
   