### PR TITLE
[#1532] Chart > Scatter Chart > Real Time Scatter > series 개수가 변경됐을 때 오류

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -113,6 +113,7 @@ class EvChart {
     }
 
     if (realTimeScatter?.use) {
+      this.dataSet = {};
       this.createRealTimeScatterDataSet(data);
     } else {
       this.createDataSet(data, labels);
@@ -723,6 +724,7 @@ class EvChart {
 
     this.resetProps();
 
+    this.updateSeries = updateSeries;
     if (updateSeries) {
       this.seriesInfo = null;
       this.seriesList = null;

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -71,10 +71,6 @@ const modules = {
   createRealTimeScatterDataSet(datas) {
     const keys = Object.keys(datas);
 
-    if (!this.isInit) {
-      this.dataSet = {};
-    }
-
     const minMaxValues = {
       maxY: 0,
       minY: Infinity,
@@ -88,14 +84,19 @@ const modules = {
       const storeLength = data.length;
       let lastTime = 0;
 
-      if (!this.isInit) {
-        this.dataSet[key] = {
+      if (!this.isInit || this.updateSeries) {
+        const defaultValues = {
           dataGroup: [],
           startIndex: 0,
           endIndex: 0,
           length: 0,
           fromTime: 0,
           toTime: 0,
+        };
+
+        this.dataSet[key] = {
+          ...defaultValues,
+          ...this.dataSet[key],
         };
         this.dataSet[key].length = this.options.realTimeScatter.range || 300;
         this.dataSet[key].toTime = Math.floor(Date.now() / 1000) * 1000;
@@ -127,12 +128,17 @@ const modules = {
           - this.dataSet[key].length * 1000;
       }
 
-      if (!this.isInit) {
+      if (!this.isInit || this.updateSeries) {
         for (let i = 0; i < this.dataSet[key].length; i++) {
-          this.dataSet[key].dataGroup[i] = {
+          const defaultValues = {
             data: [],
             max: 0,
             min: Infinity,
+          };
+
+          this.dataSet[key].dataGroup[i] = {
+            ...defaultValues,
+            ...this.dataSet[key].dataGroup[i],
           };
         }
       } else if (gapCount > 0) {


### PR DESCRIPTION
# 이슈
- 예를 들어 series의 개수가 1개 => 2개로 변경 될 때 아래와 같은 오류 발생.
![image](https://github.com/ex-em/EVUI/assets/22311883/a3aa750d-2c33-4d7d-b088-c94e459ee0b3)

# 해결
- series update를 감지하여 init일 때와 똑같이 처리하되, 기존 데이터를 남겨둘 수 있게 처리.
