### PR TITLE
[#1645] Brush Chart 마우스 스크롤 옵션화 (3.0 반영 작업)

### DIFF
--- a/docs/views/brushChart/api/brushChart.md
+++ b/docs/views/brushChart/api/brushChart.md
@@ -34,6 +34,7 @@
 | useDebounce | Boolean | true               | true 이면 마지막 브러쉬 영역으로 차트가 업데이트 되고 false 이면 브러쉬 영역 조절에 따라 동시에 차트도 업데이트 됨. |                                 |
 | showLabel   | Boolean | false              | Brush의 x, y 축 라벨을 보여줄지 설정                                               |                                 |
 | selection   | Object  | ([상세](#selection)) | Brush 영역의 스타일 설정                                                        |                                 |
+| useWheelMove | Boolean | true               | Brush 영역에서 마우스 휠을 사용하여 브러쉬를 이동할지 설정                           |                                 |
 
 #### selection
 | 이름         | 타입      | 디폴트  | 설명              | 종류(예시)                       | 

--- a/docs/views/brushChart/example/Default.vue
+++ b/docs/views/brushChart/example/Default.vue
@@ -19,6 +19,10 @@
       <ev-toggle v-model="isUseDebounce"/>
       <br/>
       <br/>
+      <span class="toggle-label"> useWheelMove 옵션 사용</span>
+      <ev-toggle v-model="isUseWheelMove"/>
+      <br/>
+      <br/>
       <span class="toggle-label">Brush 생성</span>
       <ev-toggle v-model="isShowBrush"/>
       <br/>
@@ -43,6 +47,7 @@ export default {
     const isShowBrush = ref(true);
     const isShowToolbar = ref(true);
     const isUseDebounce = ref(true);
+    const isUseWheelMove = ref(true);
     const zoomRef = ref();
     let timeValue = dayjs().format('YYYY-MM-DD HH:mm:ss');
 
@@ -96,6 +101,7 @@ export default {
     const brushOptions = reactive({
       show: isShowBrush,
       useDebounce: isUseDebounce,
+      useWheelMove: isUseWheelMove,
       chartIdx: 0,
       height: 80,
     });
@@ -155,6 +161,7 @@ export default {
       isShowBrush,
       isExpandChartArea,
       isUseDebounce,
+      isUseWheelMove,
       zoomRef,
       onUpdateChartData,
     };

--- a/src/components/chartBrush/chartBrush.core.js
+++ b/src/components/chartBrush/chartBrush.core.js
@@ -372,8 +372,11 @@ export default class EvChartBrush {
     this.brushCanvas[type]('mousedown', this.onMouseDown);
     this.brushCanvas[type]('mouseup', this.onMouseUp);
     this.brushCanvas[type]('mouseleave', this.onMouseLeave);
-    this.brushCanvas[type]('wheel', this.onWheel);
-    this.brushCanvas[type]('wheel', this.onWheelDebounce);
+
+    if (this.evChartBrushOptions.value.useWheelMove) {
+      this.brushCanvas[type]('wheel', this.onWheel);
+      this.brushCanvas[type]('wheel', this.onWheelDebounce);
+    }
   }
 
   removeBrushWrapper() {

--- a/src/components/chartBrush/uses.js
+++ b/src/components/chartBrush/uses.js
@@ -10,6 +10,7 @@ const DEFAULT_OPTIONS = {
     fillColor: '#38ACEC',
     opacity: 0.65,
   },
+  useWheelMove: true,
 };
 
 // eslint-disable-next-line import/prefer-default-export


### PR DESCRIPTION
# 작업 배경

3.3-rc에 반영되어 있는 작업을 3.0에 반영하기 위함. (3.3-rc: https://github.com/ex-em/EVUI/pull/1644)

# 변경 사항 요약

- 브러쉬의 `DEFAULT_OPTION` 에 `useWheelMove: true` 추가
- useWheelMove가 true인 경우에만 wheel 이벤트가 추가되도록 분기 처리

# 기대 동작

![evui-brush-chart-수정](https://github.com/ex-em/EVUI/assets/75205035/920ba694-7b9e-4260-9b61-20569cd62f0b)
