### PR TITLE
[#1540] Grid > Row Detail 슬롯 추가

### DIFF
--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -18,10 +18,12 @@
 >
   <template #{필드명}></template>
   <template #toolbar="{ item }"></template>
+  <template #rowDetail="{ item }"></template>
 </ev-grid>
 ```
  - `#{필드명}` 지정해서 Cell Render 설정
  - `#toolbar` 지정해서 Toolbar 표시
+ - `#rowDetail` Row 하단에 사용자 정의 컴포넌트 표현, 사용시 가상스크롤 미적용
 
 ### Props
 | 이름 | 타입 | 디폴트 | 설명 | 종류 |

--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -23,7 +23,7 @@
 ```
  - `#{필드명}` 지정해서 Cell Render 설정
  - `#toolbar` 지정해서 Toolbar 표시
- - `#rowDetail` Row 하단에 사용자 정의 컴포넌트 표현, 사용시 가상스크롤 미적용
+ - `#rowDetail` Row 하단에 사용자 정의 컴포넌트 표현, 사용시 가상스크롤 미적용 rowDetail 옵션과 같이 사용
 
 ### Props
 | 이름 | 타입 | 디폴트 | 설명 | 종류 |
@@ -34,6 +34,7 @@
 | height | String, Number | '100%' | 그리드 높이 | '50%', '50px', 50 |
 | selected | Array | [] | 선택된 row 데이터 |  |
 | checked | Array | [] | 체크된 row 데이터 |  |
+| expanded | Array | [] | 확장된 Row 데이터 |  |
 | option | Object | {} | 그리드 옵션 |  |
 |  | adjust | false | 그리드의 너비에 맞게 컬럼 너비를 자동으로 조절한다. |  |
 |  | showHeader | true | 헤더 표시 여부를 설정한다. |  |
@@ -63,6 +64,8 @@
 |  |  | visiblePage | 보여지는 Pagination 버튼 수 | Number |
 |  |  | order | Pagination 위치 | 'center', 'left', 'right' |
 |  |  | showPageInfo | 페이지 정보 표시 여부 | Boolean |
+|  | rowDetail | {} | rowDetail 설정 | |
+|  |  | use | rowDetail 사용여부 | Boolean |
 |  | useSummary | false | 하단에 summary row 가 표시 된다. | Boolean |
 |  | useColumnSetting | false | 컬럼 목록 설정 여부  | Boolean |
 
@@ -93,3 +96,4 @@
  | dblclick-row | event, row | row가 더블 클릭 되었을 때 호출된다. |
  | page-change | event | page 정보가 변경되었을 때 호출된다. |
  | sort-column | event | column을 기준으로 정렬이 변경되었을 때 호출된다. |
+ | expand-row | event, row, isExpand, index | row가 확장되었을 때 호출된다. |

--- a/docs/views/grid/example/RowDetail.vue
+++ b/docs/views/grid/example/RowDetail.vue
@@ -1,44 +1,48 @@
 <template>
   <div class="case">
     <ev-grid
+      v-model:expanded="expandedRowsMV"
       :columns="columns"
       :rows="rows"
       :height="400"
       :option="{
         adjust: true,
+        rowDetail: {
+          use: useRowDetail,
+        }
       }"
+      @expand-row="onExpandRow"
     >
-      <!-- cell renderer slot -->
-      <template #toggle="{ item }">
-        <div
-          class="toggle-wrapper"
-          @click="expendedRowDetail(item.row)"
-        >
-          <ev-icon
-            icon="ev-icon-s-play"
-            :class="{
-              toggle: true,
-              expended: item.row[2][0],
-            }"
-          />
-        </div>
-      </template>
-
-      <!-- expended row slot -->
       <template #rowDetail="{ item }">
-        <div class="row-detail-wrapper">
-          <row-detail-content
-            v-if="item.row[2][0]"
-            :data="item.row[2]"
-          />
-        </div>
+        <row-detail-content
+          :data="item.row[2]"
+        />
       </template>
     </ev-grid>
