### PR TITLE
[#1555] Grid > Summary > 컬럼 별 decimal 설정 옵션 추가

### DIFF
--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -61,25 +61,24 @@
 |          |                   | visiblePage  | 보여지는 Pagination 버튼 수                     | Number                    |
 |          |                   | order        | Pagination 위치                            | 'center', 'left', 'right' |
 |          |                   | showPageInfo | 페이지 정보 표시 여부                             | Boolean                   |
-|          | summary           | {}           | 하단에 summary row 가 표시 된다.                 |                           |
-|          |                   | use          | Summary 사용 여부                            | Boolean                   |
-|          |                   | decimal      | Summary 소수점 표현 단위                        | Number                    |
+|          | useSummary        | boolean      | 하단에 summary row 가 표시 된다.                 |                           |
 
 ### Columns
-| 이름 | 타입 | 설명 | 종류 | 필수 |
-| --- | ---- | ----- | ---- | --- |
-| caption | String | 컬럼명 | ex) '인스턴스명' | Y |
-| field | String | 필드명 | ex) 'instance_name' | Y |
-| type | String | 데이터 타입 | 'string', 'number', 'stringNumber', 'float', 'boolean' | Y |
-| hide | Boolean | 컬럼 숨김 여부 | Boolean | N |
-| width | Number | 컬럼 넓이 | ex) 150 | N |
-| searchable | Boolean | 검색 대상 여부 | Boolean | N |
-| sortable | Boolean | 정렬 대상 여부 | Boolean | N |
-| align | String | 사용자 지정 정렬 | 'center', 'left', 'right' | N |
-| decimal | Number | 데이터 타입이 float 일 때 소수점 자리 표시 수 | ex) 0~20 (디폴트: 3 ) | N |
-| summaryType | String | 계산 타입 | 'sum', 'average', 'max', 'min', 'count' | N |
-| summaryRenderer | String | Summary 에 표시할 텍스트 또는 계산 값 | ex) 'Sum: {0}' | N |
-| summaryData | Array | Summary 할 대상 추가 시 summaryRenderer 와 함께 사용 | ex) '{0}({1}%)' | N |
+| 이름              | 타입      | 설명                                                   | 종류                                                     | 필수 |
+|-----------------|---------|------------------------------------------------------|--------------------------------------------------------| --- |
+| caption         | String  | 컬럼명                                                  | ex) '인스턴스명'                                            | Y |
+| field           | String  | 필드명                                                  | ex) 'instance_name'                                    | Y |
+| type            | String  | 데이터 타입                                               | 'string', 'number', 'stringNumber', 'float', 'boolean' | Y |
+| hide            | Boolean | 컬럼 숨김 여부                                             | Boolean                                                | N |
+| width           | Number  | 컬럼 넓이                                                | ex) 150                                                | N |
+| searchable      | Boolean | 검색 대상 여부                                             | Boolean                                                | N |
+| sortable        | Boolean | 정렬 대상 여부                                             | Boolean                                                | N |
+| align           | String  | 사용자 지정 정렬                                            | 'center', 'left', 'right'                              | N |
+| decimal         | Number  | 데이터 타입이 float 일 때 소수점 자리 표시 수                        | ex) 0~20 (디폴트: 3 )                                     | N |
+| summaryType     | String  | 계산 타입                                                | 'sum', 'average', 'max', 'min', 'count'                | N |
+| summaryDecimal  | Number  | Summary 계산 타입 중 'sum', 'average'를 선택한 경우 소수점 표현 자리수  | ex) 0~20 (디폴트: 3 )                            | N |
+| summaryRenderer | String  | Summary 에 표시할 텍스트 또는 계산 값                            | ex) 'Sum: {0}'                                         | N |
+| summaryData     | Array   | Summary 할 대상 추가 시 summaryRenderer 와 함께 사용            | ex) '{0}({1}%)'                                        | N |
 
 ### Event
 | 이름 | 파라미터 | 설명 |

--- a/docs/views/grid/example/Summary.vue
+++ b/docs/views/grid/example/Summary.vue
@@ -19,8 +19,7 @@
         style: {
           border: 'rows',
         },
-        page: pageInfo,
-        summary: summaryInfo,
+        useSummary: true,
       }"
     >
       <template #increment_mb="{ item }">
@@ -37,20 +36,31 @@
           />
         </div>
         <div class="form-row">
