### PR TITLE
[#1630] Line Chart > label 개수보다 data 개수가 많을 경우 예외 처리

### DIFF
--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -140,7 +140,10 @@ class Line {
         }
       }
 
-      const isNullValue = Util.isNullOrUndefined(prev.o) || Util.isNullOrUndefined(curr.o);
+      const isNullValue = Util.isNullOrUndefined(prev.o)
+        || Util.isNullOrUndefined(curr.o)
+        || Util.isNullOrUndefined(curr.x)
+        || Util.isNullOrUndefined(curr.y);
       if (isNullValue || needCutoff) {
         ctx.moveTo(x, y);
         needCutoff = false;
@@ -308,7 +311,7 @@ class Line {
     const xp = offset[0];
     const yp = offset[1];
     const item = { data: null, hit: false, color: this.color };
-    const gdata = this.data;
+    const gdata = this.data.filter(data => !Util.isNullOrUndefined(data.x));
     const SPARE_XP = 0.5;
 
     if (gdata?.length) {
@@ -392,7 +395,7 @@ class Line {
       }
     }
 
-    if (item?.data?.o === this.passingValue) {
+    if (this.usePassingValue && item?.data?.o === this.passingValue) {
       item.data = null;
     }
 
@@ -409,7 +412,7 @@ class Line {
     const xp = offset[0];
     const yp = offset[1];
     const item = { data: null, hit: false, color: this.color };
-    const gdata = this.data;
+    const gdata = this.data.filter(data => !Util.isNullOrUndefined(data.x));
 
     let s = 0;
     let e = gdata.length - 1;


### PR DESCRIPTION
## 이슈 내용
- ![image](https://github.com/ex-em/EVUI/assets/53548023/3cf165db-043b-4d95-a198-3829c13b3980)
-  기존 로직 
   - label개수와 상관 없이, data(o)를 기준으로 position을 계산하고 line을 그림 
   - label이 없고 data만 있을 땐 내부 로직상 x값이 없고 o값은 있는 형태임
   - o값의 유무로만 체크하여 line을 그리고 있었음 

## 수정 내용
- line Chart 그릴 때 x값이 undefined면 o(original value)가 null일 때와 동일하게 처리되도록 로직 추가
- 툴팁에 표시할 아이템을 찾는 로직에서 x값이 undefined인 요소는 제외하고 탐색하도록 로직 수정

## 정리된 스펙 
- Label보다 넘치게 들어온 data에 대해서 null과 동일하게 취급한다. 
   - line, point, tooltip 표시 X

## Before / After
![image](https://github.com/ex-em/EVUI/assets/53548023/6e233eda-1ba8-45f7-b394-699bc0a6a9d8)
![image](https://github.com/ex-em/EVUI/assets/53548023/3bbb9b56-bbf5-4178-9510-4591b6dd7d8b)

