### PR TITLE
[#1542] Grid, TreeGrid > Grid Option > ContextMenu 옵션 추가

### DIFF
--- a/docs/views/contextMenu/api/contextMenu.md
+++ b/docs/views/contextMenu/api/contextMenu.md
@@ -9,6 +9,7 @@
       text: '텍스트명',
       iconClass: '텍스트 앞에 위치하는 아이콘 태그 클래스명',
       disabled: true, // Boolean - 사용여부
+      isShowMenu: true, // Boolean - 항목 클릭시에도 메뉴 유지
       click: () => { ... }, // 클릭 시 발생하는 메소드
     },
     { ... },

--- a/docs/views/contextMenu/api/contextMenu.md
+++ b/docs/views/contextMenu/api/contextMenu.md
@@ -38,5 +38,7 @@
 | | | text | <컨텍스트메뉴> 항목 텍스트 | |
 | | | icon-class | <컨텍스트메뉴> 항목 텍스트 앞에 위치하는 <i> 클래스 | |
 | | | disabled | <컨텍스트메뉴> 항목 사용 여부 | false, true |
+| | | isShowMenu | 클릭한 항목 선택 후에도 <컨텍스트 메뉴> 유지 | false, true |
 | | | click | <컨텍스트메뉴> 항목 클릭 시 발생하는 메소드 |  |
 | customClass | String | '' | <컨텍스트메뉴>에 지정할 클래스명 | |
+| isShowMenuOnClick | Boolean | false | <컨텍스트 메뉴> 항목 및 영역 외 클릭 시에도 메뉴 유지 | |

--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -62,7 +62,10 @@
 |  |  | order | Pagination 위치 | 'center', 'left', 'right' |
 |  |  | showPageInfo | 페이지 정보 표시 여부 | Boolean |
 |  | useSummary | false | 하단에 summary row 가 표시 된다. | Boolean |
-|  | useColumnSetting | false | 컬럼 목록 설정 여부  | Boolean |
+|  | useGridSetting | {} | 그리드 옵션 설정  | |
+|  |  | use | 그리드 옵션 설정 사용 여부 | Boolean |
+|  |  | mode | 그리드 옵션 모드 선택 설정 | 'default', 'menu' |
+|  |  | customContextMenu | mode가 'menu'인 경우, 그리드옵션 클릭시 보여지는 컨텍스트 메뉴를 설정한다. |  |
 
 ### Columns
 | 이름 | 타입 | 설명 | 종류 | 필수 |

--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -64,8 +64,7 @@
 |  | useSummary | false | 하단에 summary row 가 표시 된다. | Boolean |
 |  | useGridSetting | {} | 그리드 옵션 설정  | |
 |  |  | use | 그리드 옵션 설정 사용 여부 | Boolean |
-|  |  | mode | 그리드 옵션 모드 선택 설정 | 'default', 'menu' |
-|  |  | customContextMenu | mode가 'menu'인 경우, 그리드옵션 클릭시 보여지는 컨텍스트 메뉴를 설정한다. |  |
+|  |  | customContextMenu | 그리드옵션 클릭시 보여지는 컨텍스트 메뉴를 설정한다. |  |
 
 ### Columns
 | 이름 | 타입 | 설명 | 종류 | 필수 |

--- a/docs/views/grid/example/CellRenderer.vue
+++ b/docs/views/grid/example/CellRenderer.vue
@@ -18,6 +18,9 @@
           mode: checkboxModeMV,
           headerCheck: headerCheckMV,
         },
