### PR TITLE
[#1633] Grid > Column 옵션 emit 이벤트 추가

### DIFF
--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -110,14 +110,16 @@
 | summaryData | Array | Summary 할 대상 추가 시 summaryRenderer 와 함께 사용 | ex) '{0}({1}%)' | N |
 
 ### Event
-| 이름 | 파라미터 | 설명 |
- | ---- | ------- | ---- |
- | check-row | event, row, index | row의 체크박스가 체크 되었을때 호출된다. |
- | check-all | event, rows | 헤더의 체크박스가 체크 되었을때 호출 된다. 전체 row의 체크박스를 체크한다. |
- | click-row | event, row | row가 클릭 되었을 때 호출된다. |
- | dblclick-row | event, row | row가 더블 클릭 되었을 때 호출된다. |
- | page-change | event | page 정보가 변경되었을 때 호출된다. |
- | sort-column | event | column을 기준으로 정렬이 변경되었을 때 호출된다. |
- | expand-row | event, row, isExpand, index | row가 확장되었을 때 호출된다. |
- | update:expanded | rows | row가 확장되었을 때 호출된다. |
- | resize:column | column | column의 width가 resize 됐을때 호출된다. |
+| 이름 | 파라미터                        | 설명                                                                  |
+ | ---- |-----------------------------|---------------------------------------------------------------------|
+ | check-row | event, row, index           | row의 체크박스가 체크 되었을때 호출된다.                                            |
+ | check-all | event, rows                 | 헤더의 체크박스가 체크 되었을때 호출 된다. 전체 row의 체크박스를 체크한다.                        |
+ | click-row | event, row                  | row가 클릭 되었을 때 호출된다.                                                 |
+ | dblclick-row | event, row                  | row가 더블 클릭 되었을 때 호출된다.                                              |
+ | page-change | event                       | page 정보가 변경되었을 때 호출된다.                                              |
+ | sort-column | event                       | column을 기준으로 정렬이 변경되었을 때 호출된다.                                      |
+ | expand-row | event, row, isExpand, index | row가 확장되었을 때 호출된다.                                                  |
+ | update:expanded | rows                        | row가 확장되었을 때 호출된다.                                                  |
+ | resize-column | column, columns             | column의 width가 resize 됐을때 호출된다.                                     |
+ | change-column-order | column, columns             | column의 위치가 변경되었을 때 호출된다.                                           |
+ | change-column-status | columns             | column의 상태(column Show/Hide)가 변경되었을 때 호출된다. |

--- a/docs/views/grid/example/ColumnEvent.vue
+++ b/docs/views/grid/example/ColumnEvent.vue
@@ -1,0 +1,151 @@
+<template>
+  <div class="case">
+    <ev-grid
+      :columns="columns"
+      :rows="tableData"
+      :width="widthMV"
+      :height="heightMV"
+      :option="{
+        adjust: true,
+        useGridSetting: {
+          use: true,
+        },
+      }"
+      @resize-column="onResizeColumn"
+      @change-column-order="onChangeColumnOrder"
+      @change-column-status="onChangeColumnStatus"
+    />
+    <!-- description -->
+    <div class="description column-event-description">
+      <div class="form-rows">
+        <div class="form-row">
+          <span class="badge yellow">
+            Resize Column Width
+          </span>
+          <ev-text-field
+            v-model="columnEventsInfo.resize"
+            class="custom-text-area"
+            type="textarea"
+            readonly
+          />
+        </div>
+        <div class="form-row">
+          <span class="badge yellow">
+            Change Column Position
+          </span>
+          <ev-text-field
+            v-model="columnEventsInfo.order"
+            class="custom-text-area"
+            type="textarea"
+            readonly
+          />
+        </div>
+      </div>
+      <div class="form-rows">
+        <div class="form-row">
+          <span class="badge yellow">
+            Grid Column Setting(Column Show/Hide Status)
+          </span>
+          <ev-text-field
+            v-model="columnEventsInfo.status"
+            class="custom-text-area"
+            type="textarea"
+            readonly
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const tableData = ref([]);
+    const widthMV = ref('100%');
+    const heightMV = ref(300);
+    const columns = ref([
+      { caption: 'A Column', field: 'aColumn', type: 'string' },
+      { caption: 'B Column', field: 'bColumn', type: 'string' },
+      { caption: 'C Column', field: 'cColumn', type: 'string' },
+      { caption: 'D Column', field: 'dColumn', type: 'string', hiddenDisplay: true },
+      { caption: 'E Column', field: 'eColumn', type: 'string' },
+    ]);
+    const columnEventsInfo = ref({
+      resize: '',
+      order: '',
+      status: '',
+    });
+    const getData = (count, startIndex) => {
+      const temp = [];
+      for (let ix = startIndex; ix < startIndex + count; ix++) {
+        temp.push([
+          `A Column Data_${ix}`,
+          `B Column Data_${ix + 1}`,
+          `C Column Data_${ix + 2}`,
+          `D Column Data_${ix + 3}`,
+          `E Column Data_${ix + 4}`,
+        ]);
+      }
+      return temp;
+    };
+
+    tableData.value = getData(10, 0);
+
+    const onResizeColumn = (columnInfo) => {
+      columnEventsInfo.value.resize = JSON.stringify(columnInfo, null, 2);
+    };
+    const onChangeColumnOrder = (columnInfo) => {
+      columnEventsInfo.value.order = JSON.stringify(columnInfo, null, 2);
+    };
+    const onChangeColumnStatus = (columnInfo) => {
+      columnEventsInfo.value.status = JSON.stringify(columnInfo, null, 2);
+    };
+
+    return {
+      columns,
+      tableData,
+      widthMV,
+      heightMV,
+      columnEventsInfo,
+      onResizeColumn,
+      onChangeColumnOrder,
+      onChangeColumnStatus,
+    };
+  },
+};
+</script>
+
+<style lang="scss">
+.description {
+  .form-rows {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+  }
+
+  .form-row {
+    width: 50%;
+  }
+
+  .badge {
+    margin-bottom: 2px;
+    margin-right: 5px !important;
+  }
+}
+
+.column-event-description {
+  min-width: 200px;
+  min-height: 300px;
+
+  .custom-text-area {
+    width: 100% !important;
+  }
+
+  .ev-textarea {
+    height: 200px !important;
+  }
+}
+</style>

