### PR TITLE
[fix] pie, scatter, heatMap 차트 호버 시, sync indicator 보이지 않는 문제

### DIFF
--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -67,6 +67,10 @@ const modules = {
           label,
           mousePosition: [e.clientX, e.clientY],
         };
+      } else {
+        args.hoveredLabel = {
+          label: '',
+        };
       }
 
       if (typeof this.listeners['mouse-move'] === 'function') {


### PR DESCRIPTION
## 이슈
pie, scatter, heatMap 차트 호버 시, sync indicator 보이지 않는 문제가 있었습니다.
![sync indicator 이슈](https://github.com/user-attachments/assets/350a27ff-e144-4e43-b503-80d7e7a57e0d)

## 변경사항
pie, scatter, heatMap
 차트 호버 시 args.hoveredLabel값이 초기값으로 세팅되도록 수정했습니다.

## 해결
![sync indicator](https://github.com/user-attachments/assets/f1dfc440-dcf5-48f7-a6fc-81e2a4619e5b)
