### PR TITLE
[#1553] Grid > Summary > 부동소수점 처리

### DIFF
--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -24,44 +24,46 @@
  - `#toolbar` 지정해서 Toolbar 표시
 
 ### Props
-| 이름 | 타입 | 디폴트 | 설명 | 종류 |
-| --- | ---- | ----- | ---- | --- |
-| columns | Array | [] | 컬럼 리스트 | |
-| rows | Array | [] | row 리스트 | |
-| width | String, Number | '100%' | 그리드 넓이 | '50%', '50px', 50 |
-| height | String, Number | '100%' | 그리드 높이 | '50%', '50px', 50 |
-| selected | Array | [] | 선택된 row 데이터 |  |
-| checked | Array | [] | 체크된 row 데이터 |  |
-| option | Object | {} | 그리드 옵션 |  |
-|  | adjust | false | 그리드의 너비에 맞게 컬럼 너비를 자동으로 조절한다. |  |
-|  | showHeader | true | 헤더 표시 여부를 설정한다. |  |
-|  | rowHeight | 35 | row 높이를 설정한다. | `min-height: 35` |
-|  | rowMinHeight | null | row 높이를 `min-height`보다 작게 설정한다. |  |
-|  | columnWidth | 40 | 기본 컬럼 너비를 설정한다. | `min-width: 40px` |
-|  | useCheckbox | {} | 각 row별 체크박스 사용 여부 및 단일 선택이나 다중 선택을 설정한다. |  |
-|  |  | use | 체크박스 사용 여부 | Boolean |
-|  |  | mode | 단일 및 다중 선택 설정 | 'multi', 'single' |
-|  |  | headerCheck | 헤더 체크박스 사용 여부 | Boolean |
-|  | useSelection | {} | 각 row별 선택 여부 및 단일 선택이나 다중 선택을 설정한다. |  |
-|  |  | use | Selection 사용 여부 | Boolean |
-|  |  | multiple | 다중 선택 설정 여부  | Boolean |
-|  | style | {} | 그리드의 스타일을 설정한다. |  |
-|  |  | stripe | row의 배경색을 Stripe 스타일로 설정한다. | Boolean |
-|  |  | border | 그리드의 Border 여부를 설정한다. | 'none', 'rows' |
-|  |  | highlight | 지정한 row에 Highlight 효과를 설정한다. | `rowIndex` |
-|  | customContextMenu | [] | 우클릭시 보여지는 컨텍스트 메뉴를 설정한다. |  |
-|  |  | menuItems | 컨텍스트 메뉴 |  |
-|  | page | {} | 페이지 설정 |  |
-|  |  | use | 페이지 사용 여부 | Boolean |
-|  |  | isInfinite | Infinite Scroll 사용 여부 | Boolean |
-|  |  | useClient | client-side Paging 사용 여부 | Boolean |
-|  |  | total | 총 항목 수 | Number |
-|  |  | perPage | 각 페이지의 항목 수 | Number |
-|  |  | currentPage | 현재 페이지 번호 | Number |
-|  |  | visiblePage | 보여지는 Pagination 버튼 수 | Number |
-|  |  | order | Pagination 위치 | 'center', 'left', 'right' |
-|  |  | showPageInfo | 페이지 정보 표시 여부 | Boolean |
-|  | useSummary | false | 하단에 summary row 가 표시 된다. | Boolean |
+| 이름       | 타입                | 디폴트          | 설명                                       | 종류                        |
+|----------|-------------------|--------------|------------------------------------------|---------------------------|
+| columns  | Array             | []           | 컬럼 리스트                                   |                           |
+| rows     | Array             | []           | row 리스트                                  |                           |
+| width    | String, Number    | '100%'       | 그리드 넓이                                   | '50%', '50px', 50         |
+| height   | String, Number    | '100%'       | 그리드 높이                                   | '50%', '50px', 50         |
+| selected | Array             | []           | 선택된 row 데이터                              |                           |
+| checked  | Array             | []           | 체크된 row 데이터                              |                           |
+| option   | Object            | {}           | 그리드 옵션                                   |                           |
+|          | adjust            | false        | 그리드의 너비에 맞게 컬럼 너비를 자동으로 조절한다.            |                           |
+|          | showHeader        | true         | 헤더 표시 여부를 설정한다.                          |                           |
+|          | rowHeight         | 35           | row 높이를 설정한다.                            | `min-height: 35`          |
+|          | rowMinHeight      | null         | row 높이를 `min-height`보다 작게 설정한다.          |                           |
+|          | columnWidth       | 40           | 기본 컬럼 너비를 설정한다.                          | `min-width: 40px`         |
+|          | useCheckbox       | {}           | 각 row별 체크박스 사용 여부 및 단일 선택이나 다중 선택을 설정한다. |                           |
+|          |                   | use          | 체크박스 사용 여부                               | Boolean                   |
+|          |                   | mode         | 단일 및 다중 선택 설정                            | 'multi', 'single'         |
+|          |                   | headerCheck  | 헤더 체크박스 사용 여부                            | Boolean                   |
+|          | useSelection      | {}           | 각 row별 선택 여부 및 단일 선택이나 다중 선택을 설정한다.      |                           |
+|          |                   | use          | Selection 사용 여부                          | Boolean                   |
+|          |                   | multiple     | 다중 선택 설정 여부                              | Boolean                   |
+|          | style             | {}           | 그리드의 스타일을 설정한다.                          |                           |
+|          |                   | stripe       | row의 배경색을 Stripe 스타일로 설정한다.              | Boolean                   |
+|          |                   | border       | 그리드의 Border 여부를 설정한다.                    | 'none', 'rows'            |
+|          |                   | highlight    | 지정한 row에 Highlight 효과를 설정한다.             | `rowIndex`                |
+|          | customContextMenu | []           | 우클릭시 보여지는 컨텍스트 메뉴를 설정한다.                 |                           |
+|          |                   | menuItems    | 컨텍스트 메뉴                                  |                           |
+|          | page              | {}           | 페이지 설정                                   |                           |
+|          |                   | use          | 페이지 사용 여부                                | Boolean                   |
+|          |                   | isInfinite   | Infinite Scroll 사용 여부                    | Boolean                   |
+|          |                   | useClient    | client-side Paging 사용 여부                 | Boolean                   |
+|          |                   | total        | 총 항목 수                                   | Number                    |
+|          |                   | perPage      | 각 페이지의 항목 수                              | Number                    |
+|          |                   | currentPage  | 현재 페이지 번호                                | Number                    |
+|          |                   | visiblePage  | 보여지는 Pagination 버튼 수                     | Number                    |
+|          |                   | order        | Pagination 위치                            | 'center', 'left', 'right' |
+|          |                   | showPageInfo | 페이지 정보 표시 여부                             | Boolean                   |
+|          | summary           | {}           | 하단에 summary row 가 표시 된다.                 |                           |
+|          |                   | use          | Summary 사용 여부                            | Boolean                   |
+|          |                   | decimal      | Summary 소수점 표현 단위                        | Number                    |
 
 ### Columns
 | 이름 | 타입 | 설명 | 종류 | 필수 |

--- a/docs/views/grid/example/Summary.vue
+++ b/docs/views/grid/example/Summary.vue
@@ -44,7 +44,7 @@
           />
         </div>
       </div>
-      <div class="form-rows summary-toggle">
+      <div class="form-rows summary-decimal">
         <div class="form-row">
           <span class="badge yellow">
             Summary Decimal
@@ -163,7 +163,7 @@ export default {
 .form-rows {
   display: flex;
 
-  &.summary-toggle {
+  &.summary-decimal {
     width: 50%;
   }
 }

--- a/docs/views/grid/example/Summary.vue
+++ b/docs/views/grid/example/Summary.vue
@@ -20,7 +20,7 @@
           border: 'rows',
         },
         page: pageInfo,
-        useSummary: true,
+        summary: summaryInfo,
       }"
     >
       <template #increment_mb="{ item }">
@@ -41,6 +41,19 @@
           <ev-select
             v-model="usedSummaryType"
             :items="summaryTypes"
+          />
+        </div>
+      </div>
+      <div class="form-rows summary-toggle">
+        <div class="form-row">
+          <span class="badge yellow">
+            Summary Decimal
+          </span>
+          <ev-input-number
+            v-model="summaryInfo.decimal"
+            :step="1"
+            :min="0"
+            :max="300"
           />
         </div>
       </div>
@@ -110,14 +123,18 @@ export default {
       ['HIDB_DATA_3', '25080', -10, 14485, 0, 0],
       ['HIDB_DATA_4', '', 20000, 14396, 2185, -11],
       ['SYSAUX', '', 11000, 9485, 0, -11],
-      ['USERS', '4004', 10000, 6485, 0, 0],
-      ['UNDOTBS1', '4004', 9000, 3486, 0, 0],
+      ['USERS', '4004', 0.1, 6485, 0, 0],
+      ['UNDOTBS1', '4004', 0.2, 3486, 0, 0],
     ];
     const pageInfo = reactive({
       use: false,
       perPage: 8,
       total: computed(() => tableData.value.length),
       useClient: true,
+    });
+    const summaryInfo = reactive({
+      use: true,
+      decimal: 1,
     });
     const getIncrementValue = (item) => {
       const row = item.row[2];
@@ -135,6 +152,7 @@ export default {
       totalSummaryType,
       summaryTypes,
       usedSummaryType,
+      summaryInfo,
       getIncrementValue,
     };
   },
@@ -144,6 +162,10 @@ export default {
 <style lang="scss" scoped>
 .form-rows {
   display: flex;
+
+  &.summary-toggle {
+    width: 50%;
+  }
 }
 .form-row {
   flex: 1;

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -30,7 +30,6 @@
         parentIcon: parentIconMV,
         childIcon: childIconMV,
         page: pageInfo,
-        useSummary: true,
       }"
       @check-row="onCheckedRow"
       @check-all="onCheckedRow"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.62",
+  "version": "3.3.67",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2232,6 +2232,17 @@
             "unique-filename": "^1.1.1"
           }
         },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -2274,6 +2285,18 @@
             "supports-color": "^7.0.0"
           }
         },
