### PR TITLE
[#1559] Tree Grid > Summary 최상단 부모 값만 계산할 수 있도록 작업 

### DIFF
--- a/docs/views/treeGrid/api/treeGrid.md
+++ b/docs/views/treeGrid/api/treeGrid.md
@@ -69,20 +69,21 @@
 |  | childIcon        | 'tree-child-icon'  | 자식 노드가 없는 노드의 아이콘                       | `ev-icon`, 'none'        |
 
 ### Columns
-| 이름              | 타입      | 설명                                                 | 종류                                               | 필수 |
-|-----------------|---------|----------------------------------------------------|--------------------------------------------------| --- |
-| caption         | String  | 컬럼명                                                | ex) '인스턴스명'                                      | Y |
-| field           | String  | 필드명                                                | ex) 'instance_name'                              | Y |
-| type            | String  | 데이터 타입                                             | 'string', 'number', 'stringNumber', 'float', 'boolean' | Y |
-| hide            | Boolean | 컬럼 숨김 여부                                           | Boolean                                          | N |
-| width           | Number  | 컬럼 넓이                                              | ex) 150                                          | N |
-| searchable      | Boolean | 검색 대상 여부                                           | Boolean                                          | N |
-| align           | String  | 사용자 지정 정렬                                          | 'center', 'left', 'right'                        | N |
-| decimal         | Number  | 데이터 타입이 float 일 때 소수점 자리 표시 수                      | ex) 0~20 (디폴트: 3 )                               | N |
-| summaryType     | String  | 계산 타입                                              | 'sum', 'average', 'max', 'min', 'count'          | N |
-| summaryRenderer | String  | Summary 에 표시할 텍스트 또는 계산 값                          | ex) 'Sum: {0}'                                   | N |
-| summaryData     | Array   | Summary 할 대상 추가 시 summaryRenderer 와 함께 사용          | ex) '{0}({1}%)'                                  | N |
-| expandColumn    | Boolean | 트리그리드를 확장하는데 사용하는 컬럼을 의미, 설정하지 않으면 자동으로 첫번째 컬럼에 적용 | ex) 'expandColumn: true'                         | N |
+| 이름                   | 타입      | 설명                                                 | 종류                                                     | 필수 |
+|----------------------|---------|----------------------------------------------------|--------------------------------------------------------| --- |
+| caption              | String  | 컬럼명                                                | ex) '인스턴스명'                                            | Y |
+| field                | String  | 필드명                                                | ex) 'instance_name'                                    | Y |
+| type                 | String  | 데이터 타입                                             | 'string', 'number', 'stringNumber', 'float', 'boolean' | Y |
+| hide                 | Boolean | 컬럼 숨김 여부                                           | Boolean                                                | N |
+| width                | Number  | 컬럼 넓이                                              | ex) 150                                                | N |
+| searchable           | Boolean | 검색 대상 여부                                           | Boolean                                                | N |
+| align                | String  | 사용자 지정 정렬                                          | 'center', 'left', 'right'                              | N |
+| decimal              | Number  | 데이터 타입이 float 일 때 소수점 자리 표시 수                      | ex) 0~20 (디폴트: 3 )                                     | N |
+| summaryType          | String  | 계산 타입                                              | 'sum', 'average', 'max', 'min', 'count'                | N |
+| summaryOnlyTopParent | Boolean | 최상위 부모만 summary 계산을 할지 선택                          | Boolean                                                | N |
+| summaryRenderer      | String  | Summary 에 표시할 텍스트 또는 계산 값                          | ex) 'Sum: {0}'                                         | N |
+| summaryData          | Array   | Summary 할 대상 추가 시 summaryRenderer 와 함께 사용          | ex) '{0}({1}%)'                                        | N |
+| expandColumn         | Boolean | 트리그리드를 확장하는데 사용하는 컬럼을 의미, 설정하지 않으면 자동으로 첫번째 컬럼에 적용 | ex) 'expandColumn: true'                               | N |
 
 ### Event
 | 이름 | 파라미터 | 설명 |

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -28,6 +28,7 @@
         expandIcon: expandIconMV,
         collapseIcon: collapseIconMV,
         parentIcon: parentIconMV,
+        useSummary: true,
         childIcon: childIconMV,
         page: pageInfo,
       }"
