### PR TITLE
[#1559] Tree Grid > Summary 최상단 부모 값만 계산할 수 있도록 작업 (3.0 반영)

### DIFF
--- a/docs/views/treeGrid/api/treeGrid.md
+++ b/docs/views/treeGrid/api/treeGrid.md
@@ -101,6 +101,7 @@
 | align           | String  | 사용자 지정 정렬                                          | 'center', 'left', 'right'                        | N |
 | decimal         | Number  | 데이터 타입이 float 일 때 소수점 자리 표시 수                      | ex) 0~20 (디폴트: 3 )                               | N |
 | summaryType     | String  | 계산 타입                                              | 'sum', 'average', 'max', 'min', 'count'          | N |
+| summaryOnlyTopParent | Boolean | 최상위 부모만 summary 계산을 할지 선택                          | Boolean                                                | N |
 | summaryRenderer | String  | Summary 에 표시할 텍스트 또는 계산 값                          | ex) 'Sum: {0}'                                   | N |
 | summaryData     | Array   | Summary 할 대상 추가 시 summaryRenderer 와 함께 사용          | ex) '{0}({1}%)'                                  | N |
 | expandColumn    | Boolean | 트리그리드를 확장하는데 사용하는 컬럼을 의미, 설정하지 않으면 자동으로 첫번째 컬럼에 적용 | ex) 'expandColumn: true'                         | N |

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -410,70 +410,82 @@ export default {
       clickedRowMV.value = JSON.stringify(rowData);
     };
     const getData = () => {
-      tableData.value = [{
-        id: 'Exem 1',
-        date: '2016-05-01',
-        name: '1',
-        expand: true,
-        children: [{
-          id: 'Exem 2',
-          date: '2016-05-02',
-          name: '2',
-          expand: false,
+      tableData.value = [
+        {
+          id: 'Exem 0',
+          date: '2016-05-01',
+          name: '1111',
+          expand: true,
+        },
+        {
+          id: 'Exem 1',
+          date: '2016-05-01',
+          name: '2222',
+          value: 123,
+          expand: true,
           children: [{
-            id: 'Exem 3',
+            id: 'Exem 2',
             date: '2016-05-02',
-            name: '3',
-            uncheckable: true,
-          }, {
-            id: 'Exem 4',
-            date: '2016-05-02',
-            name: '4',
+            name: '2',
+            value: 222,
             expand: false,
-            uncheckable: true,
             children: [{
-              id: 'Exem 5',
+              id: 'Exem 3',
               date: '2016-05-02',
-              name: '5',
-              children: [{
-                id: 'Exem 51',
-                date: '2016-05-02',
-                name: '1251',
-                children: [{
-                  id: 'Exem 52',
-                  date: '2016-05-02',
-                  name: '20000',
-                }],
-              }],
+              name: '3',
+              value: 3333,
+              uncheckable: true,
             }, {
-              id: 'Exem 6',
+              id: 'Exem 4',
               date: '2016-05-02',
-              name: '6',
+              name: '4',
+              expand: false,
+              uncheckable: true,
+              children: [{
+                id: 'Exem 5',
+                date: '2016-05-02',
+                name: '5',
+                children: [{
+                  id: 'Exem 51',
+                  date: '2016-05-02',
+                  name: '1251',
+                  children: [{
+                    id: 'Exem 52',
+                    date: '2016-05-02',
+                    name: '20000',
+                  }],
+                }],
+              }, {
+                id: 'Exem 6',
+                date: '2016-05-02',
+                name: '6',
+              }],
             }],
-          }],
-        }, {
-          id: 'Exem 7',
-          date: '2016-05-03',
-          name: '7',
-          children: [{
-            id: 'Exem 8',
-            date: '2016-05-03',
-            name: '8',
           }, {
-            id: 'Exem 9',
+            id: 'Exem 7',
             date: '2016-05-03',
-            name: '9',
+            name: '7',
+            children: [{
+              id: 'Exem 8',
+              date: '2016-05-03',
+              name: '8',
+              value: 333,
+            }, {
+              id: 'Exem 9',
+              date: '2016-05-03',
+              name: '9',
+            }, {
+              id: 'Exem 10',
+              date: '2016-05-03',
+              name: '10',
+            }],
           }, {
-            id: 'Exem 10',
-            date: '2016-05-03',
-            name: '10',
+            id: 'Exem 11',
+            date: '2016-05-04',
+            name: '11',
           }],
-        }, {
-          id: 'Exem 11',
-          date: '2016-05-04',
-          name: '11',
-        }],
-      }];
+        },
+      ];
     };
     const columns = ref([
       { caption: 'ID', field: 'id', type: 'number' },
@@ -483,7 +495,16 @@ export default {
         field: 'name',
         type: 'float',
         summaryType: 'sum',
-        summaryRenderer: 'Sum: {0}',
+        summaryOnlyTopParent: true,
+        summaryRenderer: 'Sum: {0} 최상위 부모만 summary',
+        decimal: 1,
+      },
+      {
+        caption: 'Value',
+        field: 'value',
+        type: 'number',
+        summaryType: 'sum',
+        summaryRenderer: 'Sum: {0} 모든 row summary',
         decimal: 1,
       },
     ]);

--- a/src/components/grid/GridSummary.vue
+++ b/src/components/grid/GridSummary.vue
@@ -131,7 +131,16 @@ export default {
         if (column.type === 'number' || column.type === 'float') {
           let columnValues = [];
           if (props.isTree) {
-            columnValues = stores.value.store.map(node => node.data?.[column.field]);
+            columnValues = stores.value.store.reduce((acc, cur) => {
+                if (column.summaryOnlyTopParent) {
+                  if (!cur.parent) {
+                    acc.push(cur.data?.[column.field]);
+                  }
+                } else {
+                  acc.push(cur.data?.[column.field]);
+                }
+                return acc;
+              }, []);
           } else {
             columnValues = stores.value.store.map(row => row[ROW_DATA_INDEX][columnIndex]);
           }


### PR DESCRIPTION
#############################
MFC는 EVUI 3.3 버전을 사용하고 있어 3.4에 반영이 가능한 PR을 따로 올립니다.

## 해결하려는 문제가 무엇인가요?
- 부모의 값이 자식의 합한 값과 같은 경우 Total에 부모의 값만 합산 되어야 하지만 부모의 값과 그 자식을 합친 값들이 중복으로 합산되고있음.   

## 어떻게 해결했나요?
- tree grid의 summary 계산에서 column에 summaryOnlyTopParent가 true일 경우 최상단 부모 값만 계산될 수 있도록 수정.
![image](https://github.com/ex-em/EVUI/assets/61274722/8ade25bc-2cac-4ba2-894b-d47f145c9787)   

## 첨부
### Before
![image](https://github.com/ex-em/EVUI/assets/61274722/9924bb4a-2c65-45aa-a47d-22d90f779869)   
### After 
summaryOnlyTopParent가 true일 경우   
![image](https://github.com/ex-em/EVUI/assets/61274722/b512e066-c70a-450b-b704-e11d2075686c)   

 