### PR TITLE
[#1731] adjust 설정 + resize 시에 컬럼 순서에 맞게 width 할당되도록 수정

### DIFF
--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -291,13 +291,14 @@ export const resizeEvent = (params) => {
    * grid resize 이벤트를 처리한다.
    */
   const onResize = () => {
+    const propColumnsMap = new Map(props.columns.map(col => [col.field, col.width]));
     nextTick(() => {
       if (resizeInfo.adjust) {
-        stores.orderedColumns.forEach((column, index) => {
+        stores.orderedColumns.forEach((column) => {
           const item = column;
 
           if (!item.resized) {
-            item.width = props.columns[index].width ?? 0;
+            item.width = propColumnsMap.get(item.field)?.width ?? 0;
           }
 
           return item;

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -298,7 +298,7 @@ export const resizeEvent = (params) => {
           const item = column;
 
           if (!item.resized) {
-            item.width = propColumnsMap.get(item.field)?.width ?? 0;
+            item.width = propColumnsMap.get(item.field) ?? 0;
           }
 
           return item;

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -293,11 +293,11 @@ export const resizeEvent = (params) => {
   const onResize = () => {
     nextTick(() => {
       if (resizeInfo.adjust) {
-        stores.orderedColumns.forEach((column) => {
+        stores.orderedColumns.forEach((column, index) => {
           const item = column;
 
           if (!item.resized) {
-            item.width = props.columns[column.index].width ?? 0;
+            item.width = props.columns[index].width ?? 0;
           }
 
           return item;


### PR DESCRIPTION
### 작업 배경

그리드 컬럼 순서 변경 후 변경된 컬럼 데이터를 위부에서 재 주입 시, 각 컬럼에 맞는 width 가 아닌 컬럼 별 index에 따른 width가 할당됨

### 변경 사항

resize 시점에 각 field에 맞게 width 할당되도록 수정

