### PR TITLE
[#1655] Grid > Row Detail 옵션 사용시 adjust 옵션 미동작

### DIFF
--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -137,7 +137,7 @@ export const scrollEvent = (params) => {
       if (pageInfo.isClientPaging) {
         store = getPagingData();
       }
-      stores.viewStore = store;
+      stores.viewStore = [...store];
       scrollInfo.vScrollTopHeight = 0;
       scrollInfo.vScrollBottomHeight = 0;
     } else {
@@ -277,8 +277,8 @@ export const resizeEvent = (params) => {
         stores.orderedColumns.forEach((column) => {
           const item = column;
 
-          if (!props.columns[column.index].width && !item.resized) {
-            item.width = 0;
+          if (!item.resized) {
+            item.width = props.columns[column.index].width ?? 0;
           }
 
           return item;


### PR DESCRIPTION
### 이슈 내용
-  Grid > Row Detail 옵션 사용시 adjust 옵션 미동작

[오동작]
![오동작](https://github.com/ex-em/EVUI/assets/65858819/b2c8dae0-c85a-487a-aa75-1e04c1d7251e)

[정상동작]
![정상동작](https://github.com/ex-em/EVUI/assets/65858819/acb0b44d-f429-4248-8022-49f1f02b5e5d)


### 변경 내용
- rowDetail 사용시 v-scroll을 미사용하는데 이에 따른 분기에서 viewStore에 대한 갱신을 하지않아 바뀐 컬럼 너비에 대하여 적용되어 보이지 않음 
  - 정상동작 로직은 데이터범위가 갱신되면서 화면이 갱신됨.

-  마지막 컬럼에 너비가 설정된 경우 리사이즈시 remainWidth 값이 누적되어서 조금씩 커지는 이슈 수정
   - onResize시에 width값 없는것만 0으로 초기화하지 않고, 모든 컬럼의 width를 초기값으로 초기화 하고 변경된 너비에 맞게 계산 하도록 함.

### 테스트 방법
```
.article-example .view {
  resize: both;
  overflow: auto;
}
```
- 리사이즈 가능하게 설정후 테스트