### PR TITLE
[#1579] Chart > Tooltip > label font color, series color shape 옵션 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -298,6 +298,8 @@ const chartData = {
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
+| fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -252,6 +252,8 @@ const chartData =
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
+| fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/lineChart/example/Tooltip.vue
+++ b/docs/views/lineChart/example/Tooltip.vue
@@ -87,15 +87,45 @@
       <div class="row">
         <div class="row-item">
           <span class="item-title">
-            글자 색상
-          </span>
-          <ev-text-field v-model="fontColor"/>
-        </div>
-        <div class="row-item">
-          <span class="item-title">
             배경 색상
           </span>
           <ev-text-field v-model="backgroundColor"/>
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            series color 모양
+          </span>
+          <ev-select
+              v-model="colorShape"
+              :items="colorShapeList"
+          />
+        </div>
+      </div>
+
+      <div class="row">
+        <h3> Font Color </h3>
+      </div>
+
+      <div class="row">
+        <div class="row-item">
+          <span class="item-title">
+            Title
+          </span>
+          <ev-text-field v-model="titleFontColor"/>
+        </div>
+
+        <div class="row-item">
+          <span class="item-title">
+            Label
+          </span>
+          <ev-text-field v-model="labelFontColor"/>
+        </div>
+
+        <div class="row-item">
+          <span class="item-title">
+            Value
+          </span>
+          <ev-text-field v-model="valueFontColor"/>
         </div>
       </div>
     </div>
@@ -115,8 +145,19 @@
       const useShadow = ref(false);
       const shadowOpacity = ref(0.25);
       const fontColor = ref('#000000');
-      const backgroundColor = ref('rgb(210, 234, 227, 0.7)');
+      const backgroundColor = ref('rgb(210, 234, 227, 1)');
       const textOverflow = ref('wrap');
+      const colorShape = ref('rect');
+      const colorShapeList = [{
+        name: 'rect (Default)',
+        value: 'rect',
+      }, {
+        name: 'circle',
+        value: 'circle',
+      }];
+      const titleFontColor = ref('#005CB5');
+      const labelFontColor = ref('#FF8C40');
+      const valueFontColor = ref('#FF00FF');
 
       const chartData = reactive({
         series: {
@@ -195,7 +236,6 @@
           use: true,
           sortByValue,
           backgroundColor,
-          fontColor,
           shadowOpacity,
           useShadow,
           useScrollbar,
@@ -205,6 +245,12 @@
           formatter: {
             title: ({ x }) => dayjs(x).format('YYYY-MM-DD HH:mm:ss'),
             value: ({ y }) => `${y.toFixed(2)}`,
+          },
+          colorShape,
+          fontColor: {
+            title: titleFontColor,
+            label: labelFontColor,
+            value: valueFontColor,
           },
         },
       });
@@ -237,6 +283,11 @@
         fontColor,
         backgroundColor,
         textOverflow,
+        colorShape,
+        colorShapeList,
+        titleFontColor,
+        labelFontColor,
+        valueFontColor,
       };
     },
   };

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -126,6 +126,8 @@ const chartData =
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
+| fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -199,23 +199,25 @@ const chartData =
 * PC버전에서는 drag, Mobile에서는 touch로 선택 영역을 지정할 수 있습니다.
 
 #### tooltip
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| use | Boolean | false | tooltip 표시 여부 | true /false |
-| backgroundColor | Hex, RGB, RGBA Code(String) | '#4C4C4C' | tooltip 배경 색상  | |
-| borderColor | Hex, RGB, RGBA Code(String) | '#666666' | tooltip 테두리 색상  | |
-| useShadow | Boolean | false | 그림자 사용 여부  | |
-| shadowOpacity | Number | 0.25 | 그림자 투명도  | |
-| throttledMove | Boolean | false | 데이터 조회 Throttling 처리 유무  | |
-| debouncedHide | Boolean | false | 좌표 이동 시 tooltip hide 여부  | |
-| sortByValue | Boolean | true | 값을 기준으로 정렬할지의 여부  | |
-| useScrollbar | Boolean | false | 스크롤바 사용 여부  | |
-| maxHeight | Number |  | 툴팁의 최대 높이  | |
-| maxWidth | Number |  | 툴팁의 최대 너비  | |
-| textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
-| fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
-| showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
-| formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
+| 이름                  | 타입                          | 디폴트       | 설명                                   | 종류(예시)                                                              |
+|---------------------|-----------------------------|-----------|--------------------------------------|---------------------------------------------------------------------|
+| use                 | Boolean                     | false     | tooltip 표시 여부                        | true /false                                                         |
+| backgroundColor     | Hex, RGB, RGBA Code(String) | '#4C4C4C' | tooltip 배경 색상                        |                                                                     |
+| borderColor         | Hex, RGB, RGBA Code(String) | '#666666' | tooltip 테두리 색상                       |                                                                     |
+| useShadow           | Boolean                     | false     | 그림자 사용 여부                            |                                                                     |
+| shadowOpacity       | Number                      | 0.25      | 그림자 투명도                              |                                                                     |
+| throttledMove       | Boolean                     | false     | 데이터 조회 Throttling 처리 유무              |                                                                     |
+| debouncedHide       | Boolean                     | false     | 좌표 이동 시 tooltip hide 여부              |                                                                     |
+| sortByValue         | Boolean                     | true      | 값을 기준으로 정렬할지의 여부                     |                                                                     |
+| useScrollbar        | Boolean                     | false     | 스크롤바 사용 여부                           |                                                                     |
+| maxHeight           | Number                      |           | 툴팁의 최대 높이                            |                                                                     |
+| maxWidth            | Number                      |           | 툴팁의 최대 너비                            |                                                                     |
+| textOverflow        | String                      | 'wrap'    | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis'                                                  |
+| fontFamily          | String                      | 'Roboto'  | 툴팁에 표시될 폰트                           | 'Roboto', 'serif'                                                   |
+| fontColor           | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러                        | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
+| showAllValueInRange | Boolean                     | false     | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
+| formatter           | function / Object           | null      | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용      | (아래 코드 참고)                                                          |
 ```
 const chartOptions = {
     tooltip: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.30",
+  "version": "3.4.31",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.31",
+  "version": "3.4.30",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -170,6 +170,24 @@ const modules = {
   },
 
   /**
+   * Draw series color shape
+   * @param {object} context    tooltip canvas context
+   * @param {string} shape  // 'circle' | 'rect' (default)
+   * @param {object} centerPosition  // {x: number, y: number}
+   */
+  drawSeriesColorShape(context, shape, centerPosition) {
+    const { x, y } = centerPosition;
+
+    if (shape === 'circle') {
+      context.beginPath();
+      context.arc(x - 2, y - 4, 6, 0, 2 * Math.PI);
+      context.fill();
+    } else {
+      context.fillRect(x - 4, y - 12, 12, 12);
+    }
+  },
+
+  /**
    * Draw tooltip canvas
    * @param {object} hitInfo    mousemove callback
    * @param {object} context    tooltip canvas context
@@ -279,13 +297,7 @@ const modules = {
       }
 
       // 1. Draw series color
-      if (opt.colorShape === 'circle') {
-        ctx.beginPath();
-        ctx.arc(itemX - 2, itemY - 4, 6, 0, 2 * Math.PI);
-        ctx.fill();
-      } else {
-        ctx.fillRect(itemX - 4, itemY - 12, 12, 12);
-      }
+      this.drawSeriesColorShape(ctx, opt.colorShape, { x: itemX, y: itemY });
 
       // 2. Draw series name
       ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
@@ -421,16 +433,10 @@ const modules = {
     }
 
     // 1. Draw value color
-    if (opt.colorShape === 'circle') {
-      ctx.beginPath();
-      ctx.arc(itemX - 2, itemY - 4, 6, 0, 2 * Math.PI);
-      ctx.fill();
-    } else {
-      ctx.fillRect(itemX - 4, itemY - 12, 12, 12);
-    }
-    ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
+    this.drawSeriesColorShape(ctx, opt.colorShape, { x: itemX, y: itemY });
 
     // 2. Draw value y names
+    ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
     ctx.textBaseline = 'Bottom';
     if (this.axesY.length) {
       ctx.fillText(this.axesY[hitAxis.y].getLabelFormat(hitItem.y), itemX + COLOR_MARGIN, itemY);
@@ -527,17 +533,10 @@ const modules = {
       }
 
       // 1. Draw series color
-      if (opt.colorShape === 'circle') {
-        ctx.beginPath();
-        ctx.arc(itemX - 2, itemY - 4, 6, 0, 2 * Math.PI);
-        ctx.fill();
-      } else {
-        ctx.fillRect(itemX - 4, itemY - 12, 12, 12);
-      }
-
-      ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
+      this.drawSeriesColorShape(ctx, opt.colorShape, { x: itemX, y: itemY });
 
       // 2. Draw series name
+      ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
       ctx.textBaseline = 'Bottom';
       const seriesNameSpaceWidth = opt.maxWidth - Math.round(ctx.measureText(maxValue).width)
         - boxPadding.l - boxPadding.r - COLOR_MARGIN - VALUE_MARGIN;

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -3,8 +3,8 @@ import debounce from '@/common/utils.debounce';
 import Canvas from '../helpers/helpers.canvas';
 import Util from '../helpers/helpers.util';
 
-const TITLE_HEIGHT = 30;
-const TEXT_HEIGHT = 14;
+const TITLE_HEIGHT = 35;
+const TEXT_HEIGHT = 20;
 const LINE_SPACING = 8;
 const COLOR_MARGIN = 16;
 const VALUE_MARGIN = 50;
@@ -77,7 +77,7 @@ const modules = {
     const [maxSeries, maxValue] = hitInfo.maxTip;
     const seriesKeys = Object.keys(items);
     const seriesLen = seriesKeys.length;
-    const boxPadding = { t: 8, b: 8, r: 20, l: 16 };
+    const boxPadding = { t: 10, b: 4, r: 20, l: 16 };
     const opt = this.options.tooltip;
 
 
@@ -279,10 +279,16 @@ const modules = {
       }
 
       // 1. Draw series color
-      ctx.fillRect(itemX - 4, itemY - 12, 12, 12);
-      ctx.fillStyle = opt.fontColor;
+      if (opt.colorShape === 'circle') {
+        ctx.beginPath();
+        ctx.arc(itemX - 2, itemY - 4, 6, 0, 2 * Math.PI);
+        ctx.fill();
+      } else {
+        ctx.fillRect(itemX - 4, itemY - 12, 12, 12);
+      }
 
       // 2. Draw series name
+      ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
       ctx.textBaseline = 'Bottom';
       const seriesNameSpaceWidth = opt.maxWidth - Math.round(ctx.measureText(maxValue).width)
         - boxPadding.l - boxPadding.r - COLOR_MARGIN - VALUE_MARGIN;
@@ -317,6 +323,7 @@ const modules = {
       ctx.save();
 
       // 3. Draw value
+      ctx.fillStyle = opt.fontColor?.value ?? opt.fontColor;
       ctx.textAlign = 'right';
       ctx.fillText(valueText, this.tooltipDOM.offsetWidth - boxPadding.r, itemY);
       ctx.restore();
@@ -414,8 +421,14 @@ const modules = {
     }
 
     // 1. Draw value color
-    ctx.fillRect(itemX - 4, itemY - 12, 12, 12);
-    ctx.fillStyle = opt.fontColor;
+    if (opt.colorShape === 'circle') {
+      ctx.beginPath();
+      ctx.arc(itemX - 2, itemY - 4, 6, 0, 2 * Math.PI);
+      ctx.fill();
+    } else {
+      ctx.fillRect(itemX - 4, itemY - 12, 12, 12);
+    }
+    ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
 
     // 2. Draw value y names
     ctx.textBaseline = 'Bottom';
@@ -514,8 +527,15 @@ const modules = {
       }
 
       // 1. Draw series color
-      ctx.fillRect(itemX - 4, itemY - 12, 12, 12);
-      ctx.fillStyle = opt.fontColor;
+      if (opt.colorShape === 'circle') {
+        ctx.beginPath();
+        ctx.arc(itemX - 2, itemY - 4, 6, 0, 2 * Math.PI);
+        ctx.fill();
+      } else {
+        ctx.fillRect(itemX - 4, itemY - 12, 12, 12);
+      }
+
+      ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
 
       // 2. Draw series name
       ctx.textBaseline = 'Bottom';
@@ -626,7 +646,7 @@ const modules = {
       this.tooltipDOM.style.overflowY = 'hidden';
       this.tooltipDOM.style.backgroundColor = opt.backgroundColor;
       this.tooltipDOM.style.border = `1px solid ${opt.borderColor}`;
-      this.tooltipDOM.style.color = opt.fontColor;
+      this.tooltipDOM.style.color = opt.fontColor?.title ?? opt.fontColor;
     }
   },
 
@@ -638,7 +658,7 @@ const modules = {
     this.tooltipDOM.style.overflowY = 'hidden';
     this.tooltipDOM.style.backgroundColor = tooltipOptions.backgroundColor;
     this.tooltipDOM.style.border = `1px solid ${tooltipOptions.borderColor}`;
-    this.tooltipDOM.style.color = tooltipOptions.fontColor;
+    this.tooltipDOM.style.color = tooltipOptions.fontColor?.title ?? tooltipOptions.fontColor;
 
     if (tooltipOptions.useShadow) {
       const shadowColor = `rgba(0, 0, 0, ${tooltipOptions.shadowOpacity})`;

--- a/src/components/chart/style/chart.scss
+++ b/src/components/chart/style/chart.scss
@@ -304,7 +304,7 @@
   border-radius: 8px;
 
   .ev-chart-tooltip-header {
-    padding: 8px 16px 0 16px;
+    padding: 16px 16px 0 16px;
     overflow: hidden;
     font-size: 16px;
 

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -100,6 +100,7 @@ const DEFAULT_OPTIONS = {
     useScrollbar: false,
     textOverflow: 'wrap',
     fontFamily: 'Roboto',
+    colorShape: 'rect',
   },
   indicator: {
     use: true,


### PR DESCRIPTION
# 요구사항 
- title, label, value 영역 각각 다르게 폰트 컬러 지정 가능 필요
   - 기존에는 fontColor 옵션으로 title, label, value 일괄 적용
   - ![image](https://github.com/ex-em/EVUI/assets/53548023/dc5487d0-9c50-4f3d-a262-8bfb8fc63355)

- series color shape 를 변경할 수 있는 옵션 필요

# 결과 
- ![image](https://github.com/ex-em/EVUI/assets/53548023/ee7ff4d9-a7c2-4fde-971b-8e1a7afb3b8e)


# 기타 
- padding 값 일부 조정
- 줄 높이 확대
