### PR TITLE
[#1741]Grid > resize시 옵셔널 체이닝 추가 필요

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.56",
+  "version": "3.4.57",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -1234,7 +1234,7 @@ export default {
         stores.orderedColumns.map((column) => {
           const item = column;
 
-          if (!props.columns[column.index].width && !item.resized) {
+          if (!props.columns[column.index]?.width && !item.resized) {
             item.width = 0;
           }
 

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -798,7 +798,7 @@ export default {
         stores.orderedColumns.map((column) => {
           const item = column;
 
-          if (!props.columns[column.index].width && !item.resized) {
+          if (!props.columns[column.index]?.width && !item.resized) {
             item.width = 0;
           }
 

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -279,7 +279,7 @@ export const resizeEvent = (params) => {
         stores.orderedColumns.forEach((column) => {
           const item = column;
 
-          if (!props.columns[column.index].width && !item.resized) {
+          if (!props.columns[column.index]?.width && !item.resized) {
             item.width = 0;
           }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c7f7d553-a402-4dff-8030-b91da977aa71)


```ts
if (!props.columns[column.index]?.width && !item.resized) {
  item.width = 0;
}
```

width앞에 옵셔널 체이닝 추가

