### PR TITLE
[#1714] Tree Grid > 마지막 컬럼 사이즈 조절 버그

### DIFF
--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -343,11 +343,7 @@ export const resizeEvent = (params) => {
 
       if (stores.orderedColumns[columnIndex]) {
         stores.orderedColumns[columnIndex].width = changedWidth;
-        stores.orderedColumns.forEach((column) => {
-          const item = column;
-          item.resized = true;
-          return item;
-        });
+        stores.orderedColumns[columnIndex].resized = true;
       }
 
       resizeInfo.showResizeLine = false;


### PR DESCRIPTION
# 변경 사항 요약

- 컬럼 사이즈 변경 시 모든 컬럼들의 resized 속성이 true로 변경되는 현상을 수정했습니다.

# 기존 동작

![트리그리드-마지막컬럼-버그](https://github.com/user-attachments/assets/2285cf90-16e7-48f9-80b9-3ef7e2aab065)

# 기대 동작

![트리그리드-마지막컬럼-버그픽스](https://github.com/user-attachments/assets/e1e02312-adc1-4de6-9498-74b9190ab66a)