### PR TITLE
[#1536] Tree > props data가 변경됐을 때 watch 감지 되지 않는 현상 수정

### DIFF
--- a/docs/views/tree/example/Default.vue
+++ b/docs/views/tree/example/Default.vue
@@ -400,7 +400,7 @@ export default {
     ]);
 
     const getCheckedNode = (checkedNode) => {
-      checkedNodeInfo.value = checkedNode;
+      checkedNodeInfo.value = checkedNode.map(node => ({ title: node.title, value: node.value }));
     };
 
     const getClickedNode = (clickedNode) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.24",
+  "version": "3.4.25",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/tree/Tree.vue
+++ b/src/components/tree/Tree.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script>
-import { ref, reactive, watch, onMounted, onBeforeUnmount } from 'vue';
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue';
 import TreeNode from './TreeNode';
 
 export default {
@@ -70,7 +70,7 @@ export default {
     check: Array,
   },
   setup(props, { emit }) {
-    let treeNodeData = reactive(props.data);
+    const treeNodeData = ref(props.data);
     let allNodeInfo = [];
     const contextMenu = ref(null);
     let contextMenuFlag = false; // flag for showing contextMenu or not
@@ -150,8 +150,8 @@ export default {
         }
       }
 
-      if (treeNodeData.length) {
-        flattenChildren(treeNodeData[0]);
+      if (treeNodeData.value.length) {
+        flattenChildren(treeNodeData.value[0]);
       }
       return flatTree;
     }
@@ -185,7 +185,7 @@ export default {
       node.indeterminate = false;
       updateTreeUp(nodeKey); // propagate up
       updateTreeDown(node, { checked: isChecked, indeterminate: false }); // reset `indeterminate`
-      const checkedNodes = allNodeInfo.filter(obj => obj.node.checked).map(obj => obj.node);
+      const checkedNodes = getCheckedNodes();
       emit('check', checkedNodes);
       rebuildTree();
     }
@@ -278,9 +278,11 @@ export default {
       });
     }
 
-    watch(props.data, (newData) => {
-      treeNodeData = newData;
+    watch(() => props.data, (newData) => {
+      treeNodeData.value = newData;
       allNodeInfo = getAllNodeInfo();
+    }, {
+      deep: true,
     });
 
 


### PR DESCRIPTION
이슈
-
props data를 초기 이후에 변경하는 경우 변경을 감지하지 못해 watch 를 타지 않음

작업 내용
-
1. treeNodeData 변수를 기존의 reactive로 되어있던 걸 ref로 변경
2. watch에서 () => 함수로 데이터 감지하도록 하고 deep: true 옵션 추가
3. Default.vue > checkedNode에 title, value만 출력되도록 변경

[AS-IS]
3초 이후에 데이터 업데이트 (업데이트 되지 않음)

![ev_tree_watch_be](https://github.com/ex-em/EVUI/assets/75718910/fed30c0b-bf0f-49f7-955d-7693f010dd61)

[TO-BE] 
3초 이후에 데이터 업데이트 (업데이트 됨을 확인)

![ev_tree_watch](https://github.com/ex-em/EVUI/assets/75718910/8d2cba33-b48e-4fee-8213-669c58c1bfb3)