--- a/docs/views/grid/example/RowDetail.vue
+++ b/docs/views/grid/example/RowDetail.vue
@@ -13,7 +13,7 @@
         }
       }"
       @expand-row="onExpandRow"
-      @resize:column="onResizeColumn"
+      @resize-column="onResizeColumn"
     >
       <template #rowDetail="{ item }">
         <row-detail-content
@@ -102,8 +102,8 @@ export default {
       });
       expandedRowText.value = result;
     };
-    const onResizeColumn = (column) => {
-      console.log('[onResizeColumn]', column);
+    const onResizeColumn = (columnInfo) => {
+      console.log('[onResizeColumn]', columnInfo);
     };
 
     pushData();

--- a/docs/views/grid/props.js
+++ b/docs/views/grid/props.js
@@ -12,6 +12,8 @@ import RowDetail from './example/RowDetail.vue';
 import RowDetailRaw from '!!raw-loader!./example/RowDetail.vue';
 import Sort from './example/Sort.vue';
 import SortRaw from '!!raw-loader!./example/Sort.vue';
+import ColumnEvent from './example/ColumnEvent.vue';
+import ColumnEventRaw from '!!raw-loader!./example/ColumnEvent.vue';
 
 export default {
   mdText,
@@ -40,6 +42,10 @@ export default {
     Sort: {
       component: Sort,
       parsedData: parseComponent(SortRaw),
+    },
+    ColumnEvent: {
+      component: ColumnEvent,
+      parsedData: parseComponent(ColumnEventRaw),
     },
   },
 };

--- a/docs/views/treeGrid/api/treeGrid.md
+++ b/docs/views/treeGrid/api/treeGrid.md
@@ -121,3 +121,5 @@
 | click-row | event, row | row가 클릭 되었을 때 호출된다. |
 | dblclick-row | event, row | row가 더블 클릭 되었을 때 호출된다. |
 | page-change | event | page 정보가 변경되었을 때 호출된다. |
+| resize-column | column, columns             | column의 width가 resize 됐을때 호출된다.                                     | |
+| change-column-status | columns             | column의 상태(column Show/Hide)가 변경되었을 때 호출된다. |

--- a/docs/views/treeGrid/example/ColumnEvent.vue
+++ b/docs/views/treeGrid/example/ColumnEvent.vue
@@ -1,0 +1,210 @@
+<template>
+  <div class="case">
+    <p class="case-title">TreeGrid</p>
+    <ev-tree-grid
+      :columns="columns"
+      :rows="tableData"
+      :width="widthMV"
+      :height="heightMV"
+      :option="{
+        adjust: true,
+        useGridSetting: {
+          use: true,
+        },
+      }"
+      @resize-column="onResizeColumn"
+      @change-column-status="onChangeColumnStatus"
+    >
+    </ev-tree-grid>
+    <div class="description column-event-description">
+      <div class="form-rows">
+        <div class="form-row">
+          <span class="badge yellow">
+            Resize Column Width
+          </span>
+          <ev-text-field
+            v-model="columnEventsInfo.resize"
+            class="custom-text-area"
+            type="textarea"
+            readonly
+          />
+        </div>
+        <div class="form-row">
+          <span class="badge yellow">
+            Grid Column Setting(Column Show/Hide Status)
+          </span>
+          <ev-text-field
+            v-model="columnEventsInfo.status"
+            class="custom-text-area"
+            type="textarea"
+            readonly
+          />
+        </div>
+      </div>
+    </div>
+
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const tableData = ref([]);
+    const widthMV = ref('100%');
+    const heightMV = ref(300);
+    const columnEventsInfo = ref({
+      resize: '',
+      order: '',
+      status: '',
+    });
+    const getData = () => {
+      tableData.value = [
+        {
+          id: 'Exem 0',
+          date: '2016-05-01',
+          name: '1111',
+          expand: true,
+        },
+        {
+          id: 'Exem 1',
+          date: '2016-05-01',
+          name: '2222',
+          value: 123,
+          expand: true,
+          children: [{
+            id: 'Exem 2',
+            date: '2016-05-02',
+            name: '2',
+            value: 222,
+            expand: false,
+            children: [{
+              id: 'Exem 3',
+              date: '2016-05-02',
+              name: '3',
+              value: 3333,
+              uncheckable: true,
+            }, {
+              id: 'Exem 4',
+              date: '2016-05-02',
+              name: '4',
+              expand: false,
+              uncheckable: true,
+              children: [{
+                id: 'Exem 5',
+                date: '2016-05-02',
+                name: '5',
+                children: [{
+                  id: 'Exem 51',
+                  date: '2016-05-02',
+                  name: '1251',
+                  children: [{
+                    id: 'Exem 52',
+                    date: '2016-05-02',
+                    name: '20000',
+                  }],
+                }],
+              }, {
+                id: 'Exem 6',
+                date: '2016-05-02',
+                name: '6',
+              }],
+            }],
+          }, {
+            id: 'Exem 7',
+            date: '2016-05-03',
+            name: '7',
+            children: [{
+              id: 'Exem 8',
+              date: '2016-05-03',
+              name: '8',
+              value: 333,
+            }, {
+              id: 'Exem 9',
+              date: '2016-05-03',
+              name: '9',
+            }, {
+              id: 'Exem 10',
+              date: '2016-05-03',
+              name: '10',
+            }],
+          }, {
+            id: 'Exem 11',
+            date: '2016-05-04',
+            name: '11',
+          }],
+        },
+      ];
+    };
+    const columns = ref([
+      { caption: 'ID', field: 'id', type: 'number' },
+      { caption: 'Date', field: 'date', type: 'string' },
+      {
+        caption: 'Name',
+        field: 'name',
+        type: 'float',
+        summaryType: 'sum',
+        summaryOnlyTopParent: true,
+        summaryRenderer: 'Sum: {0} 최상위 부모만 summary',
+        decimal: 1,
+      },
+      {
+        caption: 'Value',
+        field: 'value',
+        type: 'number',
+        summaryType: 'sum',
+        summaryRenderer: 'Sum: {0} 모든 row summary',
+        decimal: 1,
+      },
+    ]);
+
+    const onResizeColumn = (columnInfo) => {
+      columnEventsInfo.value.resize = JSON.stringify(columnInfo, null, 2);
+    };
+    const onChangeColumnStatus = (columnInfo) => {
+      columnEventsInfo.value.status = JSON.stringify(columnInfo, null, 2);
+    };
+
+    getData();
+
+    return {
+      columns,
+      tableData,
+      widthMV,
+      heightMV,
+      columnEventsInfo,
+      onResizeColumn,
+      onChangeColumnStatus,
+    };
+  },
+};
+</script>
+
+<style lang="scss">
+.description {
+  .form-rows {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+  }
+
+  .form-row {
+    width: 50%;
+  }
+
+  .badge {
+    margin-bottom: 2px;
+    margin-right: 5px !important;
+  }
+}
+
+.column-event-description {
+  min-width: 200px;
+  min-height: 300px;
+
+  .ev-textarea {
+    height: 200px !important;
+  }
+}
+</style>

