### PR TITLE
[#1538] Grid, TreeGrid > check 할 수 없는 row 에 대한 disable 처리

### DIFF
--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -32,6 +32,7 @@
 | height | String, Number | '100%' | 그리드 높이 | '50%', '50px', 50 |
 | selected | Array | [] | 선택된 row 데이터 |  |
 | checked | Array | [] | 체크된 row 데이터 |  |
+| uncheckableRows | Array | [] | 체크할 수 없는 row 데이터 |  |
 | option | Object | {} | 그리드 옵션 |  |
 |  | adjust | false | 그리드의 너비에 맞게 컬럼 너비를 자동으로 조절한다. |  |
 |  | showHeader | true | 헤더 표시 여부를 설정한다. |  |

--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -8,6 +8,7 @@
     v-model:checked="checkedMV"
     :columns="columns"
     :rows="tableData"
+    :uncheckable-rows="uncheckableRows"
     :width="widthMV"
     :height="heightMV"
     :option="{}"

--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -6,9 +6,9 @@
 <ev-grid
     v-model:selected="selectedMV"
     v-model:checked="checkedMV"
+    :uncheckable="uncheckable"
     :columns="columns"
     :rows="tableData"
-    :uncheckable-rows="uncheckableRows"
     :width="widthMV"
     :height="heightMV"
     :option="{}"
@@ -33,7 +33,7 @@
 | height | String, Number | '100%' | 그리드 높이 | '50%', '50px', 50 |
 | selected | Array | [] | 선택된 row 데이터 |  |
 | checked | Array | [] | 체크된 row 데이터 |  |
-| uncheckableRows | Array | [] | 체크할 수 없는 row 데이터 |  |
+| uncheckable | Array | [] | 체크할 수 없는 row 데이터 |  |
 | option | Object | {} | 그리드 옵션 |  |
 |  | adjust | false | 그리드의 너비에 맞게 컬럼 너비를 자동으로 조절한다. |  |
 |  | showHeader | true | 헤더 표시 여부를 설정한다. |  |

--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -3,9 +3,9 @@
     <ev-grid
       v-model:selected="selected"
       v-model:checked="checked"
+      :uncheckable="uncheckable"
       :columns="columns"
       :rows="tableData"
-      :uncheckable-rows="uncheckableRows"
       :width="widthMV"
       :height="heightMV"
       :option="{
@@ -219,7 +219,7 @@ export default {
     const tableData = ref([]);
     const selected = ref([]);
     const checked = ref([]);
-    const uncheckableRows = ref([]);
+    const uncheckable = ref([]);
     const widthMV = ref('100%');
     const heightMV = ref(300);
     const showHeaderMV = ref(true);
@@ -327,13 +327,13 @@ export default {
     });
 
     tableData.value = getData(50, 0);
-    uncheckableRows.value = [tableData.value[0]];
+    uncheckable.value = [tableData.value[0]];
     return {
       columns,
       tableData,
       selected,
       checked,
-      uncheckableRows,
+      uncheckable,
       widthMV,
       heightMV,
       showHeaderMV,

--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -5,6 +5,7 @@
       v-model:checked="checked"
       :columns="columns"
       :rows="tableData"
+      :uncheckable-rows="uncheckableRows"
       :width="widthMV"
       :height="heightMV"
       :option="{
@@ -218,6 +219,7 @@ export default {
     const tableData = ref([]);
     const selected = ref([]);
     const checked = ref([]);
+    const uncheckableRows = ref([]);
     const widthMV = ref('100%');
     const heightMV = ref(300);
     const showHeaderMV = ref(true);
@@ -325,11 +327,13 @@ export default {
     });
 
     tableData.value = getData(50, 0);
+    uncheckableRows.value = [tableData.value[0]];
     return {
       columns,
       tableData,
       selected,
       checked,
+      uncheckableRows,
       widthMV,
       heightMV,
       showHeaderMV,

--- a/docs/views/treeGrid/api/treeGrid.md
+++ b/docs/views/treeGrid/api/treeGrid.md
@@ -90,7 +90,7 @@
 | 이름              | 타입      | 설명                                                 | 종류                                               | 필수 |
 |-----------------|---------|----------------------------------------------------|--------------------------------------------------| --- |
 | caption         | String  | 컬럼명                                                | ex) '인스턴스명'                                      | Y |
-| field           | String  | 필드명                                                | ex) 'instance_name'                              | Y |
+| field  | String  | 필드명 <br> ('index', 'level', 'parent', 'children', 'checked', 'selected', 'expand', 'show', 'isFilter', 'uncheckable'와 같은 필드명은  Tree Option과 관련된 속성 명칭으로 중복 사용을 피하도록 권고함) | ex) 'instance_name'  | Y |
 | type            | String  | 데이터 타입                                             | 'string', 'number', 'stringNumber', 'float', 'boolean' | Y |
 | hide            | Boolean | 컬럼 숨김 여부                                           | Boolean                                          | N |
 | hiddenDisplay | Boolean | 컬럼 목록 체크 여부 | Boolean | N |