+    <div class="description">
+      <div class="form-rows">
+        <span class="badge yellow">
+          Use Row Detail
+        </span>
+        <ev-toggle
+            v-model="useRowDetail"
+        />
+      </div>
+      <div class="form-row">
+        <span class="badge yellow">
+          Expanded Row
+        </span>
+        <ev-text-field
+            v-model="expandedRowText"
+            type="textarea"
+        />
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 import RowDetailContent from './partitals/RowDetailContent.vue';
 
 export default {
@@ -47,9 +51,6 @@ export default {
   },
   setup() {
     const columns = [
-      {
-        caption: '', field: 'toggle', type: 'boolean', width: 80,
-      },
       {
         caption: 'Name', field: 'name', type: 'string',
       },
@@ -67,14 +68,14 @@ export default {
       },
     ];
     const rows = ref([]);
-
-
+    const useRowDetail = ref(true);
+    const expandedRowsMV = ref([]);
+    const expandedRowText = ref('');
     const pushData = () => {
       const startIdx = rows.value.length + 1;
 
       for (let ix = startIdx; ix < startIdx + 30; ix++) {
         rows.value.push([
-          (ix === 1),
           `name-${ix}`,
           `column1-${ix}`,
           `column2-${ix}`,
@@ -83,36 +84,51 @@ export default {
         ]);
       }
     };
-    const expendedRowDetail = (row) => {
-      const idx = row[0];
-      rows.value[idx][0] = !rows.value[idx][0];
+    const onExpandRow = (a, b, c, d) => {
+      console.log(a);
+      console.log(b);
+      console.log(c);
+      console.log(d);
+      let result = '';
+      expandedRowsMV.value.forEach((row) => {
+        result += JSON.stringify(row);
+      });
+      expandedRowText.value = result;
     };
 
     pushData();
 
+    watch(useRowDetail, () => {
+      onExpandRow();
+    });
+
     return {
       columns,
       rows,
-      expendedRowDetail,
+      useRowDetail,
+      expandedRowsMV,
+      expandedRowText,
+      onExpandRow,
     };
   },
 };
 </script>
 
 <style lang="scss">
-@import '../../../style/index.scss';
-
-.toggle-wrapper {
-  display: flex;
-  width: 100%;
-  height: 100%;
-  justify-content: center;
-  align-items: center;
-}
-.toggle {
-  transition: transform $animate-fast;
-  &.expended {
-    transform: rotate(90deg);
+.description {
+  .form-rows {
+    display: flex;
+    margin-bottom: 5px;
+  }
+  .ev-text-field, .ev-input-number, .ev-select {
+    width: 80%;
+  }
+  .badge {
+    margin-bottom: 2px;
+    margin-right: 5px !important;
+  }
+  .ev-toggle {
+    margin-right: 10px;
   }
 }
 </style>

--- a/docs/views/grid/example/RowDetail.vue
+++ b/docs/views/grid/example/RowDetail.vue
@@ -7,6 +7,7 @@
       :height="400"
       :option="{
         adjust: true,
+        customContextMenu: menuItems,
         rowDetail: {
           use: useRowDetail,
         }
@@ -33,8 +34,8 @@
           Expanded Row
         </span>
         <ev-text-field
-            v-model="expandedRowText"
-            type="textarea"
+          v-model="expandedRowText"
+          type="textarea"
         />
       </div>
     </div>
@@ -50,6 +51,15 @@ export default {
     RowDetailContent,
   },
   setup() {
+    const menuItems = ref([
+      {
+        text: 'Menu1',
+        click: param => console.log(`[Menu1] Selected Row Data: ${param?.selectedRow}`),
+      }, {
+        text: 'Menu2',
+        click: param => console.log('[Menu2]', param.contextmenuInfo),
+      },
+    ]);
     const columns = [
       {
         caption: 'Name', field: 'name', type: 'string',
@@ -99,6 +109,7 @@ export default {
     });
 
     return {
+      menuItems,
       columns,
       rows,
       useRowDetail,

--- a/docs/views/grid/example/RowDetail.vue
+++ b/docs/views/grid/example/RowDetail.vue
@@ -1,0 +1,119 @@
+<template>
+  <div class="case">
+    <ev-grid
+      :columns="columns"
+      :rows="rows"
+      :height="400"
+      :option="{
+        adjust: true,
+      }"
+    >
+      <!-- cell renderer slot -->
+      <template #toggle="{ item }">
+        <div
+            class="toggle-wrapper"
+            @click="expendedRowDetail(item.row)"
+        >
+          <ev-icon
+            icon="ev-icon-s-play"
+            :class="{
+              toggle: true,
+              expended: item.row[2][0],
+            }"
+          />
+        </div>
+      </template>
+
+      <!-- expended row slot -->
+      <template #rowDetail="{ item }">
+        <div class="row-detail-wrapper">
+          <row-detail-content
+            v-if="item.row[2][0]"
+            :data="item.row[2]"
+          />
+        </div>
+      </template>
+    </ev-grid>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+import RowDetailContent from './partitals/RowDetailContent.vue';
+
+
+export default {
+  components: {
+    RowDetailContent,
+  },
+  setup() {
+    const columns = [
+      {
+        caption: '', field: 'toggle', type: 'boolean', width: 80,
+      },
+      {
+        caption: 'Name', field: 'name', type: 'string',
+      },
+      {
+        caption: 'Column1', field: 'column1', type: 'string',
+      },
+      {
+        caption: 'Column2', field: 'column2', type: 'string',
+      },
+      {
+        caption: 'Column3', field: 'column3', type: 'string',
+      },
+      {
+        caption: 'Column4', field: 'column4', type: 'string', width: 100,
+      },
+    ];
+    const rows = ref([]);
+
+
+    const pushData = () => {
+      const startIdx = rows.value.length + 1;
+
+      for (let ix = startIdx; ix < startIdx + 30; ix++) {
+        rows.value.push([
+          (ix === 1),
+          `name-${ix}`,
+          `column1-${ix}`,
+          `column2-${ix}`,
+          `column3-${ix}`,
+          `column4-${ix}`,
+        ]);
+      }
+    };
+    const expendedRowDetail = (row) => {
+      const idx = row[0];
+      rows.value[idx][0] = !rows.value[idx][0];
+    };
+
+    pushData();
+
+    return {
+      columns,
+      rows,
+      expendedRowDetail,
+    };
+  },
+};
+</script>
+
+<style lang="scss">
+@import '../../../style/index.scss';
+
+.toggle-wrapper {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+}
+.toggle {
+  transition: transform $animate-fast;
+  &.expended {
+    transform: rotate(90deg);
+  }
+}
+</style>

--- a/docs/views/grid/example/RowDetail.vue
+++ b/docs/views/grid/example/RowDetail.vue
@@ -84,11 +84,7 @@ export default {
         ]);
       }
     };
-    const onExpandRow = (a, b, c, d) => {
-      console.log(a);
-      console.log(b);
-      console.log(c);
-      console.log(d);
+    const onExpandRow = () => {
       let result = '';
       expandedRowsMV.value.forEach((row) => {
         result += JSON.stringify(row);

--- a/docs/views/grid/example/RowDetail.vue
+++ b/docs/views/grid/example/RowDetail.vue
@@ -11,8 +11,8 @@
       <!-- cell renderer slot -->
       <template #toggle="{ item }">
         <div
-            class="toggle-wrapper"
-            @click="expendedRowDetail(item.row)"
+          class="toggle-wrapper"
+          @click="expendedRowDetail(item.row)"
         >
           <ev-icon
             icon="ev-icon-s-play"
@@ -40,7 +40,6 @@
 <script>
 import { ref } from 'vue';
 import RowDetailContent from './partitals/RowDetailContent.vue';
-
 
 export default {
   components: {

--- a/docs/views/grid/example/partitals/RowDetailContent.vue
+++ b/docs/views/grid/example/partitals/RowDetailContent.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="row-detail">
+    Row Detail Info
+    <br>
+    {{ $props.data }}
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'RowDetail',
+  props: {
+    data: {
+      type: Object,
+      default: () => {},
+    },
+  },
+  setup() {
+    return {};
+  },
+};
+</script>
+
+<style scoped lang="scss">
+  .row-detail {
+    display: flex;
+    width: 100%;
+    height: 100px;
+    padding: 10px;
+    align-items: center;
+    background-color: rgba(250, 222, 76, 0.6);
+  }
+</style>

--- a/docs/views/grid/props.js
+++ b/docs/views/grid/props.js
@@ -8,6 +8,8 @@ import Toolbar from './example/Toolbar';
 import ToolbarRaw from '!!raw-loader!./example/Toolbar';
 import Summary from './example/Summary';
 import SummaryRaw from '!!raw-loader!./example/Summary';
+import RowDetail from './example/RowDetail.vue';
+import RowDetailRaw from '!!raw-loader!./example/RowDetail.vue';
 
 export default {
   mdText,
@@ -28,6 +30,10 @@ export default {
     Summary: {
       component: Summary,
       parsedData: parseComponent(SummaryRaw),
+    },
+    RowDetail: {
+      component: RowDetail,
+      parsedData: parseComponent(RowDetailRaw),
     },
   },
 };

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -200,6 +200,7 @@
             v-if="useCheckbox.use"
             :class="{
               'column': true,
+              'checkbox-all': true,
               'non-border': !!borderStyle,
             }"
             :style="{

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -347,114 +347,121 @@
         <table ref="table">
           <tbody>
             <!-- Row List -->
-            <tr
+            <template
               v-for="(row, rowIndex) in viewStore"
               :key="rowIndex"
-              :data-index="row[0]"
-              :class="{
-                row: true,
-                selected: row[3],
-                highlight: row[0] === highlightIdx,
-                'non-border': !!borderStyle && borderStyle !== 'rows',
-              }"
-              @click="onRowClick($event, row)"
-              @contextmenu="onRowClick($event, row, true)"
-              @dblclick="onRowDblClick($event, row)"
             >
-              <!-- Row Checkbox -->
-              <td
-                v-if="useCheckbox.use"
+              <tr
+                :data-index="row[0]"
                 :class="{
-                  cell: true,
-                  'row-checkbox': true,
-                  'non-border': !!borderStyle,
+                  row: true,
+                  selected: row[3],
+                  highlight: row[0] === highlightIdx,
+                  'non-border': !!borderStyle && borderStyle !== 'rows',
                 }"
-                :style="{
-                  width: `${minWidth}px`,
-                  height: `${rowHeight}px`,
-                  'border-right': '1px solid #CFCFCF',
-                }"
+                @click="onRowClick($event, row)"
+                @contextmenu="onRowClick($event, row, true)"
+                @dblclick="onRowDblClick($event, row)"
               >
-                <ev-checkbox
-                  v-model="row[1]"
-                  class="row-checkbox-input"
-                  @change="onCheck($event, row)"
-                />
-              </td>
-              <!-- Cell -->
-              <template
-                v-for="(column, cellIndex) in orderedColumns"
-                :key="cellIndex"
-              >
+                <!-- Row Checkbox -->
                 <td
-                  v-if="!column.hide && !column.hiddenDisplay"
-                  :data-name="column.field"
-                  :data-index="column.index"
+                  v-if="useCheckbox.use"
                   :class="{
                     cell: true,
-                    render: isRenderer(column),
-                    [column.type]: column.type,
-                    [column.align]: column.align,
-                    [column.field]: column.field,
+                    'row-checkbox': true,
                     'non-border': !!borderStyle,
                   }"
                   :style="{
-                    width: `${column.width}px`,
+                    width: `${minWidth}px`,
                     height: `${rowHeight}px`,
-                    'line-height': `${rowHeight}px`,
-                    'min-width': `${isRenderer(column) ? rendererMinWidth : minWidth}px`,
-                    'border-right': orderedColumns.length - 1 === cellIndex
-                      ? 'none' : '1px solid #CFCFCF',
+                    'border-right': '1px solid #CFCFCF',
                   }"
                 >
-                  <!-- Cell Renderer -->
-                  <div v-if="!!$slots[column.field]">
-                    <slot
-                      :name="column.field"
-                      :item="{ row, column }"
-                    />
-                  </div>
-                  <!-- Cell Value -->
-                  <template v-else>
-                    <div :title="getConvertValue(column, row[2][column.index])">
-                      {{ getConvertValue(column, row[2][column.index]) }}
+                  <ev-checkbox
+                    v-model="row[1]"
+                    class="row-checkbox-input"
+                    @change="onCheck($event, row)"
+                  />
+                </td>
+                <!-- Cell -->
+                <template
+                  v-for="(column, cellIndex) in orderedColumns"
+                  :key="cellIndex"
+                >
+                  <td
+                    v-if="!column.hide && !column.hiddenDisplay"
+                    :data-name="column.field"
+                    :data-index="column.index"
+                    :class="{
+                      cell: true,
+                      render: isRenderer(column),
+                      [column.type]: column.type,
+                      [column.align]: column.align,
+                      [column.field]: column.field,
+                      'non-border': !!borderStyle,
+                    }"
+                    :style="{
+                      width: `${column.width}px`,
+                      height: `${rowHeight}px`,
+                      'line-height': `${rowHeight}px`,
+                      'min-width': `${isRenderer(column) ? rendererMinWidth : minWidth}px`,
+                      'border-right': orderedColumns.length - 1 === cellIndex
+                        ? 'none' : '1px solid #CFCFCF',
+                    }"
+                  >
+                    <!-- Cell Renderer -->
+                    <div v-if="!!$slots[column.field]">
+                      <slot
+                        :name="column.field"
+                        :item="{ row, column }"
+                      />
                     </div>