+        useGridSetting: {
+          use: true,
+        },
         customContextMenu: menuItems,
         style: {
           stripe: stripeMV,

--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -14,7 +14,6 @@
         columnWidth: columnWidthMV,
         useGridSetting: {
           use: useGridSettingMV,
-          mode: gridSettingModeMV,
           customContextMenu: gridSettingMenuItems,
         },
         useFilter: useFilterMV,
@@ -84,33 +83,12 @@
         <ev-toggle
           v-model="isSelectionMultiple"
         />
-      </div>
-      <div class="form-rows">
-        <div class="form-row">
-          <span class="badge yellow">
+        <span class="badge yellow">
             Use Grid Setting
           </span>
-          <ev-toggle
-            v-model="useGridSettingMV"
-          />
-        </div>
-        <div class="form-row">
-          <span class="badge yellow">
-            Grid Setting Mode
-          </span>
-          <ev-radio-group
-            v-model="gridSettingModeMV"
-            type="button"
-            @change="changeGridSettingMode"
-          >
-            <ev-radio label="default" />
-            <ev-radio label="menu" />
-          </ev-radio-group>
-          <span class="badge">
-            Mode
-          </span>
-          {{ gridSettingModeMV }}
-        </div>
+        <ev-toggle
+          v-model="useGridSettingMV"
+        />
       </div>
       <div class="form-rows">
         <div class="form-row">
@@ -259,8 +237,12 @@ export default {
     const useSelectionMV = ref(true);
     const isSelectionMultiple = ref(false);
     const useGridSettingMV = ref(true);
-    const gridSettingModeMV = ref('default');
-    const gridSettingMenuItems = ref([]);
+    const gridSettingMenuItems = ref([
+      {
+        text: 'Menu1',
+        click: param => console.log(`[Menu1]: ${param}`),
+      },
+    ]);
     const menuItems = ref([
       {
         text: 'Menu1',
@@ -314,19 +296,6 @@ export default {
         clickedRow += JSON.stringify(row);
       });
       clickedRowMV.value = clickedRow;
-    };
-    const changeGridSettingMode = (mode) => {
-      gridSettingModeMV.value = mode;
-      if (mode === 'menu') {
-        gridSettingMenuItems.value = [
-          {
-            text: 'Menu1',
-            click: param => console.log(`[Menu1]: ${param}`),
-          },
-        ];
-      } else {
-        gridSettingMenuItems.value = [];
-      }
     };
     const getData = (count, startIndex) => {
       const temp = [];
@@ -391,7 +360,6 @@ export default {
       isSelectionMultiple,
       useSelectionMV,
       useGridSettingMV,
-      gridSettingModeMV,
       gridSettingMenuItems,
       changeMode,
       onCheckedRow,
@@ -399,7 +367,6 @@ export default {
       onClickRow,
       resetBorderStyle,
       onRequestData,
-      changeGridSettingMode,
     };
   },
 };

--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -84,8 +84,8 @@
           v-model="isSelectionMultiple"
         />
         <span class="badge yellow">
-            Use Grid Setting
-          </span>
+          Use Grid Setting
+        </span>
         <ev-toggle
           v-model="useGridSettingMV"
         />

--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -12,7 +12,11 @@
         showHeader: showHeaderMV,
         rowHeight: rowHeightMV,
         columnWidth: columnWidthMV,
-        useColumnSetting: useColumnSettingMV,
+        useGridSetting: {
+          use: useGridSettingMV,
+          mode: gridSettingModeMV,
+          customContextMenu: gridSettingMenuItems,
+        },
         useFilter: useFilterMV,
         customContextMenu: menuItems,
         useCheckbox: {
@@ -80,12 +84,33 @@
         <ev-toggle
           v-model="isSelectionMultiple"
         />
-        <span class="badge yellow">
-          Use Column Setting
-        </span>
-        <ev-toggle
-          v-model="useColumnSettingMV"
-        />
+      </div>
+      <div class="form-rows">
+        <div class="form-row">
+          <span class="badge yellow">
+            Use Grid Setting
+          </span>
+          <ev-toggle
+            v-model="useGridSettingMV"
+          />
+        </div>
+        <div class="form-row">
+          <span class="badge yellow">
+            Grid Setting Mode
+          </span>
+          <ev-radio-group
+            v-model="gridSettingModeMV"
+            type="button"
+            @change="changeGridSettingMode"
+          >
+            <ev-radio label="default" />
+            <ev-radio label="menu" />
+          </ev-radio-group>
+          <span class="badge">
+            Mode
+          </span>
+          {{ gridSettingModeMV }}
+        </div>
       </div>
       <div class="form-rows">
         <div class="form-row">
@@ -224,7 +249,6 @@ export default {
     const stripeMV = ref(false);
     const rowHeightMV = ref(45);
     const columnWidthMV = ref(80);
-    const useColumnSettingMV = ref(true);
     const useFilterMV = ref(false);
     const useCheckboxMV = ref(true);
     const checkboxModeMV = ref('multi');
@@ -234,6 +258,9 @@ export default {
     const DbClickedRowsMV = ref();
     const useSelectionMV = ref(true);
     const isSelectionMultiple = ref(false);
+    const useGridSettingMV = ref(true);
+    const gridSettingModeMV = ref('default');
+    const gridSettingMenuItems = ref([]);
     const menuItems = ref([
       {
         text: 'Menu1',
@@ -288,6 +315,19 @@ export default {
       });
       clickedRowMV.value = clickedRow;
     };
+    const changeGridSettingMode = (mode) => {
+      gridSettingModeMV.value = mode;
+      if (mode === 'menu') {
+        gridSettingMenuItems.value = [
+          {
+            text: 'Menu1',
+            click: param => console.log(`[Menu1]: ${param}`),
+          },
+        ];
+      } else {
+        gridSettingMenuItems.value = [];
+      }
+    };
     const getData = (count, startIndex) => {
       const temp = [];
       const roles = ['Common', 'Admin'];
@@ -336,7 +376,6 @@ export default {
       stripeMV,
       rowHeightMV,
       columnWidthMV,
-      useColumnSettingMV,
       useFilterMV,
       useCheckboxMV,
       checkboxModeMV,
@@ -351,12 +390,16 @@ export default {
       pageInfo,
       isSelectionMultiple,
       useSelectionMV,
+      useGridSettingMV,
+      gridSettingModeMV,
+      gridSettingMenuItems,
       changeMode,
       onCheckedRow,
       onDoubleClickRow,
       onClickRow,
       resetBorderStyle,
       onRequestData,
+      changeGridSettingMode,
     };
   },
 };

--- a/docs/views/grid/example/Summary.vue
+++ b/docs/views/grid/example/Summary.vue
@@ -11,7 +11,9 @@
         adjust: true,
         rowHeight: 45,
         useFilter: false,
-        useColumnSetting: true,
+        useGridOption: {
+          use: true,
+        },
         useCheckbox: {
           use: true,
           mode: 'multi',

--- a/docs/views/grid/example/Toolbar.vue
+++ b/docs/views/grid/example/Toolbar.vue
@@ -13,7 +13,9 @@
         rowHeight: rowHeightMV,
         columnWidth: columnWidthMV,
         useFilter: false,
-        useColumnSetting: true,
+        useGridSetting: {
+          use: true,
+        },
         useCheckbox: {
           use: useCheckboxMV,
           mode: checkboxModeMV,

--- a/docs/views/treeGrid/api/treeGrid.md
+++ b/docs/views/treeGrid/api/treeGrid.md
@@ -63,7 +63,10 @@
 |  |                  | order              | Pagination 위치                           | 'center', 'left', 'right' |
 |  |                  | showPageInfo       | 페이지 정보 표시 여부                            | Boolean                  |
 |  | useSummary       | false              | 하단에 summary row 가 표시 된다.                | Boolean                  |
-|  | useColumnSetting | false              | 컬럼 목록 설정 여부                              | Boolean                   |
+|  | useGridSetting | {} | 그리드 옵션 설정  | |
+|  |  | use | 그리드 옵션 설정 사용 여부 | Boolean |
+|  |  | mode | 그리드 옵션 모드 선택 설정 | 'default', 'menu' |
+|  |  | customContextMenu | mode가 'menu'인 경우, 그리드옵션 클릭시 보여지는 컨텍스트 메뉴를 설정한다. |  |
 |  | expandIcon       | 'tree-expand-icon' | expand 상태인 노드의 아이콘                      | `ev-icon`                |
 |  | collapseIcon     | 'tree-expand-icon' | collapse 상태인 노드의 아이콘                    | `ev-icon`                |
 |  | parentIcon       | 'tree-parent-icon' | 자식 노드가 있는 노드의 아이콘                       | `ev-icon`, 'none'        |

--- a/docs/views/treeGrid/api/treeGrid.md
+++ b/docs/views/treeGrid/api/treeGrid.md
@@ -65,8 +65,7 @@
 |  | useSummary       | false              | 하단에 summary row 가 표시 된다.                | Boolean                  |
 |  | useGridSetting | {} | 그리드 옵션 설정  | |
 |  |  | use | 그리드 옵션 설정 사용 여부 | Boolean |
-|  |  | mode | 그리드 옵션 모드 선택 설정 | 'default', 'menu' |
-|  |  | customContextMenu | mode가 'menu'인 경우, 그리드옵션 클릭시 보여지는 컨텍스트 메뉴를 설정한다. |  |
+|  |  | customContextMenu | 그리드옵션 클릭시 보여지는 컨텍스트 메뉴를 설정한다. |  |
 |  | expandIcon       | 'tree-expand-icon' | expand 상태인 노드의 아이콘                      | `ev-icon`                |
 |  | collapseIcon     | 'tree-expand-icon' | collapse 상태인 노드의 아이콘                    | `ev-icon`                |
 |  | parentIcon       | 'tree-parent-icon' | 자식 노드가 있는 노드의 아이콘                       | `ev-icon`, 'none'        |

--- a/docs/views/treeGrid/example/CellRenderer.vue
+++ b/docs/views/treeGrid/example/CellRenderer.vue
@@ -8,7 +8,9 @@
           use: useCheckboxMV.use,
           headerCheck: useCheckboxMV.headerCheck,
         },
-        useColumnSetting: true,
+        useGridSetting: {
+          use: true,
+        },
       }"
     >
       <!-- renderer start -->

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -77,8 +77,8 @@
           v-model="useSelection.multiple"
         />
         <span class="badge yellow">
-            Use Grid Setting
-          </span>
+          Use Grid Setting
+        </span>
         <ev-toggle
           v-model="useGridSettingMV"
         />

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -15,7 +15,6 @@
         columnWidth: columnWidthMV,
         useGridSetting: {
           use: useGridSettingMV,
-          mode: gridSettingModeMV,
           customContextMenu: gridSettingMenuItems,
         },
         useCheckbox: {
@@ -77,33 +76,12 @@
         <ev-toggle
           v-model="useSelection.multiple"
         />
-      </div>
-      <div class="form-rows">
-        <div class="form-row">
-          <span class="badge yellow">
+        <span class="badge yellow">
             Use Grid Setting
           </span>
-          <ev-toggle
-            v-model="useGridSettingMV"
-          />
-        </div>
-        <div class="form-row">
-          <span class="badge yellow">
-            Grid Setting Mode
-          </span>
-          <ev-radio-group
-            v-model="gridSettingModeMV"
-            type="button"
-            @change="changeGridSettingMode"
-          >
-            <ev-radio label="default" />
-            <ev-radio label="menu" />
-          </ev-radio-group>
-          <span class="badge">
-            Mode
-          </span>
-          {{ gridSettingModeMV }}
-        </div>
+        <ev-toggle
+          v-model="useGridSettingMV"
+        />
       </div>
       <div class="form-rows">
         <div class="form-row">
@@ -323,8 +301,12 @@ export default {
     const DbClickedRowsMV = ref();
     const expandColumnMV = ref(0);
     const useGridSettingMV = ref(true);
-    const gridSettingModeMV = ref('default');
-    const gridSettingMenuItems = ref([]);
+    const gridSettingMenuItems = ref([
+      {
+        text: 'Menu1',
+        click: param => console.log(`[Menu1]: ${param}`),
+      },
+    ]);
     const menuItems = ref([
       {
         text: 'Menu1',
@@ -407,19 +389,6 @@ export default {
     };
     const onClickButton = (e) => {
       console.log(`button component click: ${e}`);
-    };
-    const changeGridSettingMode = (mode) => {
-      gridSettingModeMV.value = mode;
-      if (mode === 'menu') {
-        gridSettingMenuItems.value = [
-          {
-          text: 'Menu1',
-          click: param => console.log(`[Menu1]: ${param}`),
-          },
-        ];
-      } else {
-        gridSettingMenuItems.value = [];
-      }
     };
     const changeMode = (mode) => {
       checkboxModeMV.value = mode;
@@ -581,7 +550,6 @@ export default {
       useSelection,
       expandColumnMV,
       useGridSettingMV,
-      gridSettingModeMV,
       gridSettingMenuItems,
       onClickCheckbox,
       onClickButton,
@@ -594,7 +562,6 @@ export default {
       resetDataIcon,
       onReset,
       changeExpandTreeColumn,
-      changeGridSettingMode,
     };
   },
 };

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -13,7 +13,11 @@
         showHeader: showHeaderMV,
         rowHeight: rowHeightMV,
         columnWidth: columnWidthMV,
-        useColumnSetting: useColumnSettingMV,
+        useGridSetting: {
+          use: useGridSettingMV,
+          mode: gridSettingModeMV,
+          customContextMenu: gridSettingMenuItems,
+        },
         useCheckbox: {
           use: useCheckboxMV,
           mode: checkboxModeMV,
@@ -73,12 +77,33 @@
         <ev-toggle
           v-model="useSelection.multiple"
         />
-        <span class="badge yellow">
-          Use Column Setting
-        </span>
-        <ev-toggle
-          v-model="useColumnSettingMV"
-        />
+      </div>
+      <div class="form-rows">
+        <div class="form-row">
+          <span class="badge yellow">
+            Use Grid Setting
+          </span>
+          <ev-toggle
+            v-model="useGridSettingMV"
+          />
+        </div>
+        <div class="form-row">
+          <span class="badge yellow">
+            Grid Setting Mode
+          </span>
+          <ev-radio-group
+            v-model="gridSettingModeMV"
+            type="button"
+            @change="changeGridSettingMode"
+          >
+            <ev-radio label="default" />
+            <ev-radio label="menu" />
+          </ev-radio-group>
+          <span class="badge">
+            Mode
+          </span>
+          {{ gridSettingModeMV }}
+        </div>
       </div>
       <div class="form-rows">
         <div class="form-row">
@@ -297,7 +322,9 @@ export default {
     const clickedRowMV = ref();
     const DbClickedRowsMV = ref();
     const expandColumnMV = ref(0);
-    const useColumnSettingMV = ref(true);
+    const useGridSettingMV = ref(true);
+    const gridSettingModeMV = ref('default');
+    const gridSettingMenuItems = ref([]);
     const menuItems = ref([
       {
         text: 'Menu1',
@@ -380,6 +407,19 @@ export default {
     };
     const onClickButton = (e) => {
       console.log(`button component click: ${e}`);
+    };
+    const changeGridSettingMode = (mode) => {
+      gridSettingModeMV.value = mode;
+      if (mode === 'menu') {
+        gridSettingMenuItems.value = [
+          {
+          text: 'Menu1',
+          click: param => console.log(`[Menu1]: ${param}`),
+          },
+        ];
+      } else {
+        gridSettingMenuItems.value = [];
+      }
     };
     const changeMode = (mode) => {
       checkboxModeMV.value = mode;
@@ -540,7 +580,9 @@ export default {
       limitItems,
       useSelection,
       expandColumnMV,
-      useColumnSettingMV,
+      useGridSettingMV,
+      gridSettingModeMV,
+      gridSettingMenuItems,
       onClickCheckbox,
       onClickButton,
       changeMode,
@@ -552,6 +594,7 @@ export default {
       resetDataIcon,
       onReset,
       changeExpandTreeColumn,
+      changeGridSettingMode,
     };
   },
 };

--- a/docs/views/treeGrid/example/Toolbar.vue
+++ b/docs/views/treeGrid/example/Toolbar.vue
@@ -12,7 +12,9 @@
         showHeader: showHeaderMV,
         rowHeight: rowHeightMV,
         columnWidth: columnWidthMV,
-        useColumnSetting: true,
+        useGridSetting: {
+          use: true,
+        },
         useCheckbox: {
           use: useCheckboxMV,
           mode: checkboxModeMV,

--- a/src/components/contextMenu/ContextMenu.vue
+++ b/src/components/contextMenu/ContextMenu.vue
@@ -47,6 +47,10 @@ export default {
       type: String,
       default: '',
     },
+    isShowMenuOnClick: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup() {
     const {

--- a/src/components/contextMenu/MenuList.vue
+++ b/src/components/contextMenu/MenuList.vue
@@ -6,8 +6,7 @@
         :key="`${item.value}_${idx}`"
         class="ev-menu-li"
         :class="{ disabled: item.disabled }"
-        @click="[item.click && !item.disabled ? item.click(item) : (() => {})()
-          , hideAll(item.children)]"
+        @click="handleItemClick(item)"
         @mouseenter="!item.disabled ? mouseenterLi($event, item.children) : (() => {})()"
       >
         <i
@@ -17,7 +16,7 @@
         />
         {{ item.text }}
         <i
-          v-if="item.children"
+          v-if="item.children || item.isShowMenu"
           class="ev-menu-li-suffix ev-icon-arrow-right2"
         />
       </li>
@@ -77,6 +76,7 @@ export default {
       menuStyle,
       childrenItems,
 
+      handleItemClick,
       mouseenterLi,
       hideAll,
     } = useMenuList();
@@ -89,6 +89,7 @@ export default {
       menuStyle,
       childrenItems,
 
+      handleItemClick,
       mouseenterLi,
       hideAll,
     };

--- a/src/components/contextMenu/uses.js
+++ b/src/components/contextMenu/uses.js
@@ -29,6 +29,8 @@ export const useModel = () => {
 };
 
 export const usePosition = () => {
+  const { props } = getCurrentInstance();
+  const isShowMenuOnClick = computed(() => props.isShowMenuOnClick);
   const isShow = ref(false);
   const rootMenuList = ref(null);
   const menuStyle = reactive({
@@ -84,6 +86,9 @@ export const usePosition = () => {
    */
   const hide = async () => {
     await nextTick();
+    if (isShowMenuOnClick.value) {
+      return;
+    }
     isShow.value = false;
   };
 
@@ -196,6 +201,16 @@ export const useMenuList = () => {
     }
   };
 
+  const handleItemClick = (item) => {
+    if (item.click && !item.disabled) {
+      item.click(item);
+    }
+
+    if (!item.isShowMenu) {
+      hideAll(item.children);
+    }
+  };
+
   return {
     computedIsShow,
     isExistChild,
@@ -203,6 +218,7 @@ export const useMenuList = () => {
     childMenu,
     menuStyle,
     childrenItems,
+    handleItemClick,
     mouseenterLi,
     hideAll,
   };

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -898,10 +898,7 @@ export default {
 
     const setGridSetting = (e) => {
       contextInfo.gridSettingContextMenuItems.length = 0;
-      if (
-        contextInfo.customGridSettingContextMenu.length
-        || props.option?.useGridSetting?.mode === 'menu'
-      ) {
+      if (contextInfo.customGridSettingContextMenu.length) {
         onGridSettingContextMenu(e);
       } else {
         columnSettingInfo.isShowColumnSetting = true;

--- a/src/components/grid/GridToolbar.vue
+++ b/src/components/grid/GridToolbar.vue
@@ -24,7 +24,7 @@ export default {
 .gridToolbar > .ev-button {
   margin: 0 2px 0 2px;
 }
-.gridToolbar > .column-setting__icon {
+.gridToolbar > .grid-setting__icon {
   float: right;
   margin: 10px 5px;
   cursor: pointer;

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1173,10 +1173,7 @@ export const columnSettingEvent = (params) => {
     }
     columnSettingInfo.columnSettingPosition.columnListMenuWidth = 0;
 
-    if (
-      props.option?.useGridSetting?.mode === 'menu'
-      || contextInfo.gridSettingContextMenuItems.length
-    ) {
+    if (contextInfo.gridSettingContextMenuItems.length) {
       // 컨텍스트 메뉴 형태인 경우
       const columnListMenu = contextInfo.gridSettingContextMenuItems.length - 1;
       const columnListMenuRect = contextInfo.gridSettingMenu?.rootMenuList?.$el?.children[0]

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1174,7 +1174,7 @@ export const columnSettingEvent = (params) => {
     columnSettingInfo.columnSettingPosition.columnListMenuWidth = 0;
 
     if (
-      props.option?.useGridSetting?.use === 'menu'
+      props.option?.useGridSetting?.mode === 'menu'
       || contextInfo.gridSettingContextMenuItems.length
     ) {
       // 컨텍스트 메뉴 형태인 경우

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -577,10 +577,7 @@ export default {
 
     const setGridSetting = (e) => {
       contextInfo.gridSettingContextMenuItems.length = 0;
-      if (
-        contextInfo.customGridSettingContextMenu.length
-        || props.option?.useGridSetting?.mode === 'menu'
-      ) {
+      if (contextInfo.customGridSettingContextMenu.length) {
         onGridSettingContextMenu(e);
       } else {
         columnSettingInfo.isShowColumnSetting = true;

--- a/src/components/treeGrid/TreeGridToolbar.vue
+++ b/src/components/treeGrid/TreeGridToolbar.vue
@@ -24,7 +24,7 @@ export default {
 .tree-grid-toolbar > .ev-button {
   margin: 0 2px 0 2px;
 }
-.tree-grid-toolbar > .column-setting__icon {
+.tree-grid-toolbar > .grid-setting__icon {
   float: right;
   margin: 10px 5px;
   cursor: pointer;

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -574,8 +574,9 @@ export const contextMenuEvent = (params) => {
     contextInfo,
     stores,
     selectInfo,
+    useGridSetting,
+    columnSettingInfo,
     setColumnHidden,
-    useColumnSetting,
   } = params;
   /**
    * 컨텍스트 메뉴를 설정한다.
@@ -609,7 +610,7 @@ export const contextMenuEvent = (params) => {
         {
           text: 'Hide',
           iconClass: 'ev-icon-visibility-off',
-          disabled: !useColumnSetting.value || stores.orderedColumns.length === 1,
+          disabled: !useGridSetting.value || stores.orderedColumns.length === 1,
           click: () => setColumnHidden(column.field),
         },
       ];
@@ -638,10 +639,36 @@ export const contextMenuEvent = (params) => {
       emit('update:selected', []);
     }
   };
+  /**
+   * 상단 우측의 Grid 옵션에 대한 Contextmenu 를 생성한다.
+   *
+   * @param {object} event - 이벤트 객체
+   */
+  const onGridSettingContextMenu = (e) => {
+    const columnListMenu = {
+      text: 'Column List',
+      isShowMenu: true,
+      click: () => {
+        columnSettingInfo.isShowColumnSetting = true;
+        contextInfo.isShowMenuOnClick = true;
+      },
+    };
+
+    if (contextInfo.customGridSettingContextMenu.length) {
+      contextInfo.gridSettingContextMenuItems = [
+        ...contextInfo.customGridSettingContextMenu,
+        columnListMenu,
+      ];
+    } else {
+      contextInfo.gridSettingContextMenuItems = [columnListMenu];
+    }
+    contextInfo.gridSettingMenu.show(e);
+  };
   return {
     setContextMenu,
     onContextMenu,
     onColumnContextMenu,
+    onGridSettingContextMenu,
   };
 };
 


### PR DESCRIPTION
### 요구사항
- Grid Option 버튼을 클릭할 때, ContextMenu로 메뉴를 보여주는 추가 요구사항이 있어 Grid Option 기능에 ContextMenu 옵션 추가
   - 외부에서 ContextMenu 옵션을 설정 및 추가한 경우, 버튼 클릭 시 해당 메뉴가 보여진다. (Column list 메뉴는 기본 설정)
   - ContextMenu 옵션을 설정하지 않은 경우, 버튼 클릭 시 기존과 같이 Column List 모달 창이 표시된다.

---

### 작업내용

**1. Grid, Tree Grid**

- Grid, Tree Grid의 설정 옵션인 `useColumnSetting`을 `useGridSetting` 명칭으로 변경
   - 그리드 옵션 버튼의 목적을 Column List 창만 보여주는 것이 아니라, 그리드의 전체 설정을 변경하는데 사용하기 위해 명칭 및 구조 변경
   - `useGridSetting` 속성 안에서 `customContextMenu`의 값이 존재하는 경우, 그리드 옵션 버튼 클릭 시 컨텍스트 메뉴로 표시되도록 옵션 추가 (Column List 메뉴 항목은 기본적으로 유지)
- 메뉴의 Column List 항목을 선택할 때, Column List 모달 창을 기본적으로 오른쪽에 위치시키되, 화면 너비가 부족한 경우에는 왼쪽에 위치

 [AS-IS]
```
:option="{ 
  useColumnSetting : Boolean
}"
```

[TO-BE]
```
:option="{
  useGridSetting: {
   use: Boolean,
   customContextMenu: []
  }
}"
```

![image](https://github.com/ex-em/EVUI/assets/79958259/58c56d57-86c9-4e98-bb59-e27c6b7f3b35)
![image](https://github.com/ex-em/EVUI/assets/79958259/7dc32bde-d092-4282-9d79-9a0599eaf571)

**2. ContextMenu**
- 현재 ContextMenu는 특정 메뉴 클릭하거나 메뉴 외부 영역을 클릭할 때, ContextMenu 창이 닫히도록 설정되어 있음
-  ContextMenu 외부 영역을 클릭하더라도 메뉴 창이 특정 시점 및 영역에서만 닫히도록 하기 위해 `isShowOnClick` props 속성 추가 
   - Column List 메뉴를 클릭 후, Column List 창에서 OK 버튼을 클릭할 때만 ContextMenu 창이 닫히도록 하기 위함
- ContextMenu에서 특정 메뉴를 클릭하더라도 메뉴가 닫히지 않도록 contextMenu의 `items` 속성 내에  `isShowMenu` 옵션 추가
   - Column List 메뉴를 클릭한 경우에도 ContextMenu 창을 유지하기 위함


```
:items="[
    {
      isShowMenu:  Boolean,
      .....
    },
```