### PR TITLE
[#1615] Grid > Column Setting > 그리드가 document 하단에 위치한 경우 column setting 영역이 가려지며 제어 불가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.37",
+  "version": "3.4.38",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/GridColumnSetting.vue
+++ b/src/components/grid/GridColumnSetting.vue
@@ -214,8 +214,11 @@ export default {
       await nextTick();
 
       const docWidth = document.documentElement.clientWidth;
+      const docHeight = document.documentElement.clientHeight;
       const columnSettingWrapperRect = columnSettingWrapper.value?.getBoundingClientRect();
       const columnSettingWidth = columnSettingWrapperRect?.width;
+      const columnSettingHeight = columnSettingWrapperRect?.height;
+
       const { top, left, columnListMenuWidth } = props.position;
       let columnSettingLeft;
 
@@ -228,8 +231,8 @@ export default {
       } else {
         columnSettingLeft = left - columnSettingWidth;
       }
-
-      columnSettingStyle.top = `${top + document.documentElement.scrollTop}px`;
+      const maximumPosY = docHeight - columnSettingHeight;
+      columnSettingStyle.top = `${Math.min(top, maximumPosY) + document.documentElement.scrollTop}px`;
       columnSettingStyle.left = `${columnSettingLeft + document.documentElement.scrollLeft}px`;
     };
 


### PR DESCRIPTION
### 이슈 내용
- ![grid_setting_position_issue](https://github.com/ex-em/EVUI/assets/53548023/b582669d-52e8-4648-a2a4-416056095e0b)
- ![image](https://github.com/ex-em/EVUI/assets/53548023/310900d4-ef81-42ec-a27b-8ed02a0601b1)
- grid Setting modal이 viewport을 넘기면서 body에 스크롤이 생기지만, 스크롤을 제어하는 순간 setting modal이 사라져 제어가 불가능한 현상 발생 


### 처리 내용 
- 그려질 gridSettingModal이 document height을 넘기지 못하도록 로직 추가 
- ![image](https://github.com/ex-em/EVUI/assets/53548023/767b7edb-aaff-45e9-8378-c9b88078aecc)
- ![image](https://github.com/ex-em/EVUI/assets/53548023/fb7838de-91e1-466a-958b-456a8404d4de)


### 기타 
- EVUI Version Update (3.4.38)

