### PR TITLE
Grid > GridColumnSetting CheckBox 체크상태(on/off) 유지불가 (사용자 태그 부분)

### DIFF
--- a/src/components/grid/GridColumnSetting.vue
+++ b/src/components/grid/GridColumnSetting.vue
@@ -268,6 +268,9 @@ export default {
     onBeforeMount(() => initWrapperDiv());
 
     watch(() => props.columns, () => {
+      if (isShowColumnSetting.value) {
+        return;
+      }
       setColumns();
     }, { immediate: true, deep: true });
 

--- a/src/components/grid/GridColumnSetting.vue
+++ b/src/components/grid/GridColumnSetting.vue
@@ -170,15 +170,11 @@ export default {
 
     const initValue = () => {
       const columns = applyColumnList.value.length ? applyColumnList.value : originColumnList.value;
-      if (isShowColumnSetting.value) {
-        checkColumnGroup.value = columns
-          .filter(col => col.checked)
-          .map(col => col.text);
-      } else {
-        checkColumnGroup.value = columns
-          .filter(col => col.originChecked)
-          .map(col => col.text);
-      }
+      
+      checkColumnGroup.value = columns
+        .filter(col => col.originChecked)
+        .map(col => col.text);
+      
       initSearchValue();
     };
     const onApplyColumn = () => {
@@ -194,6 +190,7 @@ export default {
     const prevColumns = ref();
     const prevCheckColumnGroup = ref();
     const setColumns = () => {
+      prevCheckColumnGroup.value = cloneDeep(checkColumnGroup.value);
       originColumnList.value = props.columns
         .filter(col => !col.hide && col.caption)
         .map((col) => {
@@ -221,7 +218,6 @@ export default {
         .map(col => col.text);
       applyColumnList.value.length = 0;
       prevColumns.value = cloneDeep(props.columns);
-      prevCheckColumnGroup.value = cloneDeep(checkColumnGroup.value);
     };
 
     const hideColumnSetting = () => {
@@ -268,9 +264,6 @@ export default {
     onBeforeMount(() => initWrapperDiv());
 
     watch(() => props.columns, () => {
-      if (isShowColumnSetting.value) {
-        return;
-      }
       setColumns();
     }, { immediate: true, deep: true });
 


### PR DESCRIPTION
-  API 호출 -> columns 값 재할당 -> watch 때문에 계속 check 된 값이 갱신되면서 체크박스가 풀리는 현상.
-  GridColumnSetting을 띄웠을 땐, 다시 값을 할당하지 않도록 하여 체크 유지할 수 있도록 수정.