### PR TITLE
[#1585] Chart > Pie > Tooltip > Tooltip Header 영역 표시 미필요

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.30",
+  "version": "3.4.31",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -219,6 +219,9 @@ const modules = {
           ? this.axesY[hitAxis.y].getLabelFormat(hitItem.y)
           : this.axesX[hitAxis.x].getLabelFormat(hitItem.x);
       }
+    } else {
+      // Pie Chart
+      this.tooltipHeaderDOM.style.display = 'none';
     }
 
     if (opt.textOverflow) {


### PR DESCRIPTION
### 이슈 내용
- #1580 에서 header의 padding사이즈를 조정함에 따라 pie Chart Tooltip Header 부분이 도드라져 보임
- ![image](https://github.com/ex-em/EVUI/assets/53548023/d2d38396-756b-4bc3-861a-fcd1e10d60c8)


### 해결
- tooltip header(title)영역에 표시할 data가 없을 경우 (예시, pie) tooltipHeaderDOM 안보이게 처리
- ![image](https://github.com/ex-em/EVUI/assets/53548023/bbda104f-691a-4847-91e0-8d8bdf8c2b8b)

### 기타 
- version update 3.4.31
