### PR TITLE
[#1544] Grid, TreeGrid > checkbox indeterminate 상태 표시 적용

### DIFF
--- a/src/components/checkbox/Checkbox.vue
+++ b/src/components/checkbox/Checkbox.vue
@@ -137,7 +137,11 @@ export default {
      */
     watch(
       () => props.indeterminate,
-      (val) => { checkbox.value.indeterminate = val; },
+      (val) => {
+        nextTick(() => {
+          checkbox.value.indeterminate = val;
+        });
+      }, { immediate: true },
     );
 
     return {

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -206,6 +206,7 @@
               v-if="useCheckbox.use && useCheckbox.headerCheck && useCheckbox.mode !== 'single'"
               v-model="isHeaderChecked"
               :disabled="isHeaderUncheckable"
+              :indeterminate="isHeaderIndeterminate"
               @change="onCheckAll"
             />
           </li>
@@ -767,6 +768,7 @@ export default {
       prevCheckedRow: [],
       isHeaderChecked: false,
       isHeaderUncheckable: false,
+      isHeaderIndeterminate: false,
       checkedRows: props.checked,
       useCheckbox: computed(() => (props.option.useCheckbox || {})),
     });
@@ -825,6 +827,7 @@ export default {
     const clearCheckInfo = () => {
       checkInfo.checkedRows = [];
       checkInfo.isHeaderChecked = false;
+      checkInfo.isHeaderIndeterminate = false;
       stores.store.forEach((row) => {
         row[ROW_CHECK_INDEX] = false;
       });
@@ -890,6 +893,7 @@ export default {
     const {
       onSearch,
       setFilter,
+      setHeaderCheckboxByFilter,
     } = filterEvent({
       columnSettingInfo,
       filterInfo,
@@ -1058,7 +1062,7 @@ export default {
     watch(
       () => props.rows,
       (value) => {
-        setStore(value);
+        setStore(value, !sortInfo.sortField);
         if (filterInfo.isSearch) {
           onSearch(filterInfo.searchWord);
         }
@@ -1305,6 +1309,8 @@ export default {
       filterInfo.isShowFilterSetting = false; // filter setting close
       stores.filterStore = [];
       setStore([], false);
+
+      setHeaderCheckboxByFilter(stores.filterStore);
     };
 
     let expandTimer = null;

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -51,7 +51,6 @@
   position: relative;
   height: 100%;
   padding: 0 10px;
-  line-height: 30px;
   justify-content: center;
   align-items: center;
   text-align: center;

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -514,6 +514,7 @@ export const checkEvent = (params) => {
       if (store.length && isAllChecked) {
         checkInfo.isHeaderChecked = true;
       }
+      checkInfo.isHeaderIndeterminate = store.length && !isAllChecked;
     } else {
       if (checkInfo.useCheckbox.mode === 'single') {
         checkInfo.checkedRows = [];
@@ -521,6 +522,7 @@ export const checkEvent = (params) => {
         checkInfo.checkedRows.splice(checkInfo.checkedRows.indexOf(row[ROW_DATA_INDEX]), 1);
       }
       checkInfo.isHeaderChecked = false;
+      checkInfo.isHeaderIndeterminate = !!(stores.store.length && checkInfo.checkedRows.length);
     }
     checkInfo.prevCheckedRow = row.slice();
     emit('update:checked', checkInfo.checkedRows);
@@ -551,6 +553,7 @@ export const checkEvent = (params) => {
         row[ROW_CHECK_INDEX] = isHeaderChecked;
       }
     });
+    checkInfo.isHeaderIndeterminate = false;
     emit('update:checked', checkInfo.checkedRows);
     emit('check-all', event, checkInfo.checkedRows);
   };
@@ -708,6 +711,25 @@ export const filterEvent = (params) => {
     updatePagingInfo,
     getColumnIndex,
   } = params;
+  /**
+   * 헤더 체크박스 상태를 체크한다.
+   *
+   * @param {array} rowData - row 데이터
+   */
+  const setHeaderCheckboxByFilter = (rowData) => {
+    let checkedCount = 0;
+    rowData.forEach((row) => {
+      const isChecked = checkInfo.checkedRows.includes(row[ROW_DATA_INDEX]);
+      row[ROW_CHECK_INDEX] = isChecked;
+      checkedCount += isChecked ? 1 : 0;
+    });
+    if (rowData.length) {
+      checkInfo.isHeaderChecked = rowData.length === checkedCount;
+      checkInfo.isHeaderIndeterminate = (rowData.length !== checkedCount) && checkedCount > 0;
+      checkInfo.isHeaderUncheckable = rowData
+        .every(row => props.uncheckable.includes(row[ROW_DATA_INDEX]));
+    }
+  };
   /**
    * 전달받은 문자열 내 해당 키워드가 존재하는지 확인한다.
    *
@@ -927,19 +949,7 @@ export const filterEvent = (params) => {
         });
         filterInfo.isSearch = true;
       }
-      const store = stores.store;
-      let checkedCount = 0;
-      store.forEach((row) => {
-        row[ROW_CHECK_INDEX] = checkInfo.checkedRows.includes(row[ROW_DATA_INDEX]);
-        if (row[ROW_CHECK_INDEX]) {
-          checkedCount += 1;
-        }
-      });
-      if (store.length && store.length === checkedCount) {
-        checkInfo.isHeaderChecked = true;
-      } else {
-        checkInfo.isHeaderChecked = false;
-      }
+      setHeaderCheckboxByFilter(stores.store);
       if (!searchWord && pageInfo.isClientPaging && pageInfo.prevPage) {
         pageInfo.currentPage = 1;
         stores.pagingStore = getPagingData();
@@ -949,7 +959,7 @@ export const filterEvent = (params) => {
       updateVScroll();
     }, 500);
   };
-  return { onSearch, setFilter };
+  return { onSearch, setFilter, setHeaderCheckboxByFilter };
 };
 
 export const contextMenuEvent = (params) => {
@@ -1147,6 +1157,7 @@ export const storeEvent = (params) => {
         store.push([idx, checked, row, selected, expanded, uncheckable]);
       });
       checkInfo.isHeaderChecked = rows.length > 0 ? !hasUnChecked : false;
+      checkInfo.isHeaderIndeterminate = hasUnChecked && !!checkInfo.checkedRows.length;
       checkInfo.isHeaderUncheckable = rows.every(row => props.uncheckable.includes(row));
       stores.originStore = store;
     }

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -57,6 +57,7 @@
               v-if="isHeaderCheckbox"
               v-model="isHeaderChecked"
               :disabled="isHeaderUncheckable"
+              :indeterminate="isHeaderIndeterminate"
               @change="onCheckAll"
             />
           </li>
@@ -396,6 +397,7 @@ export default {
       prevCheckedRow: [],
       isHeaderChecked: false,
       isHeaderUncheckable: false,
+      isHeaderIndeterminate: false,
       checkedRows: props.checked,
       useCheckbox: computed(() => props.option.useCheckbox || {}),
     });
@@ -467,9 +469,11 @@ export default {
     };
     const clearCheckInfo = () => {
       checkInfo.isHeaderChecked = false;
+      checkInfo.isHeaderIndeterminate = false;
       checkInfo.checkedRows.length = 0;
       stores.store.forEach((row) => {
         row.checked = false;
+        row.indeterminate = false;
       });
     };
     const {

--- a/src/components/treeGrid/TreeGridNode.vue
+++ b/src/components/treeGrid/TreeGridNode.vue
@@ -17,6 +17,7 @@
       <ev-checkbox
         v-model="node.checked"
         :disabled="node.uncheckable"
+        :indeterminate="node.indeterminate"
         class="row-checkbox-input"
         @change="onCheck($event, node)"
       />

--- a/src/components/treeGrid/style/treeGrid.scss
+++ b/src/components/treeGrid/style/treeGrid.scss
@@ -47,7 +47,6 @@
   position: relative;
   height: 100%;
   padding: 0 10px;
-  line-height: 30px;
   justify-content: center;
   align-items: center;
   text-align: center;

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -72,6 +72,9 @@ export const commonFunctions = (params) => {
         && (uncheckableList.length + checkedList.length === rows.length);
       checkInfo.isHeaderUncheckable = isAllUncheckable;
     }
+    checkInfo.isHeaderIndeterminate = !!rows.length
+      && rows.some(row => row.checked || row.indeterminate)
+      && !checkInfo.isHeaderChecked;
   };
   return {
     isRenderer,
@@ -477,6 +480,10 @@ export const checkEvent = (params) => {
           parentNode.checked = true;
         }
       }
+
+      parentNode.indeterminate = !isCheck
+        && parentNode.children.some(n => n.checked || n.indeterminate);
+
       if (!parentNode.checked) {
         checkInfo.checkedRows = checkInfo.checkedRows
           .filter(checked => checked.index !== parentNode.index);
@@ -519,6 +526,7 @@ export const checkEvent = (params) => {
       onCheckChildren(row);
       onCheckParent(row);
       checkInfo.checkedRows.push(row);
+      row.indeterminate = false;
     };
     const removeCheckedRow = (row) => {
       if (isSingleMode()) {
@@ -563,7 +571,9 @@ export const checkEvent = (params) => {
         checkInfo.checkedRows = checkInfo.checkedRows
           .filter(checked => checked.index !== row.index);
       }
+      row.indeterminate = false;
     });
+    checkInfo.isHeaderIndeterminate = false;
     emit('update:checked', checkInfo.checkedRows);
     emit('check-all', event, checkInfo.checkedRows);
   };
@@ -718,6 +728,10 @@ export const treeEvent = (params) => {
 
         if (!Object.hasOwnProperty.call(node, 'uncheckable')) {
           node.uncheckable = uncheckable;
+        }
+
+        if (!Object.hasOwnProperty.call(node, 'indeterminate')) {
+          node.indeterminate = false;
         }
 
         if (!Object.hasOwnProperty.call(node, 'data')) {


### PR DESCRIPTION
### 요구사항
- Grid > 체크박스 헤더에 indeterminate 표시 적용
- Tree Grid > 체크박스 헤더 및 부모 노드에 대한 indeterminate 표시 적용
---
### 작업 내용
**1. Grid**
- Grid > 그리드 체크박스 헤더에 indeterminate 상태 표시 적용
- Grid > 필터링 된 상태(검색 및 필터기능 적용)에 따라 헤더의 체크박스 상태를 체크하는 로직 추가 (uncheckable, indeterminate, Checked)
- Grid > 정렬시, uncheckable 상태가 풀리는 버그가 있어 정렬하더라도 상태가 풀리지 않도록 수정
![image](https://github.com/ex-em/EVUI/assets/79958259/90454bfe-2a18-4554-a2a4-91cd2a45ddb5)


**2. Tree Grid**
- Tree Grid > 그리드 체크박스 헤더 및 자식노드를 가지고 있는 부모노드에 indeterminate 상태 표시 적용
![image](https://github.com/ex-em/EVUI/assets/79958259/89edadc0-346a-45ac-9104-fd1264bac8bf)
