### PR TITLE
[#1743]Chart 내 최대값에 단위 변환 적용

### DIFF
--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -1,5 +1,5 @@
-import { numberWithComma } from '@/common/utils';
 import dayjs from 'dayjs';
+import { numberWithComma } from '@/common/utils';
 import Canvas from '../helpers/helpers.canvas';
 import { truthyNumber } from '../../../common/utils';
 
@@ -12,6 +12,9 @@ const modules = {
    */
   drawTips(tipLocationInfo) {
     const opt = this.options;
+    const tooltipValueFormatter = typeof opt.tooltip?.formatter === 'function'
+      ? opt.tooltip?.formatter
+      : opt.tooltip?.formatter?.value;
     const isHorizontal = !!opt.horizontal;
     const maxTipOpt = opt.maxTip;
     const selTipOpt = opt.selectItem;
@@ -84,7 +87,13 @@ const modules = {
       maxArgs = this.calculateTipInfo(seriesInfo, 'max', null);
 
       if (maxTipOpt.use && maxArgs) {
-        maxArgs.text = numberWithComma(maxArgs.value);
+        if (tooltipValueFormatter) {
+          maxArgs.text = isHorizontal
+            ? tooltipValueFormatter({ x: maxArgs.value })
+            : tooltipValueFormatter({ y: maxArgs.value });
+        } else {
+          maxArgs.text = numberWithComma(maxArgs.value);
+        }
         this.drawTextTip({ opt: maxTipOpt, tipType: 'max', seriesOpt: seriesInfo, ...maxArgs });
 
         if (maxTipOpt.showIndicator) {

--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -12,15 +12,19 @@ const modules = {
    */
   drawTips(tipLocationInfo) {
     const opt = this.options;
-    const tooltipValueFormatter = typeof opt.tooltip?.formatter === 'function'
-      ? opt.tooltip?.formatter
-      : opt.tooltip?.formatter?.value;
+    let tooltipValueFormatter = null;
     const isHorizontal = !!opt.horizontal;
     const maxTipOpt = opt.maxTip;
     const selTipOpt = opt.selectItem;
     const labelTipOpt = opt.selectLabel;
     let maxArgs;
     let isExistSelectedLabel;
+
+    if (typeof opt.tooltip?.formatter === 'function') {
+      tooltipValueFormatter = opt.tooltip?.formatter;
+    } else if (typeof opt.tooltip?.formatter?.value === 'function') {
+      tooltipValueFormatter = opt.tooltip?.formatter?.value;
+    }
 
     if (labelTipOpt.use && labelTipOpt.showTip) {
       const isHeatMap = opt.type === 'heatMap';


### PR DESCRIPTION
## 작업 배경
차트 내 최대값이 툴팁과 다르게 단위 변환 적용이 안되어 있음

## 변경 사항 요약
- toolTip의 formatter 옵션이 있을 경우 maxTip도 따라서 formatter 적용

## 이전 동작
![image](https://github.com/user-attachments/assets/eeac25ba-4e7f-4cae-a10e-e6d1e0609dec)


## 기대 동작
![image](https://github.com/user-attachments/assets/6b833ed7-7f29-497a-bb3a-8cf14b7abb95)

## 테스트 가이드
tooltip에 formatter옵션을 주었을 시 maxTip도 값이 변환되는지 확인해주세요

