### PR TITLE
[#1589] Chart > tooltip > Row Padding 옵션 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -302,6 +302,7 @@ const chartData = {
 | fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
 | fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
 | colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
+ | rowPadding | Object | { top: 0, bottom: 8, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값 | |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -197,6 +197,10 @@ const chartData =
 | maxWidth | Number |  | 툴팁의 최대 너비  | |
 | textOverflow | String | 'wrap' | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis |
 | fontFamily | String | 'Roboto' | 툴팁에 표시될 폰트  | 'Roboto', 'serif |
+| fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
+| colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
+| rowPadding | Object | { top: 0, bottom: 8, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값 | |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -256,6 +256,7 @@ const chartData =
 | fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
 | fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
 | colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
+| rowPadding | Object | { top: 0, bottom: 8, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값 | |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/docs/views/lineChart/example/Tooltip.vue
+++ b/docs/views/lineChart/example/Tooltip.vue
@@ -157,6 +157,35 @@
           />
         </div>
       </div>
+
+      <div class="row">
+        <h3> Row Padding </h3>
+      </div>
+
+      <div class="row">
+        <div class="row-item">
+          <span class="item-title">
+            left
+          </span>
+          <ev-input-number
+            v-model="leftPadding"
+            :step="1"
+            :min="0"
+            :max="50"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            right
+          </span>
+          <ev-input-number
+            v-model="rightPadding"
+            :step="1"
+            :min="0"
+            :max="50"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -189,6 +218,8 @@
       const valueFontColor = ref('#FF00FF');
       const titleFontSize = ref(16);
       const contentsFontSize = ref(14);
+      const leftPadding = ref(16);
+      const rightPadding = ref(20);
 
       const chartData = reactive({
         series: {
@@ -287,6 +318,10 @@
             title: titleFontSize,
             contents: contentsFontSize,
           },
+          rowPadding: {
+            left: leftPadding,
+            right: rightPadding,
+          }
         },
       });
 
@@ -325,6 +360,8 @@
         valueFontColor,
         titleFontSize,
         contentsFontSize,
+        leftPadding,
+        rightPadding,
       };
     },
   };

--- a/docs/views/lineChart/example/Tooltip.vue
+++ b/docs/views/lineChart/example/Tooltip.vue
@@ -185,6 +185,28 @@
             :max="50"
           />
         </div>
+        <div class="row-item">
+          <span class="item-title">
+            top
+          </span>
+          <ev-input-number
+              v-model="topPadding"
+              :step="1"
+              :min="0"
+              :max="50"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            bottom
+          </span>
+          <ev-input-number
+              v-model="bottomPadding"
+              :step="1"
+              :min="0"
+              :max="50"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -220,6 +242,8 @@
       const contentsFontSize = ref(14);
       const leftPadding = ref(16);
       const rightPadding = ref(20);
+      const topPadding = ref(0);
+      const bottomPadding = ref(8);
 
       const chartData = reactive({
         series: {
@@ -321,7 +345,9 @@
           rowPadding: {
             left: leftPadding,
             right: rightPadding,
-          }
+            top: topPadding,
+            bottom: bottomPadding,
+          },
         },
       });
 
@@ -362,6 +388,8 @@
         contentsFontSize,
         leftPadding,
         rightPadding,
+        topPadding,
+        bottomPadding,
       };
     },
   };

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -129,6 +129,7 @@ const chartData =
 | fontColor | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
 | fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
 | colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
+| rowPadding | Object | { top: 0, bottom: 8, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값 | |
 | showAllValueInRange | Boolean | false | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter | function / Object | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (아래 코드 참고) |
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.31",
+  "version": "3.4.32",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -69,6 +69,22 @@ const modules = {
     return (this.options?.tooltip?.fontSize?.contents ?? 14) + 2;
   },
 
+  getBoxPadding() {
+    const {
+      top = 0,
+      right = 20,
+      bottom = 8,
+      left = 16,
+    } = this.options?.tooltip?.rowPadding ?? {};
+
+    return {
+      t: top,
+      l: left,
+      b: bottom,
+      r: right,
+    };
+  },
+
   /**
    * Set tooltip DOM's position and style
    * @param {object} hitInfo    value and mouse position touched
@@ -84,7 +100,7 @@ const modules = {
     const [maxSeries, maxValue] = hitInfo.maxTip;
     const seriesKeys = Object.keys(items);
     const seriesLen = seriesKeys.length;
-    const boxPadding = { t: 0, b: 8, r: 20, l: 16 };
+    const boxPadding = this.getBoxPadding();
     const opt = this.options.tooltip;
     const seriesColorMarginRight = this.getColorMargin();
 
@@ -214,7 +230,7 @@ const modules = {
     const hitAxis = items[sId].axis;
     const [, maxValue] = hitInfo.maxTip;
     const seriesKeys = this.alignSeriesList(Object.keys(items));
-    const boxPadding = { t: 0, b: 8, r: 20, l: 16 };
+    const boxPadding = this.getBoxPadding();
     const isHorizontal = this.options.horizontal;
     const opt = this.options.tooltip;
     const titleFormatter = opt.formatter?.title;
@@ -380,7 +396,7 @@ const modules = {
     const hitItem = items[sId].data;
     const hitAxis = items[sId].axis;
     const hitColor = items[sId].color;
-    const boxPadding = { t: 0, b: 8, r: 20, l: 16 };
+    const boxPadding = this.getBoxPadding();
     const isHorizontal = this.options.horizontal;
     const opt = this.options.tooltip;
     const titleFormatter = opt.formatter?.title;
@@ -480,7 +496,7 @@ const modules = {
     const items = hitInfo.items;
     const [, maxValue] = hitInfo.maxTip;
     const seriesKeys = this.alignSeriesList(Object.keys(items));
-    const boxPadding = { t: 0, b: 8, r: 8, l: 8 };
+    const boxPadding = this.getBoxPadding();
     const opt = this.options.tooltip;
     const textHeight = this.getTextHeight();
     const seriesColorMarginRight = this.getColorMargin();

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -105,6 +105,12 @@ const DEFAULT_OPTIONS = {
       title: 16,
       contents: 14,
     },
+    rowPadding: {
+      top: 0,
+      bottom: 8,
+      right: 20,
+      left: 16,
+    },
   },
   indicator: {
     use: true,


### PR DESCRIPTION
### 요구사항 
![image](https://github.com/ex-em/EVUI/assets/53548023/b1d5a376-4ef6-48bc-bee2-2b3250faeda8)
- Tooltip의 Series 표현하는 Row의 padding값 조절하는 옵션 필요 

#### 해결
- 사용자가 Tooltip의 Row Padding사이즈를 조절 할 수 있도록 로직 추가
![tooltip_padding](https://github.com/ex-em/EVUI/assets/53548023/d5510c31-b0b3-4f62-b419-3cc08788768b)