+                    <!-- Cell Value -->
+                    <template v-else>
+                      <div :title="getConvertValue(column, row[2][column.index])">
+                        {{ getConvertValue(column, row[2][column.index]) }}
+                      </div>
+                    </template>
+                  </td>
+                </template>
+                <!-- Row Contextmenu Button -->
+                <td
+                  v-if="$props.option.customContextMenu?.length"
+                  :class="{
+                    'row-contextmenu': true,
+                    'non-border': !!borderStyle,
+                  }"
+                  :style="{
+                    position: 'sticky',
+                    right: 0,
+                    width: '30px',
+                    height: `${rowHeight}px`,
+                    'min-width': '30px',
+                    'line-height': `${rowHeight}px`,
+                  }"
+                >
+                  <template v-if="$slots.contextmenuIcon">
+                    <span
+                      class="row-contextmenu__btn"
+                      @click="onContextMenu($event)"
+                    >
+                      <slot name="contextmenuIcon"></slot>
+                    </span>
+                  </template>
+                  <template v-else>
+                    <grid-option-button
+                      icon="ev-icon-warning2"
+                      class="row-contextmenu__btn"
+                      @click="onContextMenu($event)"
+                    />
                   </template>
                 </td>
-              </template>
-              <!-- Row Contextmenu Button -->
-              <td
-                v-if="$props.option.customContextMenu?.length"
-                :class="{
-                  'row-contextmenu': true,
-                  'non-border': !!borderStyle,
-                }"
-                :style="{
-                  position: 'sticky',
-                  right: 0,
-                  width: '30px',
-                  height: `${rowHeight}px`,
-                  'min-width': '30px',
-                  'line-height': `${rowHeight}px`,
-                }"
-              >
-                <template v-if="$slots.contextmenuIcon">
-                  <span
-                    class="row-contextmenu__btn"
-                    @click="onContextMenu($event)"
-                  >
-                    <slot name="contextmenuIcon"></slot>
-                  </span>
-                </template>
-                <template v-else>
-                  <grid-option-button
-                    icon="ev-icon-warning2"
-                    class="row-contextmenu__btn"
-                    @click="onContextMenu($event)"
-                  />
-                </template>
-              </td>
-            </tr>
+              </tr>
+              <slot
+                name="rowDetail"
+                :item="{ row }"
+              />
+            </template>
             <tr v-if="!viewStore.length">
               <td class="is-empty">No records</td>
             </tr>
