### PR TITLE
[#1562][2.0] Grid > Improved column resize function

### DIFF
--- a/src/components/grid/grid.vue
+++ b/src/components/grid/grid.vue
@@ -26,18 +26,17 @@
             :after-type="`check`"
             @on-click="onCheckAll"
           />
-        </li>
-        <li
-          v-for="(column, index) in orderedColumns"
-          v-if="!column.hide"
-          :key="index"
-          :data-index="index"
-          :style="`width: ${column.width}px;`"
-          :class="{
-              column: true,
-              render: isRenderer(column),
-            }"
-        >
+        </li><li
+        v-for="(column, index) in orderedColumns"
+        v-if="!column.hide"
+        :key="index"
+        :data-index="index"
+        :style="`width: ${column.width}px;`"
+        :class="{
+            column: true,
+            render: isRenderer(column),
+          }"
+      >
           <span
             v-if="isFiltering &&
             filterList[column.field] &&
@@ -70,7 +69,7 @@
           />
         </li>
         <li
-          :style="`width: ${hasVerticalScrollBar ? scrollWidth : 0}px;`"
+          :style="`width: ${(hasVerticalScrollBar && hasHorizontalScrollBar) ? scrollWidth : 0}px;`"
           class="column-dummy"
         />
       </ul>
@@ -345,19 +344,6 @@ export default {
      * @param {number} index - 컬럼 인덱스
      * @returns {boolean} 마지막 컬럼 유무
      */
-    isLastColumn(index) {
-      const columns = this.orderedColumns;
-      let lastIndex = -1;
-
-      for (let ix = columns.length - 1; ix >= 0; ix--) {
-        if (!columns[ix].hide) {
-          lastIndex = ix;
-          break;
-        }
-      }
-
-      return lastIndex === index;
-    },
     /**
      * 전달받은 필드명과 일치하는 컬럼 인덱스를 반환한다.
      *


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
- 컬럼 너비 확장 시 다음 컬럼이 최소 너비 이상인 경우에만 확장
- 마지막 컬럼에 대한 확장 제한
- 각 컬럼 너비 조정 시 그리드 전체 너비를 유지하는 제약사항이 있어 이에 대한 사용성 편의 개선
## 어떻게 해결했나요?
- 다음 컬럼의 너비와 상관 없이 마우스 move 지점까지 확장되도록 수정
- 마지막 컬럼도 확장 가능하며 그리드 영역 밖으로의 영역까지 확장되도록 수정 (추후 3.0 에도 반영 예정)
## 확인 방법
- 각 컬럼의 우측 border 에 마우스 눌러 이동하며 리사이즈하여 확인
- 다음 컬럼의 너비와 그리드 전체너비에 상관없이 자유롭게 확장 가능한지 확인
- 마지막 컬럼도 리사이즈 가능한지 확인
## 첨부
  | Before | After  |
  | ------ | ------ |
  | ![2 0_grid_resize_before](https://github.com/ex-em/EVUI/assets/61657275/fa02d46a-9191-47b0-9b78-5cc599ff9c11) | ![2 0_grid_resize](https://github.com/ex-em/EVUI/assets/61657275/5c227b94-361b-4f96-82b2-c576301e3fe3) |
## 관련 링크
- #1243 