### PR TITLE
[#1711] Grid, Tree Grid > Columns Resize 이벤트 emit 시, 컬럼 값 업데이트 안 되는 현상 수정

### DIFF
--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -615,6 +615,7 @@ import {
   pagingEvent,
   columnSettingEvent,
   dragEvent,
+  getUpdatedColumns,
 } from './uses';
 
 export default {
@@ -775,24 +776,7 @@ export default {
           ? stores.movedColumns : stores.originColumns;
         return stores.filteredColumns.length ? stores.filteredColumns : columns;
       }),
-      updatedColumns: computed(() => {
-        if (stores.movedColumns?.length) {
-          const orderedColumnsIndexes = stores.orderedColumns?.map(column => column.index);
-          const extraColumns = stores.originColumns?.filter(
-              column => !orderedColumnsIndexes.includes(column.index),
-          );
-          const copyOrderedColumns = stores.orderedColumns;
-          return [...copyOrderedColumns, ...extraColumns];
-        }
-        const { originColumns, filteredColumns } = stores;
-        return originColumns.map((col) => {
-          const changedCol = filteredColumns.find(fcol => fcol.index === col.index) ?? {};
-          return {
-            ...col,
-            ...changedCol,
-          };
-        });
-      }),
+      updatedColumns: computed(() => getUpdatedColumns(stores)),
     });
     const pageInfo = reactive({
       usePage: computed(() => (props.option.page?.use || false)),

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1400,7 +1400,6 @@ export const columnSettingEvent = (params) => {
     const columns = stores.orderedColumns.filter(col => !col.hide && !col.hiddenDisplay);
 
     if (columns.length === 1) {
-      stores.filteredColumns = columns;
       return;
     }
     stores.filteredColumns = columns

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -77,6 +77,25 @@ export const commonFunctions = () => {
   };
 };
 
+export const getUpdatedColumns = (stores) => {
+  if (stores.movedColumns?.length) {
+    const orderedColumnsIndexes = stores.orderedColumns?.map(column => column.index);
+    const extraColumns = stores.originColumns?.filter(
+      column => !orderedColumnsIndexes.includes(column.index),
+    );
+    const copyOrderedColumns = stores.orderedColumns;
+    return [...copyOrderedColumns, ...extraColumns];
+  }
+  const { originColumns, filteredColumns } = stores;
+  return originColumns.map((col) => {
+    const changedCol = filteredColumns.find(fcol => fcol.index === col.index) ?? {};
+    return {
+      ...col,
+      ...changedCol,
+    };
+  });
+};
+
 export const scrollEvent = (params) => {
   const {
     scrollInfo,
@@ -348,14 +367,14 @@ export const resizeEvent = (params) => {
       document.removeEventListener('mousemove', handleMouseMove);
       onResize();
 
+      const updatedColumns = getUpdatedColumns(stores);
       emit('resize-column', {
         column: stores.orderedColumns[columnIndex],
-        columns: stores.updatedColumns,
+        columns: updatedColumns,
       });
-
       emit('change-column-info', {
         type: 'resize',
-        columns: stores.updatedColumns,
+        columns: updatedColumns,
       });
     };
 
@@ -1381,6 +1400,7 @@ export const columnSettingEvent = (params) => {
     const columns = stores.orderedColumns.filter(col => !col.hide && !col.hiddenDisplay);
 
     if (columns.length === 1) {
+      stores.filteredColumns = columns;
       return;
     }
     stores.filteredColumns = columns

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -275,6 +275,7 @@ import {
   treeEvent,
   filterEvent,
   pagingEvent,
+  getUpdatedColumns,
 } from './uses';
 import {
   columnSettingEvent,
@@ -393,16 +394,7 @@ export default {
       }))),
       orderedColumns: computed(() => (stores.filteredColumns.length
         ? stores.filteredColumns : stores.originColumns)),
-      updatedColumns: computed(() => {
-        const { originColumns, filteredColumns } = stores;
-        return originColumns.map((col) => {
-          const changedCol = filteredColumns.find(fcol => fcol.index === col.index) ?? {};
-          return {
-            ...col,
-            ...changedCol,
-          };
-        });
-      }),
+      updatedColumns: computed(() => getUpdatedColumns(stores)),
     });
     const pageInfo = reactive({
       usePage: computed(() => (props.option.page?.use || false)),

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -86,6 +86,17 @@ export const commonFunctions = (params) => {
   };
 };
 
+export const getUpdatedColumns = (stores) => {
+  const { originColumns, filteredColumns } = stores;
+  return originColumns.map((col) => {
+    const changedCol = filteredColumns.find(fcol => fcol.index === col.index) ?? {};
+    return {
+      ...col,
+      ...changedCol,
+    };
+  });
+};
+
 export const scrollEvent = (params) => {
   const {
     scrollInfo,
@@ -342,13 +353,15 @@ export const resizeEvent = (params) => {
       resizeInfo.showResizeLine = false;
       document.removeEventListener('mousemove', handleMouseMove);
       onResize();
+
+      const updatedColumns = getUpdatedColumns(stores);
       emit('resize-column', {
         column: stores.orderedColumns[columnIndex],
-        columns: stores.updatedColumns,
+        columns: updatedColumns,
       });
       emit('change-column-info', {
         type: 'resize',
-        columns: stores.updatedColumns,
+        columns: updatedColumns,
       });
     };
 


### PR DESCRIPTION
### 변경 사항
- `resize-column` 이벤트 emit 시점에 `getUpdatedColumns` 호출하여 updatedColumns 가져올 수 있도록 수정