### PR TITLE
[#1575] Chart > Scatter Chart > Real Time Scatter 시리즈 그리는 순서 변경 필요

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.29",
+  "version": "3.4.30",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -253,7 +253,7 @@
 
       watch(() => props.realTimeScatterReset, (flag) => {
         if (flag) {
-          Object.keys(evChart.dataSet).forEach((series) => {
+          Object.keys(evChart.dataSet ?? {}).forEach((series) => {
             if (evChart.dataSet[series]) {
               evChart.dataSet[series].dataGroup = [];
             }

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -246,7 +246,7 @@ class EvChart {
       const chartTypeSet = this.seriesInfo.charts[chartType];
 
       for (let jx = 0; jx < chartTypeSet.length; jx++) {
-        const series = this.seriesList[chartTypeSet[jx]];
+        let series = this.seriesList[chartTypeSet[jx]];
 
         switch (chartType) {
           case 'line': {
@@ -325,6 +325,10 @@ class EvChart {
               } else {
                 selectInfo = null;
               }
+            }
+
+            if (this.options.realTimeScatter?.use) {
+              series = this.seriesList[chartTypeSet[chartTypeSet.length - 1 - jx]];
             }
 
             series.draw({

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -328,7 +328,7 @@ class EvChart {
             }
 
             if (this.options.realTimeScatter?.use) {
-              series = this.seriesList[chartTypeSet[chartTypeSet.length - 1 - jx]];
+              series = this.seriesList[chartTypeSet.at(-1 - jx)];
             }
 
             series.draw({


### PR DESCRIPTION
## 이슈
![scatter_bug](https://github.com/ex-em/EVUI/assets/22311883/695317e0-6336-49ad-afc9-6439581b4431)  
- scatter <=> realTimeScatter 전환 시 내부 로직의 차이로 인한 표현의 차이가 있음.
    - 기본 scatter는 중복 처리가 안되어 있음. => 이미 그려진 좌표도 덮어서 또 그리는 방식.
    - realTimeScatter는 극한의 성능 때문에 이미 그려진 좌표를 그려지지 않게 처리하였음.
    - 그 결과 기본 scatter는 마지막 시리즈가 표현되는 반면, realTimeScatter는 첫번째 시리즈가 표현됨.

## 해결
![scatter_fix](https://github.com/ex-em/EVUI/assets/22311883/1f79ed0a-595b-422a-b3b1-71b6818d3352)

- realTimeScatter일 경우 series를 reverse