### PR TITLE
[#1647] Grid > Column Setting > Default로 설정되어 있는 ColumnList 옵션화

### DIFF
--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -27,68 +27,69 @@
  - `#rowDetail` Row 하단에 사용자 정의 컴포넌트 표현, 사용시 가상스크롤 미적용 rowDetail 옵션과 같이 사용
 
 ### Props
-| 이름 | 타입 | 디폴트 | 설명 | 종류 |
-| --- | ---- | ----- | ---- | --- |
-| columns | Array | [] | 컬럼 리스트 | |
-| rows | Array | [] | row 리스트 | |
-| width | String, Number | '100%' | 그리드 넓이 | '50%', '50px', 50 |
-| height | String, Number | '100%' | 그리드 높이 | '50%', '50px', 50 |
-| selected | Array | [] | 선택된 row 데이터 |  |
-| checked | Array | [] | 체크된 row 데이터 |  |
-| uncheckable | Array | [] | 체크할 수 없는 row 데이터 |  |
-| expanded | Array | [] | 확장된 Row 데이터 |  |
-| option | Object | {} | 그리드 옵션 |  |
-|  | adjust | false | 그리드의 너비에 맞게 컬럼 너비를 자동으로 조절한다. |  |
-|  | showHeader | true | 헤더 표시 여부를 설정한다. |  |
-|  | rowHeight | 35 | row 높이를 설정한다. | `min-height: 35` |
-|  | rowMinHeight | null | row 높이를 `min-height`보다 작게 설정한다. |  |
-|  | columnWidth | 40 | 기본 컬럼 너비를 설정한다. | `min-width: 40px` |
-|  | customAscFunction | {} | 그리드 오름차순 정렬 시 사용할 커스텀 함수를 정의한다. 내림차순 정렬 함수는 자동으로 구성된다. |  |
-|  |  | `[Column Field]` | 커스텀 함수, 형태는 `Array.prototype.sort` 함수의 첫 번째 인자와 같다. | (a: any, b: any) => number |
-|  | useCheckbox | {} | 각 row별 체크박스 사용 여부 및 단일 선택이나 다중 선택을 설정한다. |  |
-|  |  | use | 체크박스 사용 여부 | Boolean |
-|  |  | mode | 단일 및 다중 선택 설정 | 'multi', 'single' |
-|  |  | headerCheck | 헤더 체크박스 사용 여부 | Boolean |
-|  | useSelection | {} | 각 row별 선택 여부 및 단일 선택이나 다중 선택을 설정한다. |  |
-|  |  | use | Selection 사용 여부 | Boolean |
-|  |  | multiple | 다중 선택 설정 여부  | Boolean |
-|  | style | {} | 그리드의 스타일을 설정한다. |  |
-|  |  | stripe | row의 배경색을 Stripe 스타일로 설정한다. | Boolean |
-|  |  | border | 그리드의 Border 여부를 설정한다. | 'none', 'rows' |
-|  |  | highlight | 지정한 row에 Highlight 효과를 설정한다. | `rowIndex` |
-|  | customContextMenu | [] | 우클릭시 보여지는 컨텍스트 메뉴를 설정한다. |  |
-|  |  | menuItems | 컨텍스트 메뉴 |  |
-|  | hiddenColumnMenuItem | {} | 그리드 헤더 클릭시 보여지는 컨텍스트 메뉴 각 아이템의 표시 여부를 설정한다. (`true`: 숨김 / `false`: 노출 / Default: `false`) |  |
-|  |  | ascending | 오름차순 정렬 | Boolean |
-|  |  | descending | 내림차순 정렬 | Boolean |
-|  |  | filter | 필터 기능 | Boolean |
-|  |  | hide | 컬럼 숨김 | Boolean |
-|  | columnMenuText | {} | 그리드 헤더 클릭시 보여지는 컨텍스트 메뉴 각 아이템의 텍스트를 설정한다. |  |
-|  |  | ascending | Default: 'Ascending' | String |
-|  |  | descending | Default: 'Descending' | String |
-|  |  | filter | Default: 'Filter' | String |
-|  |  | hide | Default: 'Hide' | String |
-|  | page | {} | 페이지 설정 |  |
-|  |  | use | 페이지 사용 여부 | Boolean |
-|  |  | isInfinite | Infinite Scroll 사용 여부 | Boolean |
-|  |  | useClient | client-side Paging 사용 여부 | Boolean |
-|  |  | total | 총 항목 수 | Number |
-|  |  | perPage | 각 페이지의 항목 수 | Number |
-|  |  | currentPage | 현재 페이지 번호 | Number |
-|  |  | visiblePage | 보여지는 Pagination 버튼 수 | Number |
-|  |  | order | Pagination 위치 | 'center', 'left', 'right' |
-|  |  | showPageInfo | 페이지 정보 표시 여부 | Boolean |
-|  | rowDetail | {} | rowDetail 설정 | |
-|  |  | use | rowDetail 사용여부 | Boolean |
-|  | useSummary | false | 하단에 summary row 가 표시 된다. | Boolean |
-|  | useGridSetting | {} | 그리드 옵션 설정  | |
-|  |  | use | 그리드 옵션 설정 사용 여부 | Boolean |
-|  |  | customContextMenu | 그리드옵션 클릭시 보여지는 컨텍스트 메뉴를 설정한다. |  |
-|  |  | columnMenuText | 컬럼 설정 메뉴의 텍스트를 설정한다.(Default: 'Column List') | String |
-|  |  | searchText | 컬럼 설정창 검색 영역의 placeholder 텍스트를 설정한다. (Default: 'Search') | String |
-|  |  | emptyText | 컬럼 설정창에 데이터가 없는 경우 표시되는 텍스트를 설정한다. (Default: 'No records') | String |
-|  |  | okBtnText | 컬럼 설정 완료 버튼의 텍스트를 설정한다. (Default: 'OK') | String |
-|  | emptyText | 'No records' | 데이터가 없는 경우 표시되는 텍스트를 설정한다. | String |
+| 이름 | 타입 | 디폴트                     | 설명                                                                                        | 종류 |
+| --- | ---- |-------------------------|-------------------------------------------------------------------------------------------| --- |
+| columns | Array | []                      | 컬럼 리스트                                                                                    | |
+| rows | Array | []                      | row 리스트                                                                                   | |
+| width | String, Number | '100%'                  | 그리드 넓이                                                                                    | '50%', '50px', 50 |
+| height | String, Number | '100%'                  | 그리드 높이                                                                                    | '50%', '50px', 50 |
+| selected | Array | []                      | 선택된 row 데이터                                                                               |  |
+| checked | Array | []                      | 체크된 row 데이터                                                                               |  |
+| uncheckable | Array | []                      | 체크할 수 없는 row 데이터                                                                          |  |
+| expanded | Array | []                      | 확장된 Row 데이터                                                                               |  |
+| option | Object | {}                      | 그리드 옵션                                                                                    |  |
+|  | adjust | false                   | 그리드의 너비에 맞게 컬럼 너비를 자동으로 조절한다.                                                             |  |
+|  | showHeader | true                    | 헤더 표시 여부를 설정한다.                                                                           |  |
+|  | rowHeight | 35                      | row 높이를 설정한다.                                                                             | `min-height: 35` |
+|  | rowMinHeight | null                    | row 높이를 `min-height`보다 작게 설정한다.                                                           |  |
+|  | columnWidth | 40                      | 기본 컬럼 너비를 설정한다.                                                                           | `min-width: 40px` |
+|  | customAscFunction | {}                      | 그리드 오름차순 정렬 시 사용할 커스텀 함수를 정의한다. 내림차순 정렬 함수는 자동으로 구성된다.                                    |  |
+|  |  | `[Column Field]`        | 커스텀 함수, 형태는 `Array.prototype.sort` 함수의 첫 번째 인자와 같다.                                       | (a: any, b: any) => number |
+|  | useCheckbox | {}                      | 각 row별 체크박스 사용 여부 및 단일 선택이나 다중 선택을 설정한다.                                                  |  |
+|  |  | use                     | 체크박스 사용 여부                                                                                | Boolean |
+|  |  | mode                    | 단일 및 다중 선택 설정                                                                             | 'multi', 'single' |
+|  |  | headerCheck             | 헤더 체크박스 사용 여부                                                                             | Boolean |
+|  | useSelection | {}                      | 각 row별 선택 여부 및 단일 선택이나 다중 선택을 설정한다.                                                       |  |
+|  |  | use                     | Selection 사용 여부                                                                           | Boolean |
+|  |  | multiple                | 다중 선택 설정 여부                                                                               | Boolean |
+|  | style | {}                      | 그리드의 스타일을 설정한다.                                                                           |  |
+|  |  | stripe                  | row의 배경색을 Stripe 스타일로 설정한다.                                                               | Boolean |
+|  |  | border                  | 그리드의 Border 여부를 설정한다.                                                                     | 'none', 'rows' |
+|  |  | highlight               | 지정한 row에 Highlight 효과를 설정한다.                                                              | `rowIndex` |
+|  | customContextMenu | []                      | 우클릭시 보여지는 컨텍스트 메뉴를 설정한다.                                                                  |  |
+|  |  | menuItems               | 컨텍스트 메뉴                                                                                   |  |
+|  | hiddenColumnMenuItem | {}                      | 그리드 헤더 클릭시 보여지는 컨텍스트 메뉴 각 아이템의 표시 여부를 설정한다. (`true`: 숨김 / `false`: 노출 / Default: `false`) |  |
+|  |  | ascending               | 오름차순 정렬                                                                                   | Boolean |
+|  |  | descending              | 내림차순 정렬                                                                                   | Boolean |
+|  |  | filter                  | 필터 기능                                                                                     | Boolean |
+|  |  | hide                    | 컬럼 숨김                                                                                     | Boolean |
+|  | columnMenuText | {}                      | 그리드 헤더 클릭시 보여지는 컨텍스트 메뉴 각 아이템의 텍스트를 설정한다.                                                 |  |
+|  |  | ascending               | Default: 'Ascending'                                                                      | String |
+|  |  | descending              | Default: 'Descending'                                                                     | String |
+|  |  | filter                  | Default: 'Filter'                                                                         | String |
+|  |  | hide                    | Default: 'Hide'                                                                           | String |
+|  | page | {}                      | 페이지 설정                                                                                    |  |
+|  |  | use                     | 페이지 사용 여부                                                                                 | Boolean |
+|  |  | isInfinite              | Infinite Scroll 사용 여부                                                                     | Boolean |
+|  |  | useClient               | client-side Paging 사용 여부                                                                  | Boolean |
+|  |  | total                   | 총 항목 수                                                                                    | Number |
+|  |  | perPage                 | 각 페이지의 항목 수                                                                               | Number |
+|  |  | currentPage             | 현재 페이지 번호                                                                                 | Number |
+|  |  | visiblePage             | 보여지는 Pagination 버튼 수                                                                      | Number |
+|  |  | order                   | Pagination 위치                                                                             | 'center', 'left', 'right' |
+|  |  | showPageInfo            | 페이지 정보 표시 여부                                                                              | Boolean |
+|  | rowDetail | {}                      | rowDetail 설정                                                                              | |
+|  |  | use                     | rowDetail 사용여부                                                                            | Boolean |
+|  | useSummary | false                   | 하단에 summary row 가 표시 된다.                                                                  | Boolean |
+|  | useGridSetting | {}                      | 그리드 옵션 설정                                                                                 | |
+|  |  | use                     | 그리드 옵션 설정 사용 여부                                                                           | Boolean |
+|  |  | customContextMenu       | 그리드옵션 클릭시 보여지는 컨텍스트 메뉴를 설정한다.                                                             |  |
+|  |  | useDefaultColumnSetting | 기본 제공되는 컬럼 설정 메뉴 사용 여부 (Default: true)                                                    | Boolean |
+|  |  | columnMenuText          | 컬럼 설정 메뉴의 텍스트를 설정한다.(Default: 'Column List')                                              | String |
+|  |  | searchText              | 컬럼 설정창 검색 영역의 placeholder 텍스트를 설정한다. (Default: 'Search')                                  | String |
+|  |  | emptyText               | 컬럼 설정창에 데이터가 없는 경우 표시되는 텍스트를 설정한다. (Default: 'No records')                                | String |
+|  |  | okBtnText               | 컬럼 설정 완료 버튼의 텍스트를 설정한다. (Default: 'OK')                                                   | String |
+|  | emptyText | 'No records'            | 데이터가 없는 경우 표시되는 텍스트를 설정한다.                                                                | String |
 
 ### Columns
 | 이름 | 타입 | 설명 | 종류 | 필수 |

--- a/docs/views/grid/example/ColumnSetting.vue
+++ b/docs/views/grid/example/ColumnSetting.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="case">
+    <ev-grid
+      :columns="gridColumns"
+      :rows="tableData"
+      :width="widthMV"
+      :height="heightMV"
+      :option="{
+        useGridSetting: {
+          use: true,
+          useDefaultColumnSetting: false,
+          customContextMenu: gridSettingMenuItems,
+        },
+        useFilter: true,
+      }"
+      @resize-column="onUpdateColumns"
+      @change-column-order="onUpdateColumns"
+      @change-column-status="onUpdateColumns"
+    >
+    </ev-grid>
+    <custom-column-list
+      v-model:is-visible="isVisible"
+      v-model:columns="gridColumns"
+    />
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+import CustomColumnList from 'docs/views/grid/example/partitals/CustomColumnList.vue';
+
+export default {
+  components: { CustomColumnList },
+  setup() {
+    const isVisible = ref(false);
+    const tableData = ref([]);
+    const selected = ref([]);
+    const checked = ref([]);
+    const widthMV = ref('100%');
+    const heightMV = ref(300);
+    const gridSettingMenuItems = ref([
+      {
+        text: 'Menu1',
+        click: param => console.log(`[Menu1]: ${JSON.stringify(param, null, 2)}`),
+      }, {
+        text: 'Menu2',
+        click: param => console.log('[Menu2]', param.contextmenuInfo),
+      }, {
+        text: 'Custom Column List',
+        click: () => {
+          isVisible.value = true;
+        },
+      },
+    ]);
+    const gridColumns = ref([
+      { caption: 'Column A', field: 'columnA', type: 'string', width: 120 },
+      { caption: 'Column B', field: 'columnB', type: 'string', width: 120, hiddenDisplay: true },
+      { caption: 'Column C', field: 'columnC', type: 'string', width: 120 },
+      { caption: 'Column D', field: 'columnD', type: 'string', width: 120 },
+      { caption: 'Column E', field: 'columnE', type: 'string', width: 120, sortable: false },
+      { caption: 'Column F', field: 'columnF', type: 'string', width: 120, hide: true },
+    ]);
+    const onUpdateColumns = ({ columns }) => {
+      gridColumns.value = columns;
+    };
+    const getData = (count, startIndex) => {
+      const temp = [];
+      for (let ix = startIndex; ix < startIndex + count; ix++) {
+        temp.push([
+          `Column A - ${ix + 1}`,
+          `Column B - ${ix + 1}`,
+          `Column C - ${ix + 1}`,
+          `Column D - ${ix + 1}`,
+          `Column E - ${ix + 1}`,
+        ]);
+      }
+      return temp;
+    };
+
+    tableData.value = getData(10, 0);
+    return {
+      isVisible,
+      gridColumns,
+      tableData,
+      selected,
+      checked,
+      widthMV,
+      heightMV,
+      gridSettingMenuItems,
+      onUpdateColumns,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.description {
+  min-width: 200px;
+}
+
+.form-rows {
+  display: flex;
+  margin-bottom: 5px;
+}
+
+.form-row {
+  width: 50%;
+}
+
+.badge {
+  margin-bottom: 2px;
+  margin-right: 5px !important;
+}
+
+.ev-toggle {
+  margin-right: 10px;
+}
+</style>

--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -15,6 +15,7 @@
         columnWidth: columnWidthMV,
         useGridSetting: {
           use: useGridSettingMV,
+          useDefaultColumnSetting: useGridDefaultSettingMV,
           customContextMenu: gridSettingMenuItems,
         },
         useFilter: useFilterMV,
@@ -84,11 +85,20 @@
         <ev-toggle
           v-model="isSelectionMultiple"
         />
+      </div>
+      <div class="form-rows">
         <span class="badge yellow">
           Use Grid Setting
         </span>
         <ev-toggle
           v-model="useGridSettingMV"
+        />
+        <span class="badge yellow">
+          Use Grid Default Setting
+        </span>
+        <ev-toggle
+          v-model="useGridDefaultSettingMV"
+          :disabled="!useGridSettingMV"
         />
       </div>
       <div class="form-rows">
@@ -239,6 +249,7 @@ export default {
     const useSelectionMV = ref(true);
     const isSelectionMultiple = ref(false);
     const useGridSettingMV = ref(true);
+    const useGridDefaultSettingMV = ref(true);
     const gridSettingMenuItems = ref([
       {
         text: 'Menu1',
@@ -364,6 +375,7 @@ export default {
       isSelectionMultiple,
       useSelectionMV,
       useGridSettingMV,
+      useGridDefaultSettingMV,
       gridSettingMenuItems,
       changeMode,
       onCheckedRow,

--- a/docs/views/grid/example/partitals/CustomColumnList.vue
+++ b/docs/views/grid/example/partitals/CustomColumnList.vue
@@ -1,0 +1,126 @@
+<template>
+  <ev-window
+    v-model:visible="visible"
+    title="Custom Column List"
+    width="20%"
+    height="40%"
+  >
+    <ev-checkbox-group
+      v-model="checkColumnGroup"
+      class="column-group"
+      @change="onCheckColumn"
+    >
+      <ev-checkbox
+        v-for="(column, idx) in getDisplayColumnList(columnList)"
+        :key="`${column.field}_${idx}`"
+        :label="column?.field"
+      >
+        {{column?.caption}}
+      </ev-checkbox>
+    </ev-checkbox-group>
+    <template #footer>
+      <ev-button
+        type="primary"
+        @click="onApplyColumn"
+      >
+        OK
+      </ev-button>
+    </template>
+  </ev-window>
+</template>
+<script>
+
+import { computed, ref, watch } from 'vue';
+
+export default {
+  name: 'CustomColumnList',
+  props: {
+    isVisible: {
+      type: Boolean,
+      default: false,
+    },
+    columns: {
+      type: [Array],
+      required: true,
+    },
+  },
+  emits: ['update:isVisible', 'update:columns'],
+  setup(props, { emit }) {
+    const visible = computed({
+      get: () => props.isVisible,
+      set: value => emit('update:isVisible', value),
+    });
+    const columnList = computed({
+      get: () => props.columns,
+      set: value => emit('update:columns', value),
+    });
+    const checkColumnGroup = ref([]);
+    let lastCheckColumn = null;
+    const onCheckColumn = (checkColumns) => {
+      if (checkColumns?.length === 1) {
+        lastCheckColumn = checkColumns[0];
+      } else if (checkColumns?.length < 1 && lastCheckColumn !== null) {
+        checkColumnGroup.value.push(lastCheckColumn);
+      }
+    };
+
+    const setCheckColumn = (columns) => {
+      checkColumnGroup.value = columns.filter(column => !column.hiddenDisplay)
+        .filter(column => !column.hiddenDisplay)
+        .map(column => (column.field));
+    };
+
+    const sort = {
+      ASC: (columns, target) => columns.sort((a, b) => a[target] - b[target]),
+      DESC: (columns, target) => columns.sort((a, b) => b[target] - a[target]),
+    };
+
+    const getSortingColumns = (columns, type = 'ASC') => {
+      const sortingTarget = 'index';
+      const existTargetInColumns = columns.every(
+        column => Object.prototype.hasOwnProperty.call(column, sortingTarget),
+      );
+      if (existTargetInColumns) {
+        return sort[type](columns, sortingTarget);
+      }
+      return columns;
+    };
+    const getDisplayColumnList = (columns) => {
+      if (!visible.value) {
+        return columns;
+      }
+      return getSortingColumns(columns.filter(column => !column?.hide));
+    };
+
+    watch(() => visible.value, (newVal, prevVal) => {
+      if (newVal && !prevVal) {
+        setCheckColumn(columnList.value);
+      }
+    });
+
+    const onApplyColumn = () => {
+      columnList.value.forEach((column) => {
+        column.hiddenDisplay = !checkColumnGroup.value.includes(column.field);
+      });
+      visible.value = false;
+    };
+
+    return {
+      visible,
+      columnList,
+      checkColumnGroup,
+      onCheckColumn,
+      onApplyColumn,
+      getDisplayColumnList,
+    };
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.column-group {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+</style>

--- a/docs/views/grid/example/partitals/CustomColumnList.vue
+++ b/docs/views/grid/example/partitals/CustomColumnList.vue
@@ -65,8 +65,8 @@ export default {
     };
 
     const setCheckColumn = (columns) => {
-      checkColumnGroup.value = columns.filter(column => !column.hiddenDisplay)
-        .filter(column => !column.hiddenDisplay)
+      checkColumnGroup.value = columns
+        .filter(column => !column.hiddenDisplay && !column.hide)
         .map(column => (column.field));
     };
 

--- a/docs/views/grid/props.js
+++ b/docs/views/grid/props.js
@@ -49,7 +49,7 @@ export default {
       component: ColumnEvent,
       parsedData: parseComponent(ColumnEventRaw),
     },
-    'Column Setting': {
+    'Custom Column List': {
       component: ColumnSetting,
       parsedData: parseComponent(ColumnSettingRaw),
     },

--- a/docs/views/grid/props.js
+++ b/docs/views/grid/props.js
@@ -1,5 +1,7 @@
 import { parseComponent } from 'vue-template-compiler';
 import mdText from 'raw-loader!./api/grid.md';
+import ColumnSetting from 'docs/views/grid/example/ColumnSetting.vue';
+import ColumnSettingRaw from '!!raw-loader!./example/ColumnSetting.vue';
 import Default from './example/Default';
 import DefaultRaw from '!!raw-loader!./example/Default';
 import CellRenderer from './example/CellRenderer';
@@ -46,6 +48,10 @@ export default {
     ColumnEvent: {
       component: ColumnEvent,
       parsedData: parseComponent(ColumnEventRaw),
+    },
+    'Column Setting': {
+      component: ColumnSetting,
+      parsedData: parseComponent(ColumnSettingRaw),
     },
   },
 };

--- a/docs/views/treeGrid/api/treeGrid.md
+++ b/docs/views/treeGrid/api/treeGrid.md
@@ -34,66 +34,67 @@
 - `#toolbar` 지정해서 Toolbar 표시
 
 ### Props
-| 이름 | 타입               | 디폴트                | 설명                                      | 종류                       |
-| --- |------------------|--------------------|-----------------------------------------|--------------------------|
-| columns | Array            | []                 | 컬럼 리스트                                  |                          |
-| rows | Array            | []                 | Tree Data 리스트                           |                          |
-|  | {}    |    | Tree Grid의 각 Row 데이터에 연결된 속성 | |
-|  |    | checked   | Row 데이터 체크 여부  | true, false |
-|  |    | selected   | Row 데이터 선택 여부  | true, false |
-|  |    | show  | Row 데이터 표시 여부  | true, false |
-|  |    | expand   | Row 데이터 확장 여부  | true, false |
-|  |    | uncheckable   | Row 데이터의 체크박스에 대한 비활성화 처리  | true, false |
-|  |    | children   | 자식 데이터  | Array |
-| width | String, Number   | '100%'             | 그리드 넓이                                  | '50%', '50px', 50        |
-| height | String, Number   | '100%'             | 그리드 높이                                  | '50%', '50px', 50        |
-| selected | Array            | []                 | 선택된 Row 데이터                             |                          |
-| checked | Array            | []                 | 체크된 Row 데이터                             |                          |
-| option | Object           | {}                 | 그리드 옵션                                  |                          |
-|  | adjust           | false              | 그리드의 너비에 맞게 컬럼 너비를 자동으로 조절한다.           |                          |
-|  | showHeader       | true               | 헤더 표시 여부를 설정한다.                         |                          |
-|  | rowHeight        | 35                 | Row 높이를 설정한다.                           | `min-height: 35`         |
-|  | rowMinHeight     | null               | Row 높이를 `min-height`보다 작게 설정한다.         |                          |
-|  | columnWidth      | 40                 | 기본 컬럼 너비를 설정 한다.                        | `min-width: 40px`        |
-|  | useCheckbox      | {}                 | 각 Row별 체크박스 사용 여부 및 단일 선택이나 다중 선택을 설정한다. |                          |
-|  |                  | use                | 체크박스 사용 여부                              | boolean                  |
-|  |                  | mode               | 단일 및 다중 선택 설정                           | 'multi', 'single'        |
-|  |                  | headerCheck        | 헤더 체크박스 사용 여부                           | boolean                  |
-|  | useSelection     | {}                 | 각 row별 선택 여부 및 단일 선택이나 다중 선택을 설정한다.     |                          |
-|  |                  | use                | Selection 사용 여부                         | Boolean                  |
-|  |                  | multiple           | 다중 선택 설정 여부                             | Boolean                  |
-|  |                  | limitCount         | 선택 가능한 row의 수를 제한                       | Number                   |
-|  | style            | {}                 | 그리드의 스타일을 설정한다.                         |                          |
-|  |                  | stripe             | Row의 배경색을 Stripe 스타일로 설정한다.             | boolean                  |
-|  |                  | border             | 그리드의 Border 여부를 설정한다.                   | 'none', 'rows'           |
-|  |                  | highlight          | 지정한 Row에 Highlight 효과를 설정한다.            | `rowIndex`               |
-|  | customContextMenu | []                 | 우클릭시 보여지는 컨텍스트 메뉴를 설정한다.                |                          |
-|  |                  | menuItems          | 컨텍스트 메뉴                                 |                          |
-|  | page             | {}                 | 페이지 설정                                  |                          |
-|  |                  | use                | 페이지 사용 여부                               | Boolean                  |
-|  |                  | isInfinite         | Infinite Scroll 사용 여부                   | Boolean                  |
-|  |                  | useClient          | client-side Paging 사용 여부                | Boolean                  |
-|  |                  | total              | 총 항목 수                                  | Number                   |
-|  |                  | perPage            | 각 페이지의 항목 수                             | Number                   |
-|  |                  | currentPage        | 현재 페이지 번호                               | Number                   |
-|  |                  | visiblePage        | 보여지는 Pagination 버튼 수                    | Number                   |
+| 이름 | 타입               | 디폴트                | 설명                                      | 종류                        |
+| --- |------------------|--------------------|-----------------------------------------|---------------------------|
+| columns | Array            | []                 | 컬럼 리스트                                  |                           |
+| rows | Array            | []                 | Tree Data 리스트                           |                           |
+|  | {}    |    | Tree Grid의 각 Row 데이터에 연결된 속성 |                           |
+|  |    | checked   | Row 데이터 체크 여부  | true, false               |
+|  |    | selected   | Row 데이터 선택 여부  | true, false               |
+|  |    | show  | Row 데이터 표시 여부  | true, false               |
+|  |    | expand   | Row 데이터 확장 여부  | true, false               |
+|  |    | uncheckable   | Row 데이터의 체크박스에 대한 비활성화 처리  | true, false               |
+|  |    | children   | 자식 데이터  | Array                     |
+| width | String, Number   | '100%'             | 그리드 넓이                                  | '50%', '50px', 50         |
+| height | String, Number   | '100%'             | 그리드 높이                                  | '50%', '50px', 50         |
+| selected | Array            | []                 | 선택된 Row 데이터                             |                           |
+| checked | Array            | []                 | 체크된 Row 데이터                             |                           |
+| option | Object           | {}                 | 그리드 옵션                                  |                           |
+|  | adjust           | false              | 그리드의 너비에 맞게 컬럼 너비를 자동으로 조절한다.           |                           |
+|  | showHeader       | true               | 헤더 표시 여부를 설정한다.                         |                           |
+|  | rowHeight        | 35                 | Row 높이를 설정한다.                           | `min-height: 35`          |
+|  | rowMinHeight     | null               | Row 높이를 `min-height`보다 작게 설정한다.         |                           |
+|  | columnWidth      | 40                 | 기본 컬럼 너비를 설정 한다.                        | `min-width: 40px`         |
+|  | useCheckbox      | {}                 | 각 Row별 체크박스 사용 여부 및 단일 선택이나 다중 선택을 설정한다. |                           |
+|  |                  | use                | 체크박스 사용 여부                              | boolean                   |
+|  |                  | mode               | 단일 및 다중 선택 설정                           | 'multi', 'single'         |
+|  |                  | headerCheck        | 헤더 체크박스 사용 여부                           | boolean                   |
+|  | useSelection     | {}                 | 각 row별 선택 여부 및 단일 선택이나 다중 선택을 설정한다.     |                           |
+|  |                  | use                | Selection 사용 여부                         | Boolean                   |
+|  |                  | multiple           | 다중 선택 설정 여부                             | Boolean                   |
+|  |                  | limitCount         | 선택 가능한 row의 수를 제한                       | Number                    |
+|  | style            | {}                 | 그리드의 스타일을 설정한다.                         |                           |
+|  |                  | stripe             | Row의 배경색을 Stripe 스타일로 설정한다.             | boolean                   |
+|  |                  | border             | 그리드의 Border 여부를 설정한다.                   | 'none', 'rows'            |
+|  |                  | highlight          | 지정한 Row에 Highlight 효과를 설정한다.            | `rowIndex`                |
+|  | customContextMenu | []                 | 우클릭시 보여지는 컨텍스트 메뉴를 설정한다.                |                           |
+|  |                  | menuItems          | 컨텍스트 메뉴                                 |                           |
+|  | page             | {}                 | 페이지 설정                                  |                           |
+|  |                  | use                | 페이지 사용 여부                               | Boolean                   |
+|  |                  | isInfinite         | Infinite Scroll 사용 여부                   | Boolean                   |
+|  |                  | useClient          | client-side Paging 사용 여부                | Boolean                   |
+|  |                  | total              | 총 항목 수                                  | Number                    |
+|  |                  | perPage            | 각 페이지의 항목 수                             | Number                    |
+|  |                  | currentPage        | 현재 페이지 번호                               | Number                    |
+|  |                  | visiblePage        | 보여지는 Pagination 버튼 수                    | Number                    |
 |  |                  | order              | Pagination 위치                           | 'center', 'left', 'right' |
-|  |                  | showPageInfo       | 페이지 정보 표시 여부                            | Boolean                  |
-|  | useSummary       | false              | 하단에 summary row 가 표시 된다.                | Boolean                  |
-|  | useGridSetting | {} | 그리드 옵션 설정  | |
-|  |  | use | 그리드 옵션 설정 사용 여부 | Boolean |
-|  |  | customContextMenu | 그리드옵션 클릭시 보여지는 컨텍스트 메뉴를 설정한다. |  |
-|  |  | columnMenuText | 컬럼 설정 메뉴의 텍스트를 설정한다.(Default: 'Column List') | String |
-|  |  | searchText | 컬럼 설정창 검색 영역의 placeholder 텍스트를 설정한다. (Default: 'Search') | String |
-|  |  | emptyText | 컬럼 설정창에 데이터가 없는 경우 표시되는 텍스트를 설정한다. (Default: 'No records') | String |
-|  |  | okBtnText | 컬럼 설정 완료 버튼의 텍스트를 설정한다. (Default: 'OK') | String |
-|  | columnMenuText | {} | 그리드 헤더 클릭시 보여지는 컨텍스트 메뉴 각 아이템의 텍스트를 설정한다. |  |
-|  |  | hide | Default: 'Hide' | String |
-|  | expandIcon       | 'tree-expand-icon' | expand 상태인 노드의 아이콘                      | `ev-icon`                |
-|  | collapseIcon     | 'tree-expand-icon' | collapse 상태인 노드의 아이콘                    | `ev-icon`                |
-|  | parentIcon       | 'tree-parent-icon' | 자식 노드가 있는 노드의 아이콘                       | `ev-icon`, 'none'        |
-|  | childIcon        | 'tree-child-icon'  | 자식 노드가 없는 노드의 아이콘                       | `ev-icon`, 'none'        |
-|  | emptyText | 'No records' | 데이터가 없는 경우 표시되는 텍스트를 설정한다. | String |
+|  |                  | showPageInfo       | 페이지 정보 표시 여부                            | Boolean                   |
+|  | useSummary       | false              | 하단에 summary row 가 표시 된다.                | Boolean                   |
+|  | useGridSetting | {} | 그리드 옵션 설정  |                           |
+|  |  | use | 그리드 옵션 설정 사용 여부 | Boolean                   |
+|  |  | customContextMenu | 그리드옵션 클릭시 보여지는 컨텍스트 메뉴를 설정한다. |                           |
+|  |  | useDefaultColumnSetting | 기본 제공되는 컬럼 설정 메뉴 사용 여부 (Default: true) | Boolean                   |
+|  |  | columnMenuText | 컬럼 설정 메뉴의 텍스트를 설정한다.(Default: 'Column List') | String                    |
+|  |  | searchText | 컬럼 설정창 검색 영역의 placeholder 텍스트를 설정한다. (Default: 'Search') | String                    |
+|  |  | emptyText | 컬럼 설정창에 데이터가 없는 경우 표시되는 텍스트를 설정한다. (Default: 'No records') | String                    |
+|  |  | okBtnText | 컬럼 설정 완료 버튼의 텍스트를 설정한다. (Default: 'OK') | String                    |
+|  | columnMenuText | {} | 그리드 헤더 클릭시 보여지는 컨텍스트 메뉴 각 아이템의 텍스트를 설정한다. |                           |
+|  |  | hide | Default: 'Hide' | String                    |
+|  | expandIcon       | 'tree-expand-icon' | expand 상태인 노드의 아이콘                      | `ev-icon`                 |
+|  | collapseIcon     | 'tree-expand-icon' | collapse 상태인 노드의 아이콘                    | `ev-icon`                 |
+|  | parentIcon       | 'tree-parent-icon' | 자식 노드가 있는 노드의 아이콘                       | `ev-icon`, 'none'         |
+|  | childIcon        | 'tree-child-icon'  | 자식 노드가 없는 노드의 아이콘                       | `ev-icon`, 'none'         |
+|  | emptyText | 'No records' | 데이터가 없는 경우 표시되는 텍스트를 설정한다. | String                    |
 
 ### Columns
 | 이름              | 타입      | 설명                                                 | 종류                                               | 필수 |

--- a/docs/views/treeGrid/example/ColumnSetting.vue
+++ b/docs/views/treeGrid/example/ColumnSetting.vue
@@ -1,0 +1,194 @@
+<template>
+  <div class="case">
+    <ev-tree-grid
+      v-model:selected="selected"
+      v-model:checked="checked"
+      :columns="gridColumns"
+      :rows="tableData"
+      :width="widthMV"
+      :height="heightMV"
+      :option="{
+        adjust: true,
+        useGridSetting: {
+          use: true,
+          useDefaultColumnSetting: false,
+          customContextMenu: gridSettingMenuItems,
+        },
+      }"
+      @resize-column="onUpdateColumns"
+      @change-column-status="onUpdateColumns"
+    >
+    </ev-tree-grid>
+    <custom-column-list
+      v-model:columns="gridColumns"
+      v-model:is-visible="isVisible"
+    />
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+import CustomColumnList from 'docs/views/grid/example/partitals/CustomColumnList.vue';
+
+export default {
+  components: { CustomColumnList },
+  setup() {
+    const isVisible = ref(false);
+    const tableData = ref([]);
+    const selected = ref([]);
+    const checked = ref([]);
+    const widthMV = ref('100%');
+    const heightMV = ref(300);
+    const gridSettingMenuItems = ref([
+      {
+        text: 'Menu1',
+        click: param => console.log(`[Menu1]: ${param}`),
+      }, {
+        text: 'Custom Column List',
+        click: () => {
+          isVisible.value = true;
+        },
+      },
+    ]);
+    const getData = () => {
+      tableData.value = [
+        {
+          id: 'Exem 0',
+          date: '2016-05-01',
+          name: '1111',
+          expand: true,
+        },
+        {
+          id: 'Exem 1',
+          date: '2016-05-01',
+          name: '2222',
+          value: 123,
+          expand: true,
+          children: [{
+            id: 'Exem 2',
+            date: '2016-05-02',
+            name: '2',
+            value: 222,
+            expand: false,
+            children: [{
+              id: 'Exem 3',
+              date: '2016-05-02',
+              name: '3',
+              value: 3333,
+              uncheckable: true,
+            }, {
+              id: 'Exem 4',
+              date: '2016-05-02',
+              name: '4',
+              expand: false,
+              uncheckable: true,
+              children: [{
+                id: 'Exem 5',
+                date: '2016-05-02',
+                name: '5',
+                children: [{
+                  id: 'Exem 51',
+                  date: '2016-05-02',
+                  name: '1251',
+                  children: [{
+                    id: 'Exem 52',
+                    date: '2016-05-02',
+                    name: '20000',
+                  }],
+                }],
+              }, {
+                id: 'Exem 6',
+                date: '2016-05-02',
+                name: '6',
+              }],
+            }],
+          }, {
+            id: 'Exem 7',
+            date: '2016-05-03',
+            name: '7',
+            children: [{
+              id: 'Exem 8',
+              date: '2016-05-03',
+              name: '8',
+              value: 333,
+            }, {
+              id: 'Exem 9',
+              date: '2016-05-03',
+              name: '9',
+            }, {
+              id: 'Exem 10',
+              date: '2016-05-03',
+              name: '10',
+            }],
+          }, {
+            id: 'Exem 11',
+            date: '2016-05-04',
+            name: '11',
+          }],
+        },
+      ];
+    };
+    const gridColumns = ref([
+      { caption: 'ID', field: 'id', type: 'number' },
+      { caption: 'Date', field: 'date', type: 'string' },
+      {
+        caption: 'Name',
+        field: 'name',
+        type: 'float',
+        summaryType: 'sum',
+        summaryOnlyTopParent: true,
+        summaryRenderer: 'Sum: {0} 최상위 부모만 summary',
+        decimal: 1,
+      },
+      {
+        caption: 'Value',
+        field: 'value',
+        type: 'number',
+        summaryType: 'sum',
+        summaryRenderer: 'Sum: {0} 모든 row summary',
+        decimal: 1,
+      },
+    ]);
+
+    const onUpdateColumns = ({ columns }) => {
+      gridColumns.value = columns;
+    };
+
+    getData();
+    return {
+      isVisible,
+      gridColumns,
+      tableData,
+      selected,
+      checked,
+      widthMV,
+      heightMV,
+      gridSettingMenuItems,
+      onUpdateColumns,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.description {
+  min-width: 200px;
+}
+.form-rows {
+  display: flex;
+  margin-bottom: 5px;
+}
+.form-row {
+  width: 50%;
+}
+.ev-text-field, .ev-input-number, .ev-select {
+  width: 80%;
+}
+.badge {
+  margin-bottom: 2px;
+  margin-right: 5px !important;
+}
+.ev-toggle {
+  margin-right: 10px;
+}
+</style>

--- a/docs/views/treeGrid/props.js
+++ b/docs/views/treeGrid/props.js
@@ -8,6 +8,8 @@ import Toolbar from './example/Toolbar';
 import ToolbarRaw from '!!raw-loader!./example/Toolbar';
 import ColumnEvent from './example/ColumnEvent.vue';
 import ColumnEventRaw from '!!raw-loader!./example/ColumnEvent.vue';
+import ColumnSetting from './example/ColumnSetting.vue';
+import ColumnSettingRaw from '!!raw-loader!./example/ColumnSetting.vue';
 
 export default {
   mdText,
@@ -28,6 +30,10 @@ export default {
     ColumnEvent: {
       component: ColumnEvent,
       parsedData: parseComponent(ColumnEventRaw),
+    },
+    'Custom Column List': {
+      component: ColumnSetting,
+      parsedData: parseComponent(ColumnSettingRaw),
     },
   },
 };

--- a/src/components/grid/GridColumnSetting.vue
+++ b/src/components/grid/GridColumnSetting.vue
@@ -8,7 +8,7 @@
         :style="columnSettingStyle"
       >
         <div class="ev-grid-column-setting__header">
-          <p class="header-title"> {{ textInfo.columnList }} </p>
+          <p class="header-title"> {{ textInfo.title }} </p>
           <ev-text-field
             v-model="searchVm"
             type="search"
@@ -92,7 +92,7 @@ export default {
     textInfo: {
       type: Object,
       default: () => ({
-        columnList: 'Column List',
+        title: 'Column List',
         search: 'Search',
         empty: 'No records',
         ok: 'OK',

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1114,8 +1114,9 @@ export const contextMenuEvent = (params) => {
    * @param {object} e - 이벤트 객체
    */
   const onGridSettingContextMenu = (e) => {
+    const { useDefaultColumnSetting, columnSettingTextInfo } = columnSettingInfo;
     const columnListMenu = {
-      text: columnSettingInfo.columnSettingTextInfo?.columnList ?? 'Column List',
+      text: columnSettingTextInfo?.columnList ?? 'Column List',
       isShowMenu: true,
       click: () => {
         columnSettingInfo.isShowColumnSetting = true;
@@ -1126,10 +1127,11 @@ export const contextMenuEvent = (params) => {
     if (contextInfo.customGridSettingContextMenu.length) {
       contextInfo.gridSettingContextMenuItems = [
         ...contextInfo.customGridSettingContextMenu,
-        columnListMenu,
       ];
-    } else {
-      contextInfo.gridSettingContextMenuItems = [columnListMenu];
+    }
+
+    if (useDefaultColumnSetting) {
+      contextInfo.gridSettingContextMenuItems.push(columnListMenu);
     }
     contextInfo.gridSettingMenu.show(e);
   };

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -666,8 +666,9 @@ export const contextMenuEvent = (params) => {
    * @param {object} e - 이벤트 객체
    */
   const onGridSettingContextMenu = (e) => {
+    const { useDefaultColumnSetting, columnSettingTextInfo } = columnSettingInfo;
     const columnListMenu = {
-      text: columnSettingInfo.columnSettingTextInfo?.columnList ?? 'Column List',
+      text: columnSettingTextInfo?.columnList ?? 'Column List',
       isShowMenu: true,
       click: () => {
         columnSettingInfo.isShowColumnSetting = true;
@@ -678,10 +679,11 @@ export const contextMenuEvent = (params) => {
     if (contextInfo.customGridSettingContextMenu.length) {
       contextInfo.gridSettingContextMenuItems = [
         ...contextInfo.customGridSettingContextMenu,
-        columnListMenu,
       ];
-    } else {
-      contextInfo.gridSettingContextMenuItems = [columnListMenu];
+    }
+
+    if (useDefaultColumnSetting) {
+      contextInfo.gridSettingContextMenuItems.push(columnListMenu);
     }
     contextInfo.gridSettingMenu.show(e);
   };


### PR DESCRIPTION
# 작업 배경

- Grid Option 중 `useGridSetting` 의 use를 true로 설정하면 기본적으로 Column List 메뉴가 활성화가 되어 있음.
- 기본적으로 활성화 되어 있는 Column List를 Option으로 show/hide 시킬 수 있는 옵션이 필요.

# 변경 사항 요약

- `useGridSetting` 옵션에 `useDefaultColumnSetting` 옵션 추가(default: true)
    - true 설정 : Column List 메뉴 사용 O
    - false 설정 : Column List 메뉴 사용 X
- Grid의 props.column watcher에 컬럼이 변경되었을 경우에만 초기화 로직이 수행되도록 분기처리 추가.
- TreeGrid 동일하게 적용

# 기대 동작
![evui-custom-grid-column-setting](https://github.com/ex-em/EVUI/assets/75205035/d4c38fcf-33f6-4558-9575-6bdeadd7df76)
