### PR TITLE
[#1672] Checkbox > checkbox 값 null 일 경우 indeterminate 속성에 값 대입 시 오류

### DIFF
--- a/src/components/checkbox/Checkbox.vue
+++ b/src/components/checkbox/Checkbox.vue
@@ -137,8 +137,11 @@ export default {
      */
     watch(
       () => props.indeterminate,
-      (val) => {
-        nextTick(() => {
+      async (val) => {
+        await nextTick(() => {
+          if (!checkbox.value) {
+            return;
+          }
           checkbox.value.indeterminate = val;
         });
       }, { immediate: true },

--- a/src/components/checkbox/Checkbox.vue
+++ b/src/components/checkbox/Checkbox.vue
@@ -137,8 +137,8 @@ export default {
      */
     watch(
       () => props.indeterminate,
-      async (val) => {
-        await nextTick(() => {
+      (val) => {
+        nextTick(() => {
           if (!checkbox.value) {
             return;
           }


### PR DESCRIPTION


# 작업 배경
![image](https://github.com/ex-em/EVUI/assets/37893979/b68eaf48-f44d-46c2-b0e0-a521b182f186)

체크박스가 있는 페이지에 진입할 때마다 nextTick 이 정상 작동하지 않아 checkbox ref에 값이 제대로 들어가지 않습니다
위 상황에서 ref가 null인 값의 indeterminate 속성을 변경하려 해서 오류가 발생합니다

# 변경 사항 요약

nextTick await 처리하였고 ref가 null인 경우 예외처리 해 주었습니다

