### PR TITLE
[#1583] Chart > Tooltip > FontSize 조정 관련 옵션 추가 

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -196,6 +196,7 @@ const chartData = {
 | fontFamily | String | 'Roboto' | 폰트 | |
 | fitWidth | Boolean | false | Label Text Ellipsis 처리 | |
 | fitDir | String | 'right' | Ellipsis 방향 | ( right => 'aaa...', left => '...aaa') |
+| padding |  Number | 0 | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0 |
 
 ##### title
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -298,6 +298,9 @@ const chartData = {
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
+| fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
+| colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -252,6 +252,9 @@ const chartData =
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
+| fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
+| colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -149,6 +149,7 @@ const chartData =
 | fontFamily | String | 'Roboto' | 폰트 | |
 | fitWidth | Boolean | false | Label Text Ellipsis 처리 | |
 | fitDir | String | 'right' | Ellipsis 방향 | ( right => 'aaa...', left => '...aaa') |
+| padding |  Number | 0 | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0 |
 
 ##### title
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/lineChart/example/Tooltip.vue
+++ b/docs/views/lineChart/example/Tooltip.vue
@@ -87,15 +87,74 @@
       <div class="row">
         <div class="row-item">
           <span class="item-title">
-            글자 색상
-          </span>
-          <ev-text-field v-model="fontColor"/>
-        </div>
-        <div class="row-item">
-          <span class="item-title">
             배경 색상
           </span>
           <ev-text-field v-model="backgroundColor"/>
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            series color 모양
+          </span>
+          <ev-select
+              v-model="colorShape"
+              :items="colorShapeList"
+          />
+        </div>
+      </div>
+
+      <div class="row">
+        <h3> Font Color </h3>
+      </div>
+
+      <div class="row">
+        <div class="row-item">
+          <span class="item-title">
+            Title
+          </span>
+          <ev-text-field v-model="titleFontColor"/>
+        </div>
+
+        <div class="row-item">
+          <span class="item-title">
+            Label
+          </span>
+          <ev-text-field v-model="labelFontColor"/>
+        </div>
+
+        <div class="row-item">
+          <span class="item-title">
+            Value
+          </span>
+          <ev-text-field v-model="valueFontColor"/>
+        </div>
+      </div>
+
+      <div class="row">
+        <h3> Font Size </h3>
+      </div>
+
+      <div class="row">
+        <div class="row-item">
+          <span class="item-title">
+            title
+          </span>
+          <ev-input-number
+              v-model="titleFontSize"
+              :step="1"
+              :min="10"
+              :max="50"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            contents
+          </span>
+          <ev-input-number
+              v-model="contentsFontSize"
+              :step="1"
+              :min="10"
+              :max="50"
+          />
         </div>
       </div>
     </div>
@@ -115,8 +174,21 @@
       const useShadow = ref(false);
       const shadowOpacity = ref(0.25);
       const fontColor = ref('#000000');
-      const backgroundColor = ref('rgb(210, 234, 227, 0.7)');
+      const backgroundColor = ref('rgb(210, 234, 227, 1)');
       const textOverflow = ref('wrap');
+      const colorShape = ref('rect');
+      const colorShapeList = [{
+        name: 'rect (Default)',
+        value: 'rect',
+      }, {
+        name: 'circle',
+        value: 'circle',
+      }];
+      const titleFontColor = ref('#005CB5');
+      const labelFontColor = ref('#FF8C40');
+      const valueFontColor = ref('#FF00FF');
+      const titleFontSize = ref(16);
+      const contentsFontSize = ref(14);
 
       const chartData = reactive({
         series: {
@@ -195,7 +267,6 @@
           use: true,
           sortByValue,
           backgroundColor,
-          fontColor,
           shadowOpacity,
           useShadow,
           useScrollbar,
@@ -205,6 +276,16 @@
           formatter: {
             title: ({ x }) => dayjs(x).format('YYYY-MM-DD HH:mm:ss'),
             value: ({ y }) => `${y.toFixed(2)}`,
+          },
+          colorShape,
+          fontColor: {
+            title: titleFontColor,
+            label: labelFontColor,
+            value: valueFontColor,
+          },
+          fontSize: {
+            title: titleFontSize,
+            contents: contentsFontSize,
           },
         },
       });
@@ -237,6 +318,13 @@
         fontColor,
         backgroundColor,
         textOverflow,
+        colorShape,
+        colorShapeList,
+        titleFontColor,
+        labelFontColor,
+        valueFontColor,
+        titleFontSize,
+        contentsFontSize,
       };
     },
   };

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -126,6 +126,9 @@ const chartData =
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
+| fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
+| colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -199,23 +199,26 @@ const chartData =
 * PC버전에서는 drag, Mobile에서는 touch로 선택 영역을 지정할 수 있습니다.
 
 #### tooltip
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| use | Boolean | false | tooltip 표시 여부 | true /false |
-| backgroundColor | Hex, RGB, RGBA Code(String) | '#4C4C4C' | tooltip 배경 색상  | |
-| borderColor | Hex, RGB, RGBA Code(String) | '#666666' | tooltip 테두리 색상  | |
-| useShadow | Boolean | false | 그림자 사용 여부  | |
-| shadowOpacity | Number | 0.25 | 그림자 투명도  | |
-| throttledMove | Boolean | false | 데이터 조회 Throttling 처리 유무  | |
-| debouncedHide | Boolean | false | 좌표 이동 시 tooltip hide 여부  | |
-| sortByValue | Boolean | true | 값을 기준으로 정렬할지의 여부  | |
-| useScrollbar | Boolean | false | 스크롤바 사용 여부  | |
-| maxHeight | Number |  | 툴팁의 최대 높이  | |
-| maxWidth | Number |  | 툴팁의 최대 너비  | |
-| textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
-| fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
-| showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
-| formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
+| 이름                  | 타입                          | 디폴트       | 설명                                   | 종류(예시)                                                              |
+|---------------------|-----------------------------|-----------|--------------------------------------|---------------------------------------------------------------------|
+| use                 | Boolean                     | false     | tooltip 표시 여부                        | true /false                                                         |
+| backgroundColor     | Hex, RGB, RGBA Code(String) | '#4C4C4C' | tooltip 배경 색상                        |                                                                     |
+| borderColor         | Hex, RGB, RGBA Code(String) | '#666666' | tooltip 테두리 색상                       |                                                                     |
+| useShadow           | Boolean                     | false     | 그림자 사용 여부                            |                                                                     |
+| shadowOpacity       | Number                      | 0.25      | 그림자 투명도                              |                                                                     |
+| throttledMove       | Boolean                     | false     | 데이터 조회 Throttling 처리 유무              |                                                                     |
+| debouncedHide       | Boolean                     | false     | 좌표 이동 시 tooltip hide 여부              |                                                                     |
+| sortByValue         | Boolean                     | true      | 값을 기준으로 정렬할지의 여부                     |                                                                     |
+| useScrollbar        | Boolean                     | false     | 스크롤바 사용 여부                           |                                                                     |
+| maxHeight           | Number                      |           | 툴팁의 최대 높이                            |                                                                     |
+| maxWidth            | Number                      |           | 툴팁의 최대 너비                            |                                                                     |
+| textOverflow        | String                      | 'wrap'    | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis'                                                  |
+| fontFamily          | String                      | 'Roboto'  | 툴팁에 표시될 폰트                           | 'Roboto', 'serif'                                                   |
+| fontColor           | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러                        | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
+| colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
+| showAllValueInRange | Boolean                     | false     | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
+| formatter           | function / Object           | null      | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용      | (아래 코드 참고)                                                          |
 ```
 const chartOptions = {
     tooltip: {

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -118,6 +118,7 @@ const chartData =
 | fontFamily | String | 'Roboto' | 폰트 | |
 | fitWidth | Boolean | false | Label Text Ellipsis 처리 | |
 | fitDir | String | 'right' | Ellipsis 방향 | ( right => 'aaa...', left => '...aaa') |
+| padding |  Number | 0 | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0 |
 
 ##### title
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/src/components/chart/style/chart.scss
+++ b/src/components/chart/style/chart.scss
@@ -304,9 +304,8 @@
   border-radius: 8px;
 
   .ev-chart-tooltip-header {
-    padding: 8px 16px 0 16px;
+    padding: 12px 16px 3px 16px;
     overflow: hidden;
-    font-size: 16px;
 
     &--wrap {
       word-wrap: break-word;

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -100,6 +100,11 @@ const DEFAULT_OPTIONS = {
     useScrollbar: false,
     textOverflow: 'wrap',
     fontFamily: 'Roboto',
+    colorShape: 'rect',
+    fontSize: {
+      title: 16,
+      contents: 14,
+    },
   },
   indicator: {
     use: true,


### PR DESCRIPTION
### 요구사항 
- Tooltip에 표시되는 font size조정 가능한 옵션 

### 결과
![tooltip_font_size](https://github.com/ex-em/EVUI/assets/53548023/e05b7ec8-c1a8-4d70-82c3-52175880e282)


### 기타 
- Tooltip header 관련 padding Bottom 값 조정
   - Before
   - ![image](https://github.com/ex-em/EVUI/assets/53548023/40d4b9c0-7721-44e2-951b-e5e623299e56)
   - After
   - ![image](https://github.com/ex-em/EVUI/assets/53548023/24f03383-a98e-4465-8a5c-ad2a04e4f500)
