### PR TITLE
[#1555] Grid > Summary > 컬럼 별 decimal 설정 옵션 추가

### DIFF
--- a/docs/components/Example.vue
+++ b/docs/components/Example.vue
@@ -1,6 +1,15 @@
 <template>
   <article class="article-wrapper">
-    <h3 class="article-title">
+    <h3
+      :id="kebabCase(title)"
+      class="article-title"
+    >
+      <a
+        class="article-title-anchor"
+        @click="$router.push({ hash: `#${kebabCase(title)}` })"
+      >
+        ¶
+      </a>
       {{ title }}
     </h3>
     <p
@@ -49,6 +58,7 @@
 
 <script>
 import { ref, onMounted } from 'vue';
+import { kebabCase } from 'lodash-es';
 import highlight from 'docs/directives/highlight';
 
 export default {
@@ -95,6 +105,7 @@ export default {
     });
 
     return {
+      kebabCase,
       codeExpend,
       codeWrapper,
       clickExpend,
@@ -126,6 +137,20 @@ export default {
   margin-bottom: 20px;
   font-size: 23px;
   font-weight: bold;
+  &-anchor {
+    float: left;
+    margin-left: -1em;
+    color: $color-blue;
+    opacity: 0;
+    cursor: pointer;
+    text-decoration: none;
+    &:hover {
+      opacity: 1;
+    }
+  }
+  &:hover .article-title-anchor {
+    opacity: 1;
+  }
 }
 .article-description {
   margin-bottom: 30px;

--- a/docs/router/index.js
+++ b/docs/router/index.js
@@ -358,10 +358,29 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(process.env.BASE_URL),
   routes,
-  scrollBehavior() {
-    return {
-      top: 0,
-    };
+  scrollBehavior(to) {
+    // hash 가 존재하는 경우 hash 위치로 스크롤 하되, header 높이만큼 더 올려야 한다.
+    const result = to.hash ? { el: to.hash, top: 60 } : { top: 0 };
+
+    // 사용자가 직접 url 에 hash 를 입력한 경우나, hash 가 존재하는 url 링크를 타고와서 이동하는 경우에는
+    // vue-router 에서 scrollBehavior 를 이용한 스크롤이 이동된 뒤에
+    // browser 의 기본 동작으로 인해 id tag 의 위치로 스크롤이 다시 이동 되는데,
+    // header 때문에 정확한 위치로 이동하지 않는 문제가 있어서 비동기 로직이 추가 된다.
+    if (document.readyState === 'loading') {
+      return new Promise((resolve) => {
+        window.addEventListener('load', () => {
+          resolve(result);
+        }, { once: true });
+      });
+    }
+    if (window.event?.type === 'popstate') {
+      return new Promise((resolve) => {
+        window.addEventListener('hashchange', () => {
+          resolve(result);
+        }, { once: true });
+      });
+    }
+    return result;
   },
 });
 

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -196,6 +196,7 @@ const chartData = {
 | fontFamily | String | 'Roboto' | 폰트 | |
 | fitWidth | Boolean | false | Label Text Ellipsis 처리 | |
 | fitDir | String | 'right' | Ellipsis 방향 | ( right => 'aaa...', left => '...aaa') |
+| padding |  Number | 0 | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0 |
 
 ##### title
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -299,6 +299,8 @@ const chartData = {
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
+| fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -300,6 +300,7 @@ const chartData = {
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
 | fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
 | colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -302,6 +302,7 @@ const chartData = {
 | fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
 | fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
 | colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
+ | rowPadding | Object | { top: 0, bottom: 8, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값 | |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -88,6 +88,7 @@
 | align | String | 사용자 지정 정렬 | 'center', 'left', 'right' | N |
 | decimal | Number | 데이터 타입이 float 일 때 소수점 자리 표시 수 | ex) 0~20 (디폴트: 3 ) | N |
 | summaryType | String | 계산 타입 | 'sum', 'average', 'max', 'min', 'count' | N |
+| summaryDecimal | Number | Summary 계산 타입 중 'sum', 'average'를 선택한 경우 소수점 표현 자리수 | ex) 0~20 (디폴트: 3 ) | N |
 | summaryRenderer | String | Summary 에 표시할 텍스트 또는 계산 값 | ex) 'Sum: {0}' | N |
 | summaryData | Array | Summary 할 대상 추가 시 summaryRenderer 와 함께 사용 | ex) '{0}({1}%)' | N |
 

--- a/docs/views/grid/example/Summary.vue
+++ b/docs/views/grid/example/Summary.vue
@@ -40,10 +40,34 @@
           />
         </div>
         <div class="form-row">
+          <span class="badge yellow">
+            Total (MB) Summary Decimal
+          </span>
+          <ev-input-number
+            v-model="totalSummaryDecimal"
+            :step="1"
+            :min="0"
+            :max="20"
+          />
+        </div>
+      </div>
+      <div class="form-rows">
+        <div class="form-row">
           <span class="badge yellow">Used (MB)</span>
           <ev-select
             v-model="usedSummaryType"
             :items="summaryTypes"
+          />
+        </div>
+        <div class="form-row">
+          <span class="badge yellow">
+            Used (MB) Summary Decimal
+          </span>
+          <ev-input-number
+            v-model="usedSummaryDecimal"
+            :step="1"
+            :min="0"
+            :max="20"
           />
         </div>
       </div>
@@ -58,7 +82,9 @@ import { numberWithComma } from '@/common/utils';
 export default {
   setup() {
     const totalSummaryType = ref('sum');
+    const totalSummaryDecimal = ref(1);
     const usedSummaryType = ref('average');
+    const usedSummaryDecimal = ref(3);
     const summaryTypes = ref([
       { name: 'sum', value: 'sum' },
       { name: 'average', value: 'average' },
@@ -79,11 +105,13 @@ export default {
         field: 'total_mb',
         type: 'number',
         summaryType: totalSummaryType,
-        summaryRenderer: 'value: {0}', // text + 해당 컬럼 값 계산
+        summaryDecimal: totalSummaryDecimal,
+        // summaryRenderer: 'value: {0}', // text + 해당 컬럼 값 계산
       },
       { caption: 'Used (MB)',
         field: 'used_mb',
         type: 'number',
+        summaryDecimal: usedSummaryDecimal,
         summaryType: usedSummaryType, // type 만 지정
       },
       { caption: 'Increment (MB)',
@@ -96,11 +124,11 @@ export default {
       { caption: 'Diff', field: 'diff', type: 'float', decimal: 1, hide: true },
     ]);
     tableData.value = [
-      ['HIDB_DATA_1', 30000, 27506, 7185, 2000.7],
-      ['HIDB_DATA_2', 29000, 23659, 0, 1500],
-      ['HIDB_LARGE_1', 28000, 21695, 1185, -4.7],
-      ['HIDB_INDEX_1', 27000, 23685, 0, 0],
-      ['HIDB_INDEX_2', 26000, 23535, 0, 0],
+      ['HIDB_DATA_1', 30000.12, 27506, 7185, 2000.7],
+      ['HIDB_DATA_2', 29000.234, 23659, 0, 1500],
+      ['HIDB_LARGE_1', 28000.3456, 21695, 1185, -4.7],
+      ['HIDB_INDEX_1', 27000.45678, 23685, 0, 0],
+      ['HIDB_INDEX_2', 26000.567891, 23535, 0, 0],
       ['HIDB_INDEX_3', 25000, 23659, 0, 0],
       ['HIDB_L_INDEX_1', 24000, 23695, 0, 0],
       ['HIDB_L_INDEX_2', 23000, 21691, 0, 0],
@@ -131,8 +159,10 @@ export default {
       checked,
       pageInfo,
       totalSummaryType,
+      totalSummaryDecimal,
       summaryTypes,
       usedSummaryType,
+      usedSummaryDecimal,
       getIncrementValue,
     };
   },

--- a/docs/views/grid/example/Summary.vue
+++ b/docs/views/grid/example/Summary.vue
@@ -106,7 +106,7 @@ export default {
         type: 'number',
         summaryType: totalSummaryType,
         summaryDecimal: totalSummaryDecimal,
-        // summaryRenderer: 'value: {0}', // text + 해당 컬럼 값 계산
+        summaryRenderer: 'value: {0}', // text + 해당 컬럼 값 계산
       },
       { caption: 'Used (MB)',
         field: 'used_mb',

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -197,6 +197,10 @@ const chartData =
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
+| fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
+| colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
+| rowPadding | Object | { top: 0, bottom: 8, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값 | |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -253,6 +253,8 @@ const chartData =
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
+| fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -254,6 +254,7 @@ const chartData =
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
 | fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
 | colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -256,6 +256,7 @@ const chartData =
 | fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
 | fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
 | colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
+| rowPadding | Object | { top: 0, bottom: 8, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값 | |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -149,6 +149,7 @@ const chartData =
 | fontFamily | String | 'Roboto' | 폰트 | |
 | fitWidth | Boolean | false | Label Text Ellipsis 처리 | |
 | fitDir | String | 'right' | Ellipsis 방향 | ( right => 'aaa...', left => '...aaa') |
+| padding |  Number | 0 | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0 |
 
 ##### title
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/lineChart/example/CustomTooltip.vue
+++ b/docs/views/lineChart/example/CustomTooltip.vue
@@ -1,12 +1,21 @@
 <template>
-  <ev-chart
-      :data="chartData"
-      :options="chartOptions"
-  />
+  <div class="case">
+    <ev-chart
+        :data="chartData"
+        :options="chartOptions"
+    />
+    <div class="description">
+      <span class="toggle-label">HTML Tooltip 사용</span>
+      <ev-toggle
+          v-model="useHtml"
+      />
+    </div>
+  </div>
+
 </template>
 
 <script>
-import { onMounted, reactive } from 'vue';
+import { onMounted, reactive, ref, watch } from 'vue';
 import dayjs from 'dayjs';
 
 export default {
@@ -24,6 +33,31 @@ export default {
         series3: [],
       },
     });
+
+    const useHtml = ref(true);
+    const htmlTooltipFormatter = {
+      html: (seriesList) => {
+        let result = '<div class="ev-chart-tooltip-custom" style="width: 250px">';
+        result += `<div class="ev-chart-tooltip-custom__header"> ${dayjs(seriesList?.[0]?.data?.x).format('mm:ss')}</div>`;
+        result += '<div class="ev-chart-tooltip-custom__body">';
+        seriesList.forEach((series) => {
+          result += '<br/>';
+          result += '<div class="row">';
+          result += `<div class="color-circle" style="background-color: ${series.color}"></div>`;
+          result += `<div class="series-name">${series.name} 값 </div>`;
+          result += `<div class="value">${series.data?.y}</div>`;
+          result += '</div>';
+          result += '<div class="row">';
+          result += `<div class="color-circle" style="background-color: ${series.color}"></div>`;
+          result += '<div class="series-name">전체 합계 </div>';
+          result += `<div class="value">${chartData.data[series?.sId].reduce((a, b) => a + b, 0)}</div>`;
+          result += '</div>';
+        });
+
+        result += '</div></div>';
+        return result;
+      },
+    };
 
     const chartOptions = reactive({
       type: 'line',
@@ -49,30 +83,17 @@ export default {
       }],
       tooltip: {
         use: true,
-        formatter: {
-          html: (seriesList) => {
-            let result = '<div class="ev-chart-tooltip-custom" style="width: 250px">';
-            result += `<div class="ev-chart-tooltip-custom__header"> ${dayjs(seriesList?.[0]?.data?.x).format('mm:ss')}</div>`;
-            result += '<div class="ev-chart-tooltip-custom__body">';
-            seriesList.forEach((series) => {
-              result += '<br/>';
-              result += '<div class="row">';
-              result += `<div class="color-circle" style="background-color: ${series.color}"></div>`;
-              result += `<div class="series-name">${series.name} 값 </div>`;
-              result += `<div class="value">${series.data?.y}</div>`;
-              result += '</div>';
-              result += '<div class="row">';
-              result += `<div class="color-circle" style="background-color: ${series.color}"></div>`;
-              result += '<div class="series-name">전체 합계 </div>';
-              result += `<div class="value">${chartData.data[series?.sId].reduce((a, b) => a + b, 0)}</div>`;
-              result += '</div>';
-            });
-
-            result += '</div></div>';
-            return result;
-          },
-        },
       },
+    });
+
+    watch(useHtml, () => {
+      if (useHtml.value) {
+        chartOptions.tooltip.formatter = htmlTooltipFormatter;
+      } else {
+        chartOptions.tooltip.formatter = null;
+      }
+    }, {
+      immediate: true,
     });
 
     let timeValue = dayjs().format('YYYY-MM-DD HH:mm:ss');
@@ -94,6 +115,7 @@ export default {
     return {
       chartData,
       chartOptions,
+      useHtml,
     };
   },
 };

--- a/docs/views/lineChart/example/Tooltip.vue
+++ b/docs/views/lineChart/example/Tooltip.vue
@@ -128,6 +128,35 @@
           <ev-text-field v-model="valueFontColor"/>
         </div>
       </div>
+
+      <div class="row">
+        <h3> Font Size </h3>
+      </div>
+
+      <div class="row">
+        <div class="row-item">
+          <span class="item-title">
+            title
+          </span>
+          <ev-input-number
+              v-model="titleFontSize"
+              :step="1"
+              :min="10"
+              :max="50"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            contents
+          </span>
+          <ev-input-number
+              v-model="contentsFontSize"
+              :step="1"
+              :min="10"
+              :max="50"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -158,6 +187,8 @@
       const titleFontColor = ref('#005CB5');
       const labelFontColor = ref('#FF8C40');
       const valueFontColor = ref('#FF00FF');
+      const titleFontSize = ref(16);
+      const contentsFontSize = ref(14);
 
       const chartData = reactive({
         series: {
@@ -252,6 +283,10 @@
             label: labelFontColor,
             value: valueFontColor,
           },
+          fontSize: {
+            title: titleFontSize,
+            contents: contentsFontSize,
+          },
         },
       });
 
@@ -288,6 +323,8 @@
         titleFontColor,
         labelFontColor,
         valueFontColor,
+        titleFontSize,
+        contentsFontSize,
       };
     },
   };

--- a/docs/views/lineChart/example/Tooltip.vue
+++ b/docs/views/lineChart/example/Tooltip.vue
@@ -157,6 +157,57 @@
           />
         </div>
       </div>
+
+      <div class="row">
+        <h3> Row Padding </h3>
+      </div>
+
+      <div class="row">
+        <div class="row-item">
+          <span class="item-title">
+            left
+          </span>
+          <ev-input-number
+            v-model="leftPadding"
+            :step="1"
+            :min="0"
+            :max="50"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            right
+          </span>
+          <ev-input-number
+            v-model="rightPadding"
+            :step="1"
+            :min="0"
+            :max="50"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            top
+          </span>
+          <ev-input-number
+              v-model="topPadding"
+              :step="1"
+              :min="0"
+              :max="50"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            bottom
+          </span>
+          <ev-input-number
+              v-model="bottomPadding"
+              :step="1"
+              :min="0"
+              :max="50"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -189,6 +240,10 @@
       const valueFontColor = ref('#FF00FF');
       const titleFontSize = ref(16);
       const contentsFontSize = ref(14);
+      const leftPadding = ref(16);
+      const rightPadding = ref(20);
+      const topPadding = ref(0);
+      const bottomPadding = ref(8);
 
       const chartData = reactive({
         series: {
@@ -287,6 +342,12 @@
             title: titleFontSize,
             contents: contentsFontSize,
           },
+          rowPadding: {
+            left: leftPadding,
+            right: rightPadding,
+            top: topPadding,
+            bottom: bottomPadding,
+          },
         },
       });
 
@@ -325,6 +386,10 @@
         valueFontColor,
         titleFontSize,
         contentsFontSize,
+        leftPadding,
+        rightPadding,
+        topPadding,
+        bottomPadding,
       };
     },
   };

