### PR TITLE
[#1562] Grid > Improved column resize function

### DIFF
--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -309,7 +309,6 @@ export const resizeEvent = (params) => {
     const minWidth = isRenderer(stores.orderedColumns[columnIndex])
       ? resizeInfo.rendererMinWidth : resizeInfo.minWidth;
     const columnRect = columnEl.getBoundingClientRect();
-    const maxRight = bodyEl.getBoundingClientRect().right - headerLeft;
     const resizeLineEl = elementInfo.resizeLine;
     const minLeft = columnRect.left - headerLeft + minWidth;
     const startLeft = columnRect.right - headerLeft;
@@ -324,9 +323,7 @@ export const resizeEvent = (params) => {
     const handleMouseMove = (evt) => {
       const deltaLeft = evt.clientX - startMouseLeft;
       const proxyLeft = startLeft + deltaLeft;
-      let resizeWidth = Math.max(minLeft, proxyLeft);
-
-      resizeWidth = Math.min(maxRight, resizeWidth);
+      const resizeWidth = Math.max(minLeft, proxyLeft);
 
       resizeLineEl.style.left = `${resizeWidth}px`;
     };


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
- 각 컬럼 너비 조정 시 그리드 전체 너비까지만 확장가능한 제약사항이 있어 이에 대한 사용성 편의 개선
## 어떻게 해결했나요?
- 그리드 영역 밖으로의 영역까지 확장되도록 수정
## 확인 방법
- 각 컬럼의 우측 border 에 마우스 눌러 이동하며 리사이즈하여 확인
- 그리드 전체너비에 상관없이 자유롭게 확장 가능한지 확인
## 첨부
  | Before | After  |
  |------ | ------ |
  |![resize_before](https://github.com/ex-em/EVUI/assets/61657275/2bd19dd4-843e-40c7-8f09-b5d2d39f8f57) | ![resize_after](https://github.com/ex-em/EVUI/assets/61657275/97f6e0e1-a469-4b97-b553-c433fe495218)|
## 관련 링크
- #1243 
- #1562