### PR TITLE
[#1735]  Grid > 외부에서 column 의 index가 주입되었을 경우, 검색 안 되는 현상 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.54",
+  "version": "3.4.55",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1034,7 +1034,7 @@ export const filterEvent = (params) => {
 
           for (let ix = 0; ix < stores.orderedColumns.length; ix++) {
             const column = stores.orderedColumns[ix] || {};
-            let columnValue = rowData[ix] ?? null;
+            let columnValue = rowData[column.index] ?? null;
             column.type = column.type || 'string';
             if (columnValue !== null) {
               if (typeof columnValue === 'object') {


### PR DESCRIPTION
### 작업 배경
ev-grid 외부에서 컬럼 index 주입되었을 경우, 컬럼 순서 변경 시 검색되지 않는 현상 발생

### 수정 내역
onSearch 함수 내에서 컬럼과 rowData 매핑 시, column.index를 기준으로 매핑하도록 수정