--- a/docs/views/treeGrid/api/treeGrid.md
+++ b/docs/views/treeGrid/api/treeGrid.md
@@ -9,9 +9,11 @@
     :columns="columns"
     :rows="[
       {
-        tableData,
+        checked: false,
+        selected: false,
+        show: false,
         expand: false,
-        disabled: false,
+        uncheckable: false,
         children: [{ ... }]
       }
       ...
@@ -37,8 +39,11 @@
 | columns | Array            | []                 | 컬럼 리스트                                  |                          |
 | rows | Array            | []                 | Tree Data 리스트                           |                          |
 |  | {}    |    | Tree Grid의 각 Row 데이터에 연결된 속성 | |
-|  |    | expand   | 부모 Row 데이터에 대한 확장 여부  | true, false |
-|  |    | disabled   | Row 데이터의 체크박스에 대한 비활성화 처리  | true, false |
+|  |    | checked   | Row 데이터 체크 여부  | true, false |
+|  |    | selected   | Row 데이터 선택 여부  | true, false |
+|  |    | show  | Row 데이터 표시 여부  | true, false |
+|  |    | expand   | Row 데이터 확장 여부  | true, false |
+|  |    | uncheckable   | Row 데이터의 체크박스에 대한 비활성화 처리  | true, false |
 |  |    | children   | 자식 데이터  | Array |
 | width | String, Number   | '100%'             | 그리드 넓이                                  | '50%', '50px', 50        |
 | height | String, Number   | '100%'             | 그리드 높이                                  | '50%', '50px', 50        |

--- a/docs/views/treeGrid/api/treeGrid.md
+++ b/docs/views/treeGrid/api/treeGrid.md
@@ -7,7 +7,15 @@
     v-model:selected="selectedMV"
     v-model:checked="checkedMV"
     :columns="columns"
-    :rows="tableData"
+    :rows="[
+      {
+        tableData,
+        expand: false,
+        disabled: false,
+        children: [{ ... }]
+      }
+      ...
+    ]"
     :width="widthMV"
     :height="heightMV"
     :option="{}"
@@ -28,6 +36,10 @@
 | --- |------------------|--------------------|-----------------------------------------|--------------------------|
 | columns | Array            | []                 | 컬럼 리스트                                  |                          |
 | rows | Array            | []                 | Tree Data 리스트                           |                          |