+        "loader-utils": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
         "ssri": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
@@ -2308,6 +2331,18 @@
             "source-map": "^0.6.1",
             "terser": "^4.6.12",
             "webpack-sources": "^1.4.3"
+          }
+        },
+        "vue-loader-v16": {
+          "version": "npm:vue-loader@16.8.3",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
+          "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "hash-sum": "^2.0.0",
+            "loader-utils": "^2.0.0"
           }
         },
         "wrap-ansi": {
@@ -3650,6 +3685,11 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
+    },
+    "bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug=="
     },
     "binary-extensions": {
       "version": "2.1.0",
@@ -17651,87 +17691,6 @@
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
-        }
-      }
-    },
-    "vue-loader-v16": {
-      "version": "npm:vue-loader@16.8.3",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
-      "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "hash-sum": "^2.0.0",
-        "loader-utils": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "loader-utils": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "main": "dist/evui.umd.js",
   "dependencies": {
+    "bignumber.js": "^9.1.2",
     "core-js": "^3.6.5",
     "dayjs": "^1.10.4",
     "korean-regexp": "^1.0.10",

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -237,6 +237,7 @@
       rowHeight,
     }"
     :scroll-left="summaryScroll"
+    :decimal="summaryDecimal"
   />
   <!-- Pagination -->
   <grid-pagination
@@ -327,7 +328,6 @@ export default {
       setPixelUnit,
     } = commonFunctions();
     const showHeader = computed(() => (props.option.showHeader ?? true));
-    const useSummary = computed(() => (props.option?.useSummary || false));
     const stripeStyle = computed(() => (props.option.style?.stripe || false));
     const borderStyle = computed(() => (props.option.style?.border || ''));
     const highlightIdx = computed(() => (props.option.style?.highlight ?? -1));
@@ -412,6 +412,10 @@ export default {
         (props.option.rowHeight > rowMinHeight ? props.option.rowHeight : rowMinHeight)),
       gridWidth: computed(() => (props.width ? setPixelUnit(props.width) : '100%')),
       gridHeight: computed(() => (props.height ? setPixelUnit(props.height) : '100%')),
+    });
+    const summaryInfo = reactive({
+      useSummary: computed(() => props.option.summary?.use || false),
+      summaryDecimal: computed(() => props.option.summary?.decimal || 0),
     });
     const clearCheckInfo = () => {
       checkInfo.checkedRows = [];
@@ -704,7 +708,6 @@ export default {
       stripeStyle,
       borderStyle,
       highlightIdx,
-      useSummary,
       stores,
       ...toRefs(elementInfo),
       ...toRefs(stores),
@@ -716,6 +719,7 @@ export default {
       ...toRefs(checkInfo),
       ...toRefs(sortInfo),
       ...toRefs(contextInfo),
+      ...toRefs(summaryInfo),
       isRenderer,
       getComponentName,
       getConvertValue,

--- a/src/components/grid/grid.summary.vue
+++ b/src/components/grid/grid.summary.vue
@@ -178,10 +178,10 @@ export default {
                 }
                 return prev;
               }, 0);
-              result = bigNumberCalculation.divide?.(sumValue, columnValues.length);
-              if (result % 1 !== 0) {
-                result = result.toFixed(1);
-              }
+              result = bigNumberCalculation.floor?.(
+                bigNumberCalculation.divide?.(sumValue, columnValues.length),
+                (props.decimal ?? 0),
+              );
               break;
             }
             case 'max': {


### PR DESCRIPTION
# 이슈

- Grid > Summary 옵션 추가 시에 부동소수점 문제로 자리수 틀어지는 현상 발생
- 버전 : `3.3.67`

# 해결

## 작업 내용

bignumber.js 라이브러리를 추가하여 부동소수점 계산을 추가하였습니다.

버전 : `9.1.2`

[AS-IS]

- Total (MB) 컬렘에 Summary를 sum으로 설정했을 시 부동소수점 문제 발생

<img width="754" alt="image" src="https://github.com/ex-em/EVUI/assets/75205035/2dafabdb-9afc-4670-bb1d-1bda4db4276b">

[TO-BE]

- bignumer.js 라이브러리로 계산하여 부동소수점 해결
(`decimal` 옵션을 sum과 average에 적용하였습니다)

<img width="759" alt="image" src="https://github.com/ex-em/EVUI/assets/75205035/cf8425ad-9725-474d-98d7-a1bbe6885781">
