### PR TITLE
[#1688] [Chart] x축 / y축 범위 계산 시 minValue 와 maxValue 가 같은 값이었는지 여부 formatter 에 전달

### DIFF
--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -70,6 +70,7 @@ class Scale {
   calculateScaleRange(minMax, scrollbarOpt) {
     let maxValue;
     let minValue;
+    let isDefaultMaxSameAsMin = false;
 
     const range = scrollbarOpt?.use ? scrollbarOpt?.range : this.range;
     if (range?.length === 2) {
@@ -95,10 +96,11 @@ class Scale {
 
     if (maxValue === minValue) {
       maxValue += 1;
+      isDefaultMaxSameAsMin = true;
     }
 
     const minLabel = this.getLabelFormat(minValue);
-    const maxLabel = this.getLabelFormat(maxValue);
+    const maxLabel = this.getLabelFormat(maxValue, isDefaultMaxSameAsMin);
 
     return {
       min: minValue,

--- a/src/components/chart/scale/scale.linear.js
+++ b/src/components/chart/scale/scale.linear.js
@@ -4,13 +4,14 @@ import Util from '../helpers/helpers.util';
 class LinearScale extends Scale {
   /**
    * Transforming label by designated format
-   * @param {number} value    label value
+   * @param {number} value                   label value
+   * @param {boolean} isMaxValueSameAsMin    is default max value same as min value
    *
    * @returns {string} formatted label
    */
-  getLabelFormat(value) {
+  getLabelFormat(value, isMaxValueSameAsMin) {
     if (this.formatter) {
-      const formattedLabel = this.formatter(value);
+      const formattedLabel = this.formatter(value, isMaxValueSameAsMin);
 
       if (typeof formattedLabel === 'string') {
         return formattedLabel;

--- a/src/components/chart/scale/scale.logarithmic.js
+++ b/src/components/chart/scale/scale.logarithmic.js
@@ -11,6 +11,7 @@ class LogarithmicScale extends Scale {
   calculateScaleRange(minMax) {
     let maxValue;
     let minValue;
+    let isDefaultMaxSameAsMin = false;
     if (this.range && this.range.length === 2) {
       maxValue = this.range[1];
       minValue = this.range[0];
@@ -28,10 +29,11 @@ class LogarithmicScale extends Scale {
 
     if (maxValue === minValue) {
       maxValue += 1;
+      isDefaultMaxSameAsMin = true;
     }
 
     const minLabel = this.getLabelFormat(minValue);
-    const maxLabel = this.getLabelFormat(maxValue);
+    const maxLabel = this.getLabelFormat(maxValue, isDefaultMaxSameAsMin);
 
     return {
       min: minValue,
@@ -96,13 +98,14 @@ class LogarithmicScale extends Scale {
 
   /**
    * Transforming label by designated format
-   * @param {any} value    label value
+   * @param {number} value                   label value
+   * @param {boolean} isMaxValueSameAsMin    is default max value same as min value
    *
    * @returns {string} formatted label
    */
-  getLabelFormat(value) {
+  getLabelFormat(value, isMaxValueSameAsMin) {
     if (this.formatter) {
-      const formattedLabel = this.formatter(value);
+      const formattedLabel = this.formatter(value, isMaxValueSameAsMin);
 
       if (typeof formattedLabel === 'string') {
         return formattedLabel;

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -12,13 +12,14 @@ class TimeCategoryScale extends Scale {
 
   /**
    * Transforming label by designated format
-   * @param {number} value       label value
+   * @param {number} value                   label value
+   * @param {boolean} isMaxValueSameAsMin    is default max value same as min value
    *
    * @returns {string} formatted label
    */
-  getLabelFormat(value) {
+  getLabelFormat(value, isMaxValueSameAsMin) {
     if (this.formatter) {
-      const formattedLabel = this.formatter(value);
+      const formattedLabel = this.formatter(value, isMaxValueSameAsMin);
 
       if (typeof formattedLabel === 'string') {
         return formattedLabel;

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -5,13 +5,14 @@ import Scale from './scale';
 class TimeScale extends Scale {
   /**
    * Transforming label by designated format
-   * @param {number} value       label value
+   * @param {number} value                   label value
+   * @param {boolean} isMaxValueSameAsMin    is default max value same as min value
    *
    * @returns {string} formatted label
    */
-  getLabelFormat(value) {
+  getLabelFormat(value, isMaxValueSameAsMin) {
     if (this.formatter) {
-      const formattedLabel = this.formatter(value);
+      const formattedLabel = this.formatter(value, isMaxValueSameAsMin);
 
       if (typeof formattedLabel === 'string') {
         return formattedLabel;


### PR DESCRIPTION
![image](https://github.com/ex-em/EVUI/assets/37893979/f7b2feab-349c-4e12-a379-3e1c9a9e757a)

- 차트의 X, Y 축 범위를 계산하는 과정에서 옵션으로 지정된 formatter 함수를 `Scale` 클래스 내에서 호출할 때
  - 만약 maxValue 와 minValue 가 같을 경우, maxValue 에 1을 더하고 있습니다 (사진)
  - 허나 `maxValue += 1` 을 해 주었음에도 formatter 의 반환값을 받아오고 나서 다시 minValue, maxValue 가 같아지는 경우가 발생할 수 있습니다
    - 예시: formatter 내부에서 value 값을 s 에서 ms 로 단위 변환한 뒤 소수점 둘째 자리를 버리는 경우
  - maxValue 가 minValue 와 같았는지 여부를 formatter 에 넘겨주도록 하여 사용처에서 formatter 지정 시에 힌트가 될 수 있도록 하였습니다
  - 타입 지정이 되어 있지 않기 때문에 사용하지 않을 경우 undefined 로 남겨두어도 에러가 없을 것으로 판단됩니다.
  - scale.step 의 경우 range 지정 로직이 다른 것으로 판단되어 해당 기능 추가하지 않았습니다.