--- a/docs/views/lineChart/example/Tooltip.vue
+++ b/docs/views/lineChart/example/Tooltip.vue
@@ -87,15 +87,45 @@
       <div class="row">
         <div class="row-item">
           <span class="item-title">
-            글자 색상
-          </span>
-          <ev-text-field v-model="fontColor"/>
-        </div>
-        <div class="row-item">
-          <span class="item-title">
             배경 색상
           </span>
           <ev-text-field v-model="backgroundColor"/>
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            series color 모양
+          </span>
+          <ev-select
+              v-model="colorShape"
+              :items="colorShapeList"
+          />
+        </div>
+      </div>
+
+      <div class="row">
+        <h3> Font Color </h3>
+      </div>
+
+      <div class="row">
+        <div class="row-item">
+          <span class="item-title">
+            Title
+          </span>
+          <ev-text-field v-model="titleFontColor"/>
+        </div>
+
+        <div class="row-item">
+          <span class="item-title">
+            Label
+          </span>
+          <ev-text-field v-model="labelFontColor"/>
+        </div>
+
+        <div class="row-item">
+          <span class="item-title">
+            Value
+          </span>
+          <ev-text-field v-model="valueFontColor"/>
         </div>
       </div>
     </div>
@@ -115,8 +145,19 @@
       const useShadow = ref(false);
       const shadowOpacity = ref(0.25);
       const fontColor = ref('#000000');
-      const backgroundColor = ref('rgb(210, 234, 227, 0.7)');
+      const backgroundColor = ref('rgb(210, 234, 227, 1)');
       const textOverflow = ref('wrap');
+      const colorShape = ref('rect');
+      const colorShapeList = [{
+        name: 'rect (Default)',
+        value: 'rect',
+      }, {
+        name: 'circle',
+        value: 'circle',
+      }];
+      const titleFontColor = ref('#005CB5');
+      const labelFontColor = ref('#FF8C40');
+      const valueFontColor = ref('#FF00FF');
 
       const chartData = reactive({
         series: {
@@ -195,7 +236,6 @@
           use: true,
           sortByValue,
           backgroundColor,
-          fontColor,
           shadowOpacity,
           useShadow,
           useScrollbar,
@@ -205,6 +245,12 @@
           formatter: {
             title: ({ x }) => dayjs(x).format('YYYY-MM-DD HH:mm:ss'),
             value: ({ y }) => `${y.toFixed(2)}`,
+          },
+          colorShape,
+          fontColor: {
+            title: titleFontColor,
+            label: labelFontColor,
+            value: valueFontColor,
           },
         },
       });
@@ -237,6 +283,11 @@
         fontColor,
         backgroundColor,
         textOverflow,
+        colorShape,
+        colorShapeList,
+        titleFontColor,
+        labelFontColor,
+        valueFontColor,
       };
     },
   };

--- a/docs/views/message/example/Default.vue
+++ b/docs/views/message/example/Default.vue
@@ -72,6 +72,11 @@
       Show HTML
     </ev-button>
   </div>
+  <div class="case">
+    <p class="case-title">Close from outside</p>
+    <ev-button @click="showForLong">Show forever</ev-button>
+    <ev-button v-show="isMessageShown" @click="hide">Hide</ev-button>
+  </div>
 </template>
 
 <script>
@@ -80,6 +85,7 @@ import { ref, getCurrentInstance } from 'vue';
 export default {
   setup() {
     const { ctx } = getCurrentInstance();
+
     const showInfo = () => {
       ctx.$message('Infomation. This is an Info type message.');
     };
@@ -135,6 +141,20 @@ export default {
         useHTML: true,
       });
     };
+    const isMessageShown = ref(false);
+    let hideFunction = () => {};
+    const showForLong = () => {
+      const { hide } = ctx.$message({
+        message: 'This message stays long time until you press close button.',
+        duration: 10000000,
+      });
+      hideFunction = hide;
+      isMessageShown.value = true;
+    };
+    const hide = () => {
+      isMessageShown.value = false;
+      hideFunction();
+    };
     return {
       showInfo,
       showSuccess,
@@ -146,6 +166,9 @@ export default {
       onCloseMsg,
       showOnClose,
       showHTML,
+      showForLong,
+      hide,
+      isMessageShown,
     };
   },
 };

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -129,6 +129,7 @@ const chartData =
 | fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
 | fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
 | colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
