### PR TITLE
[#1633] Grid > Column 옵션 emit 이벤트 추가

### DIFF
--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -110,14 +110,17 @@
 | summaryData | Array | Summary 할 대상 추가 시 summaryRenderer 와 함께 사용 | ex) '{0}({1}%)' | N |
 
 ### Event
-| 이름 | 파라미터 | 설명 |
- | ---- | ------- | ---- |
- | check-row | event, row, index | row의 체크박스가 체크 되었을때 호출된다. |
- | check-all | event, rows | 헤더의 체크박스가 체크 되었을때 호출 된다. 전체 row의 체크박스를 체크한다. |
- | click-row | event, row | row가 클릭 되었을 때 호출된다. |
- | dblclick-row | event, row | row가 더블 클릭 되었을 때 호출된다. |
- | page-change | event | page 정보가 변경되었을 때 호출된다. |
- | sort-column | event | column을 기준으로 정렬이 변경되었을 때 호출된다. |
- | expand-row | event, row, isExpand, index | row가 확장되었을 때 호출된다. |
- | update:expanded | rows | row가 확장되었을 때 호출된다. |
- | resize:column | column | column의 width가 resize 됐을때 호출된다. |
+| 이름 | 파라미터                        | 설명                                                                  |
+ | ---- |-----------------------------|---------------------------------------------------------------------|
+ | check-row | event, row, index           | row의 체크박스가 체크 되었을때 호출된다.                                            |
+ | check-all | event, rows                 | 헤더의 체크박스가 체크 되었을때 호출 된다. 전체 row의 체크박스를 체크한다.                        |
+ | click-row | event, row                  | row가 클릭 되었을 때 호출된다.                                                 |
+ | dblclick-row | event, row                  | row가 더블 클릭 되었을 때 호출된다.                                              |
+ | page-change | event                       | page 정보가 변경되었을 때 호출된다.                                              |
+ | sort-column | event                       | column을 기준으로 정렬이 변경되었을 때 호출된다.                                      |
+ | expand-row | event, row, isExpand, index | row가 확장되었을 때 호출된다.                                                  |
+ | update:expanded | rows                        | row가 확장되었을 때 호출된다.                                                  |
+ | resize:column | column                      | column의 width가 resize 됐을때 호출된다.                                     |
+ | resize-column | column, columns             | column의 width가 resize 됐을때 호출된다.                                     |
+ | change-column-order | column, columns             | column의 위치가 변경되었을 때 호출된다.                                           |
+ | change-column-status | columns             | column의 상태(column Show/Hide)가 변경되었을 때 호출된다. |

--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -120,7 +120,6 @@
  | sort-column | event                       | column을 기준으로 정렬이 변경되었을 때 호출된다.                                      |
  | expand-row | event, row, isExpand, index | row가 확장되었을 때 호출된다.                                                  |
  | update:expanded | rows                        | row가 확장되었을 때 호출된다.                                                  |
- | resize:column | column                      | column의 width가 resize 됐을때 호출된다.                                     |
  | resize-column | column, columns             | column의 width가 resize 됐을때 호출된다.                                     |
  | change-column-order | column, columns             | column의 위치가 변경되었을 때 호출된다.                                           |
  | change-column-status | columns             | column의 상태(column Show/Hide)가 변경되었을 때 호출된다. |

--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -43,6 +43,8 @@
 |  | rowHeight | 35 | row 높이를 설정한다. | `min-height: 35` |
 |  | rowMinHeight | null | row 높이를 `min-height`보다 작게 설정한다. |  |
 |  | columnWidth | 40 | 기본 컬럼 너비를 설정한다. | `min-width: 40px` |
+|  | customAscFunction | {} | 그리드 오름차순 정렬 시 사용할 커스텀 함수를 정의한다. 내림차순 정렬 함수는 자동으로 구성된다. |  |
+|  |  | `[Column Field]` | 커스텀 함수, 형태는 `Array.prototype.sort` 함수의 첫 번째 인자와 같다. | (a: any, b: any) => number |
 |  | useCheckbox | {} | 각 row별 체크박스 사용 여부 및 단일 선택이나 다중 선택을 설정한다. |  |
 |  |  | use | 체크박스 사용 여부 | Boolean |
 |  |  | mode | 단일 및 다중 선택 설정 | 'multi', 'single' |

