### PR TITLE
[#1631] Grid > Custom Sort 기능 추가

### DIFF
--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -43,6 +43,8 @@
 |  | rowHeight | 35 | row 높이를 설정한다. | `min-height: 35` |
 |  | rowMinHeight | null | row 높이를 `min-height`보다 작게 설정한다. |  |
 |  | columnWidth | 40 | 기본 컬럼 너비를 설정한다. | `min-width: 40px` |
+|  | customAscFunction | {} | 그리드 오름차순 정렬 시 사용할 커스텀 함수를 정의한다. 내림차순 정렬 함수는 자동으로 구성된다. |  |
+|  |  | `[Column Field]` | 커스텀 함수, 형태는 `Array.prototype.sort` 함수의 첫 번째 인자와 같다. | (a: any, b: any) => number |
 |  | useCheckbox | {} | 각 row별 체크박스 사용 여부 및 단일 선택이나 다중 선택을 설정한다. |  |
 |  |  | use | 체크박스 사용 여부 | Boolean |
 |  |  | mode | 단일 및 다중 선택 설정 | 'multi', 'single' |

--- a/docs/views/grid/example/Sort.vue
+++ b/docs/views/grid/example/Sort.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="case">
+    <ev-grid
+      :columns="columns"
+      :rows="tableData"
+      :height="500"
+      :option="{
+        sort: {
+          field: {
+            asc: (a, b) => {
+              return (
+                (a.split('_')[1] === null) - (b.split('_')[1] === null) ||
+                Number(b.split('_')[1]) - Number(a.split('_')[1])
+              );
+            },
+            desc: (a, b) => {
+              return (
+                (a.split('_')[1] === null) - (b.split('_')[1] === null) ||
+                Number(a.split('_')[1]) - Number(b.split('_')[1])
+              );
+            },
+          },
+          value: {
+            asc: (a, b) => {
+              return (
+                (a.split('-')[1] === null) - (b.split('-')[1] === null) ||
+                Number(b.split('-')[1]) - Number(a.split('-')[1])
+              );
+            },
+            desc: (a, b) => {
+              return (
+                (a.split('-')[1] === null) - (b.split('-')[1] === null) ||
+                Number(a.split('-')[1]) - Number(b.split('-')[1])
+              );
+            },
+          },
+        },
+      }"
+    />
+    <!-- description -->
+    <div class="description"></div>
+  </div>
+</template>
+
+<script>
+import { cloneDeep } from 'lodash-es';
+import { ref } from 'vue';
+
+const arr = Array.from({ length: 50 }, () => [
+  `field_${Math.round(Math.random() * 10000)}`,
+  `value-${Math.round(Math.random() * 10000)}`,
+]);
+
+export default {
+  setup() {
+    const tableData = ref(cloneDeep(arr));
+    const columns = ref([
+      { caption: 'Field', field: 'field', type: 'string', width: 200 },
+      { caption: 'Value', field: 'value', type: 'string', width: 200 },
+    ]);
+
+    return {
+      tableData,
+      columns,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.description {
+  min-width: 200px;
+}
+.form-rows {
+  display: flex;
+  margin-bottom: 5px;
+}
+.form-row {
+  width: 50%;
+}
+.ev-text-field,
+.ev-input-number,
+.ev-select {
+  width: 80%;
+}
+.badge {
+  margin-bottom: 2px;
+  margin-right: 5px !important;
+}
+.ev-toggle {
+  margin-right: 10px;
+}
+</style>

--- a/docs/views/grid/example/Sort.vue
+++ b/docs/views/grid/example/Sort.vue
@@ -10,13 +10,13 @@
             asc: (a, b) => {
               return (
                 (a.split('_')[1] === null) - (b.split('_')[1] === null) ||
-                Number(b.split('_')[1]) - Number(a.split('_')[1])
+                Number(a.split('_')[1]) - Number(b.split('_')[1])
               );
             },
             desc: (a, b) => {
               return (
                 (a.split('_')[1] === null) - (b.split('_')[1] === null) ||
-                Number(a.split('_')[1]) - Number(b.split('_')[1])
+                Number(b.split('_')[1]) - Number(a.split('_')[1])
               );
             },
           },
@@ -24,13 +24,13 @@
             asc: (a, b) => {
               return (
                 (a.split('-')[1] === null) - (b.split('-')[1] === null) ||
-                Number(b.split('-')[1]) - Number(a.split('-')[1])
+                Number(a.split('-')[1]) - Number(b.split('-')[1])
               );
             },
             desc: (a, b) => {
               return (
                 (a.split('-')[1] === null) - (b.split('-')[1] === null) ||
-                Number(a.split('-')[1]) - Number(b.split('-')[1])
+                Number(b.split('-')[1]) - Number(a.split('-')[1])
               );
             },
           },

--- a/docs/views/grid/example/Sort.vue
+++ b/docs/views/grid/example/Sort.vue
@@ -5,45 +5,26 @@
       :rows="tableData"
       :height="500"
       :option="{
-        sort: {
-          field: {
-            asc: (a, b) => {
-              return (
-                (a.split('_')[1] === null) - (b.split('_')[1] === null) ||
-                Number(a.split('_')[1]) - Number(b.split('_')[1])
-              );
-            },
-            desc: (a, b) => {
-              return (
-                (a.split('_')[1] === null) - (b.split('_')[1] === null) ||
-                Number(b.split('_')[1]) - Number(a.split('_')[1])
-              );
-            },
+        customAscFunction: {
+          field: (a, b) => {
+            return (
+              (a.split('_')[1] === null) - (b.split('_')[1] === null) ||
+              Number(a.split('_')[1]) - Number(b.split('_')[1])
+            );
           },
-          value: {
-            asc: (a, b) => {
-              return (
-                (a.split('-')[1] === null) - (b.split('-')[1] === null) ||
-                Number(a.split('-')[1]) - Number(b.split('-')[1])
-              );
-            },
-            desc: (a, b) => {
-              return (
-                (a.split('-')[1] === null) - (b.split('-')[1] === null) ||
-                Number(b.split('-')[1]) - Number(a.split('-')[1])
-              );
-            },
+          value: (a, b) => {
+            return (
+              (a.split('-')[1] === null) - (b.split('-')[1] === null) ||
+               Number(a.split('-')[1]) - Number(b.split('-')[1])
+             );
           },
         },
       }"
     />
-    <!-- description -->
-    <div class="description"></div>
   </div>
 </template>
 
 <script>
-import { cloneDeep } from 'lodash-es';
 import { ref } from 'vue';
 
 const arr = Array.from({ length: 50 }, () => [
@@ -53,7 +34,7 @@ const arr = Array.from({ length: 50 }, () => [
 
 export default {
   setup() {
-    const tableData = ref(cloneDeep(arr));
+    const tableData = ref(arr);
     const columns = ref([
       { caption: 'Field', field: 'field', type: 'string', width: 200 },
       { caption: 'Value', field: 'value', type: 'string', width: 200 },

--- a/docs/views/grid/props.js
+++ b/docs/views/grid/props.js
@@ -10,6 +10,8 @@ import Summary from './example/Summary';
 import SummaryRaw from '!!raw-loader!./example/Summary';
 import RowDetail from './example/RowDetail.vue';
 import RowDetailRaw from '!!raw-loader!./example/RowDetail.vue';
+import Sort from './example/Sort.vue';
+import SortRaw from '!!raw-loader!./example/Sort.vue';
 
 export default {
   mdText,
@@ -34,6 +36,10 @@ export default {
     RowDetail: {
       component: RowDetail,
       parsedData: parseComponent(RowDetailRaw),
+    },
+    Sort: {
+      component: Sort,
+      parsedData: parseComponent(SortRaw),
     },
   },
 };

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -804,7 +804,7 @@ export default {
       sortField: '',
       sortOrder: '',
       sortColumn: {},
-      sortFunction: props.option.sort ?? {},
+      sortFunction: props.option.customAscFunction ?? {},
     });
     const contextInfo = reactive({
       menu: null,

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -804,6 +804,7 @@ export default {
       sortField: '',
       sortOrder: '',
       sortColumn: {},
+      sortFunction: props.option.sort ?? {},
     });
     const contextInfo = reactive({
       menu: null,

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -625,6 +625,9 @@ export const sortEvent = (params) => {
    * 설정값에 따라 해당 컬럼 데이터에 대해 정렬한다.
    */
   const setSort = () => {
+    const { field, index } = sortInfo.sortColumn;
+    const customSetDesc = sortInfo.sortFunction?.[field]?.desc ?? null;
+    const customSetAsc = sortInfo.sortFunction?.[field]?.asc ?? null;
     const setDesc = (a, b) => (a > b ? -1 : 1);
     const setAsc = (a, b) => (a < b ? -1 : 1);
     const numberSetDesc = (a, b) => ((a === null) - (b === null) || Number(b) - Number(a));
@@ -638,8 +641,8 @@ export const sortEvent = (params) => {
       });
       return;
     }
-    const index = sortInfo.sortColumn.index;
     const type = sortInfo.sortColumn.type || 'string';
+    const customSortFn = sortInfo.sortOrder === 'desc' ? customSetDesc : customSetAsc;
     const sortFn = sortInfo.sortOrder === 'desc' ? setDesc : setAsc;
     const numberSortFn = sortInfo.sortOrder === 'desc' ? numberSetDesc : numberSetAsc;
     const getColumnValue = (a, b) => {
@@ -651,6 +654,14 @@ export const sortEvent = (params) => {
       }
       return { aCol, bCol };
     };
+
+    if (customSortFn) {
+      stores.store.sort((a, b) => {
+        const { aCol, bCol } = getColumnValue(a, b);
+        return customSortFn(aCol, bCol);
+      });
+      return;
+    }
     switch (type) {
       case 'string':
         stores.store.sort((a, b) => {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -626,8 +626,7 @@ export const sortEvent = (params) => {
    */
   const setSort = () => {
     const { field, index } = sortInfo.sortColumn;
-    const customSetDesc = sortInfo.sortFunction?.[field]?.desc ?? null;
-    const customSetAsc = sortInfo.sortFunction?.[field]?.asc ?? null;
+    const customSetAsc = sortInfo.sortFunction?.[field] ?? null;
     const setDesc = (a, b) => (a > b ? -1 : 1);
     const setAsc = (a, b) => (a < b ? -1 : 1);
     const numberSetDesc = (a, b) => ((a === null) - (b === null) || Number(b) - Number(a));
@@ -642,7 +641,6 @@ export const sortEvent = (params) => {
       return;
     }
     const type = sortInfo.sortColumn.type || 'string';
-    const customSortFn = sortInfo.sortOrder === 'desc' ? customSetDesc : customSetAsc;
     const sortFn = sortInfo.sortOrder === 'desc' ? setDesc : setAsc;
     const numberSortFn = sortInfo.sortOrder === 'desc' ? numberSetDesc : numberSetAsc;
     const getColumnValue = (a, b) => {
@@ -655,10 +653,11 @@ export const sortEvent = (params) => {
       return { aCol, bCol };
     };
 
-    if (customSortFn) {
+    if (customSetAsc) {
       stores.store.sort((a, b) => {
         const { aCol, bCol } = getColumnValue(a, b);
-        return customSortFn(aCol, bCol);
+        const compareAscReturn = customSetAsc(aCol, bCol);
+        return sortInfo.sortOrder === 'desc' ? -compareAscReturn : compareAscReturn;
       });
       return;
     }


### PR DESCRIPTION
## 이슈

- 문자열과 숫자가 섞인 값이 존재할 경우, 해당 컬럼은 문자열 기준으로 정렬됩니다
- 이 부분에 대해서 숫자 기준으로 정렬하고자 하는 요청이 들어와서, 외부에서 정렬 기준을 주입할 수 있도록 하였습니다

## 해결
![Mar-07-2024 18-37-39](https://github.com/ex-em/EVUI/assets/37893979/b85eaadb-31a0-4072-a833-451ca5f08604)

- sortInfo 에 sortFunction 옵션을 추가하였습니다
- props 로 다음과 같이 함수를 추가하면 동작합니다

```js
option: {
  sort: {
    [fieldName]: { // 컬럼 필드명
      asc: (a, b) => {}, // 오름차순 함수
      desc: (a, b) => {}, // 내림차순 함수
    }
  }
}
// 함수는 number 반환, Array.prototype.sort() 함수의 첫 번째 인자로 들어가는 형태
```

- 문서에 예제를 추가하였습니다