### PR TITLE
[#1534] Tree > 검색했을 때 부모 text가 검색된 경우 자식까지 보이게 하는 props 추가

### DIFF
--- a/docs/views/tree/api/tree.md
+++ b/docs/views/tree/api/tree.md
@@ -12,14 +12,14 @@
 
  | 이름                      | 타입      | 디폴트                                  | 설명                                                      | 종류 |
   |-------------------------|---------|--------------------------------------|---------------------------------------------------------|------|
-  | data                    | Array   | []                                   | 트리 컴포넌트에 사용될 데이터                                        |  |
-  | use-checkbox            | Boolean | false                                | 체크 박스를 사용 유무                                            |  |
-  | empty-text              | String  | 'No Data'                            | 트리 데이터가 없을 경우 나타낼 문구                                    | |
+  | data                    | Array   | [] | 트리 컴포넌트에 사용될 데이터                                        |  |
+  | use-checkbox            | Boolean | false | 체크 박스를 사용 유무                                            |  |
+  | empty-text              | String  | 'No Data' | 트리 데이터가 없을 경우 나타낼 문구                                    | |
   | expand-icon             | String  | 'ev-icon-s-play' 아이콘을 우측으로 90도 회전한 모양 | 트리를 펼쳤을 때 보여질 아이콘                                       | |
-  | collapse-icon           | String  | 'ev-icon-s-play' 아이콘                 | 트리를 접었을 때 보여질 아이콘                                       | |
-  | context-menu-items      | Array   | []                                   | 우클릭 시 보여지는 컨텍스트 메뉴, 사용하지 않을 경우 컨텍스트 메뉴는 보이지 않음          | |
-  | search-word             | String  | ''                                   | 'ev-text-field' 컴포넌트를 사용해서 검색할 때 필터링 할 단어               | |
- | search-include-children | Boolean | false                                | 'ev-text-field' 컴포넌트를 사용해서 검색할 때 부모가 검색될 경우 자식까지 보일지 여부 | |
+  | collapse-icon           | String  | 'ev-icon-s-play' 아이콘 | 트리를 접었을 때 보여질 아이콘                                       | |
+  | context-menu-items      | Array   | [] | 우클릭 시 보여지는 컨텍스트 메뉴, 사용하지 않을 경우 컨텍스트 메뉴는 보이지 않음          | |
+  | search-word             | String  | '' | 'ev-text-field' 컴포넌트를 사용해서 검색할 때 필터링 할 단어               | |
+ | search-include-children | Boolean | false | 'ev-text-field' 컴포넌트를 사용해서 검색할 때 부모가 검색될 경우 자식까지 보일지 여부 | |
 
 >### Event
 

--- a/docs/views/tree/api/tree.md
+++ b/docs/views/tree/api/tree.md
@@ -10,15 +10,16 @@
 - 원하는 바인딩 옵션을 추가하여 트리 구현
 >### Props
 
- | 이름 | 타입 | 디폴트 | 설명 | 종류 |
-  |------|--------|------|------|------|
-  | data | Array | [] | 트리 컴포넌트에 사용될 데이터|  |
-  | use-checkbox | Boolean | false | 체크 박스를 사용 유무 |  |
-  | empty-text | String | 'No Data' | 트리 데이터가 없을 경우 나타낼 문구 | |
-  | expand-icon | String | 'ev-icon-s-play' 아이콘을 우측으로 90도 회전한 모양 | 트리를 펼쳤을 때 보여질 아이콘 | |
-  | collapse-icon | String | 'ev-icon-s-play' 아이콘 | 트리를 접었을 때 보여질 아이콘 | |
-  | context-menu-items | Array | [] | 우클릭 시 보여지는 컨텍스트 메뉴, 사용하지 않을 경우 컨텍스트 메뉴는 보이지 않음 | |
-  | search-word | String | '' | 'ev-text-field' 컴포넌트를 사용해서 검색할 때 필터링 할 단어 | |
+ | 이름                      | 타입      | 디폴트                                  | 설명                                                      | 종류 |
+  |-------------------------|---------|--------------------------------------|---------------------------------------------------------|------|
+  | data                    | Array   | []                                   | 트리 컴포넌트에 사용될 데이터                                        |  |
+  | use-checkbox            | Boolean | false                                | 체크 박스를 사용 유무                                            |  |
+  | empty-text              | String  | 'No Data'                            | 트리 데이터가 없을 경우 나타낼 문구                                    | |
+  | expand-icon             | String  | 'ev-icon-s-play' 아이콘을 우측으로 90도 회전한 모양 | 트리를 펼쳤을 때 보여질 아이콘                                       | |
+  | collapse-icon           | String  | 'ev-icon-s-play' 아이콘                 | 트리를 접었을 때 보여질 아이콘                                       | |
+  | context-menu-items      | Array   | []                                   | 우클릭 시 보여지는 컨텍스트 메뉴, 사용하지 않을 경우 컨텍스트 메뉴는 보이지 않음          | |
+  | search-word             | String  | ''                                   | 'ev-text-field' 컴포넌트를 사용해서 검색할 때 필터링 할 단어               | |
+ | search-include-children | Boolean | false                                | 'ev-text-field' 컴포넌트를 사용해서 검색할 때 부모가 검색될 경우 자식까지 보일지 여부 | |
 
 >### Event
 

--- a/docs/views/tree/example/Default.vue
+++ b/docs/views/tree/example/Default.vue
@@ -80,7 +80,7 @@
   <div class="case">
     <p class="case-title">Filter node</p>
     <div class="option">
-      <span>부모의 자식까지 검색 여부</span>
+      <span>부모가 검색될 경우 자식 노드까지 보일지 여부</span>
       <ev-toggle v-model="searchIncludeChildren" />
     </div>
     <ev-text-field

--- a/docs/views/tree/example/Default.vue
+++ b/docs/views/tree/example/Default.vue
@@ -79,6 +79,10 @@
   </div>
   <div class="case">
     <p class="case-title">Filter node</p>
+    <div class="option">
+      <span>부모의 자식까지 검색 여부</span>
+      <ev-toggle v-model="searchIncludeChildren" />
+    </div>
     <ev-text-field
       v-model="searchVm"
       placeholder="Search"
@@ -89,6 +93,7 @@
       :data="searchExData"
       :use-checkbox="true"
       :search-word="searchValue"
+      :search-include-children="searchIncludeChildren"
     />
     <div class="description">
       'ev-text-field' 컴포넌트를 사용해 필터링할 단어를 검색하면 'ev-tree' 컴포넌트 내부에서 검색되는 구조입니다.
@@ -316,7 +321,7 @@ export default {
                             iconClass: 'ev-icon-dolphin',
                           },
                           {
-                            title: 'tEAm C',
+                            title: 'Team C',
                             expand: true,
                             iconClass: 'ev-icon-folder',
                             children: [
@@ -408,6 +413,7 @@ export default {
 
     const searchVm = ref('');
     const searchValue = ref('');
+    const searchIncludeChildren = ref(false);
     const searchInput = (val) => {
       searchValue.value = val;
     };
@@ -427,6 +433,7 @@ export default {
       contextMenuInfo,
       searchValue,
       searchVm,
+      searchIncludeChildren,
       getCheckedNode,
       getClickedNode,
       getDblClickedNode,
@@ -436,5 +443,9 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
+.option {
+  display: flex;
+  gap: 10px;
+}
 </style>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.23",
+  "version": "3.4.24",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/tree/Tree.vue
+++ b/src/components/tree/Tree.vue
@@ -59,6 +59,10 @@ export default {
       type: String,
       default: '',
     },
+    searchIncludeChildren: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: {
     'click-node': null,
@@ -216,6 +220,21 @@ export default {
       showContextMenu(e);
     };
 
+    const isIncluded = (value, searchWord) => value.toLowerCase()
+        .includes(searchWord.toString().toLowerCase());
+
+    const makeChildrenVisible = (node) => {
+      if (node.children) {
+        const isSearchedChildren = !!(node.children
+            .filter(child => isIncluded(child.title, props.searchWord))?.length);
+        node.children.forEach((child) => {
+          makeChildrenVisible(child);
+          child.visible = (isSearchedChildren && isIncluded(child.title, props.searchWord))
+              || !isSearchedChildren;
+        });
+      }
+    };
+
     function makeChildrenInvisible(node) {
       if (node.children) {
         node.children.forEach((child) => {
@@ -243,13 +262,18 @@ export default {
         node.visible = false;
       });
 
-      const filteredNodes = allNodeInfo.filter(nodeObj => nodeObj.node.title.includes(value));
+      const filteredNodes = allNodeInfo
+          .filter(nodeObj => isIncluded(nodeObj.node.title, value));
 
       filteredNodes.forEach((nodeObj) => {
         const node = nodeObj.node;
         node.visible = true;
-        // make children invisible, traverse down
-        makeChildrenInvisible(node);
+        if (props.searchIncludeChildren) {
+          makeChildrenVisible(node);
+        } else {
+          // make children invisible, traverse down
+          makeChildrenInvisible(node);
+        }
         // make parent visible, traverse up
         const parentKey = allNodeInfo[node.nodeKey].parent;
         makeParentVisible(parentKey);

--- a/src/components/tree/Tree.vue
+++ b/src/components/tree/Tree.vue
@@ -185,11 +185,7 @@ export default {
       node.indeterminate = false;
       updateTreeUp(nodeKey); // propagate up
       updateTreeDown(node, { checked: isChecked, indeterminate: false }); // reset `indeterminate`
-      const checkedNodes = allNodeInfo.filter(obj => obj.node.checked)
-        .map(obj => ({
-            title: obj.node.title,
-            value: obj.node.value,
-          }));
+      const checkedNodes = allNodeInfo.filter(obj => obj.node.checked).map(obj => obj.node);
       emit('check', checkedNodes);
       rebuildTree();
     }
@@ -223,7 +219,7 @@ export default {
     };
 
     const isIncluded = (value, searchWord) => value.toLowerCase()
-        .includes(searchWord.toString().toLowerCase());
+        .includes(searchWord.toLowerCase());
 
     const makeChildrenVisible = (node) => {
       if (node.children) {

--- a/src/components/tree/Tree.vue
+++ b/src/components/tree/Tree.vue
@@ -150,7 +150,9 @@ export default {
         }
       }
 
-      flattenChildren(treeNodeData[0]);
+      if (treeNodeData.length) {
+        flattenChildren(treeNodeData[0]);
+      }
       return flatTree;
     }
 

--- a/src/components/tree/Tree.vue
+++ b/src/components/tree/Tree.vue
@@ -309,10 +309,7 @@ export default {
       rebuildTree();
       const checkedNodes = getCheckedNodes();
       if (checkedNodes.length) {
-        emit('check', checkedNodes.map(node => ({
-          title: node.title,
-          value: node.value,
-        })));
+        emit('check', checkedNodes);
       }
     });
     onBeforeUnmount(() => {


### PR DESCRIPTION
이슈
-
부모의 text가 검색됐을 때 부모까지만 검색됨

![Tree search](https://github.com/ex-em/EVUI/assets/75718910/a2fd93bf-9685-4a4c-a4c9-31ffd7f9c61e)

부모의 text가 검색됐을 때 부모 뿐만 아니라 부모에 포함된 자식도 보여주는 경우가 필요할 수 있음

작업 내용
-
1. searchIncludeChildren props를 추가하여 false로 했을 때 부모까지만 보여지고 true했을 경우 자식까지 보여지도록 로직 추가
2. searchIncludeChildren이 true일 경우
    2-1. searchWord가 부모와 자식에 text가 있을 경우 and 조건으로 보여지게 함
      ex) 
      root
        ⌞AB_1
                 ⌞⌞  A_2
                 ⌞⌞  B_3
        ⌞C_4
        
      A만 검색한 경우 아래와 같이 검색됨
      root
        ⌞AB_1
               ⌞⌞  A_2
  2-2. searchWord가 부모 text에만 해당되는 경우 부모의 자식이 모두 보여짐
     위의 예제에서 AB_1를 검색한 경우 아래와 같이 검색됨
      root
        ⌞AB_1
               ⌞⌞  A_2
               ⌞⌞  B_3
   
3. 대문자, 소문자 상관없이 검색되도록 수정
4. check emit 할 때 title, value 속성만 넘기지 않고 node 전체 속성 넘기도록 변경
5. props data가 빈배열일 경우 에러 발생 예외 처리

참고
-
![Tree search fix](https://github.com/ex-em/EVUI/assets/75718910/e883ba25-2a54-4d8d-87d5-a50cd4a1c327)