--- a/docs/views/grid/example/ColumnEvent.vue
+++ b/docs/views/grid/example/ColumnEvent.vue
@@ -1,0 +1,151 @@
+<template>
+  <div class="case">
+    <ev-grid
+      :columns="columns"
+      :rows="tableData"
+      :width="widthMV"
+      :height="heightMV"
+      :option="{
+        adjust: true,
+        useGridSetting: {
+          use: true,
+        },
+      }"
+      @resize-column="onResizeColumn"
+      @change-column-order="onChangeColumnOrder"
+      @change-column-status="onChangeColumnStatus"
+    />
+    <!-- description -->
+    <div class="description column-event-description">
+      <div class="form-rows">
+        <div class="form-row">
+          <span class="badge yellow">
+            Resize Column Width
+          </span>
+          <ev-text-field
+            v-model="columnEventsInfo.resize"
+            class="custom-text-area"
+            type="textarea"
+            readonly
+          />
+        </div>
+        <div class="form-row">
+          <span class="badge yellow">
+            Change Column Position
+          </span>
+          <ev-text-field
+            v-model="columnEventsInfo.order"
+            class="custom-text-area"
+            type="textarea"
+            readonly
+          />
+        </div>
+      </div>
+      <div class="form-rows">
+        <div class="form-row">
+          <span class="badge yellow">
+            Grid Column Setting(Column Show/Hide Status)
+          </span>
+          <ev-text-field
+            v-model="columnEventsInfo.status"
+            class="custom-text-area"
+            type="textarea"
+            readonly
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const tableData = ref([]);
+    const widthMV = ref('100%');
+    const heightMV = ref(300);
+    const columns = ref([
+      { caption: 'A Column', field: 'aColumn', type: 'string' },
+      { caption: 'B Column', field: 'bColumn', type: 'string' },
+      { caption: 'C Column', field: 'cColumn', type: 'string' },
+      { caption: 'D Column', field: 'dColumn', type: 'string', hiddenDisplay: true },
+      { caption: 'E Column', field: 'eColumn', type: 'string' },
+    ]);
+    const columnEventsInfo = ref({
+      resize: '',
+      order: '',
+      status: '',
+    });
+    const getData = (count, startIndex) => {
+      const temp = [];
+      for (let ix = startIndex; ix < startIndex + count; ix++) {
+        temp.push([
+          `A Column Data_${ix}`,
+          `B Column Data_${ix + 1}`,
+          `C Column Data_${ix + 2}`,
+          `D Column Data_${ix + 3}`,
+          `E Column Data_${ix + 4}`,
+        ]);
+      }
+      return temp;
+    };
+
+    tableData.value = getData(10, 0);
+
+    const onResizeColumn = (columnInfo) => {
+      columnEventsInfo.value.resize = JSON.stringify(columnInfo, null, 2);
+    };
+    const onChangeColumnOrder = (columnInfo) => {
+      columnEventsInfo.value.order = JSON.stringify(columnInfo, null, 2);
+    };
+    const onChangeColumnStatus = (columnInfo) => {
+      columnEventsInfo.value.status = JSON.stringify(columnInfo, null, 2);
+    };
+
+    return {
+      columns,
+      tableData,
+      widthMV,
+      heightMV,
+      columnEventsInfo,
+      onResizeColumn,
+      onChangeColumnOrder,
+      onChangeColumnStatus,
+    };
+  },
+};
+</script>
+
+<style lang="scss">
+.description {
+  .form-rows {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+  }
+
+  .form-row {
+    width: 50%;
+  }
+
+  .badge {
+    margin-bottom: 2px;
+    margin-right: 5px !important;
+  }
+}
+
+.column-event-description {
+  min-width: 200px;
+  min-height: 300px;
+
+  .custom-text-area {
+    width: 100% !important;
+  }
+
+  .ev-textarea {
+    height: 200px !important;
+  }
+}
+</style>

--- a/docs/views/grid/example/RowDetail.vue
+++ b/docs/views/grid/example/RowDetail.vue
@@ -13,7 +13,7 @@
         }
       }"
       @expand-row="onExpandRow"
-      @resize:column="onResizeColumn"
+      @resize-column="onResizeColumn"
     >
       <template #rowDetail="{ item }">
         <row-detail-content
@@ -102,8 +102,8 @@ export default {
       });
       expandedRowText.value = result;
     };
