### PR TITLE
[#1594] Grid > header context menu 숨김/노출 여부 관련 옵션 추가

### DIFF
--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -56,6 +56,11 @@
 |  |  | highlight | 지정한 row에 Highlight 효과를 설정한다. | `rowIndex` |
 |  | customContextMenu | [] | 우클릭시 보여지는 컨텍스트 메뉴를 설정한다. |  |
 |  |  | menuItems | 컨텍스트 메뉴 |  |
+|  | hiddenColumnMenuItem | {} | 그리드 헤더 클릭시 보여지는 컨텍스트 메뉴 각 아이템의 표시 여부를 설정한다. (`true`: 숨김 / `false`: 노출 / Default: `false`) |  |
+|  |  | ascending | 오름차순 정렬 | Boolean |
+|  |  | descending | 내림차순 정렬 | Boolean |
+|  |  | filter | 필터 기능 | Boolean |
+|  |  | hide | 컬럼 숨김 | Boolean |
 |  | page | {} | 페이지 설정 |  |
 |  |  | use | 페이지 사용 여부 | Boolean |
 |  |  | isInfinite | Infinite Scroll 사용 여부 | Boolean |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.32",
+  "version": "3.4.33",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -801,6 +801,7 @@ export default {
       contextMenuItems: [],
       columnMenu: null,
       columnMenuItems: [],
+      hiddenColumnMenuItem: props.option.hiddenColumnMenuItem || {},
       customContextMenu: props.option.customContextMenu || [],
       gridSettingMenu: null,
       gridSettingContextMenuItems: [],

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1025,21 +1025,19 @@ export const contextMenuEvent = (params) => {
       const sortable = column.sortable === undefined ? true : column.sortable;
       const filterable = filterInfo.isFiltering
       && column.filterable === undefined ? true : column.filterable;
-      if (!sortable && !filterable) {
-        contextInfo.columnMenuItems = [];
-        return;
-      }
-      contextInfo.columnMenuItems = [
+      const columnMenuItems = [
         {
           text: 'Ascending',
           iconClass: 'ev-icon-allow2-up',
           disabled: !sortable,
+          hidden: contextInfo.hiddenColumnMenuItem?.ascending,
           click: () => onSort(column, 'asc'),
         },
         {
           text: 'Descending',
           iconClass: 'ev-icon-allow2-down',
           disabled: !sortable,
+          hidden: contextInfo.hiddenColumnMenuItem?.descending,
           click: () => onSort(column, 'desc'),
         },
         {
@@ -1062,14 +1060,25 @@ export const contextMenuEvent = (params) => {
             filterInfo.filteringColumn = column;
           },
           disabled: !filterable,
+          hidden: contextInfo.hiddenColumnMenuItem?.filter,
         },
         {
           text: 'Hide',
           iconClass: 'ev-icon-visibility-off',
           disabled: !useGridSetting.value || stores.orderedColumns.length === 1,
+          hidden: contextInfo.hiddenColumnMenuItem?.hide,
           click: () => setColumnHidden(column.field),
         },
       ];
+      contextInfo.columnMenuItems = [];
+      if (!sortable && !filterable) {
+        return;
+      }
+      columnMenuItems.forEach((item) => {
+        if (!item.hidden) {
+          contextInfo.columnMenuItems.push(item);
+        }
+      });
     }
   };
   /**

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1074,11 +1074,7 @@ export const contextMenuEvent = (params) => {
       if (!sortable && !filterable) {
         return;
       }
-      columnMenuItems.forEach((item) => {
-        if (!item.hidden) {
-          contextInfo.columnMenuItems.push(item);
-        }
-      });
+      contextInfo.columnMenuItems = columnMenuItems.filter(item => !item.hidden);
     }
   };
   /**


### PR DESCRIPTION
# 이슈
- 그리드 헤더 컬럼 메뉴의 특정 아이템을 숨김 처리 해야하는 기획 요청 사항

# 작업 내용
- 각 item 별로 숨김/노출 여부를 결정하는 객체 형태의 hiddenColumnMenuItem 옵션 추가

# 사용 방법
- 헤더 컬럼 메뉴에서 숨기고자 하는 아이템이 있을 경우 hiddenColumnMenuItem 옵션에 각 아이템 key 값에 대해 boolean 값 적용하여 숨김/노출 설정
- `true`이면 숨김 / `false`이면 노출 / 기본값은 `false` 로, 아무것도 설정 안할 경우 모든 메뉴 아이템 노출
![image](https://github.com/ex-em/EVUI/assets/46876380/61d4a039-5cb6-4a5e-aee8-689186cdb800)

# 스크린샷
> Before

![image](https://github.com/ex-em/EVUI/assets/46876380/9555ecf0-31d0-4072-b78b-7eee07fa2840)


> After

![image](https://github.com/ex-em/EVUI/assets/46876380/cc7f4623-6757-4f05-baaa-87d7f0ca86a7)




