### PR TITLE
[#1659] TextField > Keypress 이벤트 추가

### DIFF
--- a/docs/views/textField/api/textField.md
+++ b/docs/views/textField/api/textField.md
@@ -23,7 +23,7 @@ height: 100px;
     </template>
 </ev-text-field>
 ```
- 
+
 
 ### Props
 
@@ -47,3 +47,4 @@ height: 100px;
  | input | (event, newValue) | 컴포넌트 input 이벤트 발생 시 호출 |
  | change | (event, newValue) | 컴포넌트 change 이벤트 발생 시 호출 |
  | search | newValue | type === 'search'일 경우, 컴포넌트 search 이벤트 발생 시 호출 |
+ | keypress | event | 컴포넌트 keypress 이벤트 발생 시 호출 |

--- a/docs/views/textField/example/Default.vue
+++ b/docs/views/textField/example/Default.vue
@@ -74,6 +74,18 @@
       @input="checkValid"
     />
   </div>
+
+  <div class="case">
+    <p class="case-title">Prevent Alphabet Input</p>
+    <div style="display: flex;">
+      <ev-text-field
+        v-model="modelValue7"
+        placeholder="Try press alphabet key"
+        type="text"
+        @keypress="onKeypress"
+      />
+    </div>
+  </div>
 </template>
 
 <script>
@@ -87,6 +99,7 @@ export default {
     const modelValue4 = ref();
     const modelValue5 = ref();
     const modelValue6 = ref('1234가나다');
+    const modelValue7 = ref();
     const errMsg = ref();
     const checkValid = () => {
       const regexp = /^[0-9]*$/;
@@ -97,6 +110,13 @@ export default {
       }
     };
     checkValid();
+    const onKeypress = (e) => {
+      const char = String.fromCharCode(e.keyCode);
+      if (!(/^[A-Za-z]+$/.test(char))) return true;
+      e.preventDefault();
+      return false;
+    };
+
     return {
       modelValue1,
       modelValue2,
@@ -104,7 +124,9 @@ export default {
       modelValue4,
       modelValue5,
       modelValue6,
+      modelValue7,
       checkValid,
+      onKeypress,
       errMsg,
     };
   },

--- a/src/components/textField/TextField.vue
+++ b/src/components/textField/TextField.vue
@@ -31,6 +31,7 @@
           @blur="blurInput"
           @input="inputMv"
           @change="changeMv"
+          @keypress="keypressEvt"
         />
       </template>
       <template v-else >
@@ -47,6 +48,7 @@
           @input="inputMv"
           @change="changeMv"
           @keyup="keyupInput"
+          @keypress="keypressEvt"
         />
         <span
           v-if="type === 'text' && clearable"
@@ -154,6 +156,7 @@ export default {
     'input',
     'change',
     'search',
+    'keypress',
   ],
   setup(props, { emit }) {
     const mv = computed({
@@ -212,6 +215,9 @@ export default {
     const changeMv = (e) => {
       emit('change', mv.value, e);
     };
+    const keypressEvt = (e) => {
+      emit('keypress', e);
+    };
 
     return {
       mv,
@@ -225,6 +231,7 @@ export default {
       blurInput,
       inputMv,
       changeMv,
+      keypressEvt,
     };
   },
 };


### PR DESCRIPTION
## 이슈

- 특정 문자를 아예 입력되지 않게 막기 위해 keypress 이벤트를 이용하고자 하였습니다
- 이벤트 콜백 함수에서 조건에 따라 event.preventDefault() 를 호출하여 키 입력을 원천적으로 막을 수 있습니다
- [참고 게시글](https://stackoverflow.com/questions/62040648/how-can-i-allow-only-numbers-and-letters-on-vue-js)

## 해결

![Apr-19-2024 18-14-46](https://github.com/ex-em/EVUI/assets/37893979/157e4dad-7904-4cef-907d-784677dfbc6c)

- keypress 이벤트 (input 요소에 기본적으로 존재하는 이벤트를 ev-text-field에 연결) 추가
- 문서에 예제를 추가하였습니다