-    const onResizeColumn = (column) => {
-      console.log('[onResizeColumn]', column);
+    const onResizeColumn = (columnInfo) => {
+      console.log('[onResizeColumn]', columnInfo);
     };
 
     pushData();

--- a/docs/views/grid/example/Sort.vue
+++ b/docs/views/grid/example/Sort.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="case">
+    <ev-grid
+      :columns="columns"
+      :rows="tableData"
+      :height="500"
+      :option="{
+        customAscFunction: {
+          field: (a, b) => {
+            return (
+              (a.split('_')[1] === null) - (b.split('_')[1] === null) ||
+              Number(a.split('_')[1]) - Number(b.split('_')[1])
+            );
+          },
+          value: (a, b) => {
+            return (
+              (a.split('-')[1] === null) - (b.split('-')[1] === null) ||
+               Number(a.split('-')[1]) - Number(b.split('-')[1])
+             );
+          },
+        },
+      }"
+    />
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+const arr = Array.from({ length: 50 }, () => [
+  `field_${Math.round(Math.random() * 10000)}`,
+  `value-${Math.round(Math.random() * 10000)}`,
+]);
+
+export default {
+  setup() {
+    const tableData = ref(arr);
+    const columns = ref([
+      { caption: 'Field', field: 'field', type: 'string', width: 200 },
+      { caption: 'Value', field: 'value', type: 'string', width: 200 },
+    ]);
+
+    return {
+      tableData,
+      columns,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.description {
+  min-width: 200px;
+}
+.form-rows {
+  display: flex;
+  margin-bottom: 5px;
+}
+.form-row {
+  width: 50%;
+}
+.ev-text-field,
+.ev-input-number,
+.ev-select {
+  width: 80%;
+}
+.badge {
+  margin-bottom: 2px;
+  margin-right: 5px !important;
+}
+.ev-toggle {
+  margin-right: 10px;
+}
+</style>

--- a/docs/views/grid/props.js
+++ b/docs/views/grid/props.js
@@ -10,6 +10,8 @@ import Summary from './example/Summary';
 import SummaryRaw from '!!raw-loader!./example/Summary';
 import RowDetail from './example/RowDetail.vue';
 import RowDetailRaw from '!!raw-loader!./example/RowDetail.vue';
+import Sort from './example/Sort.vue';
+import SortRaw from '!!raw-loader!./example/Sort.vue';
 
 export default {
   mdText,
@@ -34,6 +36,10 @@ export default {
     RowDetail: {
       component: RowDetail,
       parsedData: parseComponent(RowDetailRaw),
+    },
+    Sort: {
+      component: Sort,
+      parsedData: parseComponent(SortRaw),
     },
   },
 };

--- a/docs/views/grid/props.js
+++ b/docs/views/grid/props.js
@@ -12,6 +12,8 @@ import RowDetail from './example/RowDetail.vue';
 import RowDetailRaw from '!!raw-loader!./example/RowDetail.vue';
 import Sort from './example/Sort.vue';
 import SortRaw from '!!raw-loader!./example/Sort.vue';
+import ColumnEvent from './example/ColumnEvent.vue';
+import ColumnEventRaw from '!!raw-loader!./example/ColumnEvent.vue';
 
 export default {
   mdText,
@@ -40,6 +42,10 @@ export default {
     Sort: {
       component: Sort,
       parsedData: parseComponent(SortRaw),
+    },
+    ColumnEvent: {
+      component: ColumnEvent,
+      parsedData: parseComponent(ColumnEventRaw),
     },
   },
 };

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -67,6 +67,7 @@ const selectedSeries = ref({
   | pointFill | Hex, RGB, RGBA Code(String) | COLOR[index] | 점(Point) 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용         |                                                                                   |
   | pointStyle | String                      | 'circle' | 점(Point) 모양                                                         | 'triangle', 'rect', 'rectRounded', 'rectRot', 'cross', 'crossRot', 'star', 'line' |
   | showLegend | Boolean                     | true | legend 표시 여부                                                        |                                                                                   |
+  | passingValue | number                      | null            | data가 passingValue와 같을 경우 (data: null/undefined 제외 ) 다음값으로 선을 이어가며 point도 그리지 않고 tooltip에 나오지 않음 | -1                                                                                |
   
 #### data example
 ```

--- a/docs/views/lineChart/example/PassingValue.vue
+++ b/docs/views/lineChart/example/PassingValue.vue
@@ -1,0 +1,292 @@
+<template>
+  <div class="case">
+    <ev-chart
+      :data="chartData"
+      :options="chartOptions"
+    />
+    <div class="description">
+      <div class="section">
+        <div class="section-body section-body--row">
+          <h3 class="section-title">chart Type</h3>
+          <div class="section-item">
+            <ev-select
+              v-model="chartType"
+              :items="chartTypeList"
+              @change="onChangeChartType"
+            />
+          </div>
+        </div>
+
+        <div
+            v-if="chartData?.series?.series2?.show"
+            class="section-body"
+        >
+          <h3 class="section-title--series2">chart Data - series 2</h3>
+          <div class="section-item">
+            <template
+                v-for="(data, jx) in chartDataForExample2"
+                :key="`series2-${jx}`"
+            >
+              <div class="column">
+                <label>{{ new Date(chartData.labels[jx]).getDate() }}</label>
+                <ev-input-number
+                    v-model="data.value"
+                    :disabled="data.isNull || data.isPassing"
+                    :step="1"
+                    @change="changeValue"
+                />
+                <p>Null</p>
+                <ev-toggle v-model="data.isNull" />
+                <p>Passing</p>
+                <ev-toggle v-model="data.isPassing" />
+              </div>
+            </template>
+          </div>
+        </div>
+
+        <div class="section-body">
+          <h3 class="section-title--series1">chart Data - series 1</h3>
+          <div class="section-item">
+            <template
+              v-for="(data, ix) in chartDataForExample1"
+              :key="`series2-${ix}`"
+            >
+              <div class="column">
+                <label>{{ new Date(chartData.labels[ix]).getDate() }}</label>
+                <ev-input-number
+                  v-model="data.value"
+                  :disabled="data.isNull || data.isPassing"
+                  :step="1"
+                  @change="changeValue"
+                />
+                <p>Null</p>
+                <ev-toggle v-model="data.isNull" />
+                <p>Passing</p>
+                <ev-toggle v-model="data.isPassing" />
+              </div>
+            </template>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { reactive, ref, watch } from 'vue';
+  import dayjs from 'dayjs';
+import EvInputNumber from '../../../../src/components/inputNumber/InputNumber';
+
+  export default {
+    components: { EvInputNumber },
+    setup() {
+      const chartDataForExample1 = ref([
+        { value: 17, isNull: false, isPassing: false },
+        { value: 20, isNull: false, isPassing: true },
+        { value: 5, isNull: false, isPassing: false },
+        { value: 30, isNull: false, isPassing: true },
+        { value: 10, isNull: false, isPassing: false },
+        { value: 18, isNull: false, isPassing: false },
+        { value: 10, isNull: false, isPassing: false },
+      ]);
+
+      const chartDataForExample2 = ref([
+        { value: 4, isNull: false, isPassing: false },
+        { value: 20, isNull: false, isPassing: true },
+        { value: 10, isNull: false, isPassing: true },
+        { value: 5, isNull: false, isPassing: false },
+        { value: 10, isNull: false, isPassing: false },
+        { value: 15, isNull: false, isPassing: true },
+        { value: 10, isNull: false, isPassing: false },
+      ]);
+
+      const time = dayjs().format('YYYY-MM-DD HH:mm:ss');
+
+      const chartData = reactive({
+        series: {
+          series1: { name: 'series#1', passingValue: -1, fill: false },
+          series2: { name: 'series#1', passingValue: -1, show: false, fill: false },
+        },
+        labels: [
+          dayjs(time),
+          dayjs(time).add(1, 'day'),
+          dayjs(time).add(2, 'day'),
+          dayjs(time).add(3, 'day'),
+          dayjs(time).add(4, 'day'),
+          dayjs(time).add(5, 'day'),
+          dayjs(time).add(6, 'day'),
+          dayjs(time).add(7, 'day'),
+          dayjs(time).add(8, 'day'),
+          dayjs(time).add(9, 'day'),
+          dayjs(time).add(10, 'day'),
+        ],
+        data: {
+          series1: [],
+          series2: [],
+        },
+      });
+
+      const chartType = ref('line');
+      const chartTypeList = [{
+        name: 'Line',
+        value: 'line',
+      }, {
+        name: 'Stack Line',
+        value: 'stackLine',
+      }, {
+        name: 'Area',
+        value: 'area',
+      }, {
+        name: 'Stack Area',
+        value: 'stackArea',
+      }];
+
+      const changeValue = () => {
+        chartData.data.series1 = [];
+        chartData.data.series2 = [];
+
+        chartDataForExample1?.value?.forEach((item) => {
+          let value = item.value;
+          if (item.isNull) {
+            value = null;
+          } else if (item.isPassing) {
+            value = -1;
+          }
+
+          chartData.data.series1.push(value);
+        });
+
+        chartDataForExample2?.value?.forEach((item) => {
+          let value = item.value;
+          if (item.isNull) {
+            value = null;
+          } else if (item.isPassing) {
+            value = -1;
+          }
+
+          chartData.data.series2.push(value);
+        });
+      };
+
+      watch([chartDataForExample1, chartDataForExample2, chartType], changeValue, { deep: true });
+
+      const chartOptions = reactive({
+        type: 'line',
+        width: '100%',
+        height: '300px',
+        title: {
+          text: 'Chart Title',
+          show: true,
+        },
+        legend: {
+          show: false,
+        },
+        axesX: [{
+          type: 'time',
+          timeFormat: 'D',
+          interval: 'day',
+        }],
+        axesY: [{
+          type: 'linear',
+          showGrid: true,
+          startToZero: true,
+          interval: 10,
+        }],
+      });
+
+      const onChangeChartType = () => {
+        switch (chartType.value) {
+          case 'line': {
+            chartData.series.series1.show = true;
+            chartData.series.series1.fill = false;
+            chartData.series.series2.show = false;
+            chartData.series.series2.fill = false;
+            chartData.groups = [];
+            break;
+          }
+
+          case 'stackLine': {
+            chartData.series.series1.show = true;
+            chartData.series.series1.fill = false;
+            chartData.series.series2.show = true;
+            chartData.series.series2.fill = false;
+            chartData.groups = [['series1', 'series2']];
+            break;
+          }
+
+          case 'area': {
+            chartData.series.series1.show = true;
+            chartData.series.series1.fill = true;
+            chartData.series.series2.show = false;
+            chartData.series.series2.fill = false;
+            chartData.groups = [];
+            break;
+          }
+
+          case 'stackArea': {
+            chartData.series.series1.show = true;
+            chartData.series.series1.fill = true;
+            chartData.series.series2.show = true;
+            chartData.series.series2.fill = true;
+            chartData.groups = [['series1', 'series2']];
+            break;
+          }
+
+          default: {
+            break;
+          }
+        }
+      };
+
+      return {
+        chartData,
+        chartOptions,
+        changeValue,
+        chartType,
+        chartTypeList,
+        onChangeChartType,
+        chartDataForExample1,
+        chartDataForExample2,
+      };
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  .section {
+    width: 100%;
+
+    &-title {
+      padding: 10px;
+
+      &--series1 {
+        padding: 10px;
+        background-color: #2B99F0;
+      }
+
+      &--series2 {
+        padding: 10px;
+        background-color: #8AC449;
+      }
+    }
+
+    &-body {
+      display: flex;
+      padding: 0 0 10px 10px;
+      flex-direction: row;
+      flex-wrap: wrap;
+
+      .section-item {
+        display: flex;
+        width: 100%;
+        flex-direction: row;
+        justify-content: stretch;
+        margin-top: 10px;
+
+        .ev-text-field, .ev-input-number, .ev-select {
+          width: auto;
+        }
+      }
+    }
+  }
+</style>

--- a/docs/views/lineChart/props.js
+++ b/docs/views/lineChart/props.js
@@ -22,6 +22,8 @@ import SelectSeries from './example/SelectSeries';
 import SelectSeriesRaw from '!!raw-loader!./example/SelectSeries';
 import AxisTitle from './example/AxisTitle';
 import AxisTitleRaw from '!!raw-loader!./example/AxisTitle';
+import PassingValue from './example/PassingValue';
+import PassingValueRaw from '!!raw-loader!./example/PassingValue';
 
 export default {
   mdText,
@@ -80,6 +82,11 @@ export default {
       description: '차트 축에 title을 설정할 수 있습니다.',
       component: AxisTitle,
       parsedData: parseComponent(AxisTitleRaw),
+    },
+    PassingValue: {
+      description: 'passingValue를 설정하여 특정 시점에 line을 끊지 않고 자연스럽게 이을 수 있습니다.',
+      component: PassingValue,
+      parsedData: parseComponent(PassingValueRaw),
     },
   },
 };

--- a/docs/views/treeGrid/api/treeGrid.md
+++ b/docs/views/treeGrid/api/treeGrid.md
@@ -121,3 +121,5 @@
 | click-row | event, row | row가 클릭 되었을 때 호출된다. |
 | dblclick-row | event, row | row가 더블 클릭 되었을 때 호출된다. |
 | page-change | event | page 정보가 변경되었을 때 호출된다. |
+| resize-column | column, columns             | column의 width가 resize 됐을때 호출된다.                                     | |
+| change-column-status | columns             | column의 상태(column Show/Hide)가 변경되었을 때 호출된다. |

--- a/docs/views/treeGrid/example/ColumnEvent.vue
+++ b/docs/views/treeGrid/example/ColumnEvent.vue
@@ -1,0 +1,210 @@
+<template>
+  <div class="case">
+    <p class="case-title">TreeGrid</p>
+    <ev-tree-grid
+      :columns="columns"
+      :rows="tableData"
+      :width="widthMV"
+      :height="heightMV"
+      :option="{
+        adjust: true,
+        useGridSetting: {
+          use: true,
+        },
+      }"
+      @resize-column="onResizeColumn"
+      @change-column-status="onChangeColumnStatus"
+    >
+    </ev-tree-grid>
+    <div class="description column-event-description">
+      <div class="form-rows">
+        <div class="form-row">
+          <span class="badge yellow">
+            Resize Column Width
+          </span>
+          <ev-text-field
+            v-model="columnEventsInfo.resize"
+            class="custom-text-area"
+            type="textarea"
+            readonly
+          />
+        </div>
+        <div class="form-row">
+          <span class="badge yellow">
+            Grid Column Setting(Column Show/Hide Status)
+          </span>
+          <ev-text-field
+            v-model="columnEventsInfo.status"
+            class="custom-text-area"
+            type="textarea"
+            readonly
+          />
+        </div>
+      </div>
+    </div>
+
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const tableData = ref([]);
+    const widthMV = ref('100%');
+    const heightMV = ref(300);
+    const columnEventsInfo = ref({
+      resize: '',
+      order: '',
+      status: '',
+    });
+    const getData = () => {
+      tableData.value = [
+        {
+          id: 'Exem 0',
+          date: '2016-05-01',
+          name: '1111',
+          expand: true,
+        },
+        {
+          id: 'Exem 1',
+          date: '2016-05-01',
+          name: '2222',
+          value: 123,
+          expand: true,
+          children: [{
+            id: 'Exem 2',
+            date: '2016-05-02',
+            name: '2',
+            value: 222,
+            expand: false,
+            children: [{
+              id: 'Exem 3',
+              date: '2016-05-02',
+              name: '3',
+              value: 3333,
+              uncheckable: true,
+            }, {
+              id: 'Exem 4',
+              date: '2016-05-02',
+              name: '4',
+              expand: false,
+              uncheckable: true,
+              children: [{
+                id: 'Exem 5',
+                date: '2016-05-02',
+                name: '5',
+                children: [{
+                  id: 'Exem 51',
+                  date: '2016-05-02',
+                  name: '1251',
+                  children: [{
+                    id: 'Exem 52',
+                    date: '2016-05-02',
+                    name: '20000',
+                  }],
+                }],
+              }, {
+                id: 'Exem 6',
+                date: '2016-05-02',
+                name: '6',
+              }],
+            }],
+          }, {
+            id: 'Exem 7',
+            date: '2016-05-03',
+            name: '7',
+            children: [{
+              id: 'Exem 8',
+              date: '2016-05-03',
+              name: '8',
+              value: 333,
+            }, {
+              id: 'Exem 9',
+              date: '2016-05-03',
+              name: '9',
+            }, {
+              id: 'Exem 10',
+              date: '2016-05-03',
+              name: '10',
+            }],
+          }, {
+            id: 'Exem 11',
+            date: '2016-05-04',
+            name: '11',
+          }],
+        },
+      ];
+    };
+    const columns = ref([
+      { caption: 'ID', field: 'id', type: 'number' },
+      { caption: 'Date', field: 'date', type: 'string' },
+      {
+        caption: 'Name',
+        field: 'name',
+        type: 'float',
+        summaryType: 'sum',
+        summaryOnlyTopParent: true,
+        summaryRenderer: 'Sum: {0} 최상위 부모만 summary',
+        decimal: 1,
+      },
+      {
+        caption: 'Value',
+        field: 'value',
+        type: 'number',
+        summaryType: 'sum',
+        summaryRenderer: 'Sum: {0} 모든 row summary',
+        decimal: 1,
+      },
+    ]);
+
+    const onResizeColumn = (columnInfo) => {
+      columnEventsInfo.value.resize = JSON.stringify(columnInfo, null, 2);
+    };
+    const onChangeColumnStatus = (columnInfo) => {
+      columnEventsInfo.value.status = JSON.stringify(columnInfo, null, 2);
+    };
+
+    getData();
+
+    return {
+      columns,
+      tableData,
+      widthMV,
+      heightMV,
+      columnEventsInfo,
+      onResizeColumn,
+      onChangeColumnStatus,
+    };
+  },
+};
+</script>
+
+<style lang="scss">
+.description {
+  .form-rows {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+  }
+
+  .form-row {
+    width: 50%;
+  }
+
+  .badge {
+    margin-bottom: 2px;
+    margin-right: 5px !important;
+  }
+}
+
+.column-event-description {
+  min-width: 200px;
+  min-height: 300px;
+
+  .ev-textarea {
+    height: 200px !important;
+  }
+}
+</style>

--- a/docs/views/treeGrid/props.js
+++ b/docs/views/treeGrid/props.js
@@ -6,6 +6,8 @@ import CellRenderer from './example/CellRenderer';
 import CellRendererRaw from '!!raw-loader!./example/CellRenderer';
 import Toolbar from './example/Toolbar';
 import ToolbarRaw from '!!raw-loader!./example/Toolbar';
+import ColumnEvent from './example/ColumnEvent.vue';
+import ColumnEventRaw from '!!raw-loader!./example/ColumnEvent.vue';
 
 export default {
   mdText,
@@ -22,6 +24,10 @@ export default {
     Toolbar: {
       component: Toolbar,
       parsedData: parseComponent(ToolbarRaw),
+    },
+    ColumnEvent: {
+      component: ColumnEvent,
+      parsedData: parseComponent(ColumnEventRaw),
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.39",
+  "version": "3.4.40",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -910,6 +910,9 @@ class EvChart {
     this.initScale();
     this.chartRect = this.getChartRect();
     this.drawChart();
+    if (this.dragInfoBackup) {
+      this.drawSelectionArea?.(this.dragInfoBackup);
+    }
 
     if (promiseRes) {
       promiseRes(true);

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -140,7 +140,10 @@ class Line {
         }
       }
 
-      const isNullValue = Util.isNullOrUndefined(prev.o) || Util.isNullOrUndefined(curr.o);
+      const isNullValue = Util.isNullOrUndefined(prev.o)
+        || Util.isNullOrUndefined(curr.o)
+        || Util.isNullOrUndefined(curr.x)
+        || Util.isNullOrUndefined(curr.y);
       if (isNullValue || needCutoff) {
         ctx.moveTo(x, y);
         needCutoff = false;
@@ -308,7 +311,7 @@ class Line {
     const xp = offset[0];
     const yp = offset[1];
     const item = { data: null, hit: false, color: this.color };
-    const gdata = this.data;
+    const gdata = this.data.filter(data => !Util.isNullOrUndefined(data.x));
     const SPARE_XP = 0.5;
 
     if (gdata?.length) {
@@ -392,7 +395,7 @@ class Line {
       }
     }
 
-    if (item?.data?.o === this.passingValue) {
+    if (this.usePassingValue && item?.data?.o === this.passingValue) {
       item.data = null;
     }
 
@@ -409,7 +412,7 @@ class Line {
     const xp = offset[0];
     const yp = offset[1];
     const item = { data: null, hit: false, color: this.color };
-    const gdata = this.data;
+    const gdata = this.data.filter(data => !Util.isNullOrUndefined(data.x));
 
     let s = 0;
     let e = gdata.length - 1;

--- a/src/components/chart/helpers/helpers.constant.js
+++ b/src/components/chart/helpers/helpers.constant.js
@@ -43,6 +43,7 @@ export const LINE_OPTION = {
   fill: false,
   fillOpacity: 0.4,
   showLegend: true,
+  passingValue: null,
 };
 
 export const BAR_OPTION = {

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -52,7 +52,7 @@ const modules = {
               if (series.isExistGrp && series.stackIndex && !series.isOverlapping) {
                 series.data = this.addSeriesStackDS(sData, label, series.bsIds, series.stackIndex);
               } else {
-                series.data = this.addSeriesDS(sData, label);
+                series.data = this.addSeriesDS(sData, label, series.isExistGrp);
               }
               series.minMax = this.getSeriesMinMax(series.data);
             }
@@ -393,8 +393,9 @@ const modules = {
       const baseDataList = baseSeries.data;
       const baseData = baseDataList[dataIndex];
       const position = isHorizontal ? baseData?.x : baseData?.y;
+      const isPassingValue = baseSeries.passingValue === baseData?.o;
 
-      if (position == null || !baseSeries.show) {
+      if (isPassingValue || position == null || !baseSeries.show) {
         if (nextBaseSeriesIndex > -1) {
           return getBaseDataPosition(nextBaseSeriesIndex, dataIndex);
         }
@@ -442,12 +443,14 @@ const modules = {
    * Take data and label to create data for each series
    * @param {object}  data    chart series info
    * @param {object}  label   chart label
+   * @param {boolean}  isBase   is Base(bottommost) series at stack chart
    *
    * @returns {array} data for each series
    */
-  addSeriesDS(data, label) {
+  addSeriesDS(data, label, isBase) {
     const isHorizontal = this.options.horizontal;
     const sdata = [];
+    const passingValue = this.seriesList[Object.keys(this.seriesList)[0]]?.passingValue;
 
     data.forEach((curr, index) => {
       let gdata = curr;
@@ -459,7 +462,10 @@ const modules = {
       }
 
       if (ldata !== null) {
-        sdata.push(this.addData(gdata, ldata, gdata));
+        const isPassingValueWithStack = isBase
+          && !Util.isNullOrUndefined(passingValue)
+          && gdata === passingValue;
+        sdata.push(this.addData(isPassingValueWithStack ? 0 : gdata, ldata, gdata));
       }
     });
 

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -804,6 +804,7 @@ export default {
       sortField: '',
       sortOrder: '',
       sortColumn: {},
+      sortFunction: props.option.customAscFunction ?? {},
     });
     const contextInfo = reactive({
       menu: null,

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -664,16 +664,19 @@ export default {
   },
   emits: {
     'update:selected': null,
-    'click-row': null,
-    'dblclick-row': null,
     'update:checked': null,
+    'update:expanded': null,
     'check-row': null,
     'check-all': null,
+    'click-row': null,
+    'dblclick-row': null,
     'page-change': null,
     'sort-column': null,
     'expand-row': null,
-    'update:expanded': null,
-    'resize:column': column => column,
+    'resize:column': column => column, // 기존에 적용된 코드를 위해 남겨둠.
+    'resize-column': ({ column, columns }) => ({ column, columns }),
+    'change-column-order': ({ column, columns }) => ({ column, columns }),
+    'change-column-status': ({ columns }) => ({ columns }),
   },
   setup(props) {
     // const ROW_INDEX = 0;
@@ -752,6 +755,14 @@ export default {
         const columns = stores.movedColumns.length
           ? stores.movedColumns : stores.originColumns;
         return stores.filteredColumns.length ? stores.filteredColumns : columns;
+      }),
+      updatedColumns: computed(() => {
+        const orderedColumnsIndexes = stores.orderedColumns?.map(column => column.index);
+        const extraColumns = stores.originColumns?.filter(
+          column => !orderedColumnsIndexes.includes(column.index),
+        );
+        const copyOrderedColumns = cloneDeep(stores.orderedColumns);
+        return [...copyOrderedColumns, ...extraColumns];
       }),
     });
     const pageInfo = reactive({

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -673,7 +673,6 @@ export default {
     'page-change': null,
     'sort-column': null,
     'expand-row': null,
-    'resize:column': column => column, // 기존에 적용된 코드를 위해 남겨둠.
     'resize-column': ({ column, columns }) => ({ column, columns }),
     'change-column-order': ({ column, columns }) => ({ column, columns }),
     'change-column-status': ({ columns }) => ({ columns }),

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -625,6 +625,8 @@ export const sortEvent = (params) => {
    * 설정값에 따라 해당 컬럼 데이터에 대해 정렬한다.
    */
   const setSort = () => {
+    const { field, index } = sortInfo.sortColumn;
+    const customSetAsc = sortInfo.sortFunction?.[field] ?? null;
     const setDesc = (a, b) => (a > b ? -1 : 1);
     const setAsc = (a, b) => (a < b ? -1 : 1);
     const numberSetDesc = (a, b) => ((a === null) - (b === null) || Number(b) - Number(a));
@@ -638,7 +640,6 @@ export const sortEvent = (params) => {
       });
       return;
     }
-    const index = sortInfo.sortColumn.index;
     const type = sortInfo.sortColumn.type || 'string';
     const sortFn = sortInfo.sortOrder === 'desc' ? setDesc : setAsc;
     const numberSortFn = sortInfo.sortOrder === 'desc' ? numberSetDesc : numberSetAsc;
@@ -651,6 +652,15 @@ export const sortEvent = (params) => {
       }
       return { aCol, bCol };
     };
+
+    if (customSetAsc) {
+      stores.store.sort((a, b) => {
+        const { aCol, bCol } = getColumnValue(a, b);
+        const compareAscReturn = customSetAsc(aCol, bCol);
+        return sortInfo.sortOrder === 'desc' ? -compareAscReturn : compareAscReturn;
+      });
+      return;
+    }
     switch (type) {
       case 'string':
         stores.store.sort((a, b) => {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1325,6 +1325,10 @@ export const dragEvent = ({ stores }) => {
     const oldIndex = parseInt(currentIndex, 10);
     const newPositionIndex = parseInt(droppedIndex, 10);
 
+    if (!Number.isInteger(oldIndex) || !Number.isInteger(newPositionIndex)) {
+      return;
+    }
+
     const columns = [...stores.orderedColumns];
     const movedColumn = columns[oldIndex];
 
@@ -1347,6 +1351,7 @@ export const dragEvent = ({ stores }) => {
     e.preventDefault();
     const currentIndex = e.dataTransfer.getData('text/plain');
     const droppedIndex = e.target.parentNode.dataset.index;
+
     setColumnMoving(currentIndex, droppedIndex);
   };
   return {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -67,7 +67,14 @@ export const commonFunctions = () => {
     }
     return size;
   };
-  return { isRenderer, getComponentName, getConvertValue, getColumnIndex, setPixelUnit };
+
+  return {
+    isRenderer,
+    getComponentName,
+    getConvertValue,
+    getColumnIndex,
+    setPixelUnit,
+  };
 };
 
 export const scrollEvent = (params) => {
@@ -239,7 +246,7 @@ export const resizeEvent = (params) => {
       resizeInfo.columnWidth = columnWidth;
     }
 
-    stores.orderedColumns.map((column) => {
+    stores.orderedColumns.forEach((column) => {
       const item = column;
       const minWidth = isRenderer(column) ? resizeInfo.rendererMinWidth : resizeInfo.minWidth;
       if (item.width && item.width < minWidth) {
@@ -267,7 +274,7 @@ export const resizeEvent = (params) => {
   const onResize = () => {
     nextTick(() => {
       if (resizeInfo.adjust) {
-        stores.orderedColumns.map((column) => {
+        stores.orderedColumns.forEach((column) => {
           const item = column;
 
           if (!props.columns[column.index].width && !item.resized) {
@@ -340,7 +347,13 @@ export const resizeEvent = (params) => {
       resizeInfo.showResizeLine = false;
       document.removeEventListener('mousemove', handleMouseMove);
       onResize();
-      emit('resize:column', stores.orderedColumns[columnIndex]);
+
+      emit('resize:column', stores.orderedColumns[columnIndex]);// 기존 적용된 코드를 위해 남겨둠.
+
+      emit('resize-column', {
+        column: stores.orderedColumns[columnIndex],
+        columns: stores.updatedColumns,
+      });
     };
 
     document.addEventListener('mousemove', handleMouseMove);
@@ -973,6 +986,7 @@ export const contextMenuEvent = (params) => {
    * @param {object} event - 이벤트 객체
    */
   let contextmenuTimer = null;
+  const { emit } = getCurrentInstance();
   const setContextMenu = (e) => {
     if (contextmenuTimer) {
       clearTimeout(contextmenuTimer);
@@ -1003,7 +1017,7 @@ export const contextMenuEvent = (params) => {
   /**
    * 마우스 우클릭 이벤트를 처리한다.
    *
-   * @param {object} event - 이벤트 객체
+   * @param {object} e - 이벤트 객체
    */
   const onContextMenu = (e) => {
     e.preventDefault();
@@ -1071,7 +1085,12 @@ export const contextMenuEvent = (params) => {
           iconClass: 'ev-icon-visibility-off',
           disabled: !useGridSetting.value || stores.orderedColumns.length === 1,
           hidden: contextInfo.hiddenColumnMenuItem?.hide,
-          click: () => setColumnHidden(column.field),
+          click: () => {
+            setColumnHidden(column.field);
+            emit('change-column-status', {
+              columns: stores.updatedColumns,
+            });
+          },
         },
       ];
       contextInfo.columnMenuItems = [];
@@ -1084,7 +1103,7 @@ export const contextMenuEvent = (params) => {
   /**
    * 상단 우측의 Grid 옵션에 대한 Contextmenu 를 생성한다.
    *
-   * @param {object} event - 이벤트 객체
+   * @param {object} e - 이벤트 객체
    */
   const onGridSettingContextMenu = (e) => {
     const columnListMenu = {
@@ -1233,7 +1252,7 @@ export const pagingEvent = (params) => {
 };
 
 export const columnSettingEvent = (params) => {
-  const { props } = getCurrentInstance();
+  const { props, emit } = getCurrentInstance();
   const {
     stores,
     columnSettingInfo,
@@ -1301,15 +1320,20 @@ export const columnSettingEvent = (params) => {
     stores.filteredColumns = stores.originColumns
       .filter((col) => {
         if (columnNames.includes(col.field) || !col.caption) {
-          if (col?.hiddenDisplay) {
-            col.hiddenDisplay = false;
-          }
+          // 보여줄 컬럼들은 hiddenDisplay 속성을 false로 전부 적용
+          col.hiddenDisplay = false;
           return true;
         }
+
+        // 보여주지 않을 컬럼들은 hiddenDisplay 속성을 전부 ture로 적용
+        col.hiddenDisplay = true;
         return false;
       });
     columnSettingInfo.hiddenColumn = '';
     setFilteringColumn();
+    emit('change-column-status', {
+      columns: stores.updatedColumns,
+    });
   };
   const setColumnHidden = (val) => {
     const columns = stores.orderedColumns.filter(col => !col.hide && !col.hiddenDisplay);
@@ -1317,7 +1341,15 @@ export const columnSettingEvent = (params) => {
     if (columns.length === 1) {
       return;
     }
-    stores.filteredColumns = columns.filter(col => col.field !== val);
+    stores.filteredColumns = columns
+      .filter((col) => {
+        if (col.field !== val) {
+          col.hiddenDisplay = false;
+          return true;
+        }
+        col.hiddenDisplay = true;
+        return false;
+      });
     columnSettingInfo.hiddenColumn = val;
     setFilteringColumn();
   };
@@ -1331,6 +1363,7 @@ export const columnSettingEvent = (params) => {
 };
 
 export const dragEvent = ({ stores }) => {
+  const { emit } = getCurrentInstance();
   const setColumnMoving = (currentIndex, droppedIndex) => {
     const oldIndex = parseInt(currentIndex, 10);
     const newPositionIndex = parseInt(droppedIndex, 10);
@@ -1363,6 +1396,10 @@ export const dragEvent = ({ stores }) => {
     const droppedIndex = e.target.parentNode.dataset.index;
 
     setColumnMoving(currentIndex, droppedIndex);
+    emit('change-column-order', {
+      column: stores.orderedColumns[droppedIndex],
+      columns: stores.updatedColumns,
+    });
   };
   return {
     onDragStart,

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -348,8 +348,6 @@ export const resizeEvent = (params) => {
       document.removeEventListener('mousemove', handleMouseMove);
       onResize();
 
-      emit('resize:column', stores.orderedColumns[columnIndex]);// 기존 적용된 코드를 위해 남겨둠.
-
       emit('resize-column', {
         column: stores.orderedColumns[columnIndex],
         columns: stores.updatedColumns,

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -258,6 +258,7 @@ import {
   onMounted,
   onUnmounted,
 } from 'vue';
+import { cloneDeep } from 'lodash-es';
 import TreeGridNode from './TreeGridNode';
 import Toolbar from './TreeGridToolbar';
 import GridPagination from '../grid/GridPagination';
@@ -329,12 +330,14 @@ export default {
   },
   emits: {
     'update:selected': null,
+    'update:checked': null,
     'click-row': null,
     'dblclick-row': null,
-    'update:checked': null,
     'check-row': null,
     'check-all': null,
     'page-change': null,
+    'resize-column': ({ column, columns }) => ({ column, columns }),
+    'change-column-status': ({ columns }) => ({ columns }),
   },
   setup(props) {
     const toolbarRef = ref(null);
@@ -382,6 +385,14 @@ export default {
       originColumns: computed(() => props.columns.map((column, index) => ({ index, ...column }))),
       orderedColumns: computed(() => (stores.filteredColumns.length
         ? stores.filteredColumns : stores.originColumns)),
+      updatedColumns: computed(() => {
+        const orderedColumnsIndexes = stores.orderedColumns?.map(column => column.index);
+        const extraColumns = stores.originColumns?.filter(
+          column => !orderedColumnsIndexes.includes(column.index),
+        );
+        const copyOrderedColumns = cloneDeep(stores.orderedColumns);
+        return [...copyOrderedColumns, ...extraColumns];
+      }),
     });
     const pageInfo = reactive({
       usePage: computed(() => (props.option.page?.use || false)),

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -171,7 +171,7 @@ export const scrollEvent = (params) => {
 };
 
 export const resizeEvent = (params) => {
-  const { props } = getCurrentInstance();
+  const { props, emit } = getCurrentInstance();
   const {
     resizeInfo,
     elementInfo,
@@ -233,7 +233,7 @@ export const resizeEvent = (params) => {
       resizeInfo.columnWidth = columnWidth;
     }
 
-    stores.orderedColumns.map((column) => {
+    stores.orderedColumns.forEach((column) => {
       const item = column;
       const minWidth = isRenderer(column) ? resizeInfo.rendererMinWidth : resizeInfo.minWidth;
       if (item.width && item.width < minWidth) {
@@ -262,7 +262,7 @@ export const resizeEvent = (params) => {
   const onResize = () => {
     nextTick(() => {
       if (resizeInfo.adjust) {
-        stores.orderedColumns.map((column) => {
+        stores.orderedColumns.forEach((column) => {
           const item = column;
 
           if (!props.columns[column.index].width && !item.resized) {
@@ -329,7 +329,7 @@ export const resizeEvent = (params) => {
 
       if (stores.orderedColumns[columnIndex]) {
         stores.orderedColumns[columnIndex].width = changedWidth;
-        stores.orderedColumns.map((column) => {
+        stores.orderedColumns.forEach((column) => {
           const item = column;
           item.resized = true;
           return item;
@@ -339,6 +339,10 @@ export const resizeEvent = (params) => {
       resizeInfo.showResizeLine = false;
       document.removeEventListener('mousemove', handleMouseMove);
       onResize();
+      emit('resize-column', {
+        column: stores.orderedColumns[columnIndex],
+        columns: stores.updatedColumns,
+      });
     };
 
     document.addEventListener('mousemove', handleMouseMove);
@@ -613,7 +617,12 @@ export const contextMenuEvent = (params) => {
           text: contextInfo.columnMenuTextInfo?.hide ?? 'Hide',
           iconClass: 'ev-icon-visibility-off',
           disabled: !useGridSetting.value || stores.orderedColumns.length === 1,
-          click: () => setColumnHidden(column.field),
+          click: () => {
+            setColumnHidden(column.field);
+            emit('change-column-status', {
+              columns: stores.updatedColumns,
+            });
+          },
         },
       ];
     } else {
@@ -644,7 +653,7 @@ export const contextMenuEvent = (params) => {
   /**
    * 상단 우측의 Grid 옵션에 대한 Contextmenu 를 생성한다.
    *
-   * @param {object} event - 이벤트 객체
+   * @param {object} e - 이벤트 객체
    */
   const onGridSettingContextMenu = (e) => {
     const columnListMenu = {


### PR DESCRIPTION
# 이슈

- EVUI Grid, Tree Grid에서 컬럼 변경(컬럼 순서, 컬럼 사이즈, 컬럼 위치, 컬럼 show/hide)시 내부적으로 변경되는 그리드 컬럼의 정보를  emit으로 올려주는 기능이 필요함.

# 해결

## 작업 내용

## Grid

### 컬럼 사이즈 변경

- 이벤트 명 : `resize-column`
- 인자
    - column : 현재 대상 target의 컬럼 정보
    - columns : 해당 이벤트가 발생된 직후의 전체 컬럼들의 정보
    
    ```jsx
    emit('resize-column', {
      column: stores.orderedColumns[columnIndex],
      columns: stores.updatedColumns,
    });
    ```
    
- 화면
    
![그리드-리사이즈](https://github.com/ex-em/EVUI/assets/75205035/b4323414-4d8d-4bdf-b41d-fbaf6f43a403)
    

### 컬럼 위치

- 이벤트 명 : `change-column-position`
- 인자
    - column : 현재 대상 target의 컬럼 정보
    - columns : 해당 이벤트가 발생된 직후의 전체 컬럼들의 정보
    
    ```jsx
    emit('change-column-position', {
      column: stores.orderedColumns[droppedIndex],
      columns: stores.updatedColumns,
    });
    ```
    
- 화면
    
![그리드-컬럼위치변경](https://github.com/ex-em/EVUI/assets/75205035/f5578c18-76d1-4715-b379-464d284b8cfe)
    

### 컬럼 설정 (컬러 Show/Hide)

- 이벤트 명 : `change-column-status`
- 인자
    - columns: 해당 이벤트가 발생된 직후의 전체 컬럼들의 정보
    
    ```jsx
    emit('change-column-status', {
      columns: stores.updatedColumns,
    });
    ```
    
- 화면
    
![그리드-컬럼-show-hide](https://github.com/ex-em/EVUI/assets/75205035/e93f4734-7b03-47e4-b1a8-c2174b4b951c)
    

## Tree Grid

Grid와 동일하나, `resize-column`, `change-column-status` 이벤트만 존재함
