### PR TITLE
2.0_MFM_checkBox-group 및 Dropdown 내부 input-text style 수정

### DIFF
--- a/src/components/checkbox/checkbox-group.vue
+++ b/src/components/checkbox/checkbox-group.vue
@@ -59,12 +59,14 @@
       onChange(e) {
         const bindValue = this.bindValue;
         const targetValue = e.target.value;
-        if (e.currentTarget.checked && bindValue.indexOf(targetValue) === -1) {
-          bindValue.push(targetValue);
-        } else if (!e.currentTarget.checked && bindValue.indexOf(targetValue) > -1) {
-          bindValue.splice(bindValue.indexOf(targetValue), 1);
-        }
-        this.$parent.$emit('input', bindValue);
+        this.$nextTick(() => {
+          if (e.currentTarget.checked && bindValue.indexOf(targetValue) === -1) {
+            bindValue.push(targetValue);
+          } else if (!e.currentTarget.checked && bindValue.indexOf(targetValue) > -1) {
+            bindValue.splice(bindValue.indexOf(targetValue), 1);
+          }
+          this.$parent.$emit('input', bindValue);
+        });
       },
     },
   };

--- a/src/components/selectbox/dropdown.vue
+++ b/src/components/selectbox/dropdown.vue
@@ -190,10 +190,10 @@
     -webkit-border-radius: 4px;
     -moz-border-radius: 4px;
     border-radius: 4px;
-  }
 
-  .ev-dropdown-multiple-input-area .input-text:focus {
-    outline: none;
+    &:focus {
+      outline: none;
+    }
   }
 
   /**  ev-dropdown > ev-dropdown-listbox-wrap **/

--- a/src/components/selectbox/dropdown.vue
+++ b/src/components/selectbox/dropdown.vue
@@ -181,14 +181,19 @@
     height: 100%;
     padding: 3px;
   }
-
+  
   .ev-dropdown-multiple-input-area .input-text {
     width: 100%;
     height: 100%;
     border: 1px solid #CCCCCC;
+    padding: 0 5px 0 5px;
     -webkit-border-radius: 4px;
     -moz-border-radius: 4px;
     border-radius: 4px;
+  }
+
+  .ev-dropdown-multiple-input-area .input-text:focus {
+    outline: none;
   }
 
   /**  ev-dropdown > ev-dropdown-listbox-wrap **/


### PR DESCRIPTION
**<작업 진행사항 Log>**    
_2023.11.23_

<br />

> 1. 작업 이유 & 달성목표

MFM 관련 작업 중 발견한 이슈로서,
 - stat 내부 checkBox-group의 값이 하위 checkBox와 UI 상호연동이 되지않는 문제
 - DropDown 내 input-text 의 스타일로 인해, cursor 가 보이지 않는 문제
 를 수정하고자 합니다. 

<br />
<br />

> 2. 부연설명
- checkBox-group에서, 10개 이상으로 클릭이 되지 않도록 사용처 쪽에 로직을 넣었음에도, checkBox-group 내 update 로직 내부
NextTick의 부재로 인해,. UI update가 먼저 처리됨으로 문제가 발현되었습니다. 
- 따라서, NextTick함수를 통해 UI update 시점을 조절하였습니다.

- Input box에서, text를 넣기 위해 클릭을 했을 때, text input cursor가 보이지 않아 사용성에 문제가 있었습니다. 
- 따라서, focus 시점에 cursor를 가리는 border Effect를 제거 / 양 옆측에 padding을 주어 corsur가 시야에서 벗어나지 않도록 수정했습니다.