### PR TITLE
[#1622] Grid > Column 이동 시 맨 앞으로 이동되는 현상 수정

### DIFF
--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1325,6 +1325,10 @@ export const dragEvent = ({ stores }) => {
     const oldIndex = parseInt(currentIndex, 10);
     const newPositionIndex = parseInt(droppedIndex, 10);
 
+    if (!Number.isInteger(oldIndex) || !Number.isInteger(newPositionIndex)) {
+      return;
+    }
+
     const columns = [...stores.orderedColumns];
     const movedColumn = columns[oldIndex];
 
@@ -1347,6 +1351,7 @@ export const dragEvent = ({ stores }) => {
     e.preventDefault();
     const currentIndex = e.dataTransfer.getData('text/plain');
     const droppedIndex = e.target.parentNode.dataset.index;
+
     setColumnMoving(currentIndex, droppedIndex);
   };
   return {


### PR DESCRIPTION
# 이슈

- Grid > Column 이동 시 맨 앞으로 이동되는 현상 발생

# 해결

## 작업 내용

- onDrop 이벤트에서 droppedIndex가 undefined가 넘어오는 경우 moving target 컬럼이 맨 앞으로 이동되었습니다.
- `setColumnMoving` 함수에서 인덱스 정보가 integer가 아닌 경우 return 하도록 수정하였습니다.

## 화면

[AS-IS]

![evui-grid-컬럼이동](https://github.com/ex-em/EVUI/assets/75205035/4b4c5337-a80c-45ca-aabd-f00e133664c6)

[TO-BE]

![evui-grid-컬럼이동-수정](https://github.com/ex-em/EVUI/assets/75205035/6f241315-3d08-43f2-8858-9d9d0a7b3ad7)