+| rowPadding | Object | { top: 0, bottom: 8, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값 | |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -126,6 +126,8 @@ const chartData =
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
+| fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -127,6 +127,7 @@ const chartData =
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
 | fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
 | colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -118,6 +118,7 @@ const chartData =
 | fontFamily | String | 'Roboto' | 폰트 | |
 | fitWidth | Boolean | false | Label Text Ellipsis 처리 | |
 | fitDir | String | 'right' | Ellipsis 방향 | ( right => 'aaa...', left => '...aaa') |
+ | padding |  Number | 0 | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0 |
 
 ##### title
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -118,7 +118,7 @@ const chartData =
 | fontFamily | String | 'Roboto' | 폰트 | |
 | fitWidth | Boolean | false | Label Text Ellipsis 처리 | |
 | fitDir | String | 'right' | Ellipsis 방향 | ( right => 'aaa...', left => '...aaa') |
- | padding |  Number | 0 | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0 |
+| padding |  Number | 0 | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0 |
 
 ##### title
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
@@ -216,6 +216,7 @@ const chartData =
 | textOverflow        | String                      | 'wrap'    | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis'                                                  |
 | fontFamily          | String                      | 'Roboto'  | 툴팁에 표시될 폰트                           | 'Roboto', 'serif'                                                   |
 | fontColor           | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러                        | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
 | colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean                     | false     | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter           | function / Object           | null      | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용      | (아래 코드 참고)                                                          |

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -200,23 +200,25 @@ const chartData =
 * PC버전에서는 drag, Mobile에서는 touch로 선택 영역을 지정할 수 있습니다.
 
 #### tooltip
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| use | Boolean | false | tooltip 표시 여부 | true /false |
-| backgroundColor | Hex, RGB, RGBA Code(String) | '#4C4C4C' | tooltip 배경 색상  | |
-| borderColor | Hex, RGB, RGBA Code(String) | '#666666' | tooltip 테두리 색상  | |
-| useShadow | Boolean | false | 그림자 사용 여부  | |
-| shadowOpacity | Number | 0.25 | 그림자 투명도  | |
-| throttledMove | Boolean | false | 데이터 조회 Throttling 처리 유무  | |
-| debouncedHide | Boolean | false | 좌표 이동 시 tooltip hide 여부  | |
-| sortByValue | Boolean | true | 값을 기준으로 정렬할지의 여부  | |
-| useScrollbar | Boolean | false | 스크롤바 사용 여부  | |
-| maxHeight | Number |  | 툴팁의 최대 높이  | |
-| maxWidth | Number |  | 툴팁의 최대 너비  | |
-| textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
-| fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
-| showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
-| formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
+| 이름                  | 타입                          | 디폴트       | 설명                                   | 종류(예시)                                                              |
+|---------------------|-----------------------------|-----------|--------------------------------------|---------------------------------------------------------------------|
+| use                 | Boolean                     | false     | tooltip 표시 여부                        | true /false                                                         |
+| backgroundColor     | Hex, RGB, RGBA Code(String) | '#4C4C4C' | tooltip 배경 색상                        |                                                                     |
+| borderColor         | Hex, RGB, RGBA Code(String) | '#666666' | tooltip 테두리 색상                       |                                                                     |
+| useShadow           | Boolean                     | false     | 그림자 사용 여부                            |                                                                     |
+| shadowOpacity       | Number                      | 0.25      | 그림자 투명도                              |                                                                     |
+| throttledMove       | Boolean                     | false     | 데이터 조회 Throttling 처리 유무              |                                                                     |
+| debouncedHide       | Boolean                     | false     | 좌표 이동 시 tooltip hide 여부              |                                                                     |
+| sortByValue         | Boolean                     | true      | 값을 기준으로 정렬할지의 여부                     |                                                                     |
+| useScrollbar        | Boolean                     | false     | 스크롤바 사용 여부                           |                                                                     |
+| maxHeight           | Number                      |           | 툴팁의 최대 높이                            |                                                                     |
+| maxWidth            | Number                      |           | 툴팁의 최대 너비                            |                                                                     |
+| textOverflow        | String                      | 'wrap'    | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis'                                                  |
+| fontFamily          | String                      | 'Roboto'  | 툴팁에 표시될 폰트                           | 'Roboto', 'serif'                                                   |
+| fontColor           | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러                        | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
+| showAllValueInRange | Boolean                     | false     | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
+| formatter           | function / Object           | null      | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용      | (아래 코드 참고)                                                          |
 ```
 const chartOptions = {
     tooltip: {

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -291,3 +291,7 @@ const chartOptions = {
  
  * drag-select는  `dragSelection` 옵션의 `use`값이 `true` 일 때 이벤트를 발생 시킬 수 있다. 
  그리고 선택영역은 그래프에 표시된 데이터의 중앙이 포함 되어야 선택영역 내 데이터로 인식 한다.
+
+### 6. v-model:realTimeScatterReset
+- realTimeScatter 옵션을 사용할 때, 내부 데이터를 모두 초기화하고 싶을 때 사용.
+- realTimeScatterReset이 true가 되면 데이터를 모두 초기화하고 자동으로 false로 바뀜. 초기화하고 싶을 때마다 true로 바꿔주면 됩니다.

--- a/docs/views/scatterChart/example/RealTimeScatter.vue
+++ b/docs/views/scatterChart/example/RealTimeScatter.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="case">
     <ev-chart
+      v-model:realTimeScatterReset="resetFlag"
       :data="chartData"
       :options="chartOptions"
     />
@@ -10,13 +11,35 @@
           <label>데이터 자동 업데이트</label>
           <ev-toggle v-model="isRealTime" />
         </div>
+        <div class="row-item">
+          <span class="item-title">
+            데이터 초기화
+          </span>
+          <ev-button
+            class="component"
+            @click="dataReset"
+          >
+            reset
+          </ev-button>
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            change range (s)
+          </span>
+          <ev-input-number
+            v-model="realTimeScatterRange"
+            class="component"
+            :min="50"
+            :step="50"
+          />
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <script>
-import { ref, shallowRef, watch, onUnmounted } from 'vue';
+import { ref, shallowRef, watch, onUnmounted, reactive } from 'vue';
 
 export default {
   setup() {
@@ -50,15 +73,16 @@ export default {
       },
     });
 
-    const chartOptions = {
+    const realTimeScatterRange = ref(300);
+    const chartOptions = reactive({
       type: 'scatter',
       width: '100%',
       height: '100%',
       padding: { top: 20, right: 2, bottom: 4, left: 2 },
       axesX: [{
         type: 'time',
-        timeFormat: 'HH:mm',
-        interval: 'minute',
+        timeFormat: 'HH:mm:ss',
+        interval: 'second',
         showAxis: true,
         showGrid: false,
         axisLineColor: '#C9CFDC',
@@ -93,9 +117,9 @@ export default {
       displayOverflow: true,
       realTimeScatter: {
         use: true,
-        range: 300, // 총 5분, 초 단위
+        range: realTimeScatterRange.value, // 총 5분, 초 단위
       },
-    };
+    });
 
     let timeoutId;
 
@@ -182,6 +206,22 @@ export default {
       }
     }, { immediate: true });
 
+    watch(() => realTimeScatterRange.value, () => {
+      chartOptions.realTimeScatter.range = realTimeScatterRange.value;
+    });
+
+    const resetFlag = ref(false);
+    const dataReset = () => {
+      resetFlag.value = true;
+      chartData.value = {
+        series,
+        data: {
+          series1: [],
+          series2: [],
+        },
+      };
+    };
+
     onUnmounted(() => {
       clearTimeout(timeoutId);
     });
@@ -190,6 +230,9 @@ export default {
       isRealTime,
       chartData,
       chartOptions,
+      realTimeScatterRange,
+      resetFlag,
+      dataReset,
     };
   },
 };

--- a/docs/views/treeGrid/api/treeGrid.md
+++ b/docs/views/treeGrid/api/treeGrid.md
@@ -101,6 +101,7 @@
 | align           | String  | 사용자 지정 정렬                                          | 'center', 'left', 'right'                        | N |
 | decimal         | Number  | 데이터 타입이 float 일 때 소수점 자리 표시 수                      | ex) 0~20 (디폴트: 3 )                               | N |
 | summaryType     | String  | 계산 타입                                              | 'sum', 'average', 'max', 'min', 'count'          | N |
+| summaryOnlyTopParent | Boolean | 최상위 부모만 summary 계산을 할지 선택                          | Boolean                                                | N |
 | summaryRenderer | String  | Summary 에 표시할 텍스트 또는 계산 값                          | ex) 'Sum: {0}'                                   | N |
 | summaryData     | Array   | Summary 할 대상 추가 시 summaryRenderer 와 함께 사용          | ex) '{0}({1}%)'                                  | N |
 | expandColumn    | Boolean | 트리그리드를 확장하는데 사용하는 컬럼을 의미, 설정하지 않으면 자동으로 첫번째 컬럼에 적용 | ex) 'expandColumn: true'                         | N |

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -410,70 +410,82 @@ export default {
       clickedRowMV.value = JSON.stringify(rowData);
     };
     const getData = () => {
-      tableData.value = [{
-        id: 'Exem 1',
-        date: '2016-05-01',
-        name: '1',
-        expand: true,
-        children: [{
-          id: 'Exem 2',
-          date: '2016-05-02',
-          name: '2',
-          expand: false,
+      tableData.value = [
+        {
+          id: 'Exem 0',
+          date: '2016-05-01',
+          name: '1111',
+          expand: true,
+        },
+        {
+          id: 'Exem 1',
+          date: '2016-05-01',
+          name: '2222',
+          value: 123,
+          expand: true,
           children: [{
-            id: 'Exem 3',
+            id: 'Exem 2',
             date: '2016-05-02',
-            name: '3',
-            uncheckable: true,
-          }, {
-            id: 'Exem 4',
-            date: '2016-05-02',
-            name: '4',
+            name: '2',
+            value: 222,
             expand: false,
-            uncheckable: true,
             children: [{
-              id: 'Exem 5',
+              id: 'Exem 3',
               date: '2016-05-02',
-              name: '5',
-              children: [{
-                id: 'Exem 51',
-                date: '2016-05-02',
-                name: '1251',
-                children: [{
-                  id: 'Exem 52',
-                  date: '2016-05-02',
-                  name: '20000',
-                }],
-              }],
+              name: '3',
+              value: 3333,
+              uncheckable: true,
             }, {
-              id: 'Exem 6',
+              id: 'Exem 4',
               date: '2016-05-02',
-              name: '6',
+              name: '4',
+              expand: false,
+              uncheckable: true,
+              children: [{
+                id: 'Exem 5',
+                date: '2016-05-02',
+                name: '5',
+                children: [{
+                  id: 'Exem 51',
+                  date: '2016-05-02',
+                  name: '1251',
+                  children: [{
+                    id: 'Exem 52',
+                    date: '2016-05-02',
+                    name: '20000',
+                  }],
+                }],
+              }, {
+                id: 'Exem 6',
+                date: '2016-05-02',
+                name: '6',
+              }],
             }],
-          }],
-        }, {
-          id: 'Exem 7',
-          date: '2016-05-03',
-          name: '7',
-          children: [{
-            id: 'Exem 8',
-            date: '2016-05-03',
-            name: '8',
           }, {
-            id: 'Exem 9',
+            id: 'Exem 7',
             date: '2016-05-03',
-            name: '9',
+            name: '7',
+            children: [{
+              id: 'Exem 8',
+              date: '2016-05-03',
+              name: '8',
+              value: 333,
+            }, {
+              id: 'Exem 9',
+              date: '2016-05-03',
+              name: '9',
+            }, {
+              id: 'Exem 10',
+              date: '2016-05-03',
+              name: '10',
+            }],
           }, {
-            id: 'Exem 10',
-            date: '2016-05-03',
-            name: '10',
+            id: 'Exem 11',
+            date: '2016-05-04',
+            name: '11',
           }],
-        }, {
-          id: 'Exem 11',
-          date: '2016-05-04',
-          name: '11',
-        }],
-      }];
+        },
+      ];
     };
     const columns = ref([
       { caption: 'ID', field: 'id', type: 'number' },
@@ -483,7 +495,16 @@ export default {
         field: 'name',
         type: 'float',
         summaryType: 'sum',
-        summaryRenderer: 'Sum: {0}',
+        summaryOnlyTopParent: true,
+        summaryRenderer: 'Sum: {0} 최상위 부모만 summary',
+        decimal: 1,
+      },
+      {
+        caption: 'Value',
+        field: 'value',
+        type: 'number',
+        summaryType: 'sum',
+        summaryRenderer: 'Sum: {0} 모든 row summary',
         decimal: 1,
       },
     ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.62",
+  "version": "3.4.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3650,6 +3650,11 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
+    },
+    "bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug=="
     },
     "binary-extensions": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "main": "dist/evui.umd.js",
   "dependencies": {
+    "bignumber.js": "^9.1.2",
     "core-js": "^3.6.5",
     "dayjs": "^1.10.4",
     "korean-regexp": "^1.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.26",
+  "version": "3.4.27",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.30",
+  "version": "3.4.31",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.29",
+  "version": "3.4.30",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.28",
+  "version": "3.4.29",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.27",
+  "version": "3.4.28",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.31",
+  "version": "3.4.32",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/common/utils.bignumber.js
+++ b/src/common/utils.bignumber.js
@@ -1,0 +1,67 @@
+import BigNumber from 'bignumber.js';
+
+/**
+ * Convert Number to BigNumber
+ * @param {Number} value
+ * @return {BigNumber}
+ */
+function toBigNumber(value) { return new BigNumber(value); }
+
+/**
+ * plus(+)
+ * @param {Number} num1
+ * @param {Number} num2
+ * @return {Number}
+ */
+function bnPlus(num1, num2) {
+  return toBigNumber(num1).plus(toBigNumber(num2)).toNumber();
+}
+
+/**
+ * minus(-)
+ * @param {Number} num1
+ * @param {Number} num2
+ * @return {Number}
+ */
+function bnMinus(num1, num2) {
+  return toBigNumber(num1).minus(toBigNumber(num2)).toNumber();
+}
+
+/**
+ * multiply(*)
+ * @param {Number} num1
+ * @param {Number} num2
+ * @return {Number}
+ */
+function bnMultiply(num1, num2) {
+  return toBigNumber(num1).multipliedBy(toBigNumber(num2)).toNumber();
+}
+
+/**
+ * divide(/)
+ * @param {Number} dividend
+ * @param {Number} divisor
+ * @return {Number}
+ */
+function bnDivide(dividend, divisor) {
+  return toBigNumber(dividend).dividedBy(toBigNumber((divisor))).toNumber();
+}
+
+/**
+ * floor
+ * @param {Number} num
+ * @param {Number} decimal
+ * @return {Number}
+ */
+function bnFloor(num, decimal) {
+  return toBigNumber(num).decimalPlaces(decimal, BigNumber.ROUND_DOWN).toNumber();
+}
+
+export {
+  toBigNumber,
+  bnPlus,
+  bnMinus,
+  bnMultiply,
+  bnDivide,
+  bnFloor,
+};

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -263,6 +263,16 @@
         }
       });
 
+      watch(() => props.options.realTimeScatter?.use, (use) => {
+        evChart.options.realTimeScatter.use = use ?? false;
+
+        evChart.update({
+          updateSeries: true,
+          updateSelTip: { update: false, keepDomain: false },
+          updateData: false,
+        });
+      });
+
       onMounted(async () => {
         if (injectEvChartPropsInGroup?.value) {
           injectEvChartPropsInGroup.value.push(props);

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -171,6 +171,10 @@
       watch(() => props.options, (chartOpt) => {
         const newOpt = getNormalizedOptions(chartOpt);
         const isUpdateLegendType = !isEqual(newOpt.legend.table, evChart.options.legend.table);
+        const isUpdateTooltipFormatter = !isEqual(
+            newOpt.tooltip.formatter,
+            evChart.options.tooltip.formatter,
+        );
 
         evChart.options = cloneDeep(newOpt);
 
@@ -178,6 +182,7 @@
           updateSeries: false,
           updateSelTip: { update: false, keepDomain: false },
           updateLegend: isUpdateLegendType,
+          updateTooltipFormatter: isUpdateTooltipFormatter,
         });
 
         if (!injectIsChartGroup) {

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -72,6 +72,10 @@
         type: Number,
         default: 0,
       },
+      realTimeScatterReset: {
+        type: Boolean,
+        default: false,
+      },
     },
     emits: [
       'click',
@@ -83,8 +87,9 @@
       'update:selectedSeries',
       'update:zoomStartIdx',
       'update:zoomEndIdx',
+      'update:realTimeScatterReset',
     ],
-    setup(props) {
+    setup(props, { emit }) {
       let evChart = null;
       const isMounted = ref(false);
       const injectIsChartGroup = inject('isChartGroup', false);
@@ -245,6 +250,18 @@
           controlZoomIdx(zoomStartIdx, zoomEndIdx);
         });
       }
+
+      watch(() => props.realTimeScatterReset, (flag) => {
+        if (flag) {
+          Object.keys(evChart.dataSet).forEach((series) => {
+            if (evChart.dataSet[series]) {
+              evChart.dataSet[series].dataGroup = [];
+            }
+          });
+
+          emit('update:realTimeScatterReset', false);
+        }
+      });
 
       onMounted(async () => {
         if (injectEvChartPropsInGroup?.value) {

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -253,7 +253,7 @@
 
       watch(() => props.realTimeScatterReset, (flag) => {
         if (flag) {
-          Object.keys(evChart.dataSet).forEach((series) => {
+          Object.keys(evChart.dataSet ?? {}).forEach((series) => {
             if (evChart.dataSet[series]) {
               evChart.dataSet[series].dataGroup = [];
             }

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -246,7 +246,7 @@ class EvChart {
       const chartTypeSet = this.seriesInfo.charts[chartType];
 
       for (let jx = 0; jx < chartTypeSet.length; jx++) {
-        const series = this.seriesList[chartTypeSet[jx]];
+        let series = this.seriesList[chartTypeSet[jx]];
 
         switch (chartType) {
           case 'line': {
@@ -325,6 +325,10 @@ class EvChart {
               } else {
                 selectInfo = null;
               }
+            }
+
+            if (this.options.realTimeScatter?.use) {
+              series = this.seriesList[chartTypeSet.at(-1 - jx)];
             }
 
             series.draw({

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -764,6 +764,9 @@ class EvChart {
     }
 
     if (this.options.realTimeScatter?.use) {
+      if (!this.dataSet) {
+        this.dataSet = {};
+      }
       this.createRealTimeScatterDataSet(data);
     } else {
       this.createDataSet(data, labels);

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -718,7 +718,13 @@ class EvChart {
     const groups = this.data.groups;
     const series = this.data.series;
 
-    const { updateSeries, updateSelTip, updateLegend, updateData } = updateInfo;
+    const {
+      updateSeries,
+      updateSelTip,
+      updateLegend,
+      updateData,
+      updateTooltipFormatter,
+    } = updateInfo;
 
     if (!this.isInit) {
       return;
@@ -789,6 +795,7 @@ class EvChart {
       this.hideTitle();
     }
 
+    // legend Update
     if (options.legend.show) {
       const useTable = !!options.legend?.table?.use
         && options.type !== 'heatMap'
@@ -810,6 +817,13 @@ class EvChart {
     } else if (this.isInitLegend) {
       this.hideLegend();
     }
+
+    // Tooltip Update
+    if (updateTooltipFormatter) {
+      this.tooltipDOM.innerHTML = '';
+      this.createTooltipDOM();
+    }
+
     this.chartRect = this.getChartRect();
 
     this.minMax = this.getStoreMinMax();

--- a/src/components/chart/element/element.scatter.js
+++ b/src/components/chart/element/element.scatter.js
@@ -144,9 +144,9 @@ class Scatter {
     const pointStyle = typeof this.pointStyle === 'string' ? this.pointStyle : this.pointStyle.value;
     const pointSize = typeof this.pointSize === 'number' ? this.pointSize : this.pointSize.value;
 
-    for (let i = 0; i < this.data[this.sId].dataGroup.length; i++) {
-      for (let j = 0; j < this.data[this.sId].dataGroup[i].data.length; j++) {
-        const item = this.data[this.sId].dataGroup[i].data[j];
+    for (let i = 0; i < this.data[this.sId]?.dataGroup?.length; i++) {
+      for (let j = 0; j < this.data[this.sId]?.dataGroup[i]?.data.length; j++) {
+        const item = this.data[this.sId]?.dataGroup[i]?.data[j];
 
         if (!duple.has(`${item.x}${item.y}`)) {
           duple.add(`${item.x}${item.y}`);

--- a/src/components/chart/helpers/helpers.constant.js
+++ b/src/components/chart/helpers/helpers.constant.js
@@ -103,6 +103,7 @@ export const AXIS_OPTION = {
     fitWidth: false,
     fitDir: 'right',
     alignToGridLine: false,
+    padding: 0,
   },
   title: {
     use: false,

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -184,12 +184,13 @@ export default {
    * Calculate text size with html
    * @param {string} text         text is needed to check size
    * @param {string} fontStyle    text font style
+   * @param {number} padding      user define text padding
    *
    * @returns {object} text size information
    */
-  calcTextSize(text, fontStyle) {
+  calcTextSize(text, fontStyle, padding = 0) {
     const calc = document.createElement('span');
-    const style = `visibility:hidden; position:absolute; top:-10000px; font: ${fontStyle};`;
+    const style = `visibility:hidden; position:absolute; top:-10000px; font: ${fontStyle}; padding: 0 ${padding}px`;
 
     calc.setAttribute('style', style);
     calc.style.font = fontStyle;

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -81,7 +81,7 @@ const modules = {
     for (let x = 0; x < keys.length; x++) {
       const key = keys[x];
       const data = datas[key];
-      const storeLength = data.length;
+      const storeLength = data?.length;
       let lastTime = 0;
 
       if (!this.isInit || this.updateSeries) {
@@ -98,12 +98,12 @@ const modules = {
           ...defaultValues,
           ...this.dataSet[key],
         };
-        this.dataSet[key].length = this.options.realTimeScatter.range || 300;
-        this.dataSet[key].toTime = Math.floor(Date.now() / 1000) * 1000;
-        this.dataSet[key].fromTime = this.dataSet[key].toTime
-          - this.dataSet[key].length * 1000;
-        this.dataSet[key].endIndex = this.dataSet[key].length - 1;
       }
+
+      this.dataSet[key].length = this.options.realTimeScatter.range || 300;
+      this.dataSet[key].toTime = Math.floor(Date.now() / 1000) * 1000;
+      this.dataSet[key].fromTime = this.dataSet[key].toTime - this.dataSet[key].length * 1000;
+      this.dataSet[key].endIndex = this.dataSet[key].length - 1;
 
       for (let i = 0; i < storeLength; i++) {
         const item = data[i];
@@ -128,20 +128,19 @@ const modules = {
           - this.dataSet[key].length * 1000;
       }
 
-      if (!this.isInit || this.updateSeries) {
-        for (let i = 0; i < this.dataSet[key].length; i++) {
-          const defaultValues = {
-            data: [],
-            max: 0,
-            min: Infinity,
-          };
+      for (let i = 0; i < this.dataSet[key].length; i++) {
+        const defaultValues = {
+          data: [],
+          max: 0,
+          min: Infinity,
+        };
 
-          this.dataSet[key].dataGroup[i] = {
-            ...defaultValues,
-            ...this.dataSet[key].dataGroup[i],
-          };
-        }
-      } else if (gapCount > 0) {
+        this.dataSet[key].dataGroup[i] = {
+          ...defaultValues,
+          ...this.dataSet[key].dataGroup[i],
+        };
+      }
+      if (gapCount > 0) {
         if (gapCount >= this.dataSet[key].length) {
           for (let i = 0; i < this.dataSet[key].length; i++) {
             this.dataSet[key].dataGroup[i].data.length = 0;

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -3,13 +3,9 @@ import debounce from '@/common/utils.debounce';
 import Canvas from '../helpers/helpers.canvas';
 import Util from '../helpers/helpers.util';
 
-const TITLE_HEIGHT = 35;
-const TEXT_HEIGHT = 20;
 const LINE_SPACING = 8;
-const COLOR_MARGIN = 16;
 const VALUE_MARGIN = 50;
 const SCROLL_WIDTH = 17;
-let fontStyle = 'normal normal lighter 14px Roboto';
 
 const modules = {
   /**
@@ -32,9 +28,8 @@ const modules = {
     this.tooltipCtx = this.tooltipCanvas.getContext('2d');
 
     this.tooltipDOM.style.display = 'none';
-    this.setFontFamily();
 
-    if (!this.options.tooltip?.formatter?.dom) {
+    if (!this.options.tooltip?.formatter?.html) {
       this.tooltipBodyDOM.appendChild(this.tooltipCanvas);
       this.tooltipDOM.appendChild(this.tooltipHeaderDOM);
       this.tooltipDOM.appendChild(this.tooltipBodyDOM);
@@ -54,12 +49,24 @@ const modules = {
   },
 
   /**
-   * set tooltip's font style
+   * get Tooltip's font style by Type ('title' | 'contents')
+   * @param {string} type  'title' | 'contents'
+   * @returns {string}
    */
-  setFontFamily() {
-    const fontFamily = this.options?.tooltip?.fontFamily ?? 'Roboto';
-    fontStyle = `normal normal lighter 14px ${fontFamily}`;
-    this.tooltipHeaderDOM.style.fontFamily = fontFamily;
+  getFontStyle(type) {
+    const opt = this.options?.tooltip;
+    const fontSize = opt?.fontSize?.[type] ?? 14;
+    const fontFamily = opt?.fontFamily ?? 'Roboto';
+
+    return `normal normal lighter ${Math.max(fontSize, 0)}px ${fontFamily}`;
+  },
+
+  getTextHeight() {
+    return (this.options?.tooltip?.fontSize?.contents ?? 14) + 6;
+  },
+
+  getColorMargin() {
+    return (this.options?.tooltip?.fontSize?.contents ?? 14) + 2;
   },
 
   /**
@@ -77,20 +84,21 @@ const modules = {
     const [maxSeries, maxValue] = hitInfo.maxTip;
     const seriesKeys = Object.keys(items);
     const seriesLen = seriesKeys.length;
-    const boxPadding = { t: 10, b: 4, r: 20, l: 16 };
+    const boxPadding = { t: 0, b: 8, r: 20, l: 16 };
     const opt = this.options.tooltip;
+    const seriesColorMarginRight = this.getColorMargin();
 
 
     // calculate and decide width of canvas El(contentsWidth)
     ctx.save();
-    ctx.font = fontStyle;
+    ctx.font = this.getFontStyle('contents');
     const isHorizontal = !!this.options.horizontal;
     const label = isHorizontal ? items[hitInfo.hitId]?.data?.y : items[hitInfo.hitId]?.data?.x;
     const tooltipValue = label?.length > maxSeries.length ? label : maxSeries;
     const nw = Math.round(ctx.measureText(tooltipValue).width);
     const vw = Math.round(ctx.measureText(maxValue).width);
     const expectedContentsWidth = nw + vw + boxPadding.l + boxPadding.r
-      + COLOR_MARGIN + VALUE_MARGIN + SCROLL_WIDTH;
+      + seriesColorMarginRight + VALUE_MARGIN + SCROLL_WIDTH;
     const contentsWidth = expectedContentsWidth > opt.maxWidth
       ? opt.maxWidth
       : expectedContentsWidth;
@@ -101,7 +109,7 @@ const modules = {
 
     if (opt.textOverflow === 'wrap') {
       const seriesNameSpaceWidth = opt.maxWidth - (Math.round(ctx.measureText(maxValue).width)
-        + boxPadding.l + boxPadding.r + COLOR_MARGIN + VALUE_MARGIN + SCROLL_WIDTH);
+        + boxPadding.l + boxPadding.r + seriesColorMarginRight + VALUE_MARGIN + SCROLL_WIDTH);
 
       // count wrap line
       const seriesNames = Object.values(items).map(s => s.name);
@@ -127,7 +135,7 @@ const modules = {
 
     // Calculate height of canvas El(tooltip body El) with useScrollbar, maxHeight option
     const expectedContentsHeight = boxPadding.t
-      + (textLineCnt * TEXT_HEIGHT)
+      + (textLineCnt * this.getTextHeight())
       + (seriesLen * LINE_SPACING)
       + boxPadding.b;
 
@@ -146,7 +154,7 @@ const modules = {
     this.tooltipCanvas.style.width = `${contentsWidth}px`;
     this.tooltipCanvas.style.height = `${expectedContentsHeight}px`;
     this.tooltipHeaderDOM.style.width = `${contentsWidth}px`;
-    this.tooltipHeaderDOM.style.height = opt.textOverflow === 'wrap' ? 'auto' : `${TITLE_HEIGHT}px`;
+    this.tooltipHeaderDOM.style.height = 'auto';
     this.tooltipDOM.style.height = 'auto';
     this.tooltipBodyDOM.style.height = `${contentsHeight + 6}px`;
 
@@ -155,12 +163,13 @@ const modules = {
     const bodyWidth = document.body.clientWidth;
     const bodyHeight = document.body.clientHeight;
     const distanceMouseAndTooltip = 20;
+    const tooltipDOMSize = this.tooltipDOM?.getBoundingClientRect();
     const maximumPosX = bodyWidth - contentsWidth - distanceMouseAndTooltip;
-    const maximumPosY = bodyHeight - (TITLE_HEIGHT + contentsHeight) - distanceMouseAndTooltip;
+    const maximumPosY = bodyHeight - tooltipDOMSize.height - distanceMouseAndTooltip;
     const expectedPosX = mouseX + distanceMouseAndTooltip;
     const expectedPosY = mouseY + distanceMouseAndTooltip;
     const reversedPosX = mouseX - contentsWidth - distanceMouseAndTooltip;
-    const reversedPosY = mouseY - (TITLE_HEIGHT + contentsHeight) - distanceMouseAndTooltip;
+    const reversedPosY = mouseY - tooltipDOMSize.height - distanceMouseAndTooltip;
     this.tooltipDOM.style.left = expectedPosX > maximumPosX
       ? `${reversedPosX}px`
       : `${expectedPosX}px`;
@@ -176,14 +185,17 @@ const modules = {
    * @param {object} centerPosition  // {x: number, y: number}
    */
   drawSeriesColorShape(context, shape, centerPosition) {
+    const fontSize = this.options.tooltip?.fontSize?.contents;
     const { x, y } = centerPosition;
 
     if (shape === 'circle') {
       context.beginPath();
-      context.arc(x - 2, y - 4, 6, 0, 2 * Math.PI);
+      const circleSize = fontSize / 2;
+      context.arc(x, y - (circleSize / 2), circleSize, 0, 2 * Math.PI);
       context.fill();
     } else {
-      context.fillRect(x - 4, y - 12, 12, 12);
+      const rectSize = fontSize;
+      context.fillRect(x - (rectSize / 3), y - (rectSize / 1.2), rectSize, rectSize);
     }
   },
 
@@ -202,10 +214,12 @@ const modules = {
     const hitAxis = items[sId].axis;
     const [, maxValue] = hitInfo.maxTip;
     const seriesKeys = this.alignSeriesList(Object.keys(items));
-    const boxPadding = { t: 8, b: 8, r: 20, l: 16 };
+    const boxPadding = { t: 0, b: 8, r: 20, l: 16 };
     const isHorizontal = this.options.horizontal;
     const opt = this.options.tooltip;
     const titleFormatter = opt.formatter?.title;
+    const textHeight = this.getTextHeight();
+    const seriesColorMarginRight = this.getColorMargin();
 
     // draw tooltip Title(axis label) and add style class for wrap line about too much long label.
     if (this.axesX.length && this.axesY.length) {
@@ -245,7 +259,7 @@ const modules = {
     x += boxPadding.l;
     y += boxPadding.t;
 
-    ctx.font = fontStyle;
+    ctx.font = this.getFontStyle('contents');
 
     const seriesList = [];
     seriesKeys.forEach((seriesName) => {
@@ -282,7 +296,7 @@ const modules = {
       const valueText = gdata.formatted;
 
       let itemX = x + 4;
-      let itemY = y + (textLineCnt * TEXT_HEIGHT);
+      let itemY = y + (textLineCnt * textHeight);
       itemX += Util.aliasPixel(itemX);
       itemY += Util.aliasPixel(itemY);
 
@@ -306,8 +320,8 @@ const modules = {
       ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
       ctx.textBaseline = 'Bottom';
       const seriesNameSpaceWidth = opt.maxWidth - Math.round(ctx.measureText(maxValue).width)
-        - boxPadding.l - boxPadding.r - COLOR_MARGIN - VALUE_MARGIN;
-      const xPos = itemX + COLOR_MARGIN;
+        - boxPadding.l - boxPadding.r - seriesColorMarginRight - VALUE_MARGIN;
+      const xPos = itemX + seriesColorMarginRight;
       const yPos = itemY;
 
       if (seriesNameSpaceWidth > ctx.measureText(name).width) { // draw normally
@@ -324,7 +338,7 @@ const modules = {
             ctx.fillText(line, xPos, yPosWithWrap);
             line = char;
             textLineCnt += 1;
-            yPosWithWrap += TEXT_HEIGHT;
+            yPosWithWrap += textHeight;
           } else {
             line = temp;
           }
@@ -366,11 +380,13 @@ const modules = {
     const hitItem = items[sId].data;
     const hitAxis = items[sId].axis;
     const hitColor = items[sId].color;
-    const boxPadding = { t: 8, b: 8, r: 20, l: 16 };
+    const boxPadding = { t: 0, b: 8, r: 20, l: 16 };
     const isHorizontal = this.options.horizontal;
     const opt = this.options.tooltip;
     const titleFormatter = opt.formatter?.title;
     const series = Object.values(this.seriesList)[0];
+    const textHeight = this.getTextHeight();
+    const seriesColorMarginRight = this.getColorMargin();
 
     let isShow = false;
     let valueText = hitItem.formatted;
@@ -418,9 +434,9 @@ const modules = {
     }
 
     const itemX = boxPadding.l + 2;
-    const itemY = boxPadding.t + TEXT_HEIGHT + 2;
+    const itemY = boxPadding.t + textHeight + 2;
 
-    ctx.font = fontStyle;
+    ctx.font = this.getFontStyle('contents');
 
     ctx.beginPath();
 
@@ -442,7 +458,10 @@ const modules = {
     ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
     ctx.textBaseline = 'Bottom';
     if (this.axesY.length) {
-      ctx.fillText(this.axesY[hitAxis.y].getLabelFormat(hitItem.y), itemX + COLOR_MARGIN, itemY);
+      ctx.fillText(
+        this.axesY[hitAxis.y].getLabelFormat(hitItem.y),
+        itemX + seriesColorMarginRight, itemY,
+      );
     }
 
     // 3. Draw value
@@ -461,8 +480,10 @@ const modules = {
     const items = hitInfo.items;
     const [, maxValue] = hitInfo.maxTip;
     const seriesKeys = this.alignSeriesList(Object.keys(items));
-    const boxPadding = { t: 8, b: 8, r: 8, l: 8 };
+    const boxPadding = { t: 0, b: 8, r: 8, l: 8 };
     const opt = this.options.tooltip;
+    const textHeight = this.getTextHeight();
+    const seriesColorMarginRight = this.getColorMargin();
 
     let x = 2;
     let y = 2;
@@ -480,7 +501,7 @@ const modules = {
     x += boxPadding.l;
     y += boxPadding.t;
 
-    ctx.font = fontStyle;
+    ctx.font = this.getFontStyle('contents');
 
     const seriesList = [];
     seriesKeys.forEach((seriesName) => {
@@ -518,7 +539,7 @@ const modules = {
       const valueText = gdata.formatted;
 
       let itemX = x + 4;
-      let itemY = y + (textLineCnt * TEXT_HEIGHT);
+      let itemY = y + (textLineCnt * textHeight);
       itemX += Util.aliasPixel(itemX);
       itemY += Util.aliasPixel(itemY);
 
@@ -542,8 +563,8 @@ const modules = {
       ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
       ctx.textBaseline = 'Bottom';
       const seriesNameSpaceWidth = opt.maxWidth - Math.round(ctx.measureText(maxValue).width)
-        - boxPadding.l - boxPadding.r - COLOR_MARGIN - VALUE_MARGIN;
-      const xPos = itemX + COLOR_MARGIN;
+        - boxPadding.l - boxPadding.r - seriesColorMarginRight - VALUE_MARGIN;
+      const xPos = itemX + seriesColorMarginRight;
       const yPos = itemY;
 
       if (seriesNameSpaceWidth > ctx.measureText(name).width) { // draw normally
@@ -560,7 +581,7 @@ const modules = {
             ctx.fillText(line, xPos, yPosWithWrap);
             line = char;
             textLineCnt += 1;
-            yPosWithWrap += TEXT_HEIGHT;
+            yPosWithWrap += textHeight;
           } else {
             line = temp;
           }
@@ -592,7 +613,7 @@ const modules = {
     const mouseY = e.pageY;
 
     const customTooltipEl = document.getElementsByClassName('ev-chart-tooltip-custom')?.[0];
-    if (!customTooltipEl) {
+    if (!customTooltipEl && !this.tooltipDOM) {
       return;
     }
 
@@ -605,13 +626,14 @@ const modules = {
 
     const bodyWidth = document.body.clientWidth;
     const bodyHeight = document.body.clientHeight;
+    const tooltipDOMSize = this.tooltipDOM?.getBoundingClientRect();
     const distanceMouseAndTooltip = 20;
     const maximumPosX = bodyWidth - contentsWidth - distanceMouseAndTooltip;
-    const maximumPosY = bodyHeight - (TITLE_HEIGHT + contentsHeight) - distanceMouseAndTooltip;
+    const maximumPosY = bodyHeight - tooltipDOMSize?.height - distanceMouseAndTooltip;
     const expectedPosX = mouseX + distanceMouseAndTooltip;
     const expectedPosY = mouseY + distanceMouseAndTooltip;
     const reversedPosX = mouseX - contentsWidth - distanceMouseAndTooltip;
-    const reversedPosY = mouseY - (TITLE_HEIGHT + contentsHeight) - distanceMouseAndTooltip;
+    const reversedPosY = mouseY - tooltipDOMSize?.height - distanceMouseAndTooltip;
     this.tooltipDOM.style.left = expectedPosX > maximumPosX
       ? `${reversedPosX}px`
       : `${expectedPosX}px`;
@@ -661,6 +683,9 @@ const modules = {
     this.tooltipDOM.style.backgroundColor = tooltipOptions.backgroundColor;
     this.tooltipDOM.style.border = `1px solid ${tooltipOptions.borderColor}`;
     this.tooltipDOM.style.color = tooltipOptions.fontColor?.title ?? tooltipOptions.fontColor;
+
+    this.tooltipHeaderDOM.style.fontSize = `${tooltipOptions.fontSize.title}px`;
+    this.tooltipHeaderDOM.style.fontFamily = this.getFontStyle('title');
 
     if (tooltipOptions.useShadow) {
       const shadowColor = `rgba(0, 0, 0, ${tooltipOptions.shadowOpacity})`;

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -3,8 +3,8 @@ import debounce from '@/common/utils.debounce';
 import Canvas from '../helpers/helpers.canvas';
 import Util from '../helpers/helpers.util';
 
-const TITLE_HEIGHT = 30;
-const TEXT_HEIGHT = 14;
+const TITLE_HEIGHT = 35;
+const TEXT_HEIGHT = 20;
 const LINE_SPACING = 8;
 const COLOR_MARGIN = 16;
 const VALUE_MARGIN = 50;
@@ -77,7 +77,7 @@ const modules = {
     const [maxSeries, maxValue] = hitInfo.maxTip;
     const seriesKeys = Object.keys(items);
     const seriesLen = seriesKeys.length;
-    const boxPadding = { t: 8, b: 8, r: 20, l: 16 };
+    const boxPadding = { t: 10, b: 4, r: 20, l: 16 };
     const opt = this.options.tooltip;
 
 
@@ -167,6 +167,24 @@ const modules = {
     this.tooltipDOM.style.top = expectedPosY > maximumPosY
       ? `${reversedPosY}px`
       : `${expectedPosY}px`;
+  },
+
+  /**
+   * Draw series color shape
+   * @param {object} context    tooltip canvas context
+   * @param {string} shape  // 'circle' | 'rect' (default)
+   * @param {object} centerPosition  // {x: number, y: number}
+   */
+  drawSeriesColorShape(context, shape, centerPosition) {
+    const { x, y } = centerPosition;
+
+    if (shape === 'circle') {
+      context.beginPath();
+      context.arc(x - 2, y - 4, 6, 0, 2 * Math.PI);
+      context.fill();
+    } else {
+      context.fillRect(x - 4, y - 12, 12, 12);
+    }
   },
 
   /**
@@ -279,10 +297,10 @@ const modules = {
       }
 
       // 1. Draw series color
-      ctx.fillRect(itemX - 4, itemY - 12, 12, 12);
-      ctx.fillStyle = opt.fontColor;
+      this.drawSeriesColorShape(ctx, opt.colorShape, { x: itemX, y: itemY });
 
       // 2. Draw series name
+      ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
       ctx.textBaseline = 'Bottom';
       const seriesNameSpaceWidth = opt.maxWidth - Math.round(ctx.measureText(maxValue).width)
         - boxPadding.l - boxPadding.r - COLOR_MARGIN - VALUE_MARGIN;
@@ -317,6 +335,7 @@ const modules = {
       ctx.save();
 
       // 3. Draw value
+      ctx.fillStyle = opt.fontColor?.value ?? opt.fontColor;
       ctx.textAlign = 'right';
       ctx.fillText(valueText, this.tooltipDOM.offsetWidth - boxPadding.r, itemY);
       ctx.restore();
@@ -414,10 +433,10 @@ const modules = {
     }
 
     // 1. Draw value color
-    ctx.fillRect(itemX - 4, itemY - 12, 12, 12);
-    ctx.fillStyle = opt.fontColor;
+    this.drawSeriesColorShape(ctx, opt.colorShape, { x: itemX, y: itemY });
 
     // 2. Draw value y names
+    ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
     ctx.textBaseline = 'Bottom';
     if (this.axesY.length) {
       ctx.fillText(this.axesY[hitAxis.y].getLabelFormat(hitItem.y), itemX + COLOR_MARGIN, itemY);
@@ -514,10 +533,10 @@ const modules = {
       }
 
       // 1. Draw series color
-      ctx.fillRect(itemX - 4, itemY - 12, 12, 12);
-      ctx.fillStyle = opt.fontColor;
+      this.drawSeriesColorShape(ctx, opt.colorShape, { x: itemX, y: itemY });
 
       // 2. Draw series name
+      ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
       ctx.textBaseline = 'Bottom';
       const seriesNameSpaceWidth = opt.maxWidth - Math.round(ctx.measureText(maxValue).width)
         - boxPadding.l - boxPadding.r - COLOR_MARGIN - VALUE_MARGIN;
@@ -626,7 +645,7 @@ const modules = {
       this.tooltipDOM.style.overflowY = 'hidden';
       this.tooltipDOM.style.backgroundColor = opt.backgroundColor;
       this.tooltipDOM.style.border = `1px solid ${opt.borderColor}`;
-      this.tooltipDOM.style.color = opt.fontColor;
+      this.tooltipDOM.style.color = opt.fontColor?.title ?? opt.fontColor;
     }
   },
 
@@ -638,7 +657,7 @@ const modules = {
     this.tooltipDOM.style.overflowY = 'hidden';
     this.tooltipDOM.style.backgroundColor = tooltipOptions.backgroundColor;
     this.tooltipDOM.style.border = `1px solid ${tooltipOptions.borderColor}`;
-    this.tooltipDOM.style.color = tooltipOptions.fontColor;
+    this.tooltipDOM.style.color = tooltipOptions.fontColor?.title ?? tooltipOptions.fontColor;
 
     if (tooltipOptions.useShadow) {
       const shadowColor = `rgba(0, 0, 0, ${tooltipOptions.shadowOpacity})`;

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -69,6 +69,22 @@ const modules = {
     return (this.options?.tooltip?.fontSize?.contents ?? 14) + 2;
   },
 
+  getBoxPadding() {
+    const {
+      top = 0,
+      right = 20,
+      bottom = 8,
+      left = 16,
+    } = this.options?.tooltip?.rowPadding ?? {};
+
+    return {
+      t: top,
+      l: left,
+      b: bottom,
+      r: right,
+    };
+  },
+
   /**
    * Set tooltip DOM's position and style
    * @param {object} hitInfo    value and mouse position touched
@@ -84,7 +100,7 @@ const modules = {
     const [maxSeries, maxValue] = hitInfo.maxTip;
     const seriesKeys = Object.keys(items);
     const seriesLen = seriesKeys.length;
-    const boxPadding = { t: 0, b: 8, r: 20, l: 16 };
+    const boxPadding = this.getBoxPadding();
     const opt = this.options.tooltip;
     const seriesColorMarginRight = this.getColorMargin();
 
@@ -214,7 +230,7 @@ const modules = {
     const hitAxis = items[sId].axis;
     const [, maxValue] = hitInfo.maxTip;
     const seriesKeys = this.alignSeriesList(Object.keys(items));
-    const boxPadding = { t: 0, b: 8, r: 20, l: 16 };
+    const boxPadding = this.getBoxPadding();
     const isHorizontal = this.options.horizontal;
     const opt = this.options.tooltip;
     const titleFormatter = opt.formatter?.title;
@@ -380,7 +396,7 @@ const modules = {
     const hitItem = items[sId].data;
     const hitAxis = items[sId].axis;
     const hitColor = items[sId].color;
-    const boxPadding = { t: 0, b: 8, r: 20, l: 16 };
+    const boxPadding = this.getBoxPadding();
     const isHorizontal = this.options.horizontal;
     const opt = this.options.tooltip;
     const titleFormatter = opt.formatter?.title;
@@ -480,7 +496,7 @@ const modules = {
     const items = hitInfo.items;
     const [, maxValue] = hitInfo.maxTip;
     const seriesKeys = this.alignSeriesList(Object.keys(items));
-    const boxPadding = { t: 0, b: 8, r: 8, l: 8 };
+    const boxPadding = this.getBoxPadding();
     const opt = this.options.tooltip;
     const textHeight = this.getTextHeight();
     const seriesColorMarginRight = this.getColorMargin();

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -219,6 +219,9 @@ const modules = {
           ? this.axesY[hitAxis.y].getLabelFormat(hitItem.y)
           : this.axesX[hitAxis.x].getLabelFormat(hitItem.x);
       }
+    } else {
+      // Pie Chart
+      this.tooltipHeaderDOM.style.display = 'none';
     }
 
     if (opt.textOverflow) {

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -574,6 +574,7 @@ const modules = {
       return;
     }
 
+    this.tooltipDOM.style.display = 'block';
     const contentsWidth = customTooltipEl.offsetWidth;
     const contentsHeight = customTooltipEl.offsetHeight;
 
@@ -595,8 +596,6 @@ const modules = {
     this.tooltipDOM.style.top = expectedPosY > maximumPosY
       ? `${reversedPosY}px`
       : `${expectedPosY}px`;
-
-    this.tooltipDOM.style.display = 'block';
   },
 
   /**

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -105,7 +105,11 @@ class Scale {
       max: maxValue,
       minLabel,
       maxLabel,
-      size: Util.calcTextSize(maxLabel, Util.getLabelStyle(this.labelStyle)),
+      size: Util.calcTextSize(
+        maxLabel,
+        Util.getLabelStyle(this.labelStyle),
+        this.labelStyle?.padding,
+      ),
     };
   }
 

--- a/src/components/chart/style/chart.scss
+++ b/src/components/chart/style/chart.scss
@@ -304,9 +304,8 @@
   border-radius: 8px;
 
   .ev-chart-tooltip-header {
-    padding: 16px 16px 0 16px;
+    padding: 12px 16px 3px 16px;
     overflow: hidden;
-    font-size: 16px;
 
     &--wrap {
       word-wrap: break-word;

--- a/src/components/chart/style/chart.scss
+++ b/src/components/chart/style/chart.scss
@@ -304,7 +304,7 @@
   border-radius: 8px;
 
   .ev-chart-tooltip-header {
-    padding: 8px 16px 0 16px;
+    padding: 16px 16px 0 16px;
     overflow: hidden;
     font-size: 16px;
 

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -105,6 +105,12 @@ const DEFAULT_OPTIONS = {
       title: 16,
       contents: 14,
     },
+    rowPadding: {
+      top: 0,
+      bottom: 8,
+      right: 20,
+      left: 16,
+    },
   },
   indicator: {
     use: true,

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -100,6 +100,7 @@ const DEFAULT_OPTIONS = {
     useScrollbar: false,
     textOverflow: 'wrap',
     fontFamily: 'Roboto',
+    colorShape: 'rect',
   },
   indicator: {
     use: true,

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -101,6 +101,10 @@ const DEFAULT_OPTIONS = {
     textOverflow: 'wrap',
     fontFamily: 'Roboto',
     colorShape: 'rect',
+    fontSize: {
+      title: 16,
+      contents: 14,
+    },
   },
   indicator: {
     use: true,

--- a/src/components/grid/GridSummary.vue
+++ b/src/components/grid/GridSummary.vue
@@ -131,7 +131,16 @@ export default {
         if (column.type === 'number' || column.type === 'float') {
           let columnValues = [];
           if (props.isTree) {
-            columnValues = stores.value.store.map(node => node.data?.[column.field]);
+            columnValues = stores.value.store.reduce((acc, cur) => {
+                if (column.summaryOnlyTopParent) {
+                  if (!cur.parent) {
+                    acc.push(cur.data?.[column.field]);
+                  }
+                } else {
+                  acc.push(cur.data?.[column.field]);
+                }
+                return acc;
+              }, []);
           } else {
             columnValues = stores.value.store.map(row => row[ROW_DATA_INDEX][columnIndex]);
           }

--- a/src/components/grid/GridSummary.vue
+++ b/src/components/grid/GridSummary.vue
@@ -151,6 +151,7 @@ export default {
         field,
         summaryType,
         summaryDecimal,
+        summaryOnlyTopParent,
       } = column;
 
       let result = '';
@@ -163,12 +164,12 @@ export default {
           let columnValues = [];
           if (props.isTree) {
             columnValues = stores.value.store.reduce((acc, cur) => {
-                if (column.summaryOnlyTopParent) {
+                if (summaryOnlyTopParent) {
                   if (!cur.parent) {
-                    acc.push(cur.data?.[column.field]);
+                    acc.push(cur.data?.[field]);
                   }
                 } else {
-                  acc.push(cur.data?.[column.field]);
+                  acc.push(cur.data?.[field]);
                 }
                 return acc;
               }, []);

--- a/src/components/grid/GridSummary.vue
+++ b/src/components/grid/GridSummary.vue
@@ -178,9 +178,9 @@ export default {
           switch (summaryType) {
             case 'sum': {
               const sumValue = columnValues.reduce((prev, curr) => {
-                // const value = Number(curr);
-                if (!Number.isNaN(curr)) {
-                  return bnPlus(prev, curr);
+                const value = Number(curr);
+                if (!Number.isNaN(value)) {
+                  return bnPlus(prev, value);
                 }
                 return prev;
               }, 0);

--- a/src/components/grid/GridSummary.vue
+++ b/src/components/grid/GridSummary.vue
@@ -53,9 +53,9 @@
             </div>
             <div
               v-else
-              :title="getSummaryValue(column, column.summaryType)"
+              :title="getSummaryValue(column)"
             >
-              {{ getSummaryValue(column, column.summaryType)}}
+              {{ getSummaryValue(column)}}
             </div>
           </span>
           <span
@@ -71,6 +71,7 @@
 <script>
 import { computed, watch, ref, nextTick } from 'vue';
 import { numberWithComma } from '@/common/utils';
+import { bnDivide, bnFloor, bnPlus } from '@/common/utils.bignumber';
 
 export default {
   name: 'EvGridSummary',
@@ -101,68 +102,109 @@ export default {
     },
   },
   setup(props) {
+    const DECIMAL = {
+      max: 20,
+      default: 3,
+    };
     const summaryRef = ref();
     const ROW_DATA_INDEX = 2;
     const stores = computed(() => props.stores);
     const columns = computed(() => props.orderedColumns);
     const showCheckbox = computed(() => props.useCheckbox);
     const styleInfo = computed(() => props.styleOption);
+
+    const getValidDecimal = (decimal) => {
+      if (decimal == null || decimal < 0) {
+        return DECIMAL.default;
+      }
+
+      if (decimal > DECIMAL.max) {
+        return DECIMAL.max;
+      }
+
+      return decimal;
+    };
+
     const getConvertValue = (column, value) => {
+      if (typeof value === 'string' && value.length === 0) {
+        return value;
+      }
+
+      const { type, decimal } = column;
       let convertValue = value;
 
-      if (column.type === 'number') {
+      if (type === 'number') {
         convertValue = numberWithComma(value);
         convertValue = convertValue === false ? value : convertValue;
-      } else if (column.type === 'float') {
-        const floatValue = convertValue.toFixed(column.decimal ?? 3);
+      } else if (type === 'float') {
+        const floatValue = convertValue.toFixed(getValidDecimal(decimal ?? DECIMAL.default));
         convertValue = floatValue.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
       }
 
       return convertValue;
     };
+
     const getColumnIndex = field => columns.value.findIndex(column => column.field === field);
-    const getSummaryValue = (column, summaryType) => {
+    const getSummaryValue = (column) => {
+      const {
+        type,
+        field,
+        summaryType,
+        summaryDecimal,
+      } = column;
+
       let result = '';
-      const columnIndex = getColumnIndex(column.field);
+      const columnIndex = getColumnIndex(field);
       if (columnIndex >= 0) {
         if (summaryType === 'count') {
           return stores.value.store.length;
         }
-        if (column.type === 'number' || column.type === 'float') {
+        if (type === 'number' || type === 'float') {
           let columnValues = [];
           if (props.isTree) {
-            columnValues = stores.value.store.map(node => node.data?.[column.field]);
+            columnValues = stores.value.store.map(node => node.data?.[field]);
           } else {
             columnValues = stores.value.store.map(row => row[ROW_DATA_INDEX][columnIndex]);
           }
           switch (summaryType) {
-            case 'sum':
-              result = columnValues.reduce((prev, curr) => {
-                const value = Number(curr);
-                if (!Number.isNaN(value)) {
-                  return prev + value;
+            case 'sum': {
+              const sumValue = columnValues.reduce((prev, curr) => {
+                // const value = Number(curr);
+                if (!Number.isNaN(curr)) {
+                  return bnPlus(prev, curr);
                 }
                 return prev;
               }, 0);
+
+              result = sumValue && bnFloor(
+                sumValue, getValidDecimal(summaryDecimal ?? DECIMAL.default),
+              );
               break;
-            case 'average':
-              result = columnValues.reduce((prev, curr) => {
+            }
+            case 'average': {
+              const sumValue = columnValues.reduce((prev, curr) => {
                 const value = Number(curr);
                 if (!Number.isNaN(value)) {
-                  return prev + value;
+                  return bnPlus(prev, value);
                 }
                 return prev;
-              }, 0) / columnValues.length;
-              if (result % 1 !== 0) {
-                result = result.toFixed(1);
-              }
+              }, 0);
+              result = sumValue && bnFloor(
+                bnDivide(sumValue, columnValues.length),
+                getValidDecimal(summaryDecimal ?? DECIMAL.default),
+              );
               break;
-            case 'max':
-              result = Math.max(...columnValues);
+            }
+            case 'max': {
+              const filteredNullValues = columnValues.filter(value => value != null);
+              result = filteredNullValues.length ? Math.max(...filteredNullValues) : '';
               break;
-            case 'min':
-              result = Math.min(...columnValues);
+            }
+            case 'min': {
+              const filteredNullValues = columnValues.filter(value => value != null);
+              result = filteredNullValues.length ? Math.min(...filteredNullValues) : '';
               break;
+            }
             default:
               break;
           }
@@ -179,10 +221,7 @@ export default {
       fields.forEach((name, idx) => {
         const columnIndex = getColumnIndex(name);
         if (columnIndex >= 0) {
-          const value = getSummaryValue(
-            stores.value.orderedColumns[columnIndex],
-            column.summaryType,
-          );
+          const value = getSummaryValue(stores.value.orderedColumns[columnIndex]);
           result = result.replace(`{${idx}}`, value);
         }
       });

--- a/src/components/grid/GridSummary.vue
+++ b/src/components/grid/GridSummary.vue
@@ -169,9 +169,9 @@ export default {
           switch (summaryType) {
             case 'sum': {
               const sumValue = columnValues.reduce((prev, curr) => {
-                // const value = Number(curr);
-                if (!Number.isNaN(curr)) {
-                  return bnPlus(prev, curr);
+                const value = Number(curr);
+                if (!Number.isNaN(value)) {
+                  return bnPlus(prev, value);
                 }
                 return prev;
               }, 0);

--- a/src/components/grid/GridSummary.vue
+++ b/src/components/grid/GridSummary.vue
@@ -178,9 +178,9 @@ export default {
           switch (summaryType) {
             case 'sum': {
               const sumValue = columnValues.reduce((prev, curr) => {
-                const value = Number(curr);
-                if (!Number.isNaN(value)) {
-                  return bnPlus(prev, value);
+                // const value = Number(curr);
+                if (!Number.isNaN(curr)) {
+                  return bnPlus(prev, curr);
                 }
                 return prev;
               }, 0);

--- a/src/components/message/Message.vue
+++ b/src/components/message/Message.vue
@@ -87,7 +87,7 @@ export default {
       default: null,
     },
   },
-  setup(props) {
+  setup(props, context) {
     const state = reactive({
       timer: null,
       isShow: true,
@@ -120,6 +120,9 @@ export default {
         closeMsg();
       }
     };
+    const hide = () => {
+      closeMsg();
+    };
 
     onMounted(() => {
       startTimer();
@@ -129,11 +132,14 @@ export default {
       document.removeEventListener('keydown', keydown);
       clearTimer();
     });
+
+    context.expose({ hide });
     return {
       startTimer,
       clearTimer,
       closeMsg,
       ...toRefs(state),
+      hide,
     };
   },
 };

--- a/src/components/message/index.js
+++ b/src/components/message/index.js
@@ -20,7 +20,10 @@ const message = (options = {}) => {
     componentObj,
     msgOption,
   );
+
   render(instance, container);
+
+  return instance.component.exposed;
 };
 
 message.install = (app) => {

--- a/src/components/timePicker/TimePicker.vue
+++ b/src/components/timePicker/TimePicker.vue
@@ -14,7 +14,7 @@
         class="ev-time-picker-wrapper"
       >
         <input
-          v-model="startTime"
+          v-model="time[0]"
           class="ev-input"
           :disabled="disabled"
           :readonly="readonly"
@@ -45,7 +45,7 @@
         class="ev-time-picker-wrapper"
       >
         <input
-          v-model="endTime"
+          v-model="time[1]"
           class="ev-input"
           :disabled="disabled"
           :readonly="readonly"
@@ -105,7 +105,7 @@
 </template>
 
 <script>
-import { ref, reactive } from 'vue';
+import { ref, reactive, computed } from 'vue';
 
 export default {
   name: 'EvTimePicker',
@@ -115,7 +115,7 @@ export default {
       default: '',
       validator: (time) => {
         const timeRegexExp = /^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$/;
-        if (Array.isArray(time) && !timeRegexExp.test(time[0]) && timeRegexExp.test(time[1])) {
+        if (Array.isArray(time) && (!timeRegexExp.test(time[0]) || !timeRegexExp.test(time[1]))) {
           // range mode
           console.warn('Please check the time format in the Timepicker.');
           return false;
@@ -152,30 +152,30 @@ export default {
     change: null,
   },
   setup(props, { emit }) {
-    let startTime = ref('00:00');
-    let endTime = ref('23:59');
-    let time = ref('00:00');
+    const time = computed({
+      get: () => props.modelValue,
+      set: (value) => {
+        if (props.type === 'range') {
+          if (Array.isArray(value)) {
+            const startTime = (value[0] > value[1] ? '00:00' : value[0]);
+            const endTime = (startTime.value > value[1] ? '23:59' : value[1]);
+
+            emit('update:modelValue', [startTime, endTime]);
+          }
+        } else {
+          emit('update:modelValue', value);
+        }
+      },
+    }); // <string | string[]>
+
+    const previousValue = ref(
+      Array.isArray(time.value) ? [`${time.value[0]}`, `${time.value[1]}`] : `${time.value}`,
+    ); // <string | string[]>
+
     const isWrongType = reactive({
       single: false,
       rangeStart: false,
       rangeEnd: false,
-    });
-
-    if (props.type === 'range') {
-      if (Array.isArray(props.modelValue)) {
-        startTime = ref(props.modelValue[0] > props.modelValue[1] ? '00:00' : props.modelValue[0]);
-        endTime = ref(startTime.value > props.modelValue[1] ? '23:59' : props.modelValue[1]);
-      }
-      emit('update:modelValue', [startTime.value, endTime.value]);
-    } else {
-      time = ref(props.modelValue || '00:00');
-      emit('update:modelValue', time.value);
-    }
-
-    const previousValue = reactive({
-      singleTime: time.value,
-      rangeStartTime: startTime.value,
-      rangeEndTime: endTime.value,
     });
 
     const validTimeExp = (timeExp) => {
@@ -184,26 +184,28 @@ export default {
     };
 
     const setValidStartTime = () => {
-      if (!validTimeExp(startTime.value)) {
-        startTime.value = previousValue.rangeStartTime;
+      if (!Array.isArray(time.value)) return;
+      if (!validTimeExp(time.value[0])) {
+        time.value[0] = previousValue.value[0];
       }
-      if (endTime.value && (startTime.value > endTime.value)) {
-        startTime.value = endTime.value;
+      if (time.value[1] && (time.value[0] > time.value[1])) {
+        time.value[0] = time.value[1];
       }
-      previousValue.rangeStartTime = startTime.value;
+      previousValue.value[0] = time.value[0];
     };
 
     const setValidEndTime = () => {
-      if (!validTimeExp(endTime.value)) {
-        endTime.value = previousValue.rangeEndTime;
+      if (!Array.isArray(time.value)) return;
+      if (!validTimeExp(time.value[1])) {
+        time.value[1] = previousValue.value[1];
       }
-      if (startTime.value && (startTime.value > endTime.value)) {
-        endTime.value = previousValue.rangeEndTime;
-        if (startTime.value > previousValue.rangeEndTime) {
-          endTime.value = startTime.value;
+      if (time.value[0] && (time.value[0] > time.value[1])) {
+        time.value[1] = previousValue.value[1];
+        if (time.value[0] > previousValue.value[1]) {
+          time.value[1] = time.value[0];
         }
       }
-      previousValue.rangeEndTime = endTime.value;
+      previousValue.value[1] = time.value[1];
     };
 
     // startTime event for range type
@@ -218,14 +220,12 @@ export default {
     const changeStartTime = (e) => {
       setValidStartTime();
       isWrongType.rangeStart = false;
-      emit('update:modelValue', [startTime.value, endTime.value]);
-      emit('change', e, [startTime.value, endTime.value]);
+      emit('change', e, time.value);
     };
 
     const clearStartTime = () => {
-      startTime.value = '';
+      time.value[0] = '';
       isWrongType.rangeStart = true;
-      emit('update:modelValue', [startTime.value, endTime.value]);
     };
 
     // endTime event for range type
@@ -240,14 +240,12 @@ export default {
     const changeEndTime = (e) => {
       setValidEndTime();
       isWrongType.rangeEnd = false;
-      emit('update:modelValue', [startTime.value, endTime.value]);
-      emit('change', e, [startTime.value, endTime.value]);
+      emit('change', e, time.value);
     };
 
     const clearEndTime = () => {
-      endTime.value = '';
+      time.value[1] = '';
       isWrongType.rangeEnd = true;
-      emit('update:modelValue', [startTime.value, endTime.value]);
     };
 
     // event for single type
@@ -261,26 +259,22 @@ export default {
 
     const changeTime = (e) => {
       if (!validTimeExp(time.value)) {
-        time.value = previousValue.singleTime;
+        time.value = previousValue.value;
       } else {
-        previousValue.singleTime = time.value;
+        previousValue.value = time.value;
       }
 
       isWrongType.single = !validTimeExp(time.value);
 
-      emit('update:modelValue', time.value);
       emit('change', e, time.value);
     };
 
     const clearContents = () => {
       time.value = '';
       isWrongType.single = true;
-      emit('update:modelValue', time.value);
     };
 
     return {
-      startTime,
-      endTime,
       time,
       isWrongType,
       previousValue,


### PR DESCRIPTION
## 작업 내용
- 3.3.rc에 적용되어 있던 컬럼 별 Summary decimal 설정 옵션을 적용
- 각 컬럼 옵션에 `summaryDecimal`을 optional로 추가하였습니다.
- bignumber.js 를 이용하는 계산을 3.3.rc에서는 `GridSummary.vue` 파일에 작성해서 사용하였으나, 해당 기능들을 `utils.bignumber.js` 파일을 만들어서 따로 분리하였습니다.

## 화면
![summary-test](https://github.com/ex-em/EVUI/assets/75205035/3909da65-fc4b-486c-8f9d-6383e6fe37c3)
