### PR TITLE
[#1610] Chart > Tooltip > Html 옵션 사용시 간혈 적으로 width, height값이 0으로 계산됨

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.35",
+  "version": "3.4.36",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -633,7 +633,7 @@ const modules = {
     const mouseX = e.pageX;
     const mouseY = e.pageY;
 
-    const customTooltipEl = document.getElementsByClassName('ev-chart-tooltip-custom')?.[0];
+    const customTooltipEl = this.tooltipDOM.getElementsByClassName('ev-chart-tooltip-custom')?.[0];
     if (!customTooltipEl && !this.tooltipDOM) {
       return;
     }


### PR DESCRIPTION
### 재현 스텝 
1. 같은 화면(document) 내에 tooltip > html 옵션을 사용하는 Chart 2개이상 배치 
2. Tooltip 확인 

### 이슈 
1. 마우스 오버한 Chart의 Tooltip Position을 계산하는 과정에서 custom Tooltip DOM을 가져오는 로직이 this.tooltipDOM이 아닌 document로 되어 있어 현재 마우스 오버하지 않은 chart의 너비를 가져와 0으로 계산됨

### 변경 내용 
- 탐색 타겟 변경

### 비고 
- EVUI version (3.4.35 -> 3.4.36)