### PR TITLE
[#1704] Grid, Tree Grid > Column 동적으로 할당될 경우, column list 옵션 창 내 상태 field명 기준으로 유지되도록 수정

### DIFF
--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -1077,7 +1077,6 @@ export default {
           // Column의 field로 동일한 컬럼인지 확인
           const newColumnsFields = newColumns.map(column => column.field);
           const prevColumnsFields = prevColumns.map(column => column.field);
-          // return prevColumnsFields.every(field => newColumnsFields.includes(field));
           return isEqual(newColumnsFields, prevColumnsFields);
         };
 
@@ -1091,7 +1090,6 @@ export default {
           setStore([], false);
           initColumnSettingInfo();
           stores.movedColumns.length = 0;
-          console.log(stores.originColumns);
         } else if (stores.filteredColumns.length) {
           // 새로운 컬럼 기준으로 filteredColumns 를 업데이트 한다.
           stores.filteredColumns = newColumns.filter(

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -593,7 +593,7 @@ import {
   onBeforeMount, onUnmounted,
 } from 'vue';
 import { clickoutside } from '@/directives/clickoutside';
-import { cloneDeep } from 'lodash-es';
+import { cloneDeep, isEqual } from 'lodash-es';
 import Toolbar from './GridToolbar';
 import GridPagination from './GridPagination';
 import GridSummary from './GridSummary';
@@ -1077,7 +1077,8 @@ export default {
           // Column의 field로 동일한 컬럼인지 확인
           const newColumnsFields = newColumns.map(column => column.field);
           const prevColumnsFields = prevColumns.map(column => column.field);
-          return prevColumnsFields.every(field => newColumnsFields.includes(field));
+          // return prevColumnsFields.every(field => newColumnsFields.includes(field));
+          return isEqual(newColumnsFields, prevColumnsFields);
         };
 
         if (newColumns.length !== prevColumns.length || !isSameColumns()) {
@@ -1089,6 +1090,8 @@ export default {
           stores.filterStore = [];
           setStore([], false);
           initColumnSettingInfo();
+          stores.movedColumns.length = 0;
+          console.log(stores.originColumns);
         } else if (stores.filteredColumns.length) {
           // 새로운 컬럼 기준으로 filteredColumns 를 업데이트 한다.
           stores.filteredColumns = newColumns.filter(
@@ -1114,7 +1117,7 @@ export default {
     watch(
       () => props.rows,
       (value) => {
-        setStore(value);
+        setStore(cloneDeep(value));
         if (filterInfo.isSearch) {
           onSearch(filterInfo.searchWord);
         }

--- a/src/components/grid/GridColumnSetting.vue
+++ b/src/components/grid/GridColumnSetting.vue
@@ -179,7 +179,6 @@ export default {
           .filter(col => col.originChecked)
           .map(col => col.text);
       }
-      console.log('ㅇㅇㅇ init value : ', isShowColumnSetting.value, cloneDeep(checkColumnGroup.value));
       initSearchValue();
     };
     const onApplyColumn = () => {
@@ -202,22 +201,20 @@ export default {
 
     const setColumns = (prevColumns) => {
       const prevCheckColumnGroup = cloneDeep(checkColumnGroup.value);
-      console.log('1. prevCheckColumnGroup : ', prevCheckColumnGroup);
       originColumnList.value = props.columns
         .filter(col => !col.hide && col.caption)
         .map((col) => {
-          const isMaintained = !!prevColumns?.find(c => c.field === col.field);
-          console.log(
-              'map', col.field,
-              prevCheckColumnGroup.includes(col.field),
-              isMaintained,
-              (isMaintained && prevCheckColumnGroup.includes(col.field))
-              || !col.hiddenDisplay,
-              col.hiddenDisplay,
-          );
-          const isChecked = isMaintained
-            ? prevCheckColumnGroup.includes(col.field)
-            : !col.hiddenDisplay;
+          const prevColumn = prevColumns?.find(c => c.field === col.field);
+          let isChecked = false;
+
+          if (prevColumn) {
+            const isHiddenChanged = prevColumn?.hiddenDisplay !== col?.hiddenDisplay;
+            isChecked = isHiddenChanged
+              ? !col?.hiddenDisplay
+              : prevCheckColumnGroup.includes(col.field);
+          } else {
+            isChecked = !col.hiddenDisplay;
+          }
           return {
             label: col.caption,
             text: col.field,
@@ -228,7 +225,6 @@ export default {
       checkColumnGroup.value = originColumnList.value
         .filter(col => col.checked)
         .map(col => col.text);
-      console.log('2. prevCheckColumnGroup : ', cloneDeep(checkColumnGroup.value));
       applyColumnList.value.length = 0;
     };
 

--- a/src/components/grid/GridColumnSetting.vue
+++ b/src/components/grid/GridColumnSetting.vue
@@ -25,9 +25,11 @@
               <ev-checkbox
                 v-for="(column, idx) in columnList"
                 :key="`column_${idx}`"
-                :label="column?.label"
+                :label="column?.text"
                 :tooltip-title="column?.label ?? ''"
-              />
+              >
+                {{ column?.label }}
+              </ev-checkbox>
             </ev-checkbox-group>
           </template>
           <template v-else>
@@ -58,6 +60,7 @@ import {
   ref,
   watch,
 } from 'vue';
+import { cloneDeep } from 'lodash-es';
 
 export default {
   name: 'EVGridColumnSetting',
@@ -167,15 +170,22 @@ export default {
 
     const initValue = () => {
       const columns = applyColumnList.value.length ? applyColumnList.value : originColumnList.value;
-      checkColumnGroup.value = columns
-        .filter(col => !col.checked)
-        .map(col => col.label);
+      if (isShowColumnSetting.value) {
+        checkColumnGroup.value = columns
+          .filter(col => col.checked)
+          .map(col => col.text);
+      } else {
+        checkColumnGroup.value = columns
+          .filter(col => col.originChecked)
+          .map(col => col.text);
+      }
+      console.log('ㅇㅇㅇ init value : ', isShowColumnSetting.value, cloneDeep(checkColumnGroup.value));
       initSearchValue();
     };
     const onApplyColumn = () => {
       applyColumnList.value = originColumnList.value
         .filter((col) => {
-          if (checkColumnGroup.value.includes(col.label)) {
+          if (checkColumnGroup.value.includes(col.text)) {
             if (col?.checked) {
               col.checked = false;
             }
@@ -190,17 +200,35 @@ export default {
       computedIsShowMenuOnClick.value = false;
     };
 
-    const setColumns = () => {
+    const setColumns = (prevColumns) => {
+      const prevCheckColumnGroup = cloneDeep(checkColumnGroup.value);
+      console.log('1. prevCheckColumnGroup : ', prevCheckColumnGroup);
       originColumnList.value = props.columns
         .filter(col => !col.hide && col.caption)
-        .map(col => ({
-          label: col.caption,
-          text: col.field,
-          checked: col.hiddenDisplay,
-        }));
+        .map((col) => {
+          const isMaintained = !!prevColumns?.find(c => c.field === col.field);
+          console.log(
+              'map', col.field,
+              prevCheckColumnGroup.includes(col.field),
+              isMaintained,
+              (isMaintained && prevCheckColumnGroup.includes(col.field))
+              || !col.hiddenDisplay,
+              col.hiddenDisplay,
+          );
+          const isChecked = isMaintained
+            ? prevCheckColumnGroup.includes(col.field)
+            : !col.hiddenDisplay;
+          return {
+            label: col.caption,
+            text: col.field,
+            originChecked: !col.hiddenDisplay,
+            checked: isChecked,
+          };
+        });
       checkColumnGroup.value = originColumnList.value
-        .filter(col => !col.checked)
-        .map(col => col.label);
+        .filter(col => col.checked)
+        .map(col => col.text);
+      console.log('2. prevCheckColumnGroup : ', cloneDeep(checkColumnGroup.value));
       applyColumnList.value.length = 0;
     };
 
@@ -247,8 +275,8 @@ export default {
 
     onBeforeMount(() => initWrapperDiv());
 
-    watch(() => props.columns, () => {
-      setColumns();
+    watch(() => props.columns, (curr, prev) => {
+      setColumns(prev);
     }, { immediate: true, deep: true });
 
     watch(() => isShowColumnSetting.value, async () => {
@@ -265,7 +293,7 @@ export default {
         : originColumnList.value.filter(col => (col.text !== value && !col.checked));
 
       applyColumnList.value = filterColumns;
-      checkColumnGroup.value = filterColumns.map(col => col.label);
+      checkColumnGroup.value = filterColumns.map(col => col.text);
     });
 
     return {

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1325,7 +1325,7 @@ export const columnSettingEvent = (params) => {
 
   const initColumnSettingInfo = () => {
     stores.filteredColumns.length = 0;
-    columnSettingInfo.isShowColumnSetting = false;
+    // columnSettingInfo.isShowColumnSetting = false;
     columnSettingInfo.isFilteringColumn = false;
     columnSettingInfo.visibleColumnIdx = [];
     columnSettingInfo.hiddenColumn = '';

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -259,6 +259,7 @@ import {
   onMounted,
   onUnmounted,
 } from 'vue';
+import { isEqual } from 'lodash-es';
 import TreeGridNode from './TreeGridNode';
 import Toolbar from './TreeGridToolbar';
 import GridPagination from '../grid/GridPagination';
@@ -655,7 +656,7 @@ export default {
           // Column의 field로 동일한 컬럼인지 확인
           const newColumnsFields = newColumns.map(column => column.field);
           const prevColumnsFields = prevColumns.map(column => column.field);
-          return prevColumnsFields.every(field => newColumnsFields.includes(field));
+          return isEqual(newColumnsFields, prevColumnsFields);
         };
 
         if (newColumns.length !== prevColumns.length || !isSameColumns()) {


### PR DESCRIPTION
## 작업 배경
그리드 컬럼 옵션 창을 연 상태에서  컬럼이 동적으로 변경될 때, 필드명이 같은 컬럼의 설정 상태 유지되도록 수정

## 수정 내용
1. 옵션창 유지되도록 수정
2. 컬럼 데이터 재할당으로 참조값이 바뀌더라도 필드명을 기준으로 비교하여 저장하지 않은 데이터의 체크여부 유지되도록 수정
    관련하여 `GridColumnSetting` 컴포넌트에서 caption 명이 아닌, field 명으로 체크하도록 수정
3. 컬럼 변경 됐을 때 movedColumn 초기화 안 되는 현상 수정

![grid-column-setting](https://github.com/user-attachments/assets/d49dfbf2-6242-4caf-8002-55bd5bdc8eca)

참고. 컬럼 초기화 분기 조건 수정  
- 컬럼 데이터 초기화 조건을 필드명 + 순서까지 모두 같을 때 curr, prev 데이터가 일치하는 것으로 변경 
- 이전: 필드명이 일치한다면, 순서 상관없이 같은 데이터로 판단하여 초기화 하지 않음
  : 컬럼 외부 세팅을 위한 작업으로, 해당 pr 내 컬럼 세팅 스펙 변경으로 정상 동작 확인함
