### PR TITLE
[#1612] Chart > Line Chart > 첫번째 데이터를 제외한 나머지 데이터가 null인 경우 첫번째 데이터가 그려지지 않음

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.36",
+  "version": "3.4.37",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -208,7 +208,8 @@ class Line {
           return;
         }
 
-        const isSingle = this.data[ix - 1]?.o === null && this.data[ix + 1]?.o === null;
+        const isSingle = Util.isNullOrUndefined(this.data[ix - 1]?.o)
+          && Util.isNullOrUndefined(this.data[ix + 1]?.o);
         const isSelectedLabel = selectedLabelIndexList.includes(ix);
         if (this.point || isSingle || isSelectedLabel) {
           ctx.fillStyle = isSelectedLabel && !legendHitInfo ? focusStyle : blurStyle;

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -358,4 +358,13 @@ export default {
     template.innerHTML = htmlString.trim();
     return template.content.firstChild;
   },
+
+  /**
+   * Check The value is null or undefined
+   * @param { number | undefined | null } value
+   * @returns {boolean}
+   */
+  isNullOrUndefined(value) {
+    return value === null || value === undefined;
+  },
 };


### PR DESCRIPTION
### 이슈 내용
![line_chart_issue](https://github.com/ex-em/EVUI/assets/53548023/6e1f179f-ff1d-4c5f-ac12-4976643263db)


### 이슈 원인
- 앞뒤 데이터가 null일경우 single point를 그리는데 맨 앞 데이터의 경우 앞의 데이터가 null이 아닌 undefined이기 때문에 그려지지 않았음 

### 해결
![image](https://github.com/ex-em/EVUI/assets/53548023/a9ceab3a-adc5-4de0-864d-a3f9f85c2010)


