### PR TITLE
[#1638] Chart > Drag 영역 Chart resize 됐을 때 Chart 크기에 맞게 위치와 크기가 변경되지 않는 현상 수정

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -910,6 +910,9 @@ class EvChart {
     this.initScale();
     this.chartRect = this.getChartRect();
     this.drawChart();
+    if (this.dragInfoBackup) {
+      this.drawSelectionArea?.(this.dragInfoBackup);
+    }
 
     if (promiseRes) {
       promiseRes(true);


### PR DESCRIPTION
이슈
-
1. chart resize 됐을 때 drag 영역 사라짐
2. chart resize 후 drag 영역 다시 그릴 때 chart 크기가 달라지면 이전과 다른 곳에 drag 영역이 그려짐

![drag_selection_resize](https://github.com/ex-em/EVUI/assets/75718910/2455018a-95cb-4c9c-ad8b-8d8a89e74963)

작업 내용
-
1. resize 이벤트가 일어난 경우 dragInfoBackup 데이터가 있으면 drag 영역을 다시 그리게 호출
2. chart 사이즈가 달라졌을 경우 chart 달라진 비율에 따라 drag 영역 그리도록 수정

![drag_selection_resize_fix](https://github.com/ex-em/EVUI/assets/75718910/a817c990-089a-4655-9631-a55ad276f9d0)

