### PR TITLE
[#1724] ContextMenu > child Menu 화면에서 짤림현상 수정

### DIFF
--- a/src/components/contextMenu/MenuList.vue
+++ b/src/components/contextMenu/MenuList.vue
@@ -7,7 +7,7 @@
         class="ev-menu-li"
         :class="{ disabled: item.disabled }"
         @click="handleItemClick(item)"
-        @mouseenter="mouseenterLi($event, item)"
+        @mouseenter="handleMouseEnter($event, item)"
       >
         <i
           v-if="!!item.iconClass"
@@ -77,7 +77,7 @@ export default {
       childrenItems,
 
       handleItemClick,
-      mouseenterLi,
+      handleMouseEnter,
       hideAll,
     } = useMenuList();
 
@@ -90,7 +90,7 @@ export default {
       childrenItems,
 
       handleItemClick,
-      mouseenterLi,
+      handleMouseEnter,
       hideAll,
     };
   },

--- a/src/components/contextMenu/uses.js
+++ b/src/components/contextMenu/uses.js
@@ -158,7 +158,9 @@ export const useMenuList = () => {
 
     const targetUlRect = e.target.parentElement?.getBoundingClientRect();
     const targetUlX = targetUlRect.x;
+    const targetUIY = targetUlRect.y;
     const targetUlWidth = targetUlRect.width;
+    const targetUlHeight = targetUlRect.height;
 
     const childMenuRect = childMenu.value?.$el?.children[0].getBoundingClientRect();
     const menuListHeight = childMenuRect.height;
@@ -168,13 +170,13 @@ export const useMenuList = () => {
     const docWidth = document.documentElement.clientWidth;
     const RIGHT_BUFFER_PX = 20;
 
-    if (docHeight < e.target.offsetTop + menuListHeight) {
+    if (docHeight < targetUIY + e.target.offsetTop + menuListHeight) {
       // dropTop
-      menuStyle.top = `${e.target.offsetTop - menuListHeight}px`;
+      menuStyle.top = `${-menuListHeight + targetUlHeight}px`;
       if (docWidth < targetUlX + targetUlWidth + menuListWidth + RIGHT_BUFFER_PX) {
-        menuStyle.left = `${e.offsetX - menuListWidth}px`;
+        menuStyle.left = `${0 - menuListWidth}px`;
       } else {
-        menuStyle.left = `${e.offsetX}px`;
+        menuStyle.left = `${targetUlWidth}px`;
       }
     } else {
       // dropDown


### PR DESCRIPTION
### **작업 배경**

![image](https://github.com/user-attachments/assets/d0207699-cf47-4d77-aa1c-cb1f69d935fc)

자식 ContextMenu가 화면에서 잘리는 현상 발견.


### **변경 사항**

ContextMenu와 브라우저 높이를 비교하는 로직을 수정.

ContextMenu가 브라우저 높이보다 밑으로 떨어질 때,
ContextMenu를 위로 끌어올려 화면에서 짤림 현상 해결.


**변경 전**
![image](https://github.com/user-attachments/assets/b041ad9d-7484-4089-828d-1c1aca6ccd48)


**변경 후**
![image](https://github.com/user-attachments/assets/32bd7af6-dd45-4c07-8311-89095038f8f0)