@@ -608,7 +615,7 @@ export default {
     'page-change': null,
     'sort-column': null,
   },
-  setup(props) {
+  setup(props, { slots }) {
     // const ROW_INDEX = 0;
     const ROW_CHECK_INDEX = 1;
     const ROW_DATA_INDEX = 2;
@@ -777,6 +784,7 @@ export default {
       resizeInfo,
       pageInfo,
       summaryScroll,
+      useRowDetail: slots?.rowDetail,
       getPagingData,
       updatePagingInfo,
     });

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -64,6 +64,17 @@
   //&:nth-last-child(1) {
   //  border-right: 0;
   //}
+  &.checkbox-all {
+    padding: 0;
+    .ev-checkbox {
+      display: inline-flex;
+      width: 100%;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+    }
+  }
+
   .column-sort__icon {
     position: absolute;
     top: 50%;

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -176,6 +176,11 @@
       }
     }
   }
+  .row-contextmenu {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+  }
 
   .cell {
     display: inline-block;

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -183,9 +183,31 @@
       text-overflow: ellipsis;
     }
     &.row-checkbox {
-      display: inline-flex;
-      justify-content: center;
-      align-items: center;
+      padding: 0;
+      .ev-checkbox {
+        display: inline-flex;
+        width: 100%;
+        height: 100%;
+        justify-content: center;
+        align-items: center;
+      }
+    }
+    &.row-detail-toggle {
+      padding: 0;
+      .row-detail-toggle-icon {
+        display: inline-flex;
+        width: 100%;
+        height: 100%;
+        justify-content: center;
+        align-items: center;
+        cursor: pointer;
+        transition: transform $animate-fast;
+      }
+      &--expanded {
+        .row-detail-toggle-icon {
+          transform: rotate(90deg);
+        }
+      }
     }
     &.render {
       overflow: initial;

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -70,8 +70,8 @@
       display: inline-flex;
       width: 100%;
       height: 100%;
-      align-items: center;
       justify-content: center;
+      align-items: center;
     }
   }
 

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -6,6 +6,7 @@ const ROW_INDEX = 0;
 const ROW_CHECK_INDEX = 1;
 const ROW_DATA_INDEX = 2;
 const ROW_SELECT_INDEX = 3;
