### PR TITLE
[#1754] ev-select 드롭박스 토글 반복 시 width 값이 계속 늘어나는 오류 수정

### DIFF
--- a/src/components/select/uses.js
+++ b/src/components/select/uses.js
@@ -202,12 +202,15 @@ export const useDropdown = (param) => {
       items.forEach((item) => {
         const itemWidth = item.scrollWidth;
         if (itemWidth > maxWidth) {
-          maxWidth = itemWidth + 2;
+          maxWidth = itemWidth;
         }
       });
 
+      const { borderLeftWidth, borderRightWidth } = window.getComputedStyle(dropbox.value);
+      const borderXWidth = parseInt(borderLeftWidth) + parseInt(borderRightWidth);
+
       const scrollbarWidth = itemWrapper.value.offsetWidth - itemWrapper.value.clientWidth;
-      maxWidth += scrollbarWidth;
+      maxWidth += (scrollbarWidth + borderXWidth);
 
       const windowWidth = window.innerWidth;
       const dropboxRect = dropbox.value.getBoundingClientRect();

--- a/src/components/select/uses.js
+++ b/src/components/select/uses.js
@@ -198,29 +198,28 @@ export const useDropdown = (param) => {
 
       const items = itemWrapper.value.querySelectorAll('.ev-select-dropbox-item');
       let maxWidth = 0;
-      let itemPadding = 0;
 
       items.forEach((item) => {
         const itemWidth = item.scrollWidth;
         if (itemWidth > maxWidth) {
-          maxWidth = itemWidth;
-        }
-        if (itemPadding === 0) {
-          const style = window.getComputedStyle(item);
-          itemPadding = parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+          maxWidth = itemWidth + 2;
         }
       });
+
+      const scrollbarWidth = itemWrapper.value.offsetWidth - itemWrapper.value.clientWidth;
+      maxWidth += scrollbarWidth;
 
       const windowWidth = window.innerWidth;
       const dropboxRect = dropbox.value.getBoundingClientRect();
       const dropboxLeft = dropboxRect.left;
-      const maxAllowedWidth = windowWidth - dropboxLeft - itemPadding - 10;
+      const maxAllowedWidth = windowWidth - dropboxLeft - 20;
 
-      const finalWidth = Math.max(Math.min(maxWidth, maxAllowedWidth), initialDropboxWidth.value);
+      const finalWidth = Math.max(
+        Math.min((maxWidth), maxAllowedWidth),
+        initialDropboxWidth.value,
+      );
 
-      if (initialDropboxWidth.value < maxWidth) {
-        dropboxWidth.value = `${Math.max(finalWidth + itemPadding - 10, 100)}px`;
-      }
+      dropboxWidth.value = `${finalWidth}px`;
     } else {
       dropboxWidth.value = '100%';
     }
@@ -241,7 +240,6 @@ export const useDropdown = (param) => {
     () => filteredItems.value,
     async () => {
       await changeDropboxPosition();
-      await calculateDropboxWidth();
     },
   );
 


### PR DESCRIPTION
# 작업 배경
- 드롭박스의 요소가 셀렉트 박스보다 길다면 드롭박스  토글 반복 시 width 값이 계속 늘어나는 오류가 있었습니다.

# 변경 사항 요약(Key changes)
- 드롭박스 width 계산식을 수정하였습니다.

# 기존 동작
![082001](https://github.com/user-attachments/assets/8012a2ef-9222-4eb1-ac54-2769e6acce25)

# 기대 동작
![082002](https://github.com/user-attachments/assets/73b29377-954f-49b0-87b3-b174c66bc6bf)