--- a/docs/views/treeGrid/props.js
+++ b/docs/views/treeGrid/props.js
@@ -6,6 +6,8 @@ import CellRenderer from './example/CellRenderer';
 import CellRendererRaw from '!!raw-loader!./example/CellRenderer';
 import Toolbar from './example/Toolbar';
 import ToolbarRaw from '!!raw-loader!./example/Toolbar';
+import ColumnEvent from './example/ColumnEvent.vue';
+import ColumnEventRaw from '!!raw-loader!./example/ColumnEvent.vue';
 
 export default {
   mdText,
@@ -22,6 +24,10 @@ export default {
     Toolbar: {
       component: Toolbar,
       parsedData: parseComponent(ToolbarRaw),
+    },
+    ColumnEvent: {
+      component: ColumnEvent,
+      parsedData: parseComponent(ColumnEventRaw),
     },
   },
 };

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -664,16 +664,18 @@ export default {
   },
   emits: {
     'update:selected': null,
-    'click-row': null,
-    'dblclick-row': null,
     'update:checked': null,
+    'update:expanded': null,
     'check-row': null,
     'check-all': null,
+    'click-row': null,
+    'dblclick-row': null,
     'page-change': null,
     'sort-column': null,
     'expand-row': null,
-    'update:expanded': null,
-    'resize:column': column => column,
+    'resize-column': ({ column, columns }) => ({ column, columns }),
+    'change-column-order': ({ column, columns }) => ({ column, columns }),
+    'change-column-status': ({ columns }) => ({ columns }),
   },
   setup(props) {
     // const ROW_INDEX = 0;
@@ -752,6 +754,14 @@ export default {
         const columns = stores.movedColumns.length
           ? stores.movedColumns : stores.originColumns;
         return stores.filteredColumns.length ? stores.filteredColumns : columns;
+      }),
+      updatedColumns: computed(() => {
+        const orderedColumnsIndexes = stores.orderedColumns?.map(column => column.index);
+        const extraColumns = stores.originColumns?.filter(
+          column => !orderedColumnsIndexes.includes(column.index),
+        );
+        const copyOrderedColumns = cloneDeep(stores.orderedColumns);
+        return [...copyOrderedColumns, ...extraColumns];
       }),
     });
     const pageInfo = reactive({

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -258,6 +258,7 @@ import {
   onMounted,
   onUnmounted,
 } from 'vue';
+import { cloneDeep } from 'lodash-es';
 import TreeGridNode from './TreeGridNode';
 import Toolbar from './TreeGridToolbar';
 import GridPagination from '../grid/GridPagination';
@@ -329,12 +330,14 @@ export default {
   },
   emits: {
     'update:selected': null,
+    'update:checked': null,
     'click-row': null,
     'dblclick-row': null,
-    'update:checked': null,
     'check-row': null,
     'check-all': null,
     'page-change': null,
+    'resize-column': ({ column, columns }) => ({ column, columns }),
+    'change-column-status': ({ columns }) => ({ columns }),
   },
   setup(props) {
     const toolbarRef = ref(null);
@@ -382,6 +385,14 @@ export default {
       originColumns: computed(() => props.columns.map((column, index) => ({ index, ...column }))),
       orderedColumns: computed(() => (stores.filteredColumns.length
         ? stores.filteredColumns : stores.originColumns)),
+      updatedColumns: computed(() => {
+        const orderedColumnsIndexes = stores.orderedColumns?.map(column => column.index);
+        const extraColumns = stores.originColumns?.filter(
+          column => !orderedColumnsIndexes.includes(column.index),
+        );
+        const copyOrderedColumns = cloneDeep(stores.orderedColumns);
+        return [...copyOrderedColumns, ...extraColumns];
+      }),
     });
     const pageInfo = reactive({
       usePage: computed(() => (props.option.page?.use || false)),

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -171,7 +171,7 @@ export const scrollEvent = (params) => {
 };
 
 export const resizeEvent = (params) => {
-  const { props } = getCurrentInstance();
+  const { props, emit } = getCurrentInstance();
   const {
     resizeInfo,
     elementInfo,
@@ -233,7 +233,7 @@ export const resizeEvent = (params) => {
       resizeInfo.columnWidth = columnWidth;
     }
 
-    stores.orderedColumns.map((column) => {
+    stores.orderedColumns.forEach((column) => {
       const item = column;
       const minWidth = isRenderer(column) ? resizeInfo.rendererMinWidth : resizeInfo.minWidth;
       if (item.width && item.width < minWidth) {
@@ -262,7 +262,7 @@ export const resizeEvent = (params) => {
   const onResize = () => {
     nextTick(() => {
       if (resizeInfo.adjust) {
-        stores.orderedColumns.map((column) => {
+        stores.orderedColumns.forEach((column) => {
           const item = column;
 
           if (!props.columns[column.index].width && !item.resized) {
@@ -329,7 +329,7 @@ export const resizeEvent = (params) => {
 
       if (stores.orderedColumns[columnIndex]) {
         stores.orderedColumns[columnIndex].width = changedWidth;
-        stores.orderedColumns.map((column) => {
+        stores.orderedColumns.forEach((column) => {
           const item = column;
           item.resized = true;
           return item;
@@ -339,6 +339,10 @@ export const resizeEvent = (params) => {
       resizeInfo.showResizeLine = false;
       document.removeEventListener('mousemove', handleMouseMove);
       onResize();
+      emit('resize-column', {
+        column: stores.orderedColumns[columnIndex],
+        columns: stores.updatedColumns,
+      });
     };
 
     document.addEventListener('mousemove', handleMouseMove);
@@ -613,7 +617,12 @@ export const contextMenuEvent = (params) => {
           text: contextInfo.columnMenuTextInfo?.hide ?? 'Hide',
           iconClass: 'ev-icon-visibility-off',
           disabled: !useGridSetting.value || stores.orderedColumns.length === 1,
-          click: () => setColumnHidden(column.field),
+          click: () => {
+            setColumnHidden(column.field);
+            emit('change-column-status', {
+              columns: stores.updatedColumns,
+            });
+          },
         },
       ];
     } else {
@@ -644,7 +653,7 @@ export const contextMenuEvent = (params) => {
   /**
    * 상단 우측의 Grid 옵션에 대한 Contextmenu 를 생성한다.
    *
-   * @param {object} event - 이벤트 객체
+   * @param {object} e - 이벤트 객체
    */
   const onGridSettingContextMenu = (e) => {
     const columnListMenu = {


### PR DESCRIPTION
# 이슈

- EVUI Grid, Tree Grid에서 컬럼 변경(컬럼 순서, 컬럼 사이즈, 컬럼 위치, 컬럼 show/hide)시 내부적으로 변경되는 그리드 컬럼의 정보를  emit으로 올려주는 기능이 필요함.

# 해결

## 작업 내용

## Grid

### 컬럼 사이즈 변경

- 이벤트 명 : `resize-column`
- 인자
    - column : 현재 대상 target의 컬럼 정보
    - columns : 해당 이벤트가 발생된 직후의 전체 컬럼들의 정보
    
    ```jsx
    emit('resize-column', {
      column: stores.orderedColumns[columnIndex],
      columns: stores.updatedColumns,
    });
    ```
    
- 화면
    
![그리드-리사이즈](https://github.com/ex-em/EVUI/assets/75205035/b4323414-4d8d-4bdf-b41d-fbaf6f43a403)
    

### 컬럼 위치

- 이벤트 명 : `change-column-position`
- 인자
    - column : 현재 대상 target의 컬럼 정보
    - columns : 해당 이벤트가 발생된 직후의 전체 컬럼들의 정보
    
    ```jsx
    emit('change-column-position', {
      column: stores.orderedColumns[droppedIndex],
      columns: stores.updatedColumns,
    });
    ```
    
- 화면
    
![그리드-컬럼위치변경](https://github.com/ex-em/EVUI/assets/75205035/f5578c18-76d1-4715-b379-464d284b8cfe)
    

### 컬럼 설정 (컬러 Show/Hide)

- 이벤트 명 : `change-column-status`
- 인자
    - columns: 해당 이벤트가 발생된 직후의 전체 컬럼들의 정보
    
    ```jsx
    emit('change-column-status', {
      columns: stores.updatedColumns,
    });
    ```
    
- 화면
    
![그리드-컬럼-show-hide](https://github.com/ex-em/EVUI/assets/75205035/e93f4734-7b03-47e4-b1a8-c2174b4b951c)
    

## Tree Grid

Grid와 동일하나, `resize-column`, `change-column-status` 이벤트만 존재함