+          <span class="badge yellow">
+            Total (MB) Summary Decimal
+          </span>
+          <ev-input-number
+            v-model="totalSummaryDecimal"
+            :step="1"
+            :min="0"
+            :max="300"
+          />
+        </div>
+      </div>
+      <div class="form-rows">
+        <div class="form-row">
           <span class="badge yellow">Used (MB)</span>
           <ev-select
             v-model="usedSummaryType"
             :items="summaryTypes"
           />
         </div>
-      </div>
-      <div class="form-rows summary-decimal">
         <div class="form-row">
           <span class="badge yellow">
-            Summary Decimal
+            Used (MB) Summary Decimal
           </span>
           <ev-input-number
-            v-model="summaryInfo.decimal"
+            v-model="usedSummaryDecimal"
             :step="1"
             :min="0"
             :max="300"
@@ -68,7 +78,9 @@ import { numberWithComma } from '@/common/utils';
 export default {
   setup() {
     const totalSummaryType = ref('sum');
+    const totalSummaryDecimal = ref(1);
     const usedSummaryType = ref('average');
+    const usedSummaryDecimal = ref(3);
     const summaryTypes = ref([
       { name: 'sum', value: 'sum' },
       { name: 'average', value: 'average' },
@@ -94,11 +106,13 @@ export default {
         field: 'total_mb',
         type: 'number',
         summaryType: totalSummaryType,
+        summaryDecimal: totalSummaryDecimal,
         summaryRenderer: 'value: {0}', // text + 해당 컬럼 값 계산
       },
       { caption: 'Used (MB)',
         field: 'used_mb',
         type: 'number',
+        summaryDecimal: usedSummaryDecimal,
         summaryType: usedSummaryType, // type 만 지정
       },
       { caption: 'Increment (MB)',
@@ -132,10 +146,6 @@ export default {
       total: computed(() => tableData.value.length),
       useClient: true,
     });
-    const summaryInfo = reactive({
-      use: true,
-      decimal: 1,
-    });
     const getIncrementValue = (item) => {
       const row = item.row[2];
       const columnIndex = item.column.index;
@@ -150,9 +160,10 @@ export default {
       checked,
       pageInfo,
       totalSummaryType,
+      totalSummaryDecimal,
       summaryTypes,
       usedSummaryType,
-      summaryInfo,
+      usedSummaryDecimal,
       getIncrementValue,
     };
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.67",
+  "version": "3.3.68",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -237,7 +237,6 @@
       rowHeight,
     }"
     :scroll-left="summaryScroll"
-    :decimal="summaryDecimal"
   />
   <!-- Pagination -->
   <grid-pagination
@@ -328,6 +327,7 @@ export default {
       setPixelUnit,
     } = commonFunctions();
     const showHeader = computed(() => (props.option.showHeader ?? true));
+    const useSummary = computed(() => (props.option?.useSummary || false));
     const stripeStyle = computed(() => (props.option.style?.stripe || false));
     const borderStyle = computed(() => (props.option.style?.border || ''));
     const highlightIdx = computed(() => (props.option.style?.highlight ?? -1));
@@ -412,10 +412,6 @@ export default {
         (props.option.rowHeight > rowMinHeight ? props.option.rowHeight : rowMinHeight)),
       gridWidth: computed(() => (props.width ? setPixelUnit(props.width) : '100%')),
       gridHeight: computed(() => (props.height ? setPixelUnit(props.height) : '100%')),
-    });
-    const summaryInfo = reactive({
-      useSummary: computed(() => props.option.summary?.use || false),
-      summaryDecimal: computed(() => props.option.summary?.decimal || 0),
     });
     const clearCheckInfo = () => {
       checkInfo.checkedRows = [];
@@ -705,6 +701,7 @@ export default {
     return {
       summaryScroll,
       showHeader,
+      useSummary,
       stripeStyle,
       borderStyle,
       highlightIdx,
@@ -719,7 +716,6 @@ export default {
       ...toRefs(checkInfo),
       ...toRefs(sortInfo),
       ...toRefs(contextInfo),
-      ...toRefs(summaryInfo),
       isRenderer,
       getComponentName,
       getConvertValue,


### PR DESCRIPTION
# 이슈

- summary 옵션 사용시 모든 그리드의 summary가 동일한 decimal로 설정되는 현상

# 해결

## 작업 내용

- 컬럼 별로 Summary의 Decimal을 설정할 수 있도록 `summaryDecimal` 추가

## 화면

<img width="574" alt="image" src="https://github.com/ex-em/EVUI/assets/75205035/cf66147d-c730-4b3c-8cf8-417957309f82">
