### PR TITLE
[#1650] Grid > Sort 적용한 이후 데이터 변경이 grid에 반영 되지 않음

### DIFF
--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -1084,7 +1084,7 @@ export default {
     watch(
       () => props.rows,
       (value) => {
-        setStore(value, !sortInfo.sortField);
+        setStore(value);
         if (filterInfo.isSearch) {
           onSearch(filterInfo.searchWord);
         }


### PR DESCRIPTION
# 작업 배경
grid에서 sorting을 세팅한 이후에는 grid에 전달하는 데이터가 변경되어도 grid에 반영되지 않는 문제가 있었습니다.
![GridSortingFilterBug](https://github.com/ex-em/EVUI/assets/106138523/f60d2d71-cc61-4d6f-9d72-1bd4204483f1)

# 변경 사항
grid row 데이터 변경 시  setStore(value, !sortInfo.sortField);가 실행되는데 sortField가 있는 경우에는 grid 내부 데이터가 업데이트 되는 로직이  !sortInfo.sortField값이 false가 되면서 실행되지 않고 있었습니다. 그 부분을 제거하였습니다.
