### PR TITLE
[#1737] Window > 클릭 이벤트 발생 시 어떤 윈도우를 클릭했는지 식별자 전달

### DIFF
--- a/src/components/window/uses.js
+++ b/src/components/window/uses.js
@@ -487,7 +487,15 @@ const useMouseEvent = (param) => {
       || (!props.draggable && pressedSpot === 'header')
       || (!props.resizable && pressedSpot === 'border')
     ) {
-      emit('mousedown', { ref: windowRef.value });
+      clickedInfo.state = '';
+      clickedInfo.pressedSpot = '';
+      clickedInfo.top = windowRef.value.offsetTop;
+      clickedInfo.left = windowRef.value.offsetLeft;
+      clickedInfo.width = windowRef.value.offsetWidth;
+      clickedInfo.height = windowRef.value.offsetHeight;
+      clickedInfo.clientX = e.clientX;
+      clickedInfo.clientY = e.clientY;
+      emit('mousedown', { ...clickedInfo, ref: windowRef.value });
       return;
     }
 

--- a/src/components/window/uses.js
+++ b/src/components/window/uses.js
@@ -487,7 +487,7 @@ const useMouseEvent = (param) => {
       || (!props.draggable && pressedSpot === 'header')
       || (!props.resizable && pressedSpot === 'border')
     ) {
-      clickedInfo.state = '';
+      clickedInfo.state = 'mousedown';
       clickedInfo.pressedSpot = '';
       clickedInfo.top = windowRef.value.offsetTop;
       clickedInfo.left = windowRef.value.offsetLeft;

--- a/src/components/window/uses.js
+++ b/src/components/window/uses.js
@@ -487,6 +487,7 @@ const useMouseEvent = (param) => {
       || (!props.draggable && pressedSpot === 'header')
       || (!props.resizable && pressedSpot === 'border')
     ) {
+      emit('mousedown', { ref: windowRef.value });
       return;
     }
 
@@ -499,7 +500,7 @@ const useMouseEvent = (param) => {
     clickedInfo.clientX = e.clientX;
     clickedInfo.clientY = e.clientY;
 
-    emit('mousedown', { ...clickedInfo });
+    emit('mousedown', { ...clickedInfo, ref: windowRef.value });
 
     window.addEventListener('mousemove', dragging);
     window.addEventListener('mouseup', endDrag);


### PR DESCRIPTION
![Aug-09-2024 19-24-56](https://github.com/user-attachments/assets/6c4b093e-1e5e-46a5-8ce6-9d6c2cb35b4d)

- 외부에서 어떤 윈도우가 클릭되었는지 알기 어려워 이벤트 emit 시 ref 를 같이 전달하도록 수정하였습니다
- resizable, draggable 이 false 이거나 window ref 가 존재하지 않을 경우 emit 하지 않는 스펙 유지하였습니다