+const ROW_EXPAND_INDEX = 4;
 
 export const commonFunctions = () => {
   const { props } = getCurrentInstance();
@@ -79,7 +80,7 @@ export const scrollEvent = (params) => {
     summaryScroll,
     getPagingData,
     updatePagingInfo,
-    useRowDetail,
+    expandedInfo,
   } = params;
   /**
    * 수직 스크롤의 위치 계산 후 적용한다.
@@ -124,12 +125,14 @@ export const scrollEvent = (params) => {
    *  rowDetail slot 시에는 가상 스크롤을 적용하지 않는다.
    */
   const updateVScroll = (isScroll) => {
-    if (useRowDetail) {
+    if (expandedInfo.useRowDetail) {
       let store = stores.store;
       if (pageInfo.isClientPaging) {
         store = getPagingData();
       }
       stores.viewStore = store;
+      scrollInfo.vScrollTopHeight = 0;
+      scrollInfo.vScrollBottomHeight = 0;
     } else {
       updateVScrollBase(isScroll);
     }
@@ -178,6 +181,7 @@ export const resizeEvent = (params) => {
     resizeInfo,
     elementInfo,
     checkInfo,
+    expandedInfo,
     stores,
     isRenderer,
     updateVScroll,
@@ -215,6 +219,10 @@ export const resizeEvent = (params) => {
       }
 
       if (checkInfo.useCheckbox.use) {
+        elWidth -= resizeInfo.minWidth;
+      }
+
+      if (expandedInfo.useRowDetail) {
         elWidth -= resizeInfo.minWidth;
       }
 
@@ -540,6 +548,34 @@ export const checkEvent = (params) => {
     emit('check-all', event, checkInfo.checkedRows);
   };
   return { onCheck, onCheckAll };
+};
+
+export const expandEvent = (params) => {
+  const { expandedInfo } = params;
+  const { emit } = getCurrentInstance();
+
+  /**
+   * expand click 이벤트를 처리한다.
+   *
+   * @param {object} event - 이벤트 객체
+   * @param {array} row - row 데이터
+   */
+  const onExpanded = (event, row) => {
+    const data = row[ROW_DATA_INDEX];
+    const index = expandedInfo.expandedRows.indexOf(data);
+    if (index === -1) {
+      expandedInfo.expandedRows.push(data);
+    } else {
+      expandedInfo.expandedRows.splice(index, 1);
+    }
+    row[ROW_EXPAND_INDEX] = !row[ROW_EXPAND_INDEX];
+    emit('update:expanded', expandedInfo.expandedRows);
+    emit('expand-row', event, row[ROW_DATA_INDEX], row[ROW_EXPAND_INDEX], row[ROW_INDEX]);
+  };
+
+  return {
+    onExpanded,
+  };
 };
 
 export const sortEvent = (params) => {
@@ -1044,6 +1080,7 @@ export const storeEvent = (params) => {
     sortInfo,
     elementInfo,
     filterInfo,
+    expandedInfo,
     setSort,
     updateVScroll,
     setFilter,
@@ -1067,7 +1104,11 @@ export const storeEvent = (params) => {
         if (!checked) {
           hasUnChecked = true;
         }
-        store.push([idx, checked, row, selected]);
+        let expanded = false;
+        if (expandedInfo.useRowDetail) {
+          expanded = props.expanded.includes(row);
+        }
+        store.push([idx, checked, row, selected, expanded]);
       });
       checkInfo.isHeaderChecked = rows.length > 0 ? !hasUnChecked : false;
       stores.originStore = store;

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -79,11 +79,12 @@ export const scrollEvent = (params) => {
     summaryScroll,
     getPagingData,
     updatePagingInfo,
+    useRowDetail,
   } = params;
   /**
    * 수직 스크롤의 위치 계산 후 적용한다.
    */
-  const updateVScroll = (isScroll) => {
+  const updateVScrollBase = (isScroll) => {
     const bodyEl = elementInfo.body;
     const rowHeight = resizeInfo.rowHeight;
     if (bodyEl) {
@@ -116,6 +117,21 @@ export const scrollEvent = (params) => {
         pageInfo.startIndex = lastIndex;
         updatePagingInfo({ onScrollEnd: true });
       }
+    }
+  };
+
+  /**
+   *  rowDetail slot 시에는 가상 스크롤을 적용하지 않는다.
+   */
+  const updateVScroll = (isScroll) => {
+    if (useRowDetail) {
+      let store = stores.store;
+      if (pageInfo.isClientPaging) {
+        store = getPagingData();
+      }
+      stores.viewStore = store;
+    } else {
+      updateVScrollBase(isScroll);
     }
   };
   /**

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -805,6 +805,7 @@ export default {
     }));
     const headerCheckboxClass = computed(() => ({
       column: true,
+      'checkbox-all': true,
       'non-border': !!styleInfo.borderStyle,
     }));
     const isHeaderCheckbox = computed(() => (

--- a/src/components/treeGrid/style/treeGrid.scss
+++ b/src/components/treeGrid/style/treeGrid.scss
@@ -70,6 +70,16 @@
       color: evThemed('font-color-base');
     }
   }
+  &.checkbox-all {
+    padding: 0;
+    .ev-checkbox {
+      display: inline-flex;
+      width: 100%;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+    }
+  }
 }
 
 .column-name {

--- a/src/components/treeGrid/style/treeGrid.scss
+++ b/src/components/treeGrid/style/treeGrid.scss
@@ -76,8 +76,8 @@
       display: inline-flex;
       width: 100%;
       height: 100%;
-      align-items: center;
       justify-content: center;
+      align-items: center;
     }
   }
 }

--- a/src/components/treeGrid/style/treeGrid.scss
+++ b/src/components/treeGrid/style/treeGrid.scss
@@ -162,9 +162,14 @@
       border-right: 1px solid evThemed('grid-bottom-border');
     }
     &.row-checkbox {
-      display: inline-flex;
-      justify-content: center;
-      align-items: center;
+      padding: 0;
+      .ev-checkbox {
+        display: inline-flex;
+        width: 100%;
+        height: 100%;
+        justify-content: center;
+        align-items: center;
+      }
     }
     &.render {
       overflow: initial;


### PR DESCRIPTION
### 요구 사항
- Row 를 클릭하여 확장된 화면에 디테일한 정보를 보고 싶은 요청사항으로 인하여 추가

### 작업 내용
1.  Grid > rowDetail 옵션 추가 및 slot 추가
     - 슬롯명:  #rowDetail
     - rowDettail 옵션 사용시에만 슬롯 사용 가능. 
     - 사용시에 가상스크롤 미적용
     - 추후 가상스크롤 처리를 위해 rowDetailHeight를 넘기면 처리 할 수 있을듯 하여 옵션은 use밖에 없지만
     오브젝트 형태로 유지
2. Example > RowDetail 추가
3. Grid > 컬럼, Cell minWidth 40으로 수정
4. 체크박스 선택할 수 있는영역 셀 전체로 수정

### 결과

![rowDetailFig](https://github.com/ex-em/EVUI/assets/65858819/3154597b-2fa2-4ed5-b4ba-a79baccc990e)
