### PR TITLE
[#1569] Chart > Scatter Chart > Real Time Scatter > realTimeScatter.use를 끄고 킬 수 있게 수정 필요

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.27",
+  "version": "3.4.28",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -263,6 +263,16 @@
         }
       });
 
+      watch(() => props.options.realTimeScatter?.use, (use) => {
+        evChart.options.realTimeScatter.use = use ?? false;
+
+        evChart.update({
+          updateSeries: true,
+          updateSelTip: { update: false, keepDomain: false },
+          updateData: false,
+        });
+      });
+
       onMounted(async () => {
         if (injectEvChartPropsInGroup?.value) {
           injectEvChartPropsInGroup.value.push(props);


### PR DESCRIPTION
# 이슈
![scatter_period_before](https://github.com/ex-em/EVUI/assets/22311883/94cf5441-772b-457e-ae57-78e28d94d6bf)  
- 실시간 데이터가 아닌 지난 데이터의 특정 구간을 표현하기 위하여 realTimeScatter.use를 끄고 킬 수 있어야 함.


# 해결
![scatter_period_after](https://github.com/ex-em/EVUI/assets/22311883/670ffcfa-0e52-472f-b59c-63cea53ec5af)  
- realTImeScatter를 끄고 킬 수 있게 하기 위해 Chart.vue에 watch 추가
- 끄고 킬 때마다 realTimeScatter의 데이터를 리셋 해줘야합니다.