### PR TITLE
[#1558] Docs > Example Anchor

### DIFF
--- a/docs/components/Example.vue
+++ b/docs/components/Example.vue
@@ -1,6 +1,15 @@
 <template>
   <article class="article-wrapper">
-    <h3 class="article-title">
+    <h3
+      :id="kebabCase(title)"
+      class="article-title"
+    >
+      <a
+        class="article-title-anchor"
+        @click="$router.push({ hash: `#${kebabCase(title)}` })"
+      >
+        ¶
+      </a>
       {{ title }}
     </h3>
     <p
@@ -49,6 +58,7 @@
 
 <script>
 import { ref, onMounted } from 'vue';
+import { kebabCase } from 'lodash-es';
 import highlight from 'docs/directives/highlight';
 
 export default {
@@ -95,6 +105,7 @@ export default {
     });
 
     return {
+      kebabCase,
       codeExpend,
       codeWrapper,
       clickExpend,
@@ -126,6 +137,20 @@ export default {
   margin-bottom: 20px;
   font-size: 23px;
   font-weight: bold;
+  &-anchor {
+    float: left;
+    margin-left: -1em;
+    color: $color-blue;
+    opacity: 0;
+    cursor: pointer;
+    text-decoration: none;
+    &:hover {
+      opacity: 1;
+    }
+  }
+  &:hover .article-title-anchor {
+    opacity: 1;
+  }
 }
 .article-description {
   margin-bottom: 30px;

--- a/docs/router/index.js
+++ b/docs/router/index.js
@@ -358,10 +358,29 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(process.env.BASE_URL),
   routes,
-  scrollBehavior() {
-    return {
-      top: 0,
-    };
+  scrollBehavior(to) {
+    // hash 가 존재하는 경우 hash 위치로 스크롤 하되, header 높이만큼 더 올려야 한다.
+    const result = to.hash ? { el: to.hash, top: 60 } : { top: 0 };
+
+    // 사용자가 직접 url 에 hash 를 입력한 경우나, hash 가 존재하는 url 링크를 타고와서 이동하는 경우에는
+    // vue-router 에서 scrollBehavior 를 이용한 스크롤이 이동된 뒤에
+    // browser 의 기본 동작으로 인해 id tag 의 위치로 스크롤이 다시 이동 되는데,
+    // header 때문에 정확한 위치로 이동하지 않는 문제가 있어서 비동기 로직이 추가 된다.
+    if (document.readyState === 'loading') {
+      return new Promise((resolve) => {
+        window.addEventListener('load', () => {
+          resolve(result);
+        }, { once: true });
+      });
+    }
+    if (window.event?.type === 'popstate') {
+      return new Promise((resolve) => {
+        window.addEventListener('hashchange', () => {
+          resolve(result);
+        }, { once: true });
+      });
+    }
+    return result;
   },
 });
 


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
- DOM id 와 hash 를 이용한 Anchor 기능이 없어서 추가 했습니다.
- 수정 사항을 확인 받기 위해 URL 에 hash 를 포함하면, 해당 항목의 정확한 위치로 바로 스크롤 됩니다.
- Docs 의 예제를 이용해서 로컬에서 수정하며 테스트 할 때, HMR 될때 마다 최상단으로 스크롤 되지 않으므로 코드 수정이 용이해 집니다.

## 어떻게 해결했나요?
- vue-router 의 scrollBehavior 함수를 이용해 스크롤 위치를 변경합니다.
- title element 에 title 값을 이용해 id 를 부여하고, scrollBehavior 에서 찾아가도록 합니다.
- Example 의 타이틀 왼쪽에 ¶ 문자로 앵커를 숨겨두고, 마우스 hover 시 노출되도록 합니다.

## 첨부
### Before
![before](https://github.com/ex-em/EVUI/assets/46586573/07896434-1bd3-4e1a-a643-94bb35d34250)
### After 
![after](https://github.com/ex-em/EVUI/assets/46586573/979d13eb-54b1-4633-a728-79f181ee6640)

## 관련 링크
- [vue-router scroll](https://router.vuejs.kr/guide/advanced/scroll-behavior.html)
- [테스트 페이지](http://10.20.141.34:9999/lineChart#select-label)