### PR TITLE
[#1681] Grid > Custom Sort > CustomAscFunc 인자 object 별도 처리 안 하도록 수정

### DIFF
--- a/docs/views/grid/example/Sort.vue
+++ b/docs/views/grid/example/Sort.vue
@@ -14,9 +14,9 @@
           },
           value: (a, b) => {
             return (
-              (a.split('-')[1] === null) - (b.split('-')[1] === null) ||
-               Number(a.split('-')[1]) - Number(b.split('-')[1])
-             );
+              (a[0].split('-')[1] === null) - (b[0].split('-')[1] === null) ||
+              Number(a[0].split('-')[1]) - Number(b[0].split('-')[1])
+            );
           },
         },
       }"
@@ -29,7 +29,7 @@ import { ref } from 'vue';
 
 const arr = Array.from({ length: 50 }, () => [
   `field_${Math.round(Math.random() * 10000)}`,
-  `value-${Math.round(Math.random() * 10000)}`,
+  [`value-${Math.round(Math.random() * 10000)}`, `value-${Math.round(Math.random() * 10000)}`],
 ]);
 
 export default {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -671,7 +671,12 @@ export const sortEvent = (params) => {
 
     if (customSetAsc) {
       stores.store.sort((a, b) => {
-        const { aCol, bCol } = getColumnValue(a, b);
+        /*
+          배열 및 객체일 경우 customAscFunc 사용자에게 데이터 전처리를 맡길 수 있게끔
+          getColumnValue 사용 안함
+        */
+        const aCol = a[ROW_DATA_INDEX][index];
+        const bCol = b[ROW_DATA_INDEX][index];
         const compareAscReturn = customSetAsc(aCol, bCol);
         return sortInfo.sortOrder === 'desc' ? -compareAscReturn : compareAscReturn;
       });


### PR DESCRIPTION
## 이슈

- 배열의 경우 typeof 으로 타입 체크했을 때 object 로 지정되기 때문에, `/src/components/grid/uses.js` 의 getColumnValue 에서 `undefined` 로 반환됩니다
- 따라서 배열의 경우 Custom Sort 를 지정할 수 없다는 문제가 있습니다
- 현재 배열로 이루어진 컬럼도 정렬이 가능해야 한다는 의견이 들어와서, Custom Sort 적용 시에만 해당 셀의 값을 그대로 반환하게끔 수정하였습니다

## 해결
![Jun-04-2024 14-00-28](https://github.com/ex-em/EVUI/assets/37893979/14d0efb8-4316-47ec-bc6b-7475a30c2153)

- custom sort 사용 시, 내부 값을 `getColumnValue` 로 처리하지 않고 셀 값 그대로 반환하도록 수정하였습니다
- 따라서 `customAscFunc` 콜백 내부에서 적절하게 값을 처리하여 정렬 기준을 세워 주어야 합니다
- customAscFunc 을 사용하지 않고, 셀 값이 배열이나 객체 형태가 아닌 경우에는 해당 PR에 아무런 영향을 받지 않습니다
- Grid > Sort 항목의 예제를 배열 정렬로 교체하였습니다