@@ -390,68 +391,80 @@ export default {
       clickedRowMV.value = JSON.stringify(rowData);
     };
     const getData = () => {
-      tableData.value = [{
-        id: 'Exem 1',
-        date: '2016-05-01',
-        name: '1',
-        expand: true,
-        children: [{
-          id: 'Exem 2',
-          date: '2016-05-02',
-          name: '2',
-          expand: false,
+      tableData.value = [
+        {
+          id: 'Exem 0',
+          date: '2016-05-01',
+          name: '1111',
+          expand: true,
+        },
+        {
+          id: 'Exem 1',
+          date: '2016-05-01',
+          name: '2222',
+          value: 123,
+          expand: true,
           children: [{
-            id: 'Exem 3',
+            id: 'Exem 2',
             date: '2016-05-02',
-            name: '3',
-          }, {
-            id: 'Exem 4',
-            date: '2016-05-02',
-            name: '4',
+            name: '2',
+            value: 222,
             expand: false,
             children: [{
-              id: 'Exem 5',
+              id: 'Exem 3',
               date: '2016-05-02',
-              name: '5',
-              children: [{
-                id: 'Exem 51',
-                date: '2016-05-02',
-                name: '1251',
-                children: [{
-                  id: 'Exem 52',
-                  date: '2016-05-02',
-                  name: '20000',
-                }],
-              }],
+              name: '3',
+              value: 3333,
             }, {
-              id: 'Exem 6',
+              id: 'Exem 4',
               date: '2016-05-02',
-              name: '6',
+              name: '4',
+              expand: false,
+              children: [{
+                id: 'Exem 5',
+                date: '2016-05-02',
+                name: '5',
+                children: [{
+                  id: 'Exem 51',
+                  date: '2016-05-02',
+                  name: '1251',
+                  children: [{
+                    id: 'Exem 52',
+                    date: '2016-05-02',
+                    name: '20000',
+                  }],
+                }],
+              }, {
+                id: 'Exem 6',
+                date: '2016-05-02',
+                name: '6',
+              }],
             }],
-          }],
-        }, {
-          id: 'Exem 7',
-          date: '2016-05-03',
-          name: '7',
-          children: [{
-            id: 'Exem 8',
-            date: '2016-05-03',
-            name: '8',
           }, {
-            id: 'Exem 9',
+            id: 'Exem 7',
             date: '2016-05-03',
-            name: '9',
+            name: '7',
+            children: [{
+              id: 'Exem 8',
+              date: '2016-05-03',
+              name: '8',
+              value: 333,
+            }, {
+              id: 'Exem 9',
+              date: '2016-05-03',
+              name: '9',
+            }, {
+              id: 'Exem 10',
+              date: '2016-05-03',
+              name: '10',
+            }],
           }, {
-            id: 'Exem 10',
-            date: '2016-05-03',
-            name: '10',
+            id: 'Exem 11',
+            date: '2016-05-04',
+            name: '11',
           }],
-        }, {
-          id: 'Exem 11',
-          date: '2016-05-04',
-          name: '11',
-        }],
-      }];
+        },
+      ];
     };
     const columns = ref([
       { caption: 'ID', field: 'id', type: 'number' },
@@ -461,7 +474,16 @@ export default {
         field: 'name',
         type: 'float',
         summaryType: 'sum',
-        summaryRenderer: 'Sum: {0}',
+        summaryOnlyTopParent: true,
+        summaryRenderer: 'Sum: {0} 최상위 부모만 summary',
+        decimal: 1,
+      },
+      {
+        caption: 'Value',
+        field: 'value',
+        type: 'number',
+        summaryType: 'sum',
+        summaryRenderer: 'Sum: {0} 모든 row summary',
         decimal: 1,
       },
     ]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.3.68",
+  "version": "3.3.69",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/grid.summary.vue
+++ b/src/components/grid/grid.summary.vue
@@ -169,6 +169,7 @@ export default {
         type,
         field,
         summaryType,
+        summaryOnlyTopParent,
         summaryDecimal,
       } = column;
 
@@ -181,7 +182,17 @@ export default {
         if (type === 'number' || type === 'float') {
           let columnValues = [];
           if (props.isTree) {
-            columnValues = stores.value.store.map(node => node.data?.[field]);
+            columnValues = stores.value.store.reduce((acc, cur) => {
+              if (summaryOnlyTopParent) {
+                if (!cur.parent) {
+                  acc.push(cur.data?.[field]);
+                }
+              } else {
+                acc.push(cur.data?.[field]);
+              }
+
+              return acc;
+            }, []);
           } else {
             columnValues = stores.value.store.map(row => row[ROW_DATA_INDEX][columnIndex]);
           }


### PR DESCRIPTION
#############################
## 해결하려는 문제가 무엇인가요?
- 부모의 값이 자식의 합한 값과 같은 경우 Total에 부모의 값만 합산 되어야 하지만 부모의 값과 그 자식을 합친 값들이 중복으로 합산되고있음.   

## 어떻게 해결했나요?
- tree grid의 summary 계산에서 column에 summaryOnlyTopParent가 true일 경우 최상단 부모 값만 계산될 수 있도록 수정.
![image](https://github.com/ex-em/EVUI/assets/61274722/8ade25bc-2cac-4ba2-894b-d47f145c9787)   

## 첨부
### Before
![image](https://github.com/ex-em/EVUI/assets/61274722/9924bb4a-2c65-45aa-a47d-22d90f779869)   
### After 
summaryOnlyTopParent가 true일 경우   
![image](https://github.com/ex-em/EVUI/assets/61274722/b512e066-c70a-450b-b704-e11d2075686c)   

 