+|  | {}    |    | Tree Grid의 각 Row 데이터에 연결된 속성 | |
+|  |    | expand   | 부모 Row 데이터에 대한 확장 여부  | true, false |
+|  |    | disabled   | Row 데이터의 체크박스에 대한 비활성화 처리  | true, false |
+|  |    | children   | 자식 데이터  | Array |
 | width | String, Number   | '100%'             | 그리드 넓이                                  | '50%', '50px', 50        |
 | height | String, Number   | '100%'             | 그리드 높이                                  | '50%', '50px', 50        |
 | selected | Array            | []                 | 선택된 Row 데이터                             |                          |

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -415,11 +415,13 @@ export default {
             id: 'Exem 3',
             date: '2016-05-02',
             name: '3',
+            _disabled: true,
           }, {
             id: 'Exem 4',
             date: '2016-05-02',
             name: '4',
             expand: false,
+            _disabled: true,
             children: [{
               id: 'Exem 5',
               date: '2016-05-02',

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -415,13 +415,13 @@ export default {
             id: 'Exem 3',
             date: '2016-05-02',
             name: '3',
-            _disabled: true,
+            disabled: true,
           }, {
             id: 'Exem 4',
             date: '2016-05-02',
             name: '4',
             expand: false,
-            _disabled: true,
+            disabled: true,
             children: [{
               id: 'Exem 5',
               date: '2016-05-02',

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -415,13 +415,13 @@ export default {
             id: 'Exem 3',
             date: '2016-05-02',
             name: '3',
-            disabled: true,
+            uncheckable: true,
           }, {
             id: 'Exem 4',
             date: '2016-05-02',
             name: '4',
             expand: false,
-            disabled: true,
+            uncheckable: true,
             children: [{
               id: 'Exem 5',
               date: '2016-05-02',

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -210,6 +210,7 @@
             <ev-checkbox
               v-if="useCheckbox.use && useCheckbox.headerCheck && useCheckbox.mode !== 'single'"
               v-model="isHeaderChecked"
+              :disabled="isHeaderDisabled"
               @change="onCheckAll"
             />
           </li>
@@ -378,6 +379,7 @@
                 <ev-checkbox
                   v-model="row[1]"
                   class="row-checkbox-input"
+                  :disabled="row[4]"
                   @change="onCheck($event, row)"
                 />
               </td>
@@ -593,6 +595,10 @@ export default {
       type: [Array],
       default: () => [],
     },
+    uncheckableRows: {
+      type: [Array],
+      default: () => [],
+    },
     option: {
       type: Object,
       default: () => ({}),
@@ -695,6 +701,7 @@ export default {
     const checkInfo = reactive({
       prevCheckedRow: [],
       isHeaderChecked: false,
+      isHeaderDisabled: false,
       checkedRows: props.checked,
       useCheckbox: computed(() => (props.option.useCheckbox || {})),
     });

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -954,6 +954,10 @@ export default {
         onResize();
       }, { deep: true },
     );
+    watch(() => props.uncheckableRows,
+      () => {
+      setStore(props.rows);
+      }, { deep: true });
     watch(
       () => props.checked,
       (value) => {

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -393,7 +393,7 @@
                   <ev-checkbox
                     v-model="row[1]"
                     class="row-checkbox-input"
-                    :disabled="row[4]"
+                    :disabled="row[5]"
                     @change="onCheck($event, row)"
                   />
                 </td>

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -210,7 +210,7 @@
             <ev-checkbox
               v-if="useCheckbox.use && useCheckbox.headerCheck && useCheckbox.mode !== 'single'"
               v-model="isHeaderChecked"
-              :disabled="isHeaderDisabled"
+              :disabled="isHeaderUncheckable"
               @change="onCheckAll"
             />
           </li>
@@ -595,7 +595,7 @@ export default {
       type: [Array],
       default: () => [],
     },
-    uncheckableRows: {
+    uncheckable: {
       type: [Array],
       default: () => [],
     },
@@ -701,7 +701,7 @@ export default {
     const checkInfo = reactive({
       prevCheckedRow: [],
       isHeaderChecked: false,
-      isHeaderDisabled: false,
+      isHeaderUncheckable: false,
       checkedRows: props.checked,
       useCheckbox: computed(() => (props.option.useCheckbox || {})),
     });
@@ -954,7 +954,7 @@ export default {
         onResize();
       }, { deep: true },
     );
-    watch(() => props.uncheckableRows,
+    watch(() => props.uncheckable,
       () => {
       setStore(props.rows);
       }, { deep: true });

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -485,7 +485,7 @@ export const checkEvent = (params) => {
       }
 
       const isAllChecked = store
-        .filter(rowData => !props.uncheckableRows.includes(rowData[ROW_DATA_INDEX]))
+        .filter(rowData => !props.uncheckable.includes(rowData[ROW_DATA_INDEX]))
         .every(d => d[ROW_CHECK_INDEX]);
       if (store.length && isAllChecked) {
         checkInfo.isHeaderChecked = true;
@@ -514,7 +514,7 @@ export const checkEvent = (params) => {
       store = getPagingData();
     }
     store.forEach((row) => {
-      const isDisabledCheckbox = props.uncheckableRows.includes(row[ROW_DATA_INDEX]);
+      const isDisabledCheckbox = props.uncheckable.includes(row[ROW_DATA_INDEX]);
       if (isHeaderChecked) {
         if (!checkInfo.checkedRows.includes(row[ROW_DATA_INDEX]) && !isDisabledCheckbox) {
           checkInfo.checkedRows.push(row[ROW_DATA_INDEX]);
@@ -1051,7 +1051,7 @@ export const storeEvent = (params) => {
       let hasUnChecked = false;
       rows.forEach((row, idx) => {
         const checked = props.checked.includes(row);
-        const isDisabledCheckbox = props.uncheckableRows.includes(row);
+        const isDisabledCheckbox = props.uncheckable.includes(row);
         let selected = false;
         if (selectInfo.useSelect) {
           selected = props.selected.includes(row);
@@ -1062,7 +1062,7 @@ export const storeEvent = (params) => {
         store.push([idx, checked, row, selected, isDisabledCheckbox]);
       });
       checkInfo.isHeaderChecked = rows.length > 0 ? !hasUnChecked : false;
-      checkInfo.isHeaderDisabled = rows.every(row => props.uncheckableRows.includes(row));
+      checkInfo.isHeaderUncheckable = rows.every(row => props.uncheckable.includes(row));
       stores.originStore = store;
     }
     if (filterInfo.isFiltering) {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1056,13 +1056,13 @@ export const storeEvent = (params) => {
         if (selectInfo.useSelect) {
           selected = props.selected.includes(row);
         }
-        if (!checked) {
+        if (!checked && !isDisabledCheckbox) {
           hasUnChecked = true;
         }
         store.push([idx, checked, row, selected, isDisabledCheckbox]);
       });
       checkInfo.isHeaderChecked = rows.length > 0 ? !hasUnChecked : false;
-      checkInfo.isHeaderDisabled = rows.length === props.uncheckableRows.length;
+      checkInfo.isHeaderDisabled = rows.every(row => props.uncheckableRows.includes(row));
       stores.originStore = store;
     }
     if (filterInfo.isFiltering) {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -514,16 +514,16 @@ export const checkEvent = (params) => {
       store = getPagingData();
     }
     store.forEach((row) => {
-      const isDisabledCheckbox = props.uncheckable.includes(row[ROW_DATA_INDEX]);
+      const uncheckable = props.uncheckable.includes(row[ROW_DATA_INDEX]);
       if (isHeaderChecked) {
-        if (!checkInfo.checkedRows.includes(row[ROW_DATA_INDEX]) && !isDisabledCheckbox) {
+        if (!checkInfo.checkedRows.includes(row[ROW_DATA_INDEX]) && !uncheckable) {
           checkInfo.checkedRows.push(row[ROW_DATA_INDEX]);
         }
       } else {
         checkInfo.checkedRows.splice(checkInfo.checkedRows.indexOf(row[ROW_DATA_INDEX]), 1);
       }
 
-      if (!isDisabledCheckbox) {
+      if (!uncheckable) {
         row[ROW_CHECK_INDEX] = isHeaderChecked;
       }
     });
@@ -1051,15 +1051,15 @@ export const storeEvent = (params) => {
       let hasUnChecked = false;
       rows.forEach((row, idx) => {
         const checked = props.checked.includes(row);
-        const isDisabledCheckbox = props.uncheckable.includes(row);
+        const uncheckable = props.uncheckable.includes(row);
         let selected = false;
         if (selectInfo.useSelect) {
           selected = props.selected.includes(row);
         }
-        if (!checked && !isDisabledCheckbox) {
+        if (!checked && !uncheckable) {
           hasUnChecked = true;
         }
-        store.push([idx, checked, row, selected, isDisabledCheckbox]);
+        store.push([idx, checked, row, selected, uncheckable]);
       });
       checkInfo.isHeaderChecked = rows.length > 0 ? !hasUnChecked : false;
       checkInfo.isHeaderUncheckable = rows.every(row => props.uncheckable.includes(row));

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -62,6 +62,7 @@
             <ev-checkbox
               v-if="isHeaderCheckbox"
               v-model="isHeaderChecked"
+              :disabled="isHeaderDisabled"
               @change="onCheckAll"
             />
           </li>
@@ -382,6 +383,7 @@ export default {
     const checkInfo = reactive({
       prevCheckedRow: [],
       isHeaderChecked: false,
+      isHeaderDisabled: false,
       checkedRows: props.checked,
       useCheckbox: computed(() => props.option.useCheckbox || {}),
     });

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -62,7 +62,7 @@
             <ev-checkbox
               v-if="isHeaderCheckbox"
               v-model="isHeaderChecked"
-              :disabled="isHeaderDisabled"
+              :disabled="isHeaderUncheckable"
               @change="onCheckAll"
             />
           </li>
@@ -383,7 +383,7 @@ export default {
     const checkInfo = reactive({
       prevCheckedRow: [],
       isHeaderChecked: false,
-      isHeaderDisabled: false,
+      isHeaderUncheckable: false,
       checkedRows: props.checked,
       useCheckbox: computed(() => props.option.useCheckbox || {}),
     });

--- a/src/components/treeGrid/TreeGridNode.vue
+++ b/src/components/treeGrid/TreeGridNode.vue
@@ -16,7 +16,7 @@
     >
       <ev-checkbox
         v-model="node.checked"
-        :disabled="node.disabled"
+        :disabled="node.uncheckable"
         class="row-checkbox-input"
         @change="onCheck($event, node)"
       />

--- a/src/components/treeGrid/TreeGridNode.vue
+++ b/src/components/treeGrid/TreeGridNode.vue
@@ -16,7 +16,7 @@
     >
       <ev-checkbox
         v-model="node.checked"
-        :disabled="node._disabled"
+        :disabled="node.disabled"
         class="row-checkbox-input"
         @change="onCheck($event, node)"
       />

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -66,9 +66,11 @@ export const commonFunctions = (params) => {
     const disabledList = rows.filter(row => row._disabled);
     if (disabledList.length) {
       const checkedList = rows.filter(row => row.checked);
-      if (disabledList.length + checkedList.length === rows.length) {
-        checkInfo.isHeaderChecked = true;
-      }
+      const isAllDisabled = disabledList.length === rows.length;
+
+      checkInfo.isHeaderChecked = !isAllDisabled
+        && (disabledList.length + checkedList.length === rows.length);
+      checkInfo.isHeaderDisabled = isAllDisabled;
     }
   };
   return {
@@ -662,7 +664,7 @@ export const treeEvent = (params) => {
     }
 
     function setNodeData(nodeInfo) {
-      const { node, level, isShow, parent } = nodeInfo;
+      const { node, level, isShow, parent, isDisabled } = nodeInfo;
       if (node !== null && typeof node === 'object') {
         node.index = nodeIndex++;
         node.level = level;
@@ -687,6 +689,10 @@ export const treeEvent = (params) => {
           node.isFilter = false;
         }
 
+        if (!Object.hasOwnProperty.call(node, '_disabled')) {
+          node._disabled = isDisabled;
+        }
+
         if (!Object.hasOwnProperty.call(node, 'data')) {
           node.data = getDataObj(node);
         }
@@ -704,6 +710,7 @@ export const treeEvent = (params) => {
               level: level + 1,
               isShow: node.show && node.expand,
               parent: node,
+              isDisabled: node._disabled,
             }),
           );
         }
@@ -715,6 +722,7 @@ export const treeEvent = (params) => {
         level: 0,
         isShow: true,
         parent: undefined,
+        isDisabled: false,
       });
     });
     return nodeList;

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -63,7 +63,7 @@ export const commonFunctions = (params) => {
   };
   const checkHeader = (rows) => {
     checkInfo.isHeaderChecked = !!rows.length && rows.every(row => row.checked);
-    const disabledList = rows.filter(row => row._disabled);
+    const disabledList = rows.filter(row => row.disabled);
     if (disabledList.length) {
       const checkedList = rows.filter(row => row.checked);
       const isAllDisabled = rows.every(row => disabledList.includes(row));
@@ -450,14 +450,14 @@ export const checkEvent = (params) => {
     if (node.hasChild) {
       node.children.forEach((children) => {
         const childNode = children;
-        if (node.checked && !childNode.checked && !childNode._disabled) {
+        if (node.checked && !childNode.checked && !childNode.disabled) {
           checkInfo.checkedRows.push(childNode);
         }
         if (!node.checked) {
           checkInfo.checkedRows = checkInfo.checkedRows
             .filter(checked => checked.index !== childNode.index);
         }
-        childNode.checked = node.checked && !childNode._disabled;
+        childNode.checked = node.checked && !childNode.disabled;
 
         if (childNode.hasChild) {
           onCheckChildren(childNode);
@@ -469,8 +469,8 @@ export const checkEvent = (params) => {
     const parentNode = node.parent;
     if (parentNode) {
       const isCheck = parentNode.children.every(n => n.checked);
-      parentNode.checked = isCheck && !parentNode._disabled;
-      const disabledList = parentNode.children.filter(n => n._disabled);
+      parentNode.checked = isCheck && !parentNode.disabled;
+      const disabledList = parentNode.children.filter(n => n.disabled);
       if (disabledList.length) {
         const checkedList = parentNode.children.filter(n => n.checked);
         if (disabledList.length + checkedList.length === parentNode.children.length) {
@@ -554,7 +554,7 @@ export const checkEvent = (params) => {
       store = getPagingData();
     }
     store.forEach((row) => {
-      row.checked = status && !row._disabled;
+      row.checked = status && !row.disabled;
       if (row.checked) {
         if (!checkInfo.checkedRows.find(checked => checked.index === row.index)) {
           checkInfo.checkedRows.push(row);
@@ -689,8 +689,8 @@ export const treeEvent = (params) => {
           node.isFilter = false;
         }
 
-        if (!Object.hasOwnProperty.call(node, '_disabled')) {
-          node._disabled = isDisabled;
+        if (!Object.hasOwnProperty.call(node, 'disabled')) {
+          node.disabled = isDisabled;
         }
 
         if (!Object.hasOwnProperty.call(node, 'data')) {
@@ -710,7 +710,7 @@ export const treeEvent = (params) => {
               level: level + 1,
               isShow: node.show && node.expand,
               parent: node,
-              isDisabled: node._disabled,
+              isDisabled: node.disabled,
             }),
           );
         }

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -66,7 +66,7 @@ export const commonFunctions = (params) => {
     const disabledList = rows.filter(row => row._disabled);
     if (disabledList.length) {
       const checkedList = rows.filter(row => row.checked);
-      const isAllDisabled = disabledList.length === rows.length;
+      const isAllDisabled = rows.every(row => disabledList.includes(row));
 
       checkInfo.isHeaderChecked = !isAllDisabled
         && (disabledList.length + checkedList.length === rows.length);

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -63,14 +63,14 @@ export const commonFunctions = (params) => {
   };
   const checkHeader = (rows) => {
     checkInfo.isHeaderChecked = !!rows.length && rows.every(row => row.checked);
-    const disabledList = rows.filter(row => row.disabled);
-    if (disabledList.length) {
+    const uncheckableList = rows.filter(row => row.uncheckable);
+    if (uncheckableList.length) {
       const checkedList = rows.filter(row => row.checked);
-      const isAllDisabled = rows.every(row => disabledList.includes(row));
+      const isAllUncheckable = rows.every(row => uncheckableList.includes(row));
 
-      checkInfo.isHeaderChecked = !isAllDisabled
-        && (disabledList.length + checkedList.length === rows.length);
-      checkInfo.isHeaderDisabled = isAllDisabled;
+      checkInfo.isHeaderChecked = !isAllUncheckable
+        && (uncheckableList.length + checkedList.length === rows.length);
+      checkInfo.isHeaderUncheckable = isAllUncheckable;
     }
   };
   return {
@@ -450,14 +450,14 @@ export const checkEvent = (params) => {
     if (node.hasChild) {
       node.children.forEach((children) => {
         const childNode = children;
-        if (node.checked && !childNode.checked && !childNode.disabled) {
+        if (node.checked && !childNode.checked && !childNode.uncheckable) {
           checkInfo.checkedRows.push(childNode);
         }
         if (!node.checked) {
           checkInfo.checkedRows = checkInfo.checkedRows
             .filter(checked => checked.index !== childNode.index);
         }
-        childNode.checked = node.checked && !childNode.disabled;
+        childNode.checked = node.checked && !childNode.uncheckable;
 
         if (childNode.hasChild) {
           onCheckChildren(childNode);
@@ -469,11 +469,11 @@ export const checkEvent = (params) => {
     const parentNode = node.parent;
     if (parentNode) {
       const isCheck = parentNode.children.every(n => n.checked);
-      parentNode.checked = isCheck && !parentNode.disabled;
-      const disabledList = parentNode.children.filter(n => n.disabled);
-      if (disabledList.length) {
+      parentNode.checked = isCheck && !parentNode.uncheckable;
+      const uncheckableList = parentNode.children.filter(n => n.uncheckable);
+      if (uncheckableList.length) {
         const checkedList = parentNode.children.filter(n => n.checked);
-        if (disabledList.length + checkedList.length === parentNode.children.length) {
+        if (uncheckableList.length + checkedList.length === parentNode.children.length) {
           parentNode.checked = true;
         }
       }
@@ -554,7 +554,7 @@ export const checkEvent = (params) => {
       store = getPagingData();
     }
     store.forEach((row) => {
-      row.checked = status && !row.disabled;
+      row.checked = status && !row.uncheckable;
       if (row.checked) {
         if (!checkInfo.checkedRows.find(checked => checked.index === row.index)) {
           checkInfo.checkedRows.push(row);
@@ -664,7 +664,7 @@ export const treeEvent = (params) => {
     }
 
     function setNodeData(nodeInfo) {
-      const { node, level, isShow, parent, isDisabled } = nodeInfo;
+      const { node, level, isShow, parent, uncheckable } = nodeInfo;
       if (node !== null && typeof node === 'object') {
         node.index = nodeIndex++;
         node.level = level;
@@ -689,8 +689,8 @@ export const treeEvent = (params) => {
           node.isFilter = false;
         }
 
-        if (!Object.hasOwnProperty.call(node, 'disabled')) {
-          node.disabled = isDisabled;
+        if (!Object.hasOwnProperty.call(node, 'uncheckable')) {
+          node.uncheckable = uncheckable;
         }
 
         if (!Object.hasOwnProperty.call(node, 'data')) {
@@ -710,7 +710,7 @@ export const treeEvent = (params) => {
               level: level + 1,
               isShow: node.show && node.expand,
               parent: node,
-              isDisabled: node.disabled,
+              uncheckable: node.uncheckable,
             }),
           );
         }
@@ -722,7 +722,7 @@ export const treeEvent = (params) => {
         level: 0,
         isShow: true,
         parent: undefined,
-        isDisabled: false,
+        uncheckable: false,
       });
     });
     return nodeList;


### PR DESCRIPTION
### 작업 내용

1. Grid
- check 할 수 없는 row를 `uncheckable` 속성에 담아주도록 함으로써 해당 row들을 disable 처리하도록 수정
- All check를 하는 경우, disable된 row 제외하여 체크되도록 수정
- 모든 row의 checkbox가 disable된 경우에는 header checkbox도 disable되도록 예외 처리
![image](https://github.com/ex-em/EVUI/assets/79958259/a7ee5363-a1bc-4b91-9283-40b0d3a1ec4d)


2. Tree Grid
- `_disabled` 속성 -> `uncheckable` 명으로 변경
- 기존에 작업된 row의 체크박스 비활성화 기능(`uncheckable` 옵션)에서 자식 row가 있는 부모 row가 disable된 경우, 자식 row도 disable 되도록 추가 수정
- 모든 row의 checkbox가 disable된 경우에는 header checkbox도 disable되도록 예외 처리
![image](https://github.com/ex-em/EVUI/assets/79958259/9b1c3b2b-3e8f-4d0e-a6ae-1bffb3c42c7e)
