### PR TITLE
[#1565] EVUI > Chart > CustomTooltip 화면 벗어나는 버그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.26",
+  "version": "3.4.27",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -574,6 +574,7 @@ const modules = {
       return;
     }
 
+    this.tooltipDOM.style.display = 'block';
     const contentsWidth = customTooltipEl.offsetWidth;
     const contentsHeight = customTooltipEl.offsetHeight;
 
@@ -595,8 +596,6 @@ const modules = {
     this.tooltipDOM.style.top = expectedPosY > maximumPosY
       ? `${reversedPosY}px`
       : `${expectedPosY}px`;
-
-    this.tooltipDOM.style.display = 'block';
   },
 
   /**


### PR DESCRIPTION
이슈
-
chart > customtooltip width가 0으로 위치를 제대로 잡지 못해 화면을 벗어남

![chart_tooltip](https://github.com/ex-em/EVUI/assets/75718910/1c2aed9e-af7f-4321-bb5e-8256500f129f)

작업 내용
-
위치를 잡기 전에 display=block으로 tooltip의 offsetWidth잡고 위치를 잡을 수 있도록 코드 위치 변경