### PR TITLE
[#1722] Grid > Colum 옵션 추가 (sortOption)

### DIFF
--- a/docs/views/grid/example/ColumnEvent.vue
+++ b/docs/views/grid/example/ColumnEvent.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="case">
     <ev-grid
-      :columns="columns"
+      :columns="gridColumns"
       :rows="tableData"
       :width="widthMV"
       :height="heightMV"
@@ -18,6 +18,14 @@
     />
     <!-- description -->
     <div class="description column-event-description">
+      <div class="form-row column-event-description__sort-type">
+        <span class="badge yellow">Initial Sorting Type of Column B</span>
+        <ev-text-field
+          model-value="desc"
+          class="component"
+          readonly
+        />
+      </div>
       <div class="form-rows">
         <div class="form-row">
           <span class="badge yellow">
@@ -78,9 +86,9 @@ export default {
     const tableData = ref([]);
     const widthMV = ref('100%');
     const heightMV = ref(300);
-    const columns = ref([
+    const gridColumns = ref([
       { caption: 'A Column', field: 'aColumn', type: 'string' },
-      { caption: 'B Column', field: 'bColumn', type: 'string' },
+      { caption: 'B Column', field: 'bColumn', type: 'string', sortOption: { sortType: 'desc' } },
       { caption: 'C Column', field: 'cColumn', type: 'string' },
       { caption: 'D Column', field: 'dColumn', type: 'string', hiddenDisplay: true },
       { caption: 'E Column', field: 'eColumn', type: 'string' },
@@ -121,7 +129,7 @@ export default {
     };
 
     return {
-      columns,
+      gridColumns,
       tableData,
       widthMV,
       heightMV,
@@ -163,6 +171,10 @@ export default {
 
   .ev-textarea {
     height: 200px !important;
+  }
+
+  &__sort-type {
+    margin-bottom: 5px;
   }
 }
 </style>

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -650,19 +650,21 @@ export const sortEvent = (params) => {
   };
 
   const order = new OrderQueue();
-  const setSortInfo = (column) => {
+  const setSortInfo = (column, emitTriggered = true) => {
     const { sortType } = column?.sortOption || {};
     sortInfo.sortColumn = column;
     sortInfo.sortField = column?.field;
     sortInfo.sortOrder = sortType;
     sortInfo.isSorting = !!(sortType);
 
-    setSortOptionToOrderedColumns(column, sortType);
+    if (emitTriggered) {
+      setSortOptionToOrderedColumns(column, sortType);
 
-    emit('change-column-info', {
-      type: 'sort',
-      columns: getUpdatedColumns(stores),
-    });
+      emit('change-column-info', {
+        type: 'sort',
+        columns: getUpdatedColumns(stores),
+      });
+    }
   };
 
   /**
@@ -1298,7 +1300,7 @@ export const storeEvent = (params) => {
     }
 
     if (sortingColumns && isInit) {
-      setSortInfo(sortingColumns);
+      setSortInfo(sortingColumns, false);
     }
 
     if (sortInfo.sortField) {


### PR DESCRIPTION
#######################

# 변경 사항 요약

- Grid 컬럼에 sortOption 속성 추가

```jsx
sortOption: {
  sortType: 'desc' | 'asc' | 'init'(Default)
}
```

- 컬럼의 sortOption에 빈 값을 넘기면 sortOption: { sortType: ‘init’}이 설정됩니다.
- EvGrid 컬럼 정보에 `SortOption`이 설정되어 있는 경우 해당 컬럼의 sortType으로 sorting됩니다    

    ![image](https://github.com/user-attachments/assets/655a9e4d-f282-43cc-85cf-0a71d862f732)

- Sorting 대상 컬럼이 Hide 된 경우 Grid Row의 sorting은 유지됩니다.
    - 이후 다른 컬럼으로 Sorting이 진행 된 경우 Hide된 컬럼의 sortType은 ‘init’으로 설정됩니다.
- Sorting이 된 경우 `change-column-info` Emit으로 변경된 컬럼 정보를 올립니다.
    ![image](https://github.com/user-attachments/assets/2222ef5a-80da-4d9a-8331-e17c903c7e74)
