### PR TITLE
[#1744] 시계열 Chart hover된 시간에 대한 indicator 동기화 기능 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -1,5 +1,6 @@
->## Desc
- - 태그는 &lt;ev-chart&gt;(이하 <차트>)으로 정의
+> ## Desc
+
+- 태그는 &lt;ev-chart&gt;(이하 <차트>)으로 정의
 
 ```
 <ev-chart
@@ -10,11 +11,15 @@
 />
 ```
 
->## Props
+> ## Props
+
 ### 1. v-model:selectedItem
- - option에서 [selectItem](#selectitem) 옵션을 사용할 경우 유효한 바인딩
- - 현재 선택된 Item에 대한 정보 (seriesID, dataIndex)
+
+- option에서 [selectItem](#selectitem) 옵션을 사용할 경우 유효한 바인딩
+- 현재 선택된 Item에 대한 정보 (seriesID, dataIndex)
+
 #### Example
+
 ```
 const selectedItem = ref({
     seriesID: 'series1', // Series ID (key)
@@ -23,34 +28,39 @@ const selectedItem = ref({
 ```
 
 ### 2. v-model:selectedLabel
+
 - option에서 [selectLabel](#selectlabel) 옵션을 사용할 경우 유효한 바인딩
 - 현재 선택된 Label의 인덱스 대한 정보 (dataIndex)
 - 차트 클릭이 아니라 특정 위치의 label 을 선택하고 싶은 경우 바인딩 하고, dataIndex 배열의 값으로 차트를 컨트롤 한다.
+
 #### Example
+
 ```
 const selectedLabel = ref({
     dataIndex: [0], // option 에 설정한 limit 갯수 까지 선택 가능.
 });
 ```
 
+### 3. data
 
-### 3. data  
-  | 이름 | 타입 | 디폴트 | 설명 | 종류 |
-  |------------ |-----------|---------|-------------------------|---------------------------------------------------|
-  | series | Object | {} | 특정 데이터에 대한 시리즈 옵션 |  |
-  | data   | Object | {} | 차트에 표시할 시리즈 별 데이터 |  |
-  | groups | Array  | [] | Stack, Overlapping 차트를 위한 시리즈 그룹을 지정 |  |
-  | labels | Array  | [] | 축의 각 눈금에 해당하는 명칭 |  |
+| 이름   | 타입   | 디폴트 | 설명                                              | 종류 |
+| ------ | ------ | ------ | ------------------------------------------------- | ---- |
+| series | Object | {}     | 특정 데이터에 대한 시리즈 옵션                    |      |
+| data   | Object | {}     | 차트에 표시할 시리즈 별 데이터                    |      |
+| groups | Array  | []     | Stack, Overlapping 차트를 위한 시리즈 그룹을 지정 |      |
+| labels | Array  | []     | 축의 각 눈금에 해당하는 명칭                      |      |
 
 #### series
-  | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-  |------------ |-----------|---------|-------------------------|---------------------------------------------------|
-  | name | String | series-${index} | 특정 데이터에 대한 시리즈 옵션 |  |
-  | type | String | 'bar' | 시리즈에 해당하는 데이터 표현 방식 | 'bar', 'pie', 'line', 'scatter' |
-  | color | Hex, RGB, RGBA Code(String) or Object | COLOR[index] | 특정 색상을 지정하지 않으면 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용 |  |
-  | showValue | Object | ([상세](#showvalue)) | 막대 위에 값 표시 여부 및 속성 |  |
+
+| 이름      | 타입                                  | 디폴트               | 설명                                                                                        | 종류(예시)                      |
+| --------- | ------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------- | ------------------------------- |
+| name      | String                                | series-\${index}     | 특정 데이터에 대한 시리즈 옵션                                                              |                                 |
+| type      | String                                | 'bar'                | 시리즈에 해당하는 데이터 표현 방식                                                          | 'bar', 'pie', 'line', 'scatter' |
+| color     | Hex, RGB, RGBA Code(String) or Object | COLOR[index]         | 특정 색상을 지정하지 않으면 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용 |                                 |
+| showValue | Object                                | ([상세](#showvalue)) | 막대 위에 값 표시 여부 및 속성                                                              |                                 |
 
 #### color Example
+
 ```
 const chartData = {
     series: {
@@ -65,18 +75,21 @@ const chartData = {
 ```
 
 #### showValue
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| use | Boolean | false | data label 표시 여부 | true /false |
-| textColor | Hex, RGB, RGBA Code(String) | '#000000' | 글자 색상  | |
-| fontSize | Number | 12 | 글자 크기 | |
-| align | String | 'end' | 텍스트 위치 (막대 시작, 막대 중간, 막대 끝, 막대 바깥쪽)  | 'start', 'center', 'end', 'out' |
-| formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (value) => value + '%' |
-| decimalPoint | Number | 0 | 소수점 자릿수  |  |
-* Stack Bar Chart의 경우 'out' 은 지원하지 않습니다. 
-* 막대 영역이 좁을 경우 값이 표시되지 않을 수 있습니다.
+
+| 이름         | 타입                        | 디폴트    | 설명                                                     | 종류(예시)                      |
+| ------------ | --------------------------- | --------- | -------------------------------------------------------- | ------------------------------- |
+| use          | Boolean                     | false     | data label 표시 여부                                     | true /false                     |
+| textColor    | Hex, RGB, RGBA Code(String) | '#000000' | 글자 색상                                                |                                 |
+| fontSize     | Number                      | 12        | 글자 크기                                                |                                 |
+| align        | String                      | 'end'     | 텍스트 위치 (막대 시작, 막대 중간, 막대 끝, 막대 바깥쪽) | 'start', 'center', 'end', 'out' |
+| formatter    | function                    | null      | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용  | (value) => value + '%'          |
+| decimalPoint | Number                      | 0         | 소수점 자릿수                                            |                                 |
+
+- Stack Bar Chart의 경우 'out' 은 지원하지 않습니다.
+- 막대 영역이 좁을 경우 값이 표시되지 않을 수 있습니다.
 
 #### data example
+
 ```
 const chartData = {
     series: {
@@ -92,234 +105,254 @@ const chartData = {
     labels: ['a', 'b', c', 'd'],
 }
 ```
-  
-### 4. options 
-  | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-  |------------ |-----------|---------|-------------------------|---------------------------------------------------|
-  | type | String | '' | series 별로 type값을 지정하지 않을 경우 일괄 적용될 차트의 타입 | 'bar', 'pie', 'line', 'scatter' |
-  | width | String / Number | '100%' | 차트의 너비 | '100%', '150px', 150 | 
-  | height | String / Number | '100%' | 차트의 높이 | '100%', '150px', 150 |
-  | thickness | Number | 1 | 차트 막대의 너비 | 0.1 ~ 1 |
-  | cPadRatio | Number | 0 | 카테고리(각 라벨간)내부 padding 영역의 비율 | 0 ~ 0.99 (1 미만) |
-  | borderRadius | Number | 0 | 막대 가장자리 부분의 border-radius 값.  | 0 ~ |
-  | horizontal | Boolean | false | 차트 막대의 방향 - 수평 전환 여부 | true, false |
-  | axesX | Object | 없음 | X축에 대한 속성 | [상세](#axesx-axesy) |
-  | axesY | Object | 없음 | Y축에 대한 속성 | [상세](#axesx-axesy) |
-  | title | Object | ([상세](#title)) | 차트 상단에 위치할 차트 제목 표시 여부 및 속성 |  |
-  | legend | Object | ([상세](#legend)) | 차트의 범례 표시 여부 및 속성 |  |
-  | tooltip | Object | ([상세](#tooltip)) | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성 | |
-  | indicator | Object | ([상세](#indicator)) | 지표선 | |
-  | maxTip | Object | ([상세](#maxtip)) | 최대값에 tip 표시(값 표시) 여부 및 속성 | |
-  | selectItem | Object | ([상세](#selectitem)) | 차트 아이템 선택 기능 활성화 여부 및 속성 | | 
-  | selectLabel  | Object | ([상세](#selectlabel)) | 차트 라벨 선택 기능 활성화 여부 및 속성 | | 
-  | padding | Object | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값 | | 
+
+### 4. options
+
+| 이름         | 타입            | 디폴트                                    | 설명                                                                                                                                                                                   | 종류(예시)                      |
+| ------------ | --------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| type         | String          | ''                                        | series 별로 type값을 지정하지 않을 경우 일괄 적용될 차트의 타입                                                                                                                        | 'bar', 'pie', 'line', 'scatter' |
+| width        | String / Number | '100%'                                    | 차트의 너비                                                                                                                                                                            | '100%', '150px', 150            |
+| height       | String / Number | '100%'                                    | 차트의 높이                                                                                                                                                                            | '100%', '150px', 150            |
+| thickness    | Number          | 1                                         | 차트 막대의 너비                                                                                                                                                                       | 0.1 ~ 1                         |
+| cPadRatio    | Number          | 0                                         | 카테고리(각 라벨간)내부 padding 영역의 비율                                                                                                                                            | 0 ~ 0.99 (1 미만)               |
+| borderRadius | Number          | 0                                         | 막대 가장자리 부분의 border-radius 값.                                                                                                                                                 | 0 ~                             |
+| horizontal   | Boolean         | false                                     | 차트 막대의 방향 - 수평 전환 여부                                                                                                                                                      | true, false                     |
+| axesX        | Object          | 없음                                      | X축에 대한 속성                                                                                                                                                                        | [상세](#axesx-axesy)            |
+| axesY        | Object          | 없음                                      | Y축에 대한 속성                                                                                                                                                                        | [상세](#axesx-axesy)            |
+| title        | Object          | ([상세](#title))                          | 차트 상단에 위치할 차트 제목 표시 여부 및 속성                                                                                                                                         |                                 |
+| legend       | Object          | ([상세](#legend))                         | 차트의 범례 표시 여부 및 속성                                                                                                                                                          |                                 |
+| tooltip      | Object          | ([상세](#tooltip))                        | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성                                                                                                                                       |                                 |
+| indicator    | Object          | ([상세](#indicator))                      | 지표선                                                                                                                                                                                 |                                 |
+| maxTip       | Object          | ([상세](#maxtip))                         | 최대값에 tip 표시(값 표시) 여부 및 속성                                                                                                                                                |                                 |
+| selectItem   | Object          | ([상세](#selectitem))                     | 차트 아이템 선택 기능 활성화 여부 및 속성                                                                                                                                              |                                 |
+| selectLabel  | Object          | ([상세](#selectlabel))                    | 차트 라벨 선택 기능 활성화 여부 및 속성                                                                                                                                                |                                 |
+| padding      | Object          | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값                                                                                                                                                                   |                                 |
+| syncHover    | boolean         | true                                      | options.syncHover가 true인 EvChartGroup으로 감싼경우, 해당 차트에서는 그룹으로 묶긴 차트들 사이의 syncHover선을 그리고싶지 않을 때 사용하는 속성 (time관련된 축을 가질때만 적용됩니다) |                                 |
 
 #### axesX axesY
+
 ##### type 공통
-  | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-  |------------ |-----------|---------|-------------------------|---------------------------------------------------|
-  | type | String | | 축의 유형 | [linear](#linear-type), [time](#time-type), [log](#Logarithmic-type), [step](#step-type) |
-  | showAxis | Boolean | true | 축 표시 여부 | true / false | 
-  | startToZero | Boolean | false | 축의 시작을 0 부터 시작할지의 여부 | true / false |
-  | autoScaleRatio | Number | null | Axis의 Max Buffer를 위한 속성 | 0.1 ~ 0.9 |
-  | showGrid | Boolean | true | 차트 내부 그리드 표시 여부 | true / false |
-  | axisLineWidth  | Number | 1 | 축의 선 굵기 | 1 ~ |
-  | axisLineColor | String | '#C9CFDC' | 축의 색상 | | 
-  | gridLineColor | String | '#C9CFDC' | 그리드의 색상 | | 
-  | range | Array | null | 축에 표시할 값의 min, max (autoScaleRatio = null, startToZero = false 이여야 정상 표현됩니다.) | [0, 100] |
-  | horizontal | Boolean | null | horizontal Bar 차트 표시를 위한 속성 | true / false | 
-  | overlapping | Object | ([상세](#overlapping)) | Overlapping Bar 차트 표시를 위한 속성<br/>data 속성의 groups 값을 같이 지정하여야 정상 표현됩니다. |  |   
-  | interval | String | null | 축에 표시되는 값의 간격 단위 (축의 타입에 따라 달라짐)
-  | labelStyle | Object | ([상세](#labelstyle)) | 라벨의 폰트 스타일을 설정 | |
-  | plotLines | Array | ([상세](#plotline)) | plot line(임계선 표시 용도) 설정 | |
-  | plotBands | Array | ([상세](#plotband)) | plot band(임계영역 표시 용도) 설정 | |
-  | formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (value) => value + '%' |
-  | title | Object | ([상세](#title)) | 라벨의 폰트 스타일을 설정 | |  
+
+| 이름           | 타입     | 디폴트                 | 설명                                                                                               | 종류(예시)                                                                               |
+| -------------- | -------- | ---------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| type           | String   |                        | 축의 유형                                                                                          | [linear](#linear-type), [time](#time-type), [log](#Logarithmic-type), [step](#step-type) |
+| showAxis       | Boolean  | true                   | 축 표시 여부                                                                                       | true / false                                                                             |
+| startToZero    | Boolean  | false                  | 축의 시작을 0 부터 시작할지의 여부                                                                 | true / false                                                                             |
+| autoScaleRatio | Number   | null                   | Axis의 Max Buffer를 위한 속성                                                                      | 0.1 ~ 0.9                                                                                |
+| showGrid       | Boolean  | true                   | 차트 내부 그리드 표시 여부                                                                         | true / false                                                                             |
+| axisLineWidth  | Number   | 1                      | 축의 선 굵기                                                                                       | 1 ~                                                                                      |
+| axisLineColor  | String   | '#C9CFDC'              | 축의 색상                                                                                          |                                                                                          |
+| gridLineColor  | String   | '#C9CFDC'              | 그리드의 색상                                                                                      |                                                                                          |
+| range          | Array    | null                   | 축에 표시할 값의 min, max (autoScaleRatio = null, startToZero = false 이여야 정상 표현됩니다.)     | [0, 100]                                                                                 |
+| horizontal     | Boolean  | null                   | horizontal Bar 차트 표시를 위한 속성                                                               | true / false                                                                             |
+| overlapping    | Object   | ([상세](#overlapping)) | Overlapping Bar 차트 표시를 위한 속성<br/>data 속성의 groups 값을 같이 지정하여야 정상 표현됩니다. |                                                                                          |
+| interval       | String   | null                   | 축에 표시되는 값의 간격 단위 (축의 타입에 따라 달라짐)                                             |
+| labelStyle     | Object   | ([상세](#labelstyle))  | 라벨의 폰트 스타일을 설정                                                                          |                                                                                          |
+| plotLines      | Array    | ([상세](#plotline))    | plot line(임계선 표시 용도) 설정                                                                   |                                                                                          |
+| plotBands      | Array    | ([상세](#plotband))    | plot band(임계영역 표시 용도) 설정                                                                 |                                                                                          |
+| formatter      | function | null                   | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용                                            | (value) => value + '%'                                                                   |
+| title          | Object   | ([상세](#title))       | 라벨의 폰트 스타일을 설정                                                                          |                                                                                          |
 
 ##### axesX
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-----|------|-------|-----|-----|
-| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부, time type에서만 사용하길 권장.<br>categoryMode일 때는 작동하지 않음. | |
+
+| 이름 | 타입    | 디폴트 | 설명                                                                                                          | 종류(예시) |
+| ---- | ------- | ------ | ------------------------------------------------------------------------------------------------------------- | ---------- |
+| flow | boolean | false  | 시간에 따라 x축 label이 움직일지의 여부, time type에서만 사용하길 권장.<br>categoryMode일 때는 작동하지 않음. |            |
 
 ##### linear type
-   - interval (Axis Label 표기를 위한 interval)
-      - 미지정 시 Chart 내부에서 해당 Axis 데이터의 max/min value를 기반으로 interval을 구함
-   - Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌
-      - 예를 들어, Label에 필요한 값이 1,500일 경우 '1.5K'로 표기
-   - decimalPoint
-     - 소수점 자릿수 표시 (default: 0)
-   - range
-     - 축의 min 값, max 값을 array로 넘겨줌 ([0, 100])
-     
-      
+
+- interval (Axis Label 표기를 위한 interval)
+  - 미지정 시 Chart 내부에서 해당 Axis 데이터의 max/min value를 기반으로 interval을 구함
+- Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌
+  - 예를 들어, Label에 필요한 값이 1,500일 경우 '1.5K'로 표기
+- decimalPoint
+  - 소수점 자릿수 표시 (default: 0)
+- range
+  - 축의 min 값, max 값을 array로 넘겨줌 ([0, 100])
+
 ##### time type
-   - interval (Axis Label 표기를 위한 interval)
-      - 'millisecond', 'second', 'minute', 'hour', 'day', 'week' ,'month', 'quarter', 'year'
-   - timeFormat
-      - dayjs의 timeFormat 이용 [참고URL](https://day.js.org/docs/en/parse/string-format/)
-   - categoryMode
-      - 축에 표시할 시간 값을 `data`옵션의 `labels`속 값들로 표시할지의 여부
-   - range
-     - 축의 min 값, max 값을 array로 넘겨줌 ([0, 100])
-   - flow
-     - 시간에 따라 x축 label이 움직일지의 여부
-     - categoryMode일 때는 작동하지 않음.
+
+- interval (Axis Label 표기를 위한 interval)
+  - 'millisecond', 'second', 'minute', 'hour', 'day', 'week' ,'month', 'quarter', 'year'
+- timeFormat
+  - dayjs의 timeFormat 이용 [참고URL](https://day.js.org/docs/en/parse/string-format/)
+- categoryMode
+  - 축에 표시할 시간 값을 `data`옵션의 `labels`속 값들로 표시할지의 여부
+- range
+  - 축의 min 값, max 값을 array로 넘겨줌 ([0, 100])
+- flow
+  - 시간에 따라 x축 label이 움직일지의 여부
+  - categoryMode일 때는 작동하지 않음.
 
 ##### Logarithmic type
-   - logarithmic Type Axis는 Axis의 min max를 로그로 계산하여 자동으로 추가 buffer값을 제공
-   - Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌
-      - 예를 들어, Label에 필요한 값이 1,500일 경우 '1.5K'로 표
-   - decimalPoint
-       - 소수점 자릿수 표시 (default: 0)
-   - range
-     - 축의 min 값, max 값을 array로 넘겨줌 ([0, 100])
-     
+
+- logarithmic Type Axis는 Axis의 min max를 로그로 계산하여 자동으로 추가 buffer값을 제공
+- Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌
+  - 예를 들어, Label에 필요한 값이 1,500일 경우 '1.5K'로 표
+- decimalPoint
+  - 소수점 자릿수 표시 (default: 0)
+- range
+
+  - 축의 min 값, max 값을 array로 넘겨줌 ([0, 100])
+
 ##### step type
-   - timeMode
-      - Step Axis를 Time 기반으로 변경, default: false
-   - timeFormat
-      - dayjs의 timeFormat 이용 [참고URL](https://day.js.org/docs/en/parse/string-format/)
-   - range
-     - 축의 label의 minIndex, maxIndex 값을 array로 넘겨줌 ([0, 5])
+
+- timeMode
+  - Step Axis를 Time 기반으로 변경, default: false
+- timeFormat
+  - dayjs의 timeFormat 이용 [참고URL](https://day.js.org/docs/en/parse/string-format/)
+- range
+  - 축의 label의 minIndex, maxIndex 값을 array로 넘겨줌 ([0, 5])
 
 ##### overlapping
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-----|------|-------|-----|-----|
-| use | Boolean | false | overlapping 사용 여부 | true / false |
+
+| 이름 | 타입    | 디폴트 | 설명                  | 종류(예시)   |
+| ---- | ------- | ------ | --------------------- | ------------ |
+| use  | Boolean | false  | overlapping 사용 여부 | true / false |
 
 ##### labelStyle
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-----|------|-------|-----|-----|
-| show | Boolean | true | label 표시 여부 | true / false |
-| fontSize | Number | 12 | 글자 크기 | |
-| color | Hex, RGB, RGBA Code(String) | '#25262E' | 글자 색상 | |
-| fontFamily | String | 'Roboto' | 폰트 | |
-| fitWidth | Boolean | false | Label Text Ellipsis 처리 | |
-| fitDir | String | 'right' | Ellipsis 방향 | ( right => 'aaa...', left => '...aaa') |
-| padding |  Number | 0 | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0 |
+
+| 이름       | 타입                        | 디폴트    | 설명                                               | 종류(예시)                             |
+| ---------- | --------------------------- | --------- | -------------------------------------------------- | -------------------------------------- |
+| show       | Boolean                     | true      | label 표시 여부                                    | true / false                           |
+| fontSize   | Number                      | 12        | 글자 크기                                          |                                        |
+| color      | Hex, RGB, RGBA Code(String) | '#25262E' | 글자 색상                                          |                                        |
+| fontFamily | String                      | 'Roboto'  | 폰트                                               |                                        |
+| fitWidth   | Boolean                     | false     | Label Text Ellipsis 처리                           |                                        |
+| fitDir     | String                      | 'right'   | Ellipsis 방향                                      | ( right => 'aaa...', left => '...aaa') |
+| padding    | Number                      | 0         | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0                                      |
 
 ##### title
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-----|------|-------|-----|-----|
-| use | Boolean | false | Chart 축(Axis) Title 표시 여부 | true / false |
-| text | String | null | Title 로 표시될 text | |
-| fontSize | Number | 12 | 글자 크기 | |
-| fontWeight | Number | 400 | 글자 굵기 | 100, 200, 300, ... 900 |
-| fontFamily | String | 'Roboto' | 폰트 | |
-| fontStyle | String | 'normal' | 폰트 스타일 | 'normal', 'italic' |
-| textAlign | String | 'right' | 텍스트 정렬| 'right', 'left', 'center' |
-| color | Hex, RGB, RGBA Code(String) | '#25262E' | 글자 색상 | |
+
+| 이름       | 타입                        | 디폴트    | 설명                           | 종류(예시)                |
+| ---------- | --------------------------- | --------- | ------------------------------ | ------------------------- |
+| use        | Boolean                     | false     | Chart 축(Axis) Title 표시 여부 | true / false              |
+| text       | String                      | null      | Title 로 표시될 text           |                           |
+| fontSize   | Number                      | 12        | 글자 크기                      |                           |
+| fontWeight | Number                      | 400       | 글자 굵기                      | 100, 200, 300, ... 900    |
+| fontFamily | String                      | 'Roboto'  | 폰트                           |                           |
+| fontStyle  | String                      | 'normal'  | 폰트 스타일                    | 'normal', 'italic'        |
+| textAlign  | String                      | 'right'   | 텍스트 정렬                    | 'right', 'left', 'center' |
+| color      | Hex, RGB, RGBA Code(String) | '#25262E' | 글자 색상                      |                           |
 
 ##### plotLine
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-----|------|-------|-----|-----|
-| value | Number(value), Date, Number(Index) | null | 선을 표시할 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
-| color | Hex, RGB, RGBA Code(String) | '#FF0000' | 선 색상 | |
-| segments | Array | null | dash 간격 | [6, 2] |
-| lineWidth | Number | 1 | 선 굵기 |  |
-| label | Object | null | 표시할 label의 스타일을 정의 | ([상세](#plotlabel)) |
+
+| 이름      | 타입                               | 디폴트    | 설명                           | 종류(예시)                                                           |
+| --------- | ---------------------------------- | --------- | ------------------------------ | -------------------------------------------------------------------- |
+| value     | Number(value), Date, Number(Index) | null      | 선을 표시할 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
+| color     | Hex, RGB, RGBA Code(String)        | '#FF0000' | 선 색상                        |                                                                      |
+| segments  | Array                              | null      | dash 간격                      | [6, 2]                                                               |
+| lineWidth | Number                             | 1         | 선 굵기                        |                                                                      |
+| label     | Object                             | null      | 표시할 label의 스타일을 정의   | ([상세](#plotlabel))                                                 |
 
 ##### plotBand
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-----|------|-------|-----|-----|
-| from | Number(value), Date, Number(Index) | null | 박스를 표시할 시작 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
-| to | Number(value), Date, Number(Index) | null | 박스를 표시할 종료 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
-| color | Hex, RGB, RGBA Code(String) | '#FF0000' | 선 색상 | |
-| label | Object | null | 표시할 label의 스타일을 정의 | ([상세](#plotlabel)) |
+
+| 이름  | 타입                               | 디폴트    | 설명                                  | 종류(예시)                                                           |
+| ----- | ---------------------------------- | --------- | ------------------------------------- | -------------------------------------------------------------------- |
+| from  | Number(value), Date, Number(Index) | null      | 박스를 표시할 시작 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
+| to    | Number(value), Date, Number(Index) | null      | 박스를 표시할 종료 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
+| color | Hex, RGB, RGBA Code(String)        | '#FF0000' | 선 색상                               |                                                                      |
+| label | Object                             | null      | 표시할 label의 스타일을 정의          | ([상세](#plotlabel))                                                 |
 
 ##### plotLabel
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-----|------|-------|-----|-----|
-| show | Boolean | false | label 표시 여부 | true / false |
-| fontSize | Number | 12 | 폰트 크기 | |
-| fontColor | Hex, RGB, RGBA Code(String) | '#FF0000' | 폰트 색상 | |
-| fillColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | 박스 배경 색상 | |
-| lineColor | Hex, RGB, RGBA Code(String) | '#FF0000' | 박스 테두리 선 색상 | |
-| lineWidth | Number | 0 | 테두리 선 굵기 | 1 ~ |
-| fontWeight | Number | 400 | 폰트 굵기 |  |
-| fontFamily | String | 'Roboto' | 폰트 스타일 |  |
-| textAlign | String | 'center' | 수평 정렬 | 'left', 'center', 'right' |
-| verticalAlign | String | 'middle' | 수직 정렬 | 'top', 'middle', 'bottom' |
-| textOverflow | String | 'none' | 라벨을 넣을 수 있는 여백 혹은 maxWidth 값을 넘었을 경우의 처리방안  | 'none', 'ellipsis' |
-| maxWidth | Number | null | 라벨의 최대 너비  |  |
+
+| 이름          | 타입                        | 디폴트    | 설명                                                               | 종류(예시)                |
+| ------------- | --------------------------- | --------- | ------------------------------------------------------------------ | ------------------------- |
+| show          | Boolean                     | false     | label 표시 여부                                                    | true / false              |
+| fontSize      | Number                      | 12        | 폰트 크기                                                          |                           |
+| fontColor     | Hex, RGB, RGBA Code(String) | '#FF0000' | 폰트 색상                                                          |                           |
+| fillColor     | Hex, RGB, RGBA Code(String) | '#FFFFFF' | 박스 배경 색상                                                     |                           |
+| lineColor     | Hex, RGB, RGBA Code(String) | '#FF0000' | 박스 테두리 선 색상                                                |                           |
+| lineWidth     | Number                      | 0         | 테두리 선 굵기                                                     | 1 ~                       |
+| fontWeight    | Number                      | 400       | 폰트 굵기                                                          |                           |
+| fontFamily    | String                      | 'Roboto'  | 폰트 스타일                                                        |                           |
+| textAlign     | String                      | 'center'  | 수평 정렬                                                          | 'left', 'center', 'right' |
+| verticalAlign | String                      | 'middle'  | 수직 정렬                                                          | 'top', 'middle', 'bottom' |
+| textOverflow  | String                      | 'none'    | 라벨을 넣을 수 있는 여백 혹은 maxWidth 값을 넘었을 경우의 처리방안 | 'none', 'ellipsis'        |
+| maxWidth      | Number                      | null      | 라벨의 최대 너비                                                   |                           |
 
 #### title
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| show | Boolean | false | 타이틀 표시 여부 | true /false |
-| height | Number | 40 | 타이틀 영역이 높이 | |
-| text | String | '' | 타이틀 | | 
-| style | Object | | 타이틀 폰트 스타일 | | 
-| style.fontSize | Number | 15 | 글자 크기 | | 
-| style.color | Hex, RGB, RGBA Code(String) | '#000' | 글자 색상 | | 
-| style.fontFamily | String | 'Roboto' | 글자체 | |  
-  
+
+| 이름             | 타입                        | 디폴트   | 설명               | 종류(예시)  |
+| ---------------- | --------------------------- | -------- | ------------------ | ----------- |
+| show             | Boolean                     | false    | 타이틀 표시 여부   | true /false |
+| height           | Number                      | 40       | 타이틀 영역이 높이 |             |
+| text             | String                      | ''       | 타이틀             |             |
+| style            | Object                      |          | 타이틀 폰트 스타일 |             |
+| style.fontSize   | Number                      | 15       | 글자 크기          |             |
+| style.color      | Hex, RGB, RGBA Code(String) | '#000'   | 글자 색상          |             |
+| style.fontFamily | String                      | 'Roboto' | 글자체             |             |
+
 #### legend
-| 이름          | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-------------| ---- | ----- | --- | ----------|
-| show        | Boolean | false | Legend 표시 여부 | true /false |
-| position    | String | 'right' | Legend 위치 | 'top', 'right', 'bottom', 'left' |
-| color       | Hex, RGB, RGBA Code(String) | '#353740' | 폰트 색상 | | 
-| inactive    | Hex, RGB, RGBA Code(String) | '#aaa' | 비활성화 상태의 폰트 색상 | | 
-| width       | Number | 140 | Legend의 넓이 *('left', 'right'의 경우 조절)* | | 
-| height      | Number | 24 | Legend의 높이 *('top', 'bottom'의 경우 조절)* | | 
-| padding     | Object | { top: 0, right: 0, left: 0, bottom: 0 } | Legend 내부 padding 값 | | 
-| allowResize | Boolean | false | Legend 영역 리사이즈 가능 여부 | | 
-| table       | Object | ([상세](#legendtable)) | Table 타입 Legend (값 표시 포함). bar, line, pie 전용 | |
-| stopClickEvt| Boolean | false | Legend 표시 여부 | true /false |
+
+| 이름         | 타입                        | 디폴트                                   | 설명                                                  | 종류(예시)                       |
+| ------------ | --------------------------- | ---------------------------------------- | ----------------------------------------------------- | -------------------------------- |
+| show         | Boolean                     | false                                    | Legend 표시 여부                                      | true /false                      |
+| position     | String                      | 'right'                                  | Legend 위치                                           | 'top', 'right', 'bottom', 'left' |
+| color        | Hex, RGB, RGBA Code(String) | '#353740'                                | 폰트 색상                                             |                                  |
+| inactive     | Hex, RGB, RGBA Code(String) | '#aaa'                                   | 비활성화 상태의 폰트 색상                             |                                  |
+| width        | Number                      | 140                                      | Legend의 넓이 _('left', 'right'의 경우 조절)_         |                                  |
+| height       | Number                      | 24                                       | Legend의 높이 _('top', 'bottom'의 경우 조절)_         |                                  |
+| padding      | Object                      | { top: 0, right: 0, left: 0, bottom: 0 } | Legend 내부 padding 값                                |                                  |
+| allowResize  | Boolean                     | false                                    | Legend 영역 리사이즈 가능 여부                        |                                  |
+| table        | Object                      | ([상세](#legendtable))                   | Table 타입 Legend (값 표시 포함). bar, line, pie 전용 |                                  |
+| stopClickEvt | Boolean                     | false                                    | Legend 표시 여부                                      | true /false                      |
 
 ##### legendTable
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| use | Boolean | false | Table 타입 표시 여부 | true /false |
-| style | Object | null | table style | { row: {}, header: {} } |
-| style.row | Object | null | table row의 CSS style | { borderBottom: '1px solid #DBDBDB' } |
-| style.header | Object | null | table header의 CSS Style | { fontSize: '15px' } |
-| columns | Object | (아래 각 항목 참고)| | | 
-| columns.name | Object | { title: 'Name' } | Series Name 표시 관련 옵션 | { title: '시리즈명', style: {...} }| 
-| columns.min | Object | { use: false, title: 'MIN' } | Minimum Value 표시 관련 옵션 | { use: true, title: '최솟값', style: {...}, formatter: (v) => `${v.toFixed(2)}` }| 
-| columns.max | Object | { use: false, title: 'MAX' } | Maximum Value 표시 관련 옵션 | { use: true, title: '최댓값', style: {...}, decimalPoint: 2 }| 
-| columns.avg | Object | { use: false, title: 'AVG' } | Average Value 표시 관련 옵션 | { use: true, title: '평균', style: {...}, decimalPoint: 2 }| 
-| columns.total | Object | { use: false, title: 'TOTAL' } | Total Value 표시 관련 옵션 | { use: true, title: '합계', style: {...}, decimalPoint: 2 }| 
-| columns.last | Object | { use: false, title: 'LAST' } | Last Value 표시 관련 옵션 | { use: true, title: 'Current', style: {...}, decimalPoint: 2 }| 
+
+| 이름          | 타입    | 디폴트                         | 설명                         | 종류(예시)                                                                        |
+| ------------- | ------- | ------------------------------ | ---------------------------- | --------------------------------------------------------------------------------- |
+| use           | Boolean | false                          | Table 타입 표시 여부         | true /false                                                                       |
+| style         | Object  | null                           | table style                  | { row: {}, header: {} }                                                           |
+| style.row     | Object  | null                           | table row의 CSS style        | { borderBottom: '1px solid #DBDBDB' }                                             |
+| style.header  | Object  | null                           | table header의 CSS Style     | { fontSize: '15px' }                                                              |
+| columns       | Object  | (아래 각 항목 참고)            |                              |                                                                                   |
+| columns.name  | Object  | { title: 'Name' }              | Series Name 표시 관련 옵션   | { title: '시리즈명', style: {...} }                                               |
+| columns.min   | Object  | { use: false, title: 'MIN' }   | Minimum Value 표시 관련 옵션 | { use: true, title: '최솟값', style: {...}, formatter: (v) => `${v.toFixed(2)}` } |
+| columns.max   | Object  | { use: false, title: 'MAX' }   | Maximum Value 표시 관련 옵션 | { use: true, title: '최댓값', style: {...}, decimalPoint: 2 }                     |
+| columns.avg   | Object  | { use: false, title: 'AVG' }   | Average Value 표시 관련 옵션 | { use: true, title: '평균', style: {...}, decimalPoint: 2 }                       |
+| columns.total | Object  | { use: false, title: 'TOTAL' } | Total Value 표시 관련 옵션   | { use: true, title: '합계', style: {...}, decimalPoint: 2 }                       |
+| columns.last  | Object  | { use: false, title: 'LAST' }  | Last Value 표시 관련 옵션    | { use: true, title: 'Current', style: {...}, decimalPoint: 2 }                    |
 
 #### tooltip
-| 이름                  | 타입                          | 디폴트                                        | 설명                                   | 종류(예시)                                                              |
-|---------------------|-----------------------------|--------------------------------------------|--------------------------------------|---------------------------------------------------------------------|
-| use                 | Boolean                     | true                                       | tooltip 표시 여부                        | true /false                                                         |
-| backgroundColor     | Hex, RGB, RGBA Code(String) | '#4C4C4C'                                  | tooltip 배경 색상                        |                                                                     |
-| borderColor         | Hex, RGB, RGBA Code(String) | '#666666'                                  | tooltip 테두리 색상                       |                                                                     |
-| useShadow           | Boolean                     | false                                      | 그림자 사용 여부                            |                                                                     |
-| shadowOpacity       | Number                      | 0.25                                       | 그림자 투명도                              |                                                                     |
-| throttledMove       | Boolean                     | false                                      | 데이터 조회 Throttling 처리 유무              |                                                                     |
-| debouncedHide       | Boolean                     | false                                      | 좌표 이동 시 tooltip hide 여부              |                                                                     |
-| sortByValue         | Boolean                     | true                                       | 값을 기준으로 정렬할지의 여부                     |                                                                     |
-| useScrollbar        | Boolean                     | false                                      | 스크롤바 사용 여부                           |                                                                     |
-| maxHeight           | Number                      |                                            | 툴팁의 최대 높이                            |                                                                     |
-| maxWidth            | Number                      |                                            | 툴팁의 최대 너비                            |                                                                     |
+
+| 이름                | 타입                        | 디폴트                                     | 설명                                                    | 종류(예시)                                                          |
+| ------------------- | --------------------------- | ------------------------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------- |
+| use                 | Boolean                     | true                                       | tooltip 표시 여부                                       | true /false                                                         |
+| backgroundColor     | Hex, RGB, RGBA Code(String) | '#4C4C4C'                                  | tooltip 배경 색상                                       |                                                                     |
+| borderColor         | Hex, RGB, RGBA Code(String) | '#666666'                                  | tooltip 테두리 색상                                     |                                                                     |
+| useShadow           | Boolean                     | false                                      | 그림자 사용 여부                                        |                                                                     |
+| shadowOpacity       | Number                      | 0.25                                       | 그림자 투명도                                           |                                                                     |
+| throttledMove       | Boolean                     | false                                      | 데이터 조회 Throttling 처리 유무                        |                                                                     |
+| debouncedHide       | Boolean                     | false                                      | 좌표 이동 시 tooltip hide 여부                          |                                                                     |
+| sortByValue         | Boolean                     | true                                       | 값을 기준으로 정렬할지의 여부                           |                                                                     |
+| useScrollbar        | Boolean                     | false                                      | 스크롤바 사용 여부                                      |                                                                     |
+| maxHeight           | Number                      |                                            | 툴팁의 최대 높이                                        |                                                                     |
+| maxWidth            | Number                      |                                            | 툴팁의 최대 너비                                        |                                                                     |
 | textOverflow        | String                      | 'wrap'                                     | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis                                                   |
-| fontFamily          | String                      | 'Roboto'                                   | 툴팁에 표시될 폰트                           | 'Roboto', 'serif                                                    |
-| fontColor           | Hex code (string), Object   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                        | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
-| fontSize            | Object                      | { title: 16, contents: 14 }                | 툴팁에 표시될 폰트 사이즈                       |                                                                     |
-| colorShape          | String                      | 'rect'                                     | 툴팁에 표시될 series color의 모양             | 'rect', 'circle'                                                    |
- | rowPadding          | Object                      | { top: 0, bottom: 3, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값        |                                                                     |
-| showAllValueInRange | Boolean                     | false                                      | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
-| showHeader          | Boolean                     | true                                       | Tooltip의 Header 영역 표시 여부             |
-| formatter           | function / Object           | null                                       | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용      | (아래 코드 참고)                                                          |
+| fontFamily          | String                      | 'Roboto'                                   | 툴팁에 표시될 폰트                                      | 'Roboto', 'serif                                                    |
+| fontColor           | Hex code (string), Object   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                                 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontSize            | Object                      | { title: 16, contents: 14 }                | 툴팁에 표시될 폰트 사이즈                               |                                                                     |
+| colorShape          | String                      | 'rect'                                     | 툴팁에 표시될 series color의 모양                       | 'rect', 'circle'                                                    |
+| rowPadding          | Object                      | { top: 0, bottom: 3, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값                   |                                                                     |
+| showAllValueInRange | Boolean                     | false                                      | 동일한 axes값을 가진 전체 series를 Tooltip에 표시       |
+| showHeader          | Boolean                     | true                                       | Tooltip의 Header 영역 표시 여부                         |
+| formatter           | function / Object           | null                                       | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용 | (아래 코드 참고)                                                    |
+
 ```
 const chartOptions = {
     tooltip: {
         // 이전 버전 호환용으로 valueFormatter를 이전버전과 같이 사용 가능
         // return type : string
         formatter: ({ x, y, name, seriesId }) => ... ,
-        
+
         // value + title Formatter
         // return type : string
         formatter: {
             title: ({ x, y }) => ...,
             value: ({ x, y, name, seriesId }) => ...,
         }
-        
+
         // custom formatter (html)
         // return type : string
         // 주의: 사용하시는 방법에 따라 차트의 성능이 저하될 수 있습니다.
@@ -331,84 +364,93 @@ const chartOptions = {
 ```
 
 #### indicator
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| use | Boolean | true | indicator 사용 여부 | |
-| color | HexCode(String) | '#EE7F44' | 색상  | |
-| segments | Array | null | dash 간격 | [6, 2] |
+
+| 이름     | 타입            | 디폴트    | 설명                | 종류(예시) |
+| -------- | --------------- | --------- | ------------------- | ---------- |
+| use      | Boolean         | true      | indicator 사용 여부 |            |
+| color    | HexCode(String) | '#EE7F44' | 색상                |            |
+| segments | Array           | null      | dash 간격           | [6, 2]     |
 
 #### maxTip
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| use | Boolean | true | maxTip 표시 여부  | |
-| fixedPosTop | Boolean | false | maxTip 위치를 최대값으로 고정  | |
-| showIndicator | Boolean | false | indicator 표시 여부  | |
-| indicatorColor | Hex, RGB, RGBA Code(String) | '#000000' | indicator 색상  | |
-| tipStyle | Object | ([상세](#tipstyle)) | tip 스타일을 설정
+
+| 이름           | 타입                        | 디폴트              | 설명                          | 종류(예시) |
+| -------------- | --------------------------- | ------------------- | ----------------------------- | ---------- |
+| use            | Boolean                     | true                | maxTip 표시 여부              |            |
+| fixedPosTop    | Boolean                     | false               | maxTip 위치를 최대값으로 고정 |            |
+| showIndicator  | Boolean                     | false               | indicator 표시 여부           |            |
+| indicatorColor | Hex, RGB, RGBA Code(String) | '#000000'           | indicator 색상                |            |
+| tipStyle       | Object                      | ([상세](#tipstyle)) | tip 스타일을 설정             |
 
 ##### etc.
-| 이름    | 타입   | 디폴트 | 설명 | 종류(예시) |
-| ------ | ------ | ---- | -----| --------- |
-| tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  | |
-| tipTextColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상  | |
-* 3.4 버전부터 없어지는 옵션입니다.
+
+| 이름          | 타입                        | 디폴트    | 설명             | 종류(예시) |
+| ------------- | --------------------------- | --------- | ---------------- | ---------- |
+| tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  |            |
+| tipTextColor  | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상 |            |
+
+- 3.4 버전부터 없어지는 옵션입니다.
 
 #### selectItem
-| 이름 | 타입 | 디폴트 | 설명                                                | 종류(예시) |
-| --- | ---- | ----- |---------------------------------------------------| ----------|
-| use | Boolean | false | 차트 아이템 선택 기능                                      | |
-| useClick            | Boolean | true      | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) | |
-| showTextTip | Boolean | false | 선택한 위치의 TextTip(text 포함 화살표, 흡사 말풍선) 생성 여부 | |
-| tipText | String | 'value' | 선택한 위치에 TextTip을 생성한다면 어떤 값 | 'value', 'label |
-| showTip | Boolean | false | 선택한 위치의 Tip(화살표) 생성 여부 | |
-| showIndicator | Boolean | false | 선택한 label의 indicator 표시 | |
-| fixedPosTop | Boolean | false | indicator 및 tip의 위치를 최대값으로 고정 | |
-| useApproximateValue | Boolean | false | 가까운 label을 선택 | |
-| indicatorColor | Hex, RGB, RGBA Code(String)| '#000000' | indicator 색상 | |
-| tipStyle | Object | ([상세](#tipstyle)) | tip 스타일을 설정
+
+| 이름                | 타입                        | 디폴트              | 설명                                                                       | 종류(예시)      |
+| ------------------- | --------------------------- | ------------------- | -------------------------------------------------------------------------- | --------------- |
+| use                 | Boolean                     | false               | 차트 아이템 선택 기능                                                      |                 |
+| useClick            | Boolean                     | true                | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) |                 |
+| showTextTip         | Boolean                     | false               | 선택한 위치의 TextTip(text 포함 화살표, 흡사 말풍선) 생성 여부             |                 |
+| tipText             | String                      | 'value'             | 선택한 위치에 TextTip을 생성한다면 어떤 값                                 | 'value', 'label |
+| showTip             | Boolean                     | false               | 선택한 위치의 Tip(화살표) 생성 여부                                        |                 |
+| showIndicator       | Boolean                     | false               | 선택한 label의 indicator 표시                                              |                 |
+| fixedPosTop         | Boolean                     | false               | indicator 및 tip의 위치를 최대값으로 고정                                  |                 |
+| useApproximateValue | Boolean                     | false               | 가까운 label을 선택                                                        |                 |
+| indicatorColor      | Hex, RGB, RGBA Code(String) | '#000000'           | indicator 색상                                                             |                 |
+| tipStyle            | Object                      | ([상세](#tipstyle)) | tip 스타일을 설정                                                          |
 
 ##### etc.
-| 이름    | 타입   | 디폴트 | 설명 | 종류(예시) |
-| ------ | ------ | ---- | -----| --------- |
-| tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  | |
-| tipTextColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상  | |
-* 3.4 버전부터 없어지는 옵션입니다.
+
+| 이름          | 타입                        | 디폴트    | 설명             | 종류(예시) |
+| ------------- | --------------------------- | --------- | ---------------- | ---------- |
+| tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  |            |
+| tipTextColor  | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상 |            |
+
+- 3.4 버전부터 없어지는 옵션입니다.
 
 ##### tipStyle
-| 이름    | 타입   | 디폴트 | 설명 | 종류(예시) |
-| ------ | ------ | ---- | -----| --------- |
-| height | Number | 20 | tip 높이 | |
-| background | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  | |
-| textColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상  | |
-| fontSize  | Number | 14 | tip 폰트 크기 | |
-| fontFamily | String | 'Roboto' | tip 폰트 | |
-| fontWeight | Number | 400 | tip 폰트 굵기 | 100, 200, 300, ... 900 |
 
+| 이름       | 타입                        | 디폴트    | 설명             | 종류(예시)             |
+| ---------- | --------------------------- | --------- | ---------------- | ---------------------- |
+| height     | Number                      | 20        | tip 높이         |                        |
+| background | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  |                        |
+| textColor  | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상 |                        |
+| fontSize   | Number                      | 14        | tip 폰트 크기    |                        |
+| fontFamily | String                      | 'Roboto'  | tip 폰트         |                        |
+| fontWeight | Number                      | 400       | tip 폰트 굵기    | 100, 200, 300, ... 900 |
 
 #### selectLabel
-| 이름                  | 타입                          | 디폴트       | 설명                                                | 종류(예시) |
-|---------------------|-----------------------------|-----------|---------------------------------------------------| ----------|
-| use                 | Boolean                     | false     | 차트 라벨 선택 기능                                       | |
-| useClick            | Boolean | true      | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) | |
-| limit               | Number                      | 1         | 선택할 라벨의 최대 갯수                                     | |
-| useDeselectOverflow | Boolean                     | false     | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부             | |
-| showTip             | Boolean                     | false     | 선택한 위치의 Tip(화살표) 생성 여부                            | |
-| useSeriesOpacity    | Boolean                     | true      | 시리즈 opacity 변경 여부                                 | |
-| useLabelOpacity     | Boolean                     | true      | Axes Label opacity 변경 여부                          | |
-| fixedPosTop         | Boolean                     | false     | tip의 위치를 최대값으로 고정                                 | |
-| useApproximateValue | Boolean                     | false     | 가까운 label을 선택                                     | |
-| tipBackground       | Hex, RGB, RGBA Code(String) | '#000000' | tip 배경색상                                          | |
+
+| 이름                | 타입                        | 디폴트    | 설명                                                                       | 종류(예시) |
+| ------------------- | --------------------------- | --------- | -------------------------------------------------------------------------- | ---------- |
+| use                 | Boolean                     | false     | 차트 라벨 선택 기능                                                        |            |
+| useClick            | Boolean                     | true      | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) |            |
+| limit               | Number                      | 1         | 선택할 라벨의 최대 갯수                                                    |            |
+| useDeselectOverflow | Boolean                     | false     | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부                       |            |
+| showTip             | Boolean                     | false     | 선택한 위치의 Tip(화살표) 생성 여부                                        |            |
+| useSeriesOpacity    | Boolean                     | true      | 시리즈 opacity 변경 여부                                                   |            |
+| useLabelOpacity     | Boolean                     | true      | Axes Label opacity 변경 여부                                               |            |
+| fixedPosTop         | Boolean                     | false     | tip의 위치를 최대값으로 고정                                               |            |
+| useApproximateValue | Boolean                     | false     | 가까운 label을 선택                                                        |            |
+| tipBackground       | Hex, RGB, RGBA Code(String) | '#000000' | tip 배경색상                                                               |            |
 
 ### 5. resize-timeout
+
 - Default : 0
 - debounce 사용. 연속으로 이벤트가 발생한 경우, 마지막 이벤트가 끝난 시점을 기준으로 `주어진 시간 (resize-timeout)` 이후 콜백 실행
 
-
 ### 6. Event
-| 이름 | 파라미터 | 설명 |
- |------|----------|------|
-| click | selectedItem | 클릭된 series의 label, value, seriesID 값을 반환 |
-| dbl-click | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환 |
-| mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                 |
-* 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환
 
+| 이름       | 파라미터     | 설명                                                                                                                                                                       |
+| ---------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| click      | selectedItem | 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                           |
+| dbl-click  | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                      |
+| mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환 |
+
+- 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환

--- a/docs/views/barChart/example/HoverWithGroup.vue
+++ b/docs/views/barChart/example/HoverWithGroup.vue
@@ -28,6 +28,23 @@
     <div class="description">
       <ev-toggle v-model="syncHover" />
       <span>그룹 호버 동기화</span>
+      <br>
+      <br>
+      <span>차트별 호버 동기화</span>
+      <br>
+      <br>
+      <div class="hover-options">
+        <span>첫번째 차트</span>
+        <ev-toggle v-model="syncHoverChart1" />
+        <span>두번째 차트</span>
+        <ev-toggle v-model="syncHoverChart2" />
+        <span>세번째 차트</span>
+        <ev-toggle v-model="syncHoverChart3" />
+        <span>네번째 차트</span>
+        <ev-toggle v-model="syncHoverChart4" />
+      </div>
+      <br>
+      <br>
       <ev-toggle v-model="isLive" />
       <span>데이터 자동 업데이트</span>
       <br>
@@ -141,7 +158,10 @@ export default {
 
     const isFixedPosTop = ref(false);
 
+    const syncHoverChart1 = ref(true);
+
     const chartOptions1 = ref({
+      syncHover: syncHoverChart1.value,
       type: 'bar',
       thickness: 0.8,
       width: '100%',
@@ -190,7 +210,15 @@ export default {
         segments: [4, 2],
       }
     });
+
+    watch(syncHoverChart1, (newSyncHover) => {
+      chartOptions1.value.syncHover = newSyncHover;
+    });
+
+    const syncHoverChart2 = ref(true);
+
     const chartOptions2 = ref({
+      syncHover: syncHoverChart2.value,
       type: 'bar',
       thickness: 0.8,
       width: '100%',
@@ -239,7 +267,15 @@ export default {
         segments: [4, 2],
       }
     });
+
+    watch(syncHoverChart2, (newSyncHover) => {
+      chartOptions2.value.syncHover = newSyncHover;
+    });
+
+    const syncHoverChart3 = ref(true);
+
     const chartOptions3 = ref({
+      syncHover: syncHoverChart3.value,
       type: 'bar',
       thickness: 0.8,
       width: '100%',
@@ -288,7 +324,16 @@ export default {
         segments: [4, 2],
       }
     });
+
+    watch(syncHoverChart3, (newSyncHover) => {
+      chartOptions3.value.syncHover = newSyncHover;
+    });
+
+
+    const syncHoverChart4 = ref(true);
+
     const chartOptions4 = ref({
+      syncHover: syncHoverChart4.value,
       type: 'bar',
       thickness: 0.8,
       width: '100%',
@@ -336,6 +381,10 @@ export default {
         color: '#626872',
         segments: [4, 2],
       }
+    });
+
+    watch(syncHoverChart4, (newSyncHover) => {
+      chartOptions4.value.syncHover = newSyncHover;
     });
 
     const clickedLabel = ref();
@@ -447,6 +496,10 @@ export default {
 
     return {
       syncHover,
+      syncHoverChart1,
+      syncHoverChart2,
+      syncHoverChart3,
+      syncHoverChart4,
       isLive,
       groupHoveredLabel,
       chart,
@@ -479,5 +532,9 @@ export default {
     position: absolute;
     left: 160px;
     padding-top: 10px;
+  }
+  .hover-options {
+    display: flex;
+    align-items: center;
   }
 </style>

--- a/docs/views/barChart/example/HoverWithGroup.vue
+++ b/docs/views/barChart/example/HoverWithGroup.vue
@@ -208,7 +208,7 @@ export default {
       indicator: {
         color: '#626872',
         segments: [4, 2],
-      }
+      },
     });
 
     watch(syncHoverChart1, (newSyncHover) => {
@@ -265,7 +265,7 @@ export default {
       indicator: {
         color: '#626872',
         segments: [4, 2],
-      }
+      },
     });
 
     watch(syncHoverChart2, (newSyncHover) => {
@@ -322,13 +322,12 @@ export default {
       indicator: {
         color: '#626872',
         segments: [4, 2],
-      }
+      },
     });
 
     watch(syncHoverChart3, (newSyncHover) => {
       chartOptions3.value.syncHover = newSyncHover;
     });
-
 
     const syncHoverChart4 = ref(true);
 
@@ -380,7 +379,7 @@ export default {
       indicator: {
         color: '#626872',
         segments: [4, 2],
-      }
+      },
     });
 
     watch(syncHoverChart4, (newSyncHover) => {

--- a/docs/views/barChart/example/HoverWithGroup.vue
+++ b/docs/views/barChart/example/HoverWithGroup.vue
@@ -1,0 +1,483 @@
+<template>
+  <ev-chart-group :options="{ syncHover }">
+    <ev-chart
+      ref="chart"
+      v-model:selectedLabel="defaultSelectLabel"
+      :data="chartData1"
+      :options="chartOptions1"
+      @click="onClick"
+    />
+    <ev-chart
+      v-model:selectedLabel="defaultSelectLabel"
+      :data="chartData2"
+      :options="chartOptions2"
+      @click="onClick"
+    />
+    <ev-chart
+      v-model:selectedLabel="defaultSelectLabel"
+      :data="chartData3"
+      :options="chartOptions3"
+      @click="onClick"
+    />
+    <ev-chart
+      v-model:selectedLabel="defaultSelectLabel"
+      :data="chartData4"
+      :options="chartOptions4"
+      @click="onClick"
+    />
+    <div class="description">
+      <ev-toggle v-model="syncHover" />
+      <span>그룹 호버 동기화</span>
+      <ev-toggle v-model="isLive" />
+      <span>데이터 자동 업데이트</span>
+      <br>
+      <br>
+      <ev-button @click="toggleSelectData">
+        select by v-model
+      </ev-button>
+      <span class="left">
+        차트 클릭이 아닌 v-model:selectedLabel 에 바인딩한 dataIndex 배열을 변경해서 라벨 선택
+      </span>
+      <br>
+      <br>
+      <ev-toggle v-model="isFixedPosTop" />
+      <span class="left">
+        tip 위치를 최상단에 고정
+      </span>
+      <br>
+      <br>
+      <ev-button @click="toggleOverflow">
+        Deselect Overflow
+      </ev-button>
+      <span class="left">
+        설정한 limit 를 넘어서 클릭했을때 선입선출로 deselect 를 할지를 옵션으로 선택 가능
+      </span>
+      <br>
+      <br>
+      <ev-button @click="updateData">
+        Update Data
+      </ev-button>
+      <span class="left">
+        차트 데이터를 변경하면 팁의 위치만 변경, 라벨은 고정
+      </span>
+      <br>
+      <br>
+      <div>
+        <div class="badge yellow">
+          v-model:selectedLabel
+        </div>
+        {{ defaultSelectLabel }}
+        <br>
+        <br>
+        <div class="badge yellow">
+          클릭 이벤트 데이터 (selected)
+        </div>
+        {{ clickedLabel }}
+        <br>
+        <br>
+      </div>
+    </div>
+  </ev-chart-group>
+</template>
+
+<script>
+import { ref, reactive, onMounted, watch, onBeforeUnmount } from 'vue';
+import dayjs from 'dayjs';
+
+export default {
+  components: {},
+
+  setup() {
+    const groupHoveredLabel = ref();
+    const chart = ref(null);
+
+    const chartData1 = reactive({
+      series: {
+        series1: { name: 'series#1' },
+        series2: { name: 'series#2' },
+      },
+      labels: [],
+      groups: [['series1', 'series2']],
+      data: {
+        series1: [],
+        series2: [],
+      },
+    });
+    const chartData2 = reactive({
+      series: {
+        series1: { name: 'series#1' },
+        series2: { name: 'series#2' },
+      },
+      labels: [],
+      groups: [['series1', 'series2']],
+      data: {
+        series1: [],
+        series2: [],
+      },
+    });
+    const chartData3 = reactive({
+      series: {
+        series1: { name: 'series#1' },
+        series2: { name: 'series#2' },
+      },
+      labels: [],
+      data: {
+        series1: [],
+        series2: [],
+      },
+    });
+    const chartData4 = reactive({
+      series: {
+        series1: { name: 'series#1' },
+        series2: { name: 'series#2' },
+      },
+      labels: [],
+      groups: [['series1', 'series2']],
+      data: {
+        series1: [],
+        series2: [],
+      },
+    });
+
+    const isFixedPosTop = ref(false);
+
+    const chartOptions1 = ref({
+      type: 'bar',
+      thickness: 0.8,
+      width: '100%',
+      horizontal: false,
+      title: {
+        show: false,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesX: [{
+        type: 'time',
+        showGrid: false,
+        categoryMode: true,
+        timeFormat: 'mm:ss',
+        interval: 'second',
+      }],
+      axesY: [{
+        showAxis: true,
+        type: 'linear',
+        startToZero: true,
+        autoScaleRatio: 0.1,
+        showGrid: false,
+      }],
+      selectLabel: {
+        use: true,
+        limit: 2,
+        useDeselectOverflow: true,
+        showTip: true,
+        fixedPosTop: isFixedPosTop,
+        useApproximateValue: true,
+        tipBackground: '#FF0000',
+        useSeriesOpacity: true,
+        useLabelOpacity: true,
+      },
+      maxTip: {
+        use: true,
+        showTextTip: true,
+        tipStyle: {
+          background: '#FF0000',
+        },
+      },
+      indicator: {
+        color: '#626872',
+        segments: [4, 2],
+      }
+    });
+    const chartOptions2 = ref({
+      type: 'bar',
+      thickness: 0.8,
+      width: '100%',
+      horizontal: false,
+      title: {
+        show: false,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesX: [{
+        type: 'time',
+        showGrid: false,
+        categoryMode: true,
+        timeFormat: 'mm:ss',
+        interval: 'second',
+      }],
+      axesY: [{
+        showAxis: true,
+        type: 'linear',
+        startToZero: true,
+        autoScaleRatio: 0.1,
+        showGrid: false,
+      }],
+      selectLabel: {
+        use: true,
+        limit: 2,
+        useDeselectOverflow: true,
+        showTip: true,
+        fixedPosTop: isFixedPosTop,
+        useApproximateValue: true,
+        tipBackground: '#FF0000',
+        useSeriesOpacity: true,
+        useLabelOpacity: true,
+      },
+      maxTip: {
+        use: true,
+        showTextTip: true,
+        tipStyle: {
+          background: '#FF0000',
+        },
+      },
+      indicator: {
+        color: '#626872',
+        segments: [4, 2],
+      }
+    });
+    const chartOptions3 = ref({
+      type: 'bar',
+      thickness: 0.8,
+      width: '100%',
+      horizontal: true,
+      title: {
+        show: false,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesY: [{
+        type: 'time',
+        showGrid: false,
+        categoryMode: true,
+        timeFormat: 'mm:ss',
+        interval: 'second',
+      }],
+      axesX: [{
+        showAxis: true,
+        type: 'linear',
+        startToZero: true,
+        autoScaleRatio: 0.1,
+        showGrid: false,
+      }],
+      selectLabel: {
+        use: true,
+        limit: 2,
+        useDeselectOverflow: true,
+        showTip: true,
+        fixedPosTop: isFixedPosTop,
+        useApproximateValue: true,
+        tipBackground: '#FF0000',
+        useSeriesOpacity: true,
+        useLabelOpacity: true,
+      },
+      maxTip: {
+        use: true,
+        showTextTip: true,
+        tipStyle: {
+          background: '#FF0000',
+        },
+      },
+      indicator: {
+        color: '#626872',
+        segments: [4, 2],
+      }
+    });
+    const chartOptions4 = ref({
+      type: 'bar',
+      thickness: 0.8,
+      width: '100%',
+      horizontal: true,
+      title: {
+        show: false,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesY: [{
+        type: 'time',
+        showGrid: false,
+        categoryMode: true,
+        timeFormat: 'mm:ss',
+        interval: 'second',
+      }],
+      axesX: [{
+        showAxis: true,
+        type: 'linear',
+        startToZero: true,
+        autoScaleRatio: 0.1,
+        showGrid: false,
+      }],
+      selectLabel: {
+        use: true,
+        limit: 2,
+        useDeselectOverflow: true,
+        showTip: true,
+        fixedPosTop: isFixedPosTop,
+        useApproximateValue: true,
+        tipBackground: '#FF0000',
+        useSeriesOpacity: true,
+        useLabelOpacity: true,
+      },
+      maxTip: {
+        use: true,
+        showTextTip: true,
+        tipStyle: {
+          background: '#FF0000',
+        },
+      },
+      indicator: {
+        color: '#626872',
+        segments: [4, 2],
+      }
+    });
+
+    const clickedLabel = ref();
+    const onClick = ({ selected }) => {
+      clickedLabel.value = selected;
+    };
+
+    const defaultSelectItem = ref({
+      seriesID: 'series1',
+      dataIndex: 1,
+    });
+    const defaultSelectLabel = ref({
+      dataIndex: [0],
+    });
+
+    const toggleSelectData = () => {
+      const arr = defaultSelectLabel.value.dataIndex;
+      const newIndex = (arr.pop() + 1) % 9;
+      if (!arr.includes(newIndex)) {
+        arr.push(newIndex);
+      }
+    };
+
+    const toggleOverflow = () => {
+      const b = chartOptions1.value.selectLabel.useDeselectOverflow;
+      chartOptions1.value.selectLabel.useDeselectOverflow = !b;
+      chartOptions2.value.selectLabel.useDeselectOverflow = !b;
+      chartOptions3.value.selectLabel.useDeselectOverflow = !b;
+      chartOptions4.value.selectLabel.useDeselectOverflow = !b;
+    };
+
+    const updateData = () => {
+      const getRandArr = count => Array(count)
+        .fill(0).map(() => Math.ceil(Math.random() * 100));
+
+      const chartList = [chartData1, chartData2, chartData3, chartData4];
+      chartList.forEach((c) => {
+        const seriesList = ['series1', 'series2'];
+        seriesList.forEach((sId) => {
+          c.value.data[sId] = getRandArr(5);
+        });
+      });
+    };
+
+    const syncHover = ref(true);
+
+    const isLive = ref(false);
+    const liveInterval = ref();
+    let timeValue = dayjs().format('YYYY-MM-DD HH:mm:ss');
+
+    const addRandomChartData = () => {
+      if (isLive.value) {
+        chartData1.labels.shift();
+        chartData2.labels.shift();
+        chartData3.labels.shift();
+        chartData4.labels.shift();
+      }
+
+      timeValue = dayjs(timeValue).add(6, 'second');
+      chartData1.labels.push(dayjs(timeValue));
+      chartData2.labels.push(dayjs(timeValue));
+      chartData3.labels.push(dayjs(timeValue));
+      chartData4.labels.push(dayjs(timeValue));
+
+      Object.values(chartData1.data).forEach((seriesData) => {
+        if (isLive.value) {
+          seriesData.shift();
+        }
+        seriesData.push(Math.floor(Math.random() * ((5000 - 5) + 1)) + 5);
+      });
+      Object.values(chartData2.data).forEach((seriesData) => {
+        if (isLive.value) {
+          seriesData.shift();
+        }
+        seriesData.push(Math.floor(Math.random() * ((5000 - 5) + 1)) + 5);
+      });
+      Object.values(chartData3.data).forEach((seriesData) => {
+        if (isLive.value) {
+          seriesData.shift();
+        }
+        seriesData.push(Math.floor(Math.random() * ((5000 - 5) + 1)) + 5);
+      });
+      Object.values(chartData4.data).forEach((seriesData) => {
+        if (isLive.value) {
+          seriesData.shift();
+        }
+        seriesData.push(Math.floor(Math.random() * ((5000 - 5) + 1)) + 5);
+      });
+    };
+
+    onMounted(() => {
+      for (let ix = 0; ix < 10; ix++) {
+        addRandomChartData();
+      }
+    });
+
+    watch(isLive, (newValue) => {
+      if (newValue) {
+        addRandomChartData();
+        liveInterval.value = setInterval(addRandomChartData, 2000);
+      } else {
+        clearInterval(liveInterval.value);
+      }
+    });
+
+    onBeforeUnmount(() => {
+      clearInterval(liveInterval.value);
+    });
+
+    return {
+      syncHover,
+      isLive,
+      groupHoveredLabel,
+      chart,
+      chartData1,
+      chartData2,
+      chartData3,
+      chartData4,
+      isFixedPosTop,
+      chartOptions1,
+      chartOptions2,
+      chartOptions3,
+      chartOptions4,
+      clickedLabel,
+      defaultSelectItem,
+      defaultSelectLabel,
+      onClick,
+      toggleSelectData,
+      toggleOverflow,
+      updateData,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+  .description {
+    position: relative;
+  }
+  .left {
+    position: absolute;
+    left: 160px;
+    padding-top: 10px;
+  }
+</style>

--- a/docs/views/barChart/props.js
+++ b/docs/views/barChart/props.js
@@ -20,6 +20,8 @@ import PlotLine from './example/PlotLine';
 import PlotLineRaw from '!!raw-loader!./example/PlotLine';
 import Overlapping from './example/Overlapping';
 import OverlappingRaw from '!!raw-loader!./example/Overlapping';
+import HoverWithGroup from './example/HoverWithGroup';
+import HoverWithGroupRaw from '!!raw-loader!./example/HoverWithGroup';
 
 export default {
   mdText,
@@ -75,6 +77,11 @@ export default {
       description: '차트 배경에 선 및 영역을 표시할 수 있습니다.',
       component: PlotLine,
       parsedData: parseComponent(PlotLineRaw),
+    },
+    HoverWithGroup: {
+      description: '',
+      component: HoverWithGroup,
+      parsedData: parseComponent(HoverWithGroupRaw),
     },
   },
 };

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -1,5 +1,6 @@
->## Desc
- - 태그는 &lt;ev-chart&gt;(이하 <차트>)으로 정의
+> ## Desc
+
+- 태그는 &lt;ev-chart&gt;(이하 <차트>)으로 정의
 
 ```
 <ev-chart
@@ -10,11 +11,15 @@
 />
 ```
 
->## Props
+> ## Props
+
 ### 1. v-model:selectedItem
+
 - option에서 [selectItem](#selectitem) 옵션을 사용할 경우 유효한 바인딩
 - 현재 선택된 Item에 대한 정보 (seriesID, dataIndex)
+
 #### Example
+
 ```
 const selectedItem = ref({
     seriesID: 'series1', // Series ID (key)
@@ -23,10 +28,13 @@ const selectedItem = ref({
 ```
 
 ### 2. v-model:selectedLabel
+
 - option에서 [selectLabel](#selectlabel) 옵션을 사용할 경우 유효한 바인딩
 - 현재 선택된 Label의 인덱스 대한 정보 (dataIndex)
 - 차트 클릭이 아니라 특정 위치의 label 을 선택하고 싶은 경우 바인딩 하고, dataIndex 배열의 값으로 차트를 컨트롤 한다.
+
 #### Example
+
 ```
 const selectedLabel = ref({
     dataIndex: [0], // option 에 설정한 limit 갯수 까지 선택 가능.
@@ -34,45 +42,51 @@ const selectedLabel = ref({
 ```
 
 ### 3. v-model:selectedSeries
+
 - option에서 [selectSeries](#selectseries) 옵션을 사용할 경우 유효한 바인딩
 - 현재 선택된 시리즈의 ID 값의 배열 (seriesId)
 - 차트 클릭이 아니라 특정 시리즈를 선택하고 싶은 경우 바인딩 하고, seriesId 배열의 값으로 차트를 컨트롤 한다.
+
 #### Example
+
 ```
 const selectedSeries = ref({
     seriesId: ['series1'], // option 에 설정한 limit 갯수 까지 선택 가능.
 });
 ```
 
-### 4. data  
-  | 이름 | 타입 | 디폴트 | 설명 | 종류 |
-  |------------ |-----------|---------|-------------------------|---------------------------------------------------|
-  | series | Object | {} | 특정 데이터에 대한 시리즈 옵션 |  |
-  | data   | Object | {} | 차트에 표시할 시리즈 별 데이터 |  |
-  | groups | Array  | [] | Stack 차트를 위한 시리즈 그룹을 지정 |  |
-  | labels | Array  | [] | 축의 각 눈금에 해당하는 명칭, line Chart 에서는 time만 인정 |  |
+### 4. data
+
+| 이름   | 타입   | 디폴트 | 설명                                                        | 종류 |
+| ------ | ------ | ------ | ----------------------------------------------------------- | ---- |
+| series | Object | {}     | 특정 데이터에 대한 시리즈 옵션                              |      |
+| data   | Object | {}     | 차트에 표시할 시리즈 별 데이터                              |      |
+| groups | Array  | []     | Stack 차트를 위한 시리즈 그룹을 지정                        |      |
+| labels | Array  | []     | 축의 각 눈금에 해당하는 명칭, line Chart 에서는 time만 인정 |      |
 
 #### series
-  | 이름 | 타입                          | 디폴트 | 설명                                                                  | 종류(예시)                                                                            |
-  |-----------------------------|-----------|---------------------------------------------------------------------|-----------------------------------------------------------------------------------|---------------------------------------------------|
-  | show | Boolean                     |true | 표시 여부                                                               |                                                                                   |
-  | name | String                      | series-${index} | 특정 데이터에 대한 시리즈 옵션                                                   |                                                                                   |
-  | lineWidth | Number                      | 2 | 선(line) 두께                                                          |                                                                                   |
-  | color | Hex, RGB, RGBA Code(String) | COLOR[index] | Line 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용             |                                                                                   |
-  | fill | Boolean / Object            | false | 선(line) 아래 부분의 영역에 색상을 채울지의 여부. area chart 전환 여부,                   | false / { gradient: true }                                                        |
-  | fillOpacity | Number                      | 0.4 | fill 영역의 투명도                                                        |                                                                                   |
-  | fillColor | Hex, RGB, RGBA Code(String) | COLOR[index] | Fill 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용             |                                                                                   |
-  | point | Boolean                     | true | 선(line) 위에 값 위치 마다 점을 표시할지의 여부, 앞/뒤 값이 null인 경우 point 표시 여부에 상관없이 표시됨 |                                                                                   |
-  | pointSize | Number                      | 3 | 점(Point)의 크기                                                        |                                                                                   |
-  | pointFill | Hex, RGB, RGBA Code(String) | COLOR[index] | 점(Point) 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용         |                                                                                   |
-  | pointStyle | String                      | 'circle' | 점(Point) 모양                                                         | 'triangle', 'rect', 'rectRounded', 'rectRot', 'cross', 'crossRot', 'star', 'line' |
-  | showLegend | Boolean                     | true | legend 표시 여부                                                        |                                                                                   |
-  | passingValue | number                      | null            | data가 passingValue와 같을 경우 (data: null/undefined 제외 ) 다음값으로 선을 이어가며 point도 그리지 않고 tooltip에 나오지 않음 | -1                                                                                |
-  
+
+| 이름         | 타입                        | 디폴트           | 설명                                                                                                                            | 종류(예시)                                                                        |
+| ------------ | --------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| show         | Boolean                     | true             | 표시 여부                                                                                                                       |                                                                                   |
+| name         | String                      | series-\${index} | 특정 데이터에 대한 시리즈 옵션                                                                                                  |                                                                                   |
+| lineWidth    | Number                      | 2                | 선(line) 두께                                                                                                                   |                                                                                   |
+| color        | Hex, RGB, RGBA Code(String) | COLOR[index]     | Line 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용                                                      |                                                                                   |
+| fill         | Boolean / Object            | false            | 선(line) 아래 부분의 영역에 색상을 채울지의 여부. area chart 전환 여부,                                                         | false / { gradient: true }                                                        |
+| fillOpacity  | Number                      | 0.4              | fill 영역의 투명도                                                                                                              |                                                                                   |
+| fillColor    | Hex, RGB, RGBA Code(String) | COLOR[index]     | Fill 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용                                                      |                                                                                   |
+| point        | Boolean                     | true             | 선(line) 위에 값 위치 마다 점을 표시할지의 여부, 앞/뒤 값이 null인 경우 point 표시 여부에 상관없이 표시됨                       |                                                                                   |
+| pointSize    | Number                      | 3                | 점(Point)의 크기                                                                                                                |                                                                                   |
+| pointFill    | Hex, RGB, RGBA Code(String) | COLOR[index]     | 점(Point) 색상. 사전에 정의된 16개 색상('#2b99f0' ~ '#df6264)을 순차적으로 적용                                                 |                                                                                   |
+| pointStyle   | String                      | 'circle'         | 점(Point) 모양                                                                                                                  | 'triangle', 'rect', 'rectRounded', 'rectRot', 'cross', 'crossRot', 'star', 'line' |
+| showLegend   | Boolean                     | true             | legend 표시 여부                                                                                                                |                                                                                   |
+| passingValue | number                      | null             | data가 passingValue와 같을 경우 (data: null/undefined 제외 ) 다음값으로 선을 이어가며 point도 그리지 않고 tooltip에 나오지 않음 | -1                                                                                |
+
 #### data example
+
 ```
 const time = dayjs().format('YYYY-MM-DD HH:mm:ss');
-const chartData = 
+const chartData =
   series: {
     series1: { name: 'series1', point: false, fill: true, color: '#FF00Ff', fillColor: '#FF0000' },
     series2: { name: 'series2', point: true, fill: false, pointFill: '#FF0000' },
@@ -89,192 +103,207 @@ const chartData =
   ],
 };
 ```
-  
-### 5. options 
-  | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-  |------------ |-----------|---------|-------------------------|---------------------------------------------------|
-  | type | String | '' | series 별로 type값을 지정하지 않을 경우 일괄 적용될 차트의 타입 | 'bar', 'pie', 'line', 'scatter' |
-  | width | String / Number | '100%' | 차트의 너비 | '100%', '150px', 150 | 
-  | height | String / Number | '100%' | 차트의 높이 | '100%', '150px', 150 |
-  | axesX | Object | 없음 | X축에 대한 속성 | [상세](#axesx-axesy) |
-  | axesY | Object | 없음 | Y축에 대한 속성 | [상세](#axesx-axesy) |
-  | title | Object | ([상세](#title)) | 차트 상단에 위치할 차트 제목 표시 여부 및 속성 |  |
-  | legend | Object | ([상세](#legend)) | 차트의 범례 표시 여부 및 속성 |  |
-  | tooltip | Object | ([상세](#tooltip)) | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성 | |
-  | indicator | Object | ([상세](#indicator)) | 지표선 | |
-  | maxTip | Object | ([상세](#maxtip)) | 최대값에 tip 표시(값 표시) 여부 및 속성 | |
-  | selectItem | Object | ([상세](#selectitem)) | 차트 아이템 선택 기능 활성화 여부 및 속성 | | 
-  | padding | Object | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값 | 
+
+### 5. options
+
+| 이름       | 타입            | 디폴트                                    | 설명                                                                                                                                                                                   | 종류(예시)                      |
+| ---------- | --------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| type       | String          | ''                                        | series 별로 type값을 지정하지 않을 경우 일괄 적용될 차트의 타입                                                                                                                        | 'bar', 'pie', 'line', 'scatter' |
+| width      | String / Number | '100%'                                    | 차트의 너비                                                                                                                                                                            | '100%', '150px', 150            |
+| height     | String / Number | '100%'                                    | 차트의 높이                                                                                                                                                                            | '100%', '150px', 150            |
+| axesX      | Object          | 없음                                      | X축에 대한 속성                                                                                                                                                                        | [상세](#axesx-axesy)            |
+| axesY      | Object          | 없음                                      | Y축에 대한 속성                                                                                                                                                                        | [상세](#axesx-axesy)            |
+| title      | Object          | ([상세](#title))                          | 차트 상단에 위치할 차트 제목 표시 여부 및 속성                                                                                                                                         |                                 |
+| legend     | Object          | ([상세](#legend))                         | 차트의 범례 표시 여부 및 속성                                                                                                                                                          |                                 |
+| tooltip    | Object          | ([상세](#tooltip))                        | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성                                                                                                                                       |                                 |
+| indicator  | Object          | ([상세](#indicator))                      | 지표선                                                                                                                                                                                 |                                 |
+| maxTip     | Object          | ([상세](#maxtip))                         | 최대값에 tip 표시(값 표시) 여부 및 속성                                                                                                                                                |                                 |
+| selectItem | Object          | ([상세](#selectitem))                     | 차트 아이템 선택 기능 활성화 여부 및 속성                                                                                                                                              |                                 |
+| padding    | Object          | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값                                                                                                                                                                   |
+| syncHover  | boolean         | true                                      | options.syncHover가 true인 EvChartGroup으로 감싼경우, 해당 차트에서는 그룹으로 묶긴 차트들 사이의 syncHover선을 그리고싶지 않을 때 사용하는 속성 (time관련된 축을 가질때만 적용됩니다) |
 
 #### axesX axesY
+
 ##### type 공통
-  | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-  |------------ |-----------|---------|-------------------------|---------------------------------------------------|
-  | type | String | | 축의 유형 | [time](#time-type) |
-  | showAxis | Boolean | true | 축 표시 여부 | true / false | 
-  | startToZero | Boolean | false | 축의 시작을 0 부터 시작할지의 여부 | true / false |
-  | autoScaleRatio | Number | null | Axis의 Max Buffer를 위한 속성 | 0.1 ~ 0.9 |
-  | showGrid | Boolean | true | 차트 내부 그리드 표시 여부 | true / false |
-  | axisLineWidth | Number | 1 | 축의 선 굵기 | 1 ~ |
-  | axisLineColor | String | '#C9CFDC' | 축의 색상 | | 
-  | gridLineColor | String | '#C9CFDC' | 그리드의 색상 | | 
-  | interval | String | null | 축에 표시되는 값의 간격 단위 (ex. 'day', 'hour', 'minute'...)
-  | labelStyle | Object | ([상세](#labelstyle)) | 라벨의 폰트 스타일을 설정 | |
-  | plotLines | Array | ([상세](#plotline)) | plot line(임계선 표시 용도) 설정 | |
-  | plotBands | Array | ([상세](#plotband)) | plot band(임계영역 표시 용도) 설정 | |
-  | formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (value) => value + '%' |
-  | title | Object | ([상세](#title)) | 라벨의 폰트 스타일을 설정 | |  
+
+| 이름           | 타입     | 디폴트                | 설명                                                          | 종류(예시)             |
+| -------------- | -------- | --------------------- | ------------------------------------------------------------- | ---------------------- |
+| type           | String   |                       | 축의 유형                                                     | [time](#time-type)     |
+| showAxis       | Boolean  | true                  | 축 표시 여부                                                  | true / false           |
+| startToZero    | Boolean  | false                 | 축의 시작을 0 부터 시작할지의 여부                            | true / false           |
+| autoScaleRatio | Number   | null                  | Axis의 Max Buffer를 위한 속성                                 | 0.1 ~ 0.9              |
+| showGrid       | Boolean  | true                  | 차트 내부 그리드 표시 여부                                    | true / false           |
+| axisLineWidth  | Number   | 1                     | 축의 선 굵기                                                  | 1 ~                    |
+| axisLineColor  | String   | '#C9CFDC'             | 축의 색상                                                     |                        |
+| gridLineColor  | String   | '#C9CFDC'             | 그리드의 색상                                                 |                        |
+| interval       | String   | null                  | 축에 표시되는 값의 간격 단위 (ex. 'day', 'hour', 'minute'...) |
+| labelStyle     | Object   | ([상세](#labelstyle)) | 라벨의 폰트 스타일을 설정                                     |                        |
+| plotLines      | Array    | ([상세](#plotline))   | plot line(임계선 표시 용도) 설정                              |                        |
+| plotBands      | Array    | ([상세](#plotband))   | plot band(임계영역 표시 용도) 설정                            |                        |
+| formatter      | function | null                  | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용       | (value) => value + '%' |
+| title          | Object   | ([상세](#title))      | 라벨의 폰트 스타일을 설정                                     |                        |
 
 ##### axesX
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-----|------|-------|-----|-----|
-| flow | boolean | false | 시간에 따라 x축 label이 움직일지의 여부, time type에서만 사용하길 권장.<br>categoryMode일 때는 작동하지 않음. | |
+
+| 이름 | 타입    | 디폴트 | 설명                                                                                                          | 종류(예시) |
+| ---- | ------- | ------ | ------------------------------------------------------------------------------------------------------------- | ---------- |
+| flow | boolean | false  | 시간에 따라 x축 label이 움직일지의 여부, time type에서만 사용하길 권장.<br>categoryMode일 때는 작동하지 않음. |            |
 
 ##### time type
-   - interval (Axis Label 표기를 위한 interval)
-      - 'millisecond', 'second', 'minute', 'hour', 'day', 'week' ,'month', 'quarter', 'year'
-   - timeFormat
-      - dayjs의 timeFormat 이용 [참고URL](https://day.js.org/docs/en/parse/string-format)
-   - categoryMode
-      - 축에 표시할 시간 값을 `data`옵션의 `labels`속 값들로 표시할지의 여부
-   - flow
-      - 시간에 따라 x축 label이 움직일지의 여부
-      - categoryMode일 때는 작동하지 않음.
+
+- interval (Axis Label 표기를 위한 interval)
+  - 'millisecond', 'second', 'minute', 'hour', 'day', 'week' ,'month', 'quarter', 'year'
+- timeFormat
+  - dayjs의 timeFormat 이용 [참고URL](https://day.js.org/docs/en/parse/string-format)
+- categoryMode
+  - 축에 표시할 시간 값을 `data`옵션의 `labels`속 값들로 표시할지의 여부
+- flow
+  - 시간에 따라 x축 label이 움직일지의 여부
+  - categoryMode일 때는 작동하지 않음.
 
 ##### labelStyle
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-----|------|-------|-----|-----|
-| show | Boolean | true | label 표시 여부 | true / false |
-| fontSize | Number | 12 | 글자 크기 | |
-| color | Hex, RGB, RGBA Code(String) | '#25262E' | 글자 색상 | |
-| fontFamily | String | 'Roboto' | 폰트 | |
-| fitWidth | Boolean | false | Label Text Ellipsis 처리 | |
-| fitDir | String | 'right' | Ellipsis 방향 | ( right => 'aaa...', left => '...aaa') |
-| padding |  Number | 0 | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0 |
+
+| 이름       | 타입                        | 디폴트    | 설명                                               | 종류(예시)                             |
+| ---------- | --------------------------- | --------- | -------------------------------------------------- | -------------------------------------- |
+| show       | Boolean                     | true      | label 표시 여부                                    | true / false                           |
+| fontSize   | Number                      | 12        | 글자 크기                                          |                                        |
+| color      | Hex, RGB, RGBA Code(String) | '#25262E' | 글자 색상                                          |                                        |
+| fontFamily | String                      | 'Roboto'  | 폰트                                               |                                        |
+| fitWidth   | Boolean                     | false     | Label Text Ellipsis 처리                           |                                        |
+| fitDir     | String                      | 'right'   | Ellipsis 방향                                      | ( right => 'aaa...', left => '...aaa') |
+| padding    | Number                      | 0         | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0                                      |
 
 ##### title
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-----|------|-------|-----|-----|
-| use | Boolean | false | Chart 축(Axis) Title 표시 여부 | true / false |
-| text | String | null | Title 로 표시될 text | |
-| fontSize | Number | 12 | 글자 크기 | |
-| fontWeight | Number | 400 | 글자 굵기 | 100, 200, 300, ... 900 |
-| fontFamily | String | 'Roboto' | 폰트 | |
-| fontStyle | String | 'normal' | 폰트 스타일 | 'normal', 'italic' |
-| textAlign | String | 'right' | 텍스트 정렬| 'right', 'left', 'center' |
-| color | Hex, RGB, RGBA Code(String) | '#25262E' | 글자 색상 | |
+
+| 이름       | 타입                        | 디폴트    | 설명                           | 종류(예시)                |
+| ---------- | --------------------------- | --------- | ------------------------------ | ------------------------- |
+| use        | Boolean                     | false     | Chart 축(Axis) Title 표시 여부 | true / false              |
+| text       | String                      | null      | Title 로 표시될 text           |                           |
+| fontSize   | Number                      | 12        | 글자 크기                      |                           |
+| fontWeight | Number                      | 400       | 글자 굵기                      | 100, 200, 300, ... 900    |
+| fontFamily | String                      | 'Roboto'  | 폰트                           |                           |
+| fontStyle  | String                      | 'normal'  | 폰트 스타일                    | 'normal', 'italic'        |
+| textAlign  | String                      | 'right'   | 텍스트 정렬                    | 'right', 'left', 'center' |
+| color      | Hex, RGB, RGBA Code(String) | '#25262E' | 글자 색상                      |                           |
 
 ##### plotLine
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-----|------|-------|-----|-----|
-| value | Number(value), Date, Number(Index) | null | 선을 표시할 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
-| color | Hex, RGB, RGBA Code(String) | '#FF0000' | 선 색상 | |
-| segments | Array | null | dash 간격 | [6, 2] |
-| lineWidth | Number | 1 | 선 굵기 |  |
-| label | Object | null | 표시할 label의 스타일을 정의 | ([상세](#plotlabel)) |
+
+| 이름      | 타입                               | 디폴트    | 설명                           | 종류(예시)                                                           |
+| --------- | ---------------------------------- | --------- | ------------------------------ | -------------------------------------------------------------------- |
+| value     | Number(value), Date, Number(Index) | null      | 선을 표시할 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
+| color     | Hex, RGB, RGBA Code(String)        | '#FF0000' | 선 색상                        |                                                                      |
+| segments  | Array                              | null      | dash 간격                      | [6, 2]                                                               |
+| lineWidth | Number                             | 1         | 선 굵기                        |                                                                      |
+| label     | Object                             | null      | 표시할 label의 스타일을 정의   | ([상세](#plotlabel))                                                 |
 
 ##### plotBand
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-----|------|-------|-----|-----|
-| from | Number(value), Date, Number(Index) | null | 박스를 표시할 시작 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
-| to | Number(value), Date, Number(Index) | null | 박스를 표시할 종료 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
-| color | Hex, RGB, RGBA Code(String) | '#FF0000' | 선 색상 | |
-| label | Object | null | 표시할 label의 스타일을 정의 | ([상세](#plotlabel)) |
+
+| 이름  | 타입                               | 디폴트    | 설명                                  | 종류(예시)                                                           |
+| ----- | ---------------------------------- | --------- | ------------------------------------- | -------------------------------------------------------------------- |
+| from  | Number(value), Date, Number(Index) | null      | 박스를 표시할 시작 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
+| to    | Number(value), Date, Number(Index) | null      | 박스를 표시할 종료 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
+| color | Hex, RGB, RGBA Code(String)        | '#FF0000' | 선 색상                               |                                                                      |
+| label | Object                             | null      | 표시할 label의 스타일을 정의          | ([상세](#plotlabel))                                                 |
 
 ##### plotLabel
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-----|------|-------|-----|-----|
-| show | Boolean | false | label 표시 여부 | true / false |
-| fontSize | Number | 12 | 폰트 크기 | |
-| fontColor | Hex, RGB, RGBA Code(String) | '#FF0000' | 폰트 색상 | |
-| fillColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | 박스 배경 색상 | |
-| lineColor | Hex, RGB, RGBA Code(String) | '#FF0000' | 박스 테두리 선 색상 | |
-| lineWidth | Number | 0 | 테두리 선 굵기 | 1 ~ |
-| fontWeight | Number | 400 | 폰트 굵기 |  |
-| fontFamily | String | 'Roboto' | 폰트 스타일 |  |
-| textAlign | String | 'center' | 수평 정렬 | 'left', 'center', 'right' |
-| verticalAlign | String | 'middle' | 수직 정렬 | 'top', 'middle', 'bottom' |
-| textOverflow | String | 'none' | 라벨을 넣을 수 있는 여백 혹은 maxWidth 값을 넘었을 경우의 처리방안  | 'none', 'ellipsis' |
-| maxWidth | Number | null | 라벨의 최대 너비  |  |
+
+| 이름          | 타입                        | 디폴트    | 설명                                                               | 종류(예시)                |
+| ------------- | --------------------------- | --------- | ------------------------------------------------------------------ | ------------------------- |
+| show          | Boolean                     | false     | label 표시 여부                                                    | true / false              |
+| fontSize      | Number                      | 12        | 폰트 크기                                                          |                           |
+| fontColor     | Hex, RGB, RGBA Code(String) | '#FF0000' | 폰트 색상                                                          |                           |
+| fillColor     | Hex, RGB, RGBA Code(String) | '#FFFFFF' | 박스 배경 색상                                                     |                           |
+| lineColor     | Hex, RGB, RGBA Code(String) | '#FF0000' | 박스 테두리 선 색상                                                |                           |
+| lineWidth     | Number                      | 0         | 테두리 선 굵기                                                     | 1 ~                       |
+| fontWeight    | Number                      | 400       | 폰트 굵기                                                          |                           |
+| fontFamily    | String                      | 'Roboto'  | 폰트 스타일                                                        |                           |
+| textAlign     | String                      | 'center'  | 수평 정렬                                                          | 'left', 'center', 'right' |
+| verticalAlign | String                      | 'middle'  | 수직 정렬                                                          | 'top', 'middle', 'bottom' |
+| textOverflow  | String                      | 'none'    | 라벨을 넣을 수 있는 여백 혹은 maxWidth 값을 넘었을 경우의 처리방안 | 'none', 'ellipsis'        |
+| maxWidth      | Number                      | null      | 라벨의 최대 너비                                                   |                           |
 
 #### title
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| show | Boolean | false | 타이틀 표시 여부 | true /false |
-| height | Number | 40 | 타이틀 영역이 높이 | |
-| text | String | '' | 타이틀 | | 
-| style | Object | | 타이틀 폰트 스타일 | | 
-| style.fontSize | Number | 15 | 글자 크기 | | 
-| style.color | Hex, RGB, RGBA Code(String) | '#000' | 글자 색상 | | 
-| style.fontFamily | String | 'Roboto' | 글자체 | |  
-  
+
+| 이름             | 타입                        | 디폴트   | 설명               | 종류(예시)  |
+| ---------------- | --------------------------- | -------- | ------------------ | ----------- |
+| show             | Boolean                     | false    | 타이틀 표시 여부   | true /false |
+| height           | Number                      | 40       | 타이틀 영역이 높이 |             |
+| text             | String                      | ''       | 타이틀             |             |
+| style            | Object                      |          | 타이틀 폰트 스타일 |             |
+| style.fontSize   | Number                      | 15       | 글자 크기          |             |
+| style.color      | Hex, RGB, RGBA Code(String) | '#000'   | 글자 색상          |             |
+| style.fontFamily | String                      | 'Roboto' | 글자체             |             |
+
 #### legend
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| show | Boolean | false | Legend 표시 여부 | true /false |
-| position | String | 'right' | Legend 위치 | 'top', 'right', 'bottom', 'left' |
-| color | Hex, RGB, RGBA Code(String) | '#353740' | 폰트 색상 | | 
-| inactive | Hex, RGB, RGBA Code(String) | '#aaa' | 비활성화 상태의 폰트 색상 | | 
-| width | Number | 140 | Legend의 넓이 *('left', 'right'의 경우 조절)* | | 
-| height | Number | 24 | Legend의 높이 *('top', 'bottom'의 경우 조절)* | | 
-| padding | Object | { top: 0, right: 0, left: 0, bottom: 0 } | Legend 내부 padding 값 | |
-| allowResize | Boolean | false | Legend 영역 리사이즈 가능 여부 | |
-| table | Object | ([상세](#legendtable)) | Table 타입 Legend (값 표시 포함). bar, line, pie 전용 | |
-| stopClickEvt| Boolean | false | Legend 표시 여부 | true /false |
+
+| 이름         | 타입                        | 디폴트                                   | 설명                                                  | 종류(예시)                       |
+| ------------ | --------------------------- | ---------------------------------------- | ----------------------------------------------------- | -------------------------------- |
+| show         | Boolean                     | false                                    | Legend 표시 여부                                      | true /false                      |
+| position     | String                      | 'right'                                  | Legend 위치                                           | 'top', 'right', 'bottom', 'left' |
+| color        | Hex, RGB, RGBA Code(String) | '#353740'                                | 폰트 색상                                             |                                  |
+| inactive     | Hex, RGB, RGBA Code(String) | '#aaa'                                   | 비활성화 상태의 폰트 색상                             |                                  |
+| width        | Number                      | 140                                      | Legend의 넓이 _('left', 'right'의 경우 조절)_         |                                  |
+| height       | Number                      | 24                                       | Legend의 높이 _('top', 'bottom'의 경우 조절)_         |                                  |
+| padding      | Object                      | { top: 0, right: 0, left: 0, bottom: 0 } | Legend 내부 padding 값                                |                                  |
+| allowResize  | Boolean                     | false                                    | Legend 영역 리사이즈 가능 여부                        |                                  |
+| table        | Object                      | ([상세](#legendtable))                   | Table 타입 Legend (값 표시 포함). bar, line, pie 전용 |                                  |
+| stopClickEvt | Boolean                     | false                                    | Legend 표시 여부                                      | true /false                      |
 
 ##### legendTable
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| use | Boolean | false | Table 타입 표시 여부 | true /false |
-| style | Object | null | table style | { row: {}, header: {} } |
-| style.row | Object | null | table row의 CSS style | { borderBottom: '1px solid #DBDBDB' } |
-| style.header | Object | null | table header의 CSS Style | { fontSize: '15px' } |
-| columns | Object | (아래 각 항목 참고)| | | 
-| columns.name | Object | { title: 'Name' } | Series Name 표시 관련 옵션 | { title: '시리즈명', style: {...} }| 
-| columns.min | Object | { use: false, title: 'MIN' } | Minimum Value 표시 관련 옵션 | { use: true, title: '최솟값', style: {...}, formatter: (v) => `${v.toFixed(2)}` }| 
-| columns.max | Object | { use: false, title: 'MAX' } | Maximum Value 표시 관련 옵션 | { use: true, title: '최댓값', style: {...}, decimalPoint: 2 }| 
-| columns.avg | Object | { use: false, title: 'AVG' } | Average Value 표시 관련 옵션 | { use: true, title: '평균', style: {...}, decimalPoint: 2 }| 
-| columns.total | Object | { use: false, title: 'TOTAL' } | Total Value 표시 관련 옵션 | { use: true, title: '합계', style: {...}, decimalPoint: 2 }| 
-| columns.last | Object | { use: false, title: 'LAST' } | Last Value 표시 관련 옵션 | { use: true, title: 'Current', style: {...}, decimalPoint: 2 }| 
 
+| 이름          | 타입    | 디폴트                         | 설명                         | 종류(예시)                                                                        |
+| ------------- | ------- | ------------------------------ | ---------------------------- | --------------------------------------------------------------------------------- |
+| use           | Boolean | false                          | Table 타입 표시 여부         | true /false                                                                       |
+| style         | Object  | null                           | table style                  | { row: {}, header: {} }                                                           |
+| style.row     | Object  | null                           | table row의 CSS style        | { borderBottom: '1px solid #DBDBDB' }                                             |
+| style.header  | Object  | null                           | table header의 CSS Style     | { fontSize: '15px' }                                                              |
+| columns       | Object  | (아래 각 항목 참고)            |                              |                                                                                   |
+| columns.name  | Object  | { title: 'Name' }              | Series Name 표시 관련 옵션   | { title: '시리즈명', style: {...} }                                               |
+| columns.min   | Object  | { use: false, title: 'MIN' }   | Minimum Value 표시 관련 옵션 | { use: true, title: '최솟값', style: {...}, formatter: (v) => `${v.toFixed(2)}` } |
+| columns.max   | Object  | { use: false, title: 'MAX' }   | Maximum Value 표시 관련 옵션 | { use: true, title: '최댓값', style: {...}, decimalPoint: 2 }                     |
+| columns.avg   | Object  | { use: false, title: 'AVG' }   | Average Value 표시 관련 옵션 | { use: true, title: '평균', style: {...}, decimalPoint: 2 }                       |
+| columns.total | Object  | { use: false, title: 'TOTAL' } | Total Value 표시 관련 옵션   | { use: true, title: '합계', style: {...}, decimalPoint: 2 }                       |
+| columns.last  | Object  | { use: false, title: 'LAST' }  | Last Value 표시 관련 옵션    | { use: true, title: 'Current', style: {...}, decimalPoint: 2 }                    |
 
 #### tooltip
-| 이름                  | 타입                          | 디폴트                                        | 설명                                   | 종류(예시)                                                              |
-|---------------------|-----------------------------|--------------------------------------------|--------------------------------------|---------------------------------------------------------------------|
-| use                 | Boolean                     | true                                       | tooltip 표시 여부                        | true /false                                                         |
-| backgroundColor     | Hex, RGB, RGBA Code(String) | '#4C4C4C'                                  | tooltip 배경 색상                        |                                                                     |
-| borderColor         | Hex, RGB, RGBA Code(String) | '#666666'                                  | tooltip 테두리 색상                       |                                                                     |
-| useShadow           | Boolean                     | false                                      | 그림자 사용 여부                            |                                                                     |
-| shadowOpacity       | Number                      | 0.25                                       | 그림자 투명도                              |                                                                     |
-| throttledMove       | Boolean                     | false                                      | 데이터 조회 Throttling 처리 유무              |                                                                     |
-| debouncedHide       | Boolean                     | false                                      | 좌표 이동 시 tooltip hide 여부              |                                                                     |
-| sortByValue         | Boolean                     | true                                       | 값을 기준으로 정렬할지의 여부                     |                                                                     |
-| useScrollbar        | Boolean                     | false                                      | 스크롤바 사용 여부                           |                                                                     |
-| maxHeight           | Number                      |                                            | 툴팁의 최대 높이                            |                                                                     |
-| maxWidth            | Number                      |                                            | 툴팁의 최대 너비                            |                                                                     |
+
+| 이름                | 타입                        | 디폴트                                     | 설명                                                    | 종류(예시)                                                          |
+| ------------------- | --------------------------- | ------------------------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------- |
+| use                 | Boolean                     | true                                       | tooltip 표시 여부                                       | true /false                                                         |
+| backgroundColor     | Hex, RGB, RGBA Code(String) | '#4C4C4C'                                  | tooltip 배경 색상                                       |                                                                     |
+| borderColor         | Hex, RGB, RGBA Code(String) | '#666666'                                  | tooltip 테두리 색상                                     |                                                                     |
+| useShadow           | Boolean                     | false                                      | 그림자 사용 여부                                        |                                                                     |
+| shadowOpacity       | Number                      | 0.25                                       | 그림자 투명도                                           |                                                                     |
+| throttledMove       | Boolean                     | false                                      | 데이터 조회 Throttling 처리 유무                        |                                                                     |
+| debouncedHide       | Boolean                     | false                                      | 좌표 이동 시 tooltip hide 여부                          |                                                                     |
+| sortByValue         | Boolean                     | true                                       | 값을 기준으로 정렬할지의 여부                           |                                                                     |
+| useScrollbar        | Boolean                     | false                                      | 스크롤바 사용 여부                                      |                                                                     |
+| maxHeight           | Number                      |                                            | 툴팁의 최대 높이                                        |                                                                     |
+| maxWidth            | Number                      |                                            | 툴팁의 최대 너비                                        |                                                                     |
 | textOverflow        | String                      | 'wrap'                                     | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis                                                   |
-| fontFamily          | String                      | 'Roboto'                                   | 툴팁에 표시될 폰트                           | 'Roboto', 'serif'                                                   |
-| fontColor           | Hex code (string), Object   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                        | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
-| fontSize            | Object                      | { title: 16, contents: 14 }                | 툴팁에 표시될 폰트 사이즈                       |                                                                     |
-| colorShape          | String                      | 'rect'                                     | 툴팁에 표시될 series color의 모양             | 'rect', 'circle'                                                    |
-| rowPadding          | Object                      | { top: 0, bottom: 3, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값        |                                                                     |
-| showAllValueInRange | Boolean                     | false                                      | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
-| showHeader          | Boolean                     | true                                       | Tooltip의 Header 영역 표시 여부             |
-| formatter           | function / Object           | null                                       | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용      | (아래 코드 참고)                                                          |
+| fontFamily          | String                      | 'Roboto'                                   | 툴팁에 표시될 폰트                                      | 'Roboto', 'serif'                                                   |
+| fontColor           | Hex code (string), Object   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                                 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontSize            | Object                      | { title: 16, contents: 14 }                | 툴팁에 표시될 폰트 사이즈                               |                                                                     |
+| colorShape          | String                      | 'rect'                                     | 툴팁에 표시될 series color의 모양                       | 'rect', 'circle'                                                    |
+| rowPadding          | Object                      | { top: 0, bottom: 3, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값                   |                                                                     |
+| showAllValueInRange | Boolean                     | false                                      | 동일한 axes값을 가진 전체 series를 Tooltip에 표시       |
+| showHeader          | Boolean                     | true                                       | Tooltip의 Header 영역 표시 여부                         |
+| formatter           | function / Object           | null                                       | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용 | (아래 코드 참고)                                                    |
+
 ```
 const chartOptions = {
     tooltip: {
         // 이전 버전 호환용으로 valueFormatter를 이전버전과 같이 사용 가능
         // return type : string
         formatter: ({ x, y, name, seriesId }) => ... ,
-        
+
         // value + title Formatter
         // return type : string
         formatter: {
             title: ({ x, y }) => ...,
             value: ({ x, y, name, seriesId }) => ...,
         }
-        
+
         // custom formatter (html)
         // return type : string
         // 주의: 사용하시는 방법에 따라 차트의 성능이 저하될 수 있습니다.
@@ -286,104 +315,117 @@ const chartOptions = {
 ```
 
 #### indicator
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| use | Boolean | true | indicator 사용 여부 | |
-| color | Hex, RGB, RGBA Code(String) | '#EE7F44' | 색상  | |
-| segments | Array | null | dash 간격 | [6, 2] |
+
+| 이름     | 타입                        | 디폴트    | 설명                | 종류(예시) |
+| -------- | --------------------------- | --------- | ------------------- | ---------- |
+| use      | Boolean                     | true      | indicator 사용 여부 |            |
+| color    | Hex, RGB, RGBA Code(String) | '#EE7F44' | 색상                |            |
+| segments | Array                       | null      | dash 간격           | [6, 2]     |
 
 #### maxTip
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| use | Boolean | true | maxTip 표시 여부  | |
-| fixedPosTop | Boolean | false | maxTip 위치를 최대값으로 고정  | |
-| showIndicator | Boolean | false | indicator 표시 여부  | |
-| indicatorColor | Hex, RGB, RGBA Code(String) | '#000000' | indicator 색상  | |
-| tipStyle | Object | ([상세](#tipstyle)) | tip 스타일을 설정
+
+| 이름           | 타입                        | 디폴트              | 설명                          | 종류(예시) |
+| -------------- | --------------------------- | ------------------- | ----------------------------- | ---------- |
+| use            | Boolean                     | true                | maxTip 표시 여부              |            |
+| fixedPosTop    | Boolean                     | false               | maxTip 위치를 최대값으로 고정 |            |
+| showIndicator  | Boolean                     | false               | indicator 표시 여부           |            |
+| indicatorColor | Hex, RGB, RGBA Code(String) | '#000000'           | indicator 색상                |            |
+| tipStyle       | Object                      | ([상세](#tipstyle)) | tip 스타일을 설정             |
 
 ##### etc.
-| 이름    | 타입   | 디폴트 | 설명 | 종류(예시) |
-| ------ | ------ | ---- | -----| --------- |
-| tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  | |
-| tipTextColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상  | |
-* 3.4 버전부터 없어지는 옵션입니다.
+
+| 이름          | 타입                        | 디폴트    | 설명             | 종류(예시) |
+| ------------- | --------------------------- | --------- | ---------------- | ---------- |
+| tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  |            |
+| tipTextColor  | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상 |            |
+
+- 3.4 버전부터 없어지는 옵션입니다.
 
 #### selectItem
-| 이름                  | 타입 | 디폴트       | 설명                                                | 종류(예시) |
-|---------------------| ---- |-----------|---------------------------------------------------| ----------|
-| use                 | Boolean | false     | 차트 아이템 선택 기능                                      | |
-| useClick            | Boolean | true      | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) | |
-| showTextTip         | Boolean | false     | 선택한 위치의 TextTip(text 포함 화살표, 흡사 말풍선) 생성 여부 | |
-| tipText             | String | 'value'   | 선택한 위치에 TextTip을 생성한다면 어떤 값 | 'value', 'label |
-| showTip             | Boolean | false     | 선택한 위치의 Tip(화살표) 생성 여부  | |
-| showIndicator       | Boolean | false     | 선택한 label의 indicator 표시  | |
-| fixedPosTop         | Boolean | false     | indicator 및 tip의 위치를 최대값으로 고정 | |
-| useApproximateValue | Boolean | false     | 가까운 label을 선택 | |
-| indicatorColor      | Hex, RGB, RGBA Code(String) | '#000000' | indicator 색상 | |
-| tipStyle | Object | ([상세](#tipstyle)) | tip 스타일을 설정 |
+
+| 이름                | 타입                        | 디폴트              | 설명                                                                       | 종류(예시)      |
+| ------------------- | --------------------------- | ------------------- | -------------------------------------------------------------------------- | --------------- |
+| use                 | Boolean                     | false               | 차트 아이템 선택 기능                                                      |                 |
+| useClick            | Boolean                     | true                | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) |                 |
+| showTextTip         | Boolean                     | false               | 선택한 위치의 TextTip(text 포함 화살표, 흡사 말풍선) 생성 여부             |                 |
+| tipText             | String                      | 'value'             | 선택한 위치에 TextTip을 생성한다면 어떤 값                                 | 'value', 'label |
+| showTip             | Boolean                     | false               | 선택한 위치의 Tip(화살표) 생성 여부                                        |                 |
+| showIndicator       | Boolean                     | false               | 선택한 label의 indicator 표시                                              |                 |
+| fixedPosTop         | Boolean                     | false               | indicator 및 tip의 위치를 최대값으로 고정                                  |                 |
+| useApproximateValue | Boolean                     | false               | 가까운 label을 선택                                                        |                 |
+| indicatorColor      | Hex, RGB, RGBA Code(String) | '#000000'           | indicator 색상                                                             |                 |
+| tipStyle            | Object                      | ([상세](#tipstyle)) | tip 스타일을 설정                                                          |
 
 ##### etc.
-| 이름    | 타입   | 디폴트 | 설명 | 종류(예시) |
-| ------ | ------ | ---- | -----| --------- |
-| tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  | |
-| tipTextColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상  | |
-* 3.4 버전부터 없어지는 옵션입니다.
+
+| 이름          | 타입                        | 디폴트    | 설명             | 종류(예시) |
+| ------------- | --------------------------- | --------- | ---------------- | ---------- |
+| tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  |            |
+| tipTextColor  | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상 |            |
+
+- 3.4 버전부터 없어지는 옵션입니다.
 
 #### selectLabel
-| 이름                 | 타입                          | 디폴트               | 설명                                                | 종류(예시) |
-|--------------------|-----------------------------|-------------------|---------------------------------------------------| ----------|
-| use                | Boolean                     | false             | 차트 라벨 선택 기능                                       | |
-| useClick            | Boolean | true              | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) | |
-| limit              | Number                      | 1                 | 선택할 라벨의 최대 갯수                                     | |
-| useDeselectOverflow | Boolean                     | false             | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부             | |
-| showTip            | Boolean                     | false             | 선택한 위치의 Tip(화살표) 생성 여부                            | |
-| useSeriesOpacity   | Boolean                     | true              | 시리즈 opacity 변경 여부                                 | |
-| useLabelOpacity   | Boolean                     | true              | Axes Label opacity 변경 여부                          | |
-| fixedPosTop        | Boolean                     | false             | tip의 위치를 최대값으로 고정                                 | |
-| useApproximateValue | Boolean                     | false             | 가까운 label을 선택                                     | |
-| tipBackground      | Hex, RGB, RGBA Code(String) | '#000000'         | tip 배경색상                                          | |
-| indicatorColor      | Hex, RGB, RGBA Code(String) | '#000000'         | indicator 색상                                      | |
-| tipText             | String | 'value'           | 선택한 위치에 TextTip을 생성한다면 어떤 값                       | 'value', 'label |
-| showTextTip         | Boolean | false     | 선택한 위치의 TextTip(text 포함 화살표, 흡사 말풍선) 생성 여부 | |
-| showIndicator       | Boolean | false     | 선택한 label의 indicator 표시  | |
-| tipStyle | Object | ([상세](#tipstyle)) | tip 스타일을 설정                                       |
+
+| 이름                | 타입                        | 디폴트              | 설명                                                                       | 종류(예시)      |
+| ------------------- | --------------------------- | ------------------- | -------------------------------------------------------------------------- | --------------- |
+| use                 | Boolean                     | false               | 차트 라벨 선택 기능                                                        |                 |
+| useClick            | Boolean                     | true                | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) |                 |
+| limit               | Number                      | 1                   | 선택할 라벨의 최대 갯수                                                    |                 |
+| useDeselectOverflow | Boolean                     | false               | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부                       |                 |
+| showTip             | Boolean                     | false               | 선택한 위치의 Tip(화살표) 생성 여부                                        |                 |
+| useSeriesOpacity    | Boolean                     | true                | 시리즈 opacity 변경 여부                                                   |                 |
+| useLabelOpacity     | Boolean                     | true                | Axes Label opacity 변경 여부                                               |                 |
+| fixedPosTop         | Boolean                     | false               | tip의 위치를 최대값으로 고정                                               |                 |
+| useApproximateValue | Boolean                     | false               | 가까운 label을 선택                                                        |                 |
+| tipBackground       | Hex, RGB, RGBA Code(String) | '#000000'           | tip 배경색상                                                               |                 |
+| indicatorColor      | Hex, RGB, RGBA Code(String) | '#000000'           | indicator 색상                                                             |                 |
+| tipText             | String                      | 'value'             | 선택한 위치에 TextTip을 생성한다면 어떤 값                                 | 'value', 'label |
+| showTextTip         | Boolean                     | false               | 선택한 위치의 TextTip(text 포함 화살표, 흡사 말풍선) 생성 여부             |                 |
+| showIndicator       | Boolean                     | false               | 선택한 label의 indicator 표시                                              |                 |
+| tipStyle            | Object                      | ([상세](#tipstyle)) | tip 스타일을 설정                                                          |
 
 ##### tipStyle
-| 이름    | 타입   | 디폴트 | 설명 | 종류(예시) |
-| ------ | ------ | ---- | -----| --------- |
-| height | Number | 20 | tip 높이 | |
-| background | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  | |
-| textColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상  | |
-| fontSize  | Number | 14 | tip 폰트 크기 | |
-| fontFamily | String | 'Roboto' | tip 폰트 | |
-| fontWeight | Number | 400 | tip 폰트 굵기 | 100, 200, 300, ... 900 |
+
+| 이름       | 타입                        | 디폴트    | 설명             | 종류(예시)             |
+| ---------- | --------------------------- | --------- | ---------------- | ---------------------- |
+| height     | Number                      | 20        | tip 높이         |                        |
+| background | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  |                        |
+| textColor  | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상 |                        |
+| fontSize   | Number                      | 14        | tip 폰트 크기    |                        |
+| fontFamily | String                      | 'Roboto'  | tip 폰트         |                        |
+| fontWeight | Number                      | 400       | tip 폰트 굵기    | 100, 200, 300, ... 900 |
 
 #### selectSeries
-| 이름                 | 타입                          | 디폴트       | 설명                                                | 종류(예시) |
-|--------------------|-----------------------------|-----------|---------------------------------------------------| ----------|
-| use                | Boolean                     | false     | 차트 라벨 선택 기능                                       | |
-| useClick            | Boolean | true      | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) | |
-| limit              | Number                      | 1         | 선택할 라벨의 최대 갯수                                     | |
-| useDeselectOverflow | Boolean                     | false     | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부             | |
+
+| 이름                | 타입    | 디폴트 | 설명                                                                       | 종류(예시) |
+| ------------------- | ------- | ------ | -------------------------------------------------------------------------- | ---------- |
+| use                 | Boolean | false  | 차트 라벨 선택 기능                                                        |            |
+| useClick            | Boolean | true   | 클릭 이벤트 사용 여부 (v-model에 바인딩한 변수로만 컨트롤 하려 할때 false) |            |
+| limit               | Number  | 1      | 선택할 라벨의 최대 갯수                                                    |            |
+| useDeselectOverflow | Boolean | false  | limit 를 넘어 클릭 했을때 자동 deselect 를 할지 여부                       |            |
 
 #### dragSelection
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-| --- | ---- | ----- | --- | ----------|
-| use | Boolean | false | drag-select 사용 여부 | true / false |
-| keepDisplay | Boolean | true | 드래그 후 선택영역 유지 여부  | true / false  |
-| fillColor | Hex, RGB, RGBA Code(String) | '#38ACEC' | 선택 영역 색상 | |
-| opacity | Number | 0.65 | 선택 영역 불투명도 | 0 ~ 1 |
+
+| 이름        | 타입                        | 디폴트    | 설명                         | 종류(예시)   |
+| ----------- | --------------------------- | --------- | ---------------------------- | ------------ |
+| use         | Boolean                     | false     | drag-select 사용 여부        | true / false |
+| keepDisplay | Boolean                     | true      | 드래그 후 선택영역 유지 여부 | true / false |
+| fillColor   | Hex, RGB, RGBA Code(String) | '#38ACEC' | 선택 영역 색상               |              |
+| opacity     | Number                      | 0.65      | 선택 영역 불투명도           | 0 ~ 1        |
 
 ### 6. resize-timeout
+
 - Default : 0
 - debounce 사용. 연속으로 이벤트가 발생한 경우, 마지막 이벤트가 끝난 시점을 기준으로 `주어진 시간 (resize-timeout)` 이후 콜백 실행
 
-
 ### 7. Event
-| 이름 | 파라미터         | 설명                                                                                                                                                                                                                                                                     |
- |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|
-| click | selectedItem | 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                                                                                                                               |
-| dbl-click | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                                                                                                                            |
-| mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                 |
+
+| 이름        | 파라미터     | 설명                                                                                                                                                                                                                                                                                                                                      |
+| ----------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| click       | selectedItem | 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                                                                                                                                                                                          |
+| dbl-click   | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                                                                                                                                                                                     |
+| mouse-move  |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                                                |
 | drag-select | data, range  | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
-* 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환
+
+- 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환

--- a/docs/views/lineChart/example/HoverWithGroup.vue
+++ b/docs/views/lineChart/example/HoverWithGroup.vue
@@ -145,7 +145,7 @@ export default {
       indicator: {
         color: '#626872',
         segments: [4, 2],
-      }
+      },
     });
 
     watch(syncHoverChart1, (newSyncHoverChart1) => {
@@ -185,7 +185,7 @@ export default {
       indicator: {
         color: '#626872',
         segments: [4, 2],
-      }
+      },
     });
 
     watch(syncHoverChart2, (newSyncHoverChart2) => {

--- a/docs/views/lineChart/example/HoverWithGroup.vue
+++ b/docs/views/lineChart/example/HoverWithGroup.vue
@@ -1,0 +1,291 @@
+<template>
+  <ev-chart-group :options="{ syncHover }">
+    <ev-chart
+      v-model:selectedSeries="defaultSelectSeries"
+      :data="chartData1"
+      :options="chartOptions1"
+      @click="onClick"
+    />
+    <ev-chart
+      v-model:selectedSeries="defaultSelectSeries"
+      :data="chartData2"
+      :options="chartOptions2"
+      @click="onClick"
+    />
+    <div class="description">
+      <ev-toggle v-model="syncHover" />
+      <span>그룹 호버 동기화</span>
+      <br>
+      <br>
+      <ev-toggle v-model="syncHoverChart1" />
+      <span>첫번째 차트 호버 동기화</span>
+      <br>
+      <br>
+      <ev-toggle v-model="syncHoverChart2" />
+      <span>두번째 차트 호버 동기화</span>
+      <br>
+      <br>
+      <ev-toggle v-model="isLive" />
+      <span>
+        데이터 자동 업데이트
+      </span>
+      <br>
+      <br>
+      <ev-button
+        type="primary"
+        shape="radius"
+        @click="changeSelectedSeries('inc')"
+      >
+        +
+      </ev-button>
+      <ev-button
+        type="primary"
+        shape="radius"
+        @click="changeSelectedSeries('dec')"
+      >
+        -
+      </ev-button>
+      <span>
+        v-model:selectedSeries 변경
+      </span>
+      <br>
+      <br>
+      <div>
+        <div class="badge yellow">
+          v-model:selectedSeries
+        </div>
+        {{ defaultSelectSeries }}
+        <br>
+        <br>
+        <div class="badge yellow">
+          클릭 이벤트 데이터 (selected)
+        </div>
+        {{ clickedSeries }}
+        <br>
+        <br>
+      </div>
+    </div>
+  </ev-chart-group>
+</template>
+
+<script>
+import { onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
+import dayjs from 'dayjs';
+
+export default {
+  setup() {
+    const groupHoveredLabel = ref();
+
+    const chartData1 = reactive({
+      series: {
+        series1: { name: 'series#1' },
+        series2: { name: 'series#2' },
+        series3: { name: 'series#3' },
+        series4: { name: 'series#4' },
+        series5: { name: 'series#5' },
+      },
+      labels: [],
+      data: {
+        series1: [],
+        series2: [],
+        series3: [],
+        series4: [],
+        series5: [],
+      },
+    });
+    const chartData2 = reactive({
+      series: {
+        series1: { name: 'series1', fill: true, point: false },
+        series2: { name: 'series2', fill: true, point: false },
+        series3: { name: 'series3', fill: true, point: false },
+        series4: { name: 'series4', fill: true, point: false },
+        series5: { name: 'series5', fill: true, point: false },
+      },
+      labels: [],
+      groups: [['series1', 'series2', 'series3', 'series4', 'series5']],
+      data: {
+        series1: [],
+        series2: [],
+        series3: [],
+        series4: [],
+        series5: [],
+      },
+    });
+
+    const syncHoverChart1 = ref(true);
+
+    const chartOptions1 = ref({
+      syncHover: syncHoverChart1.value,
+      type: 'line',
+      width: '100%',
+      height: '80%',
+      title: {
+        show: false,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesX: [{
+        type: 'time',
+        timeFormat: 'HH:mm:ss',
+        interval: 'second',
+      }],
+      axesY: [{
+        type: 'linear',
+        showGrid: true,
+        startToZero: true,
+        autoScaleRatio: 0.1,
+      }],
+      selectSeries: {
+        use: true,
+        limit: 2,
+        useDeselectOverflow: true,
+      },
+      indicator: {
+        color: '#626872',
+        segments: [4, 2],
+      }
+    });
+
+    watch(syncHoverChart1, (newSyncHoverChart1) => {
+      chartOptions1.value.syncHover = newSyncHoverChart1;
+    });
+
+    const syncHoverChart2 = ref(true);
+
+    const chartOptions2 = ref({
+      syncHover: syncHoverChart2.value,
+      type: 'line',
+      width: '100%',
+      height: '80%',
+      title: {
+        show: false,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesX: [{
+        type: 'time',
+        timeFormat: 'HH:mm:ss',
+        interval: 'second',
+      }],
+      axesY: [{
+        type: 'linear',
+        showGrid: true,
+        startToZero: true,
+        autoScaleRatio: 0.1,
+      }],
+      selectSeries: {
+        use: true,
+        limit: 2,
+        useDeselectOverflow: true,
+      },
+      indicator: {
+        color: '#626872',
+        segments: [4, 2],
+      }
+    });
+
+    watch(syncHoverChart2, (newSyncHoverChart2) => {
+      chartOptions2.value.syncHover = newSyncHoverChart2;
+    });
+
+    const clickedSeries = ref();
+    const onClick = (e) => {
+      clickedSeries.value = e.selected;
+    };
+
+    const defaultSelectSeries = ref({
+      seriesId: ['series1'],
+    });
+    const changeSelectedSeries = (type) => {
+      const selectedList = defaultSelectSeries.value.seriesId;
+      let idx;
+      if (selectedList.length === 0) {
+        selectedList.push('series1');
+      } else {
+        idx = +(selectedList.pop()[6]);
+        if (type === 'inc') {
+          idx = idx < 5 ? idx + 1 : 1;
+        } else {
+          idx = idx > 1 ? idx - 1 : 5;
+        }
+      }
+      selectedList.push(`series${idx}`);
+    };
+
+    const syncHover = ref(true);
+
+    const isLive = ref(false);
+    const liveInterval = ref();
+    let timeValue = dayjs().format('YYYY-MM-DD HH:mm:ss');
+
+    const addRandomChartData = () => {
+      if (isLive.value) {
+        chartData1.labels.shift();
+        chartData2.labels.shift();
+      }
+
+      timeValue = dayjs(timeValue).add(6, 'second');
+      chartData1.labels.push(dayjs(timeValue));
+      chartData2.labels.push(dayjs(timeValue));
+
+      Object.values(chartData1.data).forEach((seriesData) => {
+        if (isLive.value) {
+          seriesData.shift();
+        }
+        seriesData.push(Math.floor(Math.random() * ((5000 - 5) + 1)) + 5);
+      });
+      Object.values(chartData2.data).forEach((seriesData) => {
+        if (isLive.value) {
+          seriesData.shift();
+        }
+        seriesData.push(Math.floor(Math.random() * ((5000 - 5) + 1)) + 5);
+      });
+    };
+
+    onMounted(() => {
+      for (let ix = 0; ix < 10; ix++) {
+        addRandomChartData();
+      }
+    });
+
+    watch(isLive, (newValue) => {
+      if (newValue) {
+        addRandomChartData();
+        liveInterval.value = setInterval(addRandomChartData, 6000);
+      } else {
+        clearInterval(liveInterval.value);
+      }
+    });
+
+    onBeforeUnmount(() => {
+      clearInterval(liveInterval.value);
+    });
+
+    return {
+      syncHover,
+      syncHoverChart1,
+      syncHoverChart2,
+      chartData1,
+      chartData2,
+      chartOptions1,
+      chartOptions2,
+      clickedSeries,
+      defaultSelectSeries,
+      isLive,
+      onClick,
+      changeSelectedSeries,
+      groupHoveredLabel,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.description {
+  position: relative;
+}
+</style>

--- a/docs/views/lineChart/props.js
+++ b/docs/views/lineChart/props.js
@@ -24,6 +24,8 @@ import AxisTitle from './example/AxisTitle';
 import AxisTitleRaw from '!!raw-loader!./example/AxisTitle';
 import PassingValue from './example/PassingValue';
 import PassingValueRaw from '!!raw-loader!./example/PassingValue';
+import HoverWithGroup from './example/HoverWithGroup';
+import HoverWithGroupRaw from '!!raw-loader!./example/HoverWithGroup';
 
 export default {
   mdText,
@@ -87,6 +89,11 @@ export default {
       description: 'passingValue를 설정하여 특정 시점에 line을 끊지 않고 자연스럽게 이을 수 있습니다.',
       component: PassingValue,
       parsedData: parseComponent(PassingValueRaw),
+    },
+    HoverWithGroup: {
+      description: '',
+      component: HoverWithGroup,
+      parsedData: parseComponent(HoverWithGroupRaw),
     },
   },
 };

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -284,7 +284,7 @@
           return;
         }
         if (props.options.syncHover !== false) {
-          if (evChart.overlayClear()) {
+          if (newHoveredLabel.label == null) {
             evChart.overlayClear();
           } else {
             evChart.drawSyncedIndicator(newHoveredLabel);

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -95,6 +95,7 @@
       const injectIsChartGroup = inject('isChartGroup', false);
       const injectBrushSeries = inject('brushSeries', { list: [], chartIdx: null });
       const injectGroupSelectedLabel = inject('groupSelectedLabel', null);
+      const injectGroupHoveredLabel = inject('groupHoveredLabel', null);
       const injectBrushIdx = inject('brushIdx', { start: 0, end: -1 });
       const injectEvChartPropsInGroup = inject('evChartPropsInGroup', []);
 
@@ -105,7 +106,7 @@
         selectSeriesInfo,
         getNormalizedData,
         getNormalizedOptions,
-      } = useModel(injectGroupSelectedLabel);
+      } = useModel(injectGroupSelectedLabel, injectGroupHoveredLabel);
 
       const normalizedData = getNormalizedData(props.data);
       const normalizedOptions = getNormalizedOptions(props.options);
@@ -277,6 +278,19 @@
           updateData: false,
         });
       });
+
+      watch(() => injectGroupHoveredLabel?.value, (newHoveredLabel) => {
+        if (!newHoveredLabel) {
+          return;
+        }
+        if (props.options.syncHover !== false) {
+          if (evChart.overlayClear()) {
+            evChart.overlayClear();
+          } else {
+            evChart.drawSyncedIndicator(newHoveredLabel);
+          }
+        }
+      }, { deep: true, flush: 'post' });
 
       onMounted(async () => {
         if (injectEvChartPropsInGroup?.value) {

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -170,6 +170,10 @@ class EvChart {
     this.chartRect = this.getChartRect();
   }
 
+  drawSyncedIndicator({ horizontal, label }) {
+    this.drawSyncedIndicator({ horizontal, label });
+  }
+
   /**
    * To draw canvas chart, it processes several sequential jobs
    * @param {any} [hitInfo=undefined]    from mousemove callback (object or object[] of undefined)

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -170,8 +170,8 @@ class EvChart {
     this.chartRect = this.getChartRect();
   }
 
-  drawSyncedIndicator({ horizontal, label }) {
-    this.drawSyncedIndicator({ horizontal, label });
+  drawSyncedIndicator({ horizontal, label, mousePosition }) {
+    this.drawSyncedIndicator({ horizontal, label, mousePosition });
   }
 
   /**

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -65,6 +65,7 @@ const modules = {
         args.hoveredLabel = {
           horizontal: this.options.horizontal,
           label,
+          mousePosition: [e.clientX, e.clientY],
         };
       }
 

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -64,8 +64,8 @@ const modules = {
         const label = this.getTimeLabel(offset);
         args.hoveredLabel = {
           horizontal: this.options.horizontal,
-          label: label,
-        }
+          label,
+        };
       }
 
       if (typeof this.listeners['mouse-move'] === 'function') {

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -61,6 +61,11 @@ const modules = {
 
       if (indicator.use && type !== 'pie' && type !== 'scatter' && type !== 'heatMap') {
         this.drawIndicator(offset, indicator.color);
+        const label = this.getTimeLabel(offset);
+        args.hoveredLabel = {
+          horizontal: this.options.horizontal,
+          label: label,
+        }
       }
 
       if (typeof this.listeners['mouse-move'] === 'function') {
@@ -92,6 +97,7 @@ const modules = {
       if (tooltip.use) {
         this.tooltipClear();
       }
+      this.listeners['mouse-leave']();
     };
 
     /**

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -778,6 +778,48 @@ const modules = {
       ctx.closePath();
     }
   },
+  /**
+   * Get hovered axis label with mousemove
+   * @param {object} offset   mousemove callback
+   *
+   * @returns {number | null} hovered axis label
+   */
+  getTimeLabel(offset) {
+    const [offsetX, offsetY] = offset;
+    const graphPos = {
+      x1: this.chartRect.x1 + this.labelOffset.left,
+      x2: this.chartRect.x2 - this.labelOffset.right,
+      y1: this.chartRect.y1 + this.labelOffset.top,
+      y2: this.chartRect.y2 - this.labelOffset.bottom,
+    };
+
+    const options = this.options;
+
+    if (
+      options.syncHover === false || 
+      (!options.horizontal && !options.axesX.every(({ type }) => type === 'time') || 
+      options.horizontal && !options.axesY.every(({ type }) => type === 'time'))) {
+      return null;
+    }
+
+    const fromTime = +this.data.labels?.[0];
+    const toTime = +this.data.labels?.[this.data.labels.length - 1];
+    if (fromTime == null || toTime == null) {
+      return null;
+    }
+
+    if (options.horizontal) {
+      const chartHeight = graphPos.y2 - graphPos.y1;
+      const hoverYAxis = offsetY - graphPos.y1;
+      const hoverTime = (hoverYAxis * (toTime - fromTime) / chartHeight) + fromTime;
+      return Math.round(hoverTime);
+    } else {
+      const chartWidth = graphPos.x2 - graphPos.x1;
+      const hoverXAxis = offsetX - graphPos.x1;
+      const hoverTime = (hoverXAxis * (toTime - fromTime) / chartWidth) + fromTime;
+      return Math.round(hoverTime);
+    }
+  },
 
   /**
    * Clear tooltip canvas

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -785,14 +785,6 @@ const modules = {
    * @returns {number | null} hovered axis label
    */
   getTimeLabel(offset) {
-    const [offsetX, offsetY] = offset;
-    const graphPos = {
-      x1: this.chartRect.x1 + this.labelOffset.left,
-      x2: this.chartRect.x2 - this.labelOffset.right,
-      y1: this.chartRect.y1 + this.labelOffset.top,
-      y2: this.chartRect.y2 - this.labelOffset.bottom,
-    };
-
     const options = this.options;
 
     if (
@@ -807,6 +799,14 @@ const modules = {
     if (fromTime == null || toTime == null) {
       return null;
     }
+
+    const [offsetX, offsetY] = offset;
+    const graphPos = {
+      x1: this.chartRect.x1 + this.labelOffset.left,
+      x2: this.chartRect.x2 - this.labelOffset.right,
+      y1: this.chartRect.y1 + this.labelOffset.top,
+      y2: this.chartRect.y2 - this.labelOffset.bottom,
+    };
 
     if (options.horizontal) {
       const chartHeight = graphPos.y2 - graphPos.y1;

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -820,6 +820,46 @@ const modules = {
       return Math.round(hoverTime);
     }
   },
+  /**
+   * Draw chart indicator with other grouped chart's mousemove
+   * @param {object} hoveredLabel   chart direction and hovered axis label
+   *
+   * @returns {undefined}
+   */
+  drawSyncedIndicator({ horizontal, label }) {
+    if (!!horizontal !== !!this.options.horizontal) {
+      return;
+    }
+    if (
+      this.options.syncHover === false || 
+      (!horizontal && !this.options.axesX.every(({ type }) => type === 'time') || 
+      horizontal && !this.options.axesY.every(({ type }) => type === 'time'))) {
+      return ;
+    }
+    this.overlayClear();
+    const graphPos = {
+      x1: this.chartRect.x1 + this.labelOffset.left,
+      x2: this.chartRect.x2 - this.labelOffset.right,
+      y1: this.chartRect.y1 + this.labelOffset.top,
+      y2: this.chartRect.y2 - this.labelOffset.bottom,
+    };
+
+    const fromTime = +this.data.labels?.[0];
+    const toTime = +this.data.labels?.[this.data.labels.length - 1];
+    if (fromTime == null || toTime == null) {
+      return null;
+    }
+
+    if (horizontal) {
+      const chartHeight = graphPos.y2 - graphPos.y1;
+      const offsetY = (chartHeight) * (label - fromTime) / (toTime - fromTime) + graphPos.y1;
+      this.drawIndicator([graphPos.x2, offsetY], this.options.indicator.color);
+    } else {
+      const chartWidth = graphPos.x2 - graphPos.x1;
+      const offsetX = (chartWidth) * (label - fromTime) / (toTime - fromTime) + graphPos.x1;
+      this.drawIndicator([offsetX, graphPos.y2], this.options.indicator.color);
+    }
+  },
 
   /**
    * Clear tooltip canvas

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -796,9 +796,9 @@ const modules = {
     const options = this.options;
 
     if (
-      options.syncHover === false || 
-      (!options.horizontal && !options.axesX.every(({ type }) => type === 'time') || 
-      options.horizontal && !options.axesY.every(({ type }) => type === 'time'))) {
+      options.syncHover === false
+      || (!options.horizontal && !options.axesX.every(({ type }) => type === 'time'))
+      || (options.horizontal && !options.axesY.every(({ type }) => type === 'time'))) {
       return null;
     }
 
@@ -811,14 +811,13 @@ const modules = {
     if (options.horizontal) {
       const chartHeight = graphPos.y2 - graphPos.y1;
       const hoverYAxis = offsetY - graphPos.y1;
-      const hoverTime = (hoverYAxis * (toTime - fromTime) / chartHeight) + fromTime;
-      return Math.round(hoverTime);
-    } else {
-      const chartWidth = graphPos.x2 - graphPos.x1;
-      const hoverXAxis = offsetX - graphPos.x1;
-      const hoverTime = (hoverXAxis * (toTime - fromTime) / chartWidth) + fromTime;
+      const hoverTime = ((hoverYAxis * (toTime - fromTime)) / chartHeight) + fromTime;
       return Math.round(hoverTime);
     }
+      const chartWidth = graphPos.x2 - graphPos.x1;
+      const hoverXAxis = offsetX - graphPos.x1;
+      const hoverTime = ((hoverXAxis * (toTime - fromTime)) / chartWidth) + fromTime;
+      return Math.round(hoverTime);
   },
   /**
    * Draw chart indicator with other grouped chart's mousemove
@@ -831,10 +830,10 @@ const modules = {
       return;
     }
     if (
-      this.options.syncHover === false || 
-      (!horizontal && !this.options.axesX.every(({ type }) => type === 'time') || 
-      horizontal && !this.options.axesY.every(({ type }) => type === 'time'))) {
-      return ;
+      this.options.syncHover === false
+      || (!horizontal && !this.options.axesX.every(({ type }) => type === 'time'))
+      || (horizontal && !this.options.axesY.every(({ type }) => type === 'time'))) {
+      return;
     }
     this.overlayClear();
     const graphPos = {
@@ -847,16 +846,16 @@ const modules = {
     const fromTime = +this.data.labels?.[0];
     const toTime = +this.data.labels?.[this.data.labels.length - 1];
     if (fromTime == null || toTime == null) {
-      return null;
+      return;
     }
 
     if (horizontal) {
       const chartHeight = graphPos.y2 - graphPos.y1;
-      const offsetY = (chartHeight) * (label - fromTime) / (toTime - fromTime) + graphPos.y1;
+      const offsetY = (chartHeight * (label - fromTime)) / (toTime - fromTime) + graphPos.y1;
       this.drawIndicator([graphPos.x2, offsetY], this.options.indicator.color);
     } else {
       const chartWidth = graphPos.x2 - graphPos.x1;
-      const offsetX = (chartWidth) * (label - fromTime) / (toTime - fromTime) + graphPos.x1;
+      const offsetX = (chartWidth * (label - fromTime)) / (toTime - fromTime) + graphPos.x1;
       this.drawIndicator([offsetX, graphPos.y2], this.options.indicator.color);
     }
   },

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -827,7 +827,7 @@ const modules = {
    * @returns {undefined}
    */
   drawSyncedIndicator({ horizontal, label, mousePosition }) {
-    if (!!horizontal !== !!this.options.horizontal) {
+    if (!mousePosition || !!horizontal !== !!this.options.horizontal) {
       return;
     }
     if (

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -1,5 +1,6 @@
 import { convertToPercent } from '@/common/utils';
 import debounce from '@/common/utils.debounce';
+import { inRange } from 'lodash-es';
 import Canvas from '../helpers/helpers.canvas';
 import Util from '../helpers/helpers.util';
 
@@ -825,7 +826,7 @@ const modules = {
    *
    * @returns {undefined}
    */
-  drawSyncedIndicator({ horizontal, label }) {
+  drawSyncedIndicator({ horizontal, label, mousePosition }) {
     if (!!horizontal !== !!this.options.horizontal) {
       return;
     }
@@ -835,6 +836,19 @@ const modules = {
       || (horizontal && !this.options.axesY.every(({ type }) => type === 'time'))) {
       return;
     }
+    const fromTime = +this.data.labels?.[0];
+    const toTime = +this.data.labels?.[this.data.labels.length - 1];
+    if (fromTime == null || toTime == null) {
+      return;
+    }
+    const [clientX, clientY] = mousePosition;
+    const { top, bottom, left, right } = this.chartDOM.getBoundingClientRect();
+
+    const isHoveredChart = inRange(clientX, left, right) && inRange(clientY, bottom, top);
+    if (isHoveredChart) {
+      return;
+    }
+
     this.overlayClear();
     const graphPos = {
       x1: this.chartRect.x1 + this.labelOffset.left,
@@ -842,12 +856,6 @@ const modules = {
       y1: this.chartRect.y1 + this.labelOffset.top,
       y2: this.chartRect.y2 - this.labelOffset.bottom,
     };
-
-    const fromTime = +this.data.labels?.[0];
-    const toTime = +this.data.labels?.[this.data.labels.length - 1];
-    if (fromTime == null || toTime == null) {
-      return;
-    }
 
     if (horizontal) {
       const chartHeight = graphPos.y2 - graphPos.y1;

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -348,7 +348,7 @@ export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
       if (injectGroupHoveredLabel?.value) {
         injectGroupHoveredLabel.value.label = null;
       }
-    }
+    },
   };
 
   return {

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -253,7 +253,7 @@ const DEFAULT_DATA = {
   data: {},
 };
 
-export const useModel = (injectGroupSelectedLabel) => {
+export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
   const { props, emit } = getCurrentInstance();
 
   const getNormalizedOptions = (options) => {
@@ -338,9 +338,17 @@ export const useModel = (injectGroupSelectedLabel) => {
       emit('drag-select', e);
     },
     'mouse-move': async (e) => {
+      if (injectGroupHoveredLabel?.value) {
+        injectGroupHoveredLabel.value = e.hoveredLabel;
+      }
       await nextTick();
       emit('mouse-move', e);
     },
+    'mouse-leave': () => {
+      if (injectGroupHoveredLabel?.value) {
+        injectGroupHoveredLabel.value.label = null;
+      }
+    }
   };
 
   return {

--- a/src/components/chartGroup/ChartGroup.vue
+++ b/src/components/chartGroup/ChartGroup.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script>
-import { onMounted, watch, provide, toRef, computed } from 'vue';
+import { onMounted, ref, watch, provide, toRef, computed } from 'vue';
 import evChartToolbar from '../chart/ChartToolbar';
 import { useGroupModel } from './uses';
 import { useZoomModel } from '../chart/uses';
@@ -50,6 +50,7 @@ export default {
     'update:groupSelectedLabel',
     'update:zoomStartIdx',
     'update:zoomEndIdx',
+    'update:groupHoveredLabel',
   ],
   setup(props, { emit }) {
     const {
@@ -70,6 +71,18 @@ export default {
       set: val => emit('update:groupSelectedLabel', val),
     });
     provide('groupSelectedLabel', groupSelectedLabel);
+    const groupHoveredLabel = ref(null);
+    provide('groupHoveredLabel', groupHoveredLabel);
+
+    watch(() => props.options.syncHover, (newSyncHover) => {
+      if (newSyncHover) {
+        groupHoveredLabel.value = { label: '', horizontal: false };
+      } else {
+        groupHoveredLabel.value = null;
+      }
+    }, {
+      immediate: true,
+    });
 
     const {
       evChartZoomOptions,


### PR DESCRIPTION
# 작업 내용
- type 'time' 인 x축, y축에 대해 indicator를 동시에 표시해주는 기능을 추가하였습니다.
# 테스트 방법
- docs에 추가된 LineChart, BarChart의 HoverWithGroup를 확인해주세요.
# 스크린샷
- Line Chart
![HoverWithGroupLine](https://github.com/user-attachments/assets/5a4147dd-f1d5-4df0-8811-e7f161e68c45)

- Bar Chart
![HoverWithGroupBar](https://github.com/user-attachments/assets/227daa66-5219-4be3-bbc9-38779d1067b0)


