### PR TITLE
[#1573] 일반 scatter => realTimeScatter로 변경 시 위 이미지와 같은 에러 발생.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.28",
+  "version": "3.4.29",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -764,6 +764,9 @@ class EvChart {
     }
 
     if (this.options.realTimeScatter?.use) {
+      if (!this.dataSet) {
+        this.dataSet = {};
+      }
       this.createRealTimeScatterDataSet(data);
     } else {
       this.createDataSet(data, labels);


### PR DESCRIPTION
## 이슈
![스크린샷 2024-01-10 오후 6 45 44](https://github.com/ex-em/EVUI/assets/22311883/aded2e24-4bca-476d-bb61-2a7acb4857eb)
일반 scatter => realTimeScatter로 변경 시 위 이미지와 같은 에러 발생.


## 해결
- 일반 scatter => realTimeScatter로 변경 시 realTimeScatter의 초기 설정 dataSet을 못찾아서 발생하는 오류.  
   update시에 dataSet이 존재하지 않는다면 dataSet 초기화