### PR TITLE
[#1762] 그리드 컬럼 sortable: false일 경우 컨텍스트 메뉴 안타나는 문제

### DIFF
--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1180,13 +1180,13 @@ export const contextMenuEvent = (params) => {
             });
           },
           disabled: !filterable,
-          hidden: contextInfo.hiddenColumnMenuItem?.filter,
+          hidden: contextInfo.hiddenColumnMenuItem?.filter || !filterInfo.isFiltering,
         },
         {
           text: contextInfo.columnMenuTextInfo?.hide ?? 'Hide',
           iconClass: 'ev-icon-visibility-off',
-          disabled: (!useGridSetting.value || stores.orderedColumns.length === 1) || column.fixed,
-          hidden: contextInfo.hiddenColumnMenuItem?.hide,
+          disabled: !useGridSetting.value || stores.orderedColumns.length === 1 || column.fixed,
+          hidden: contextInfo.hiddenColumnMenuItem?.hide || !useGridSetting.value,
           click: () => {
             setColumnHidden(column.field);
             emit('change-column-status', {
@@ -1201,7 +1201,7 @@ export const contextMenuEvent = (params) => {
         },
       ];
       contextInfo.columnMenuItems = [];
-      if (!sortable && !filterable) {
+      if (!sortable && !filterable && !useGridSetting.value) {
         return;
       }
       contextInfo.columnMenuItems = columnMenuItems.filter(item => !item.hidden);


### PR DESCRIPTION
## 작업 배경
sortable: false일 경우 그리드 컬럼 contextMenu 노출 안됨
![sortable_false일 경우 contextMenu 안뜸](https://github.com/user-attachments/assets/c7678778-3c59-48bd-887f-ec94da238c75)
![컬럼 sortable_flase 코드](https://github.com/user-attachments/assets/8f4eedda-a1b5-469b-a164-89aa8d605c26)

## 변경 사항 요약
- 그리드 옵션(filter, useGridSetting)으로 false인 경우 hidden & disable, 컬럼 옵션(fixed, sortable)일 경우 disable
- 그리드 컬럼 contenxtMenu에 useGridSetting 체크 추가

## 기대 동작
![그리드 옵션일 경우 disable](https://github.com/user-attachments/assets/668a781c-6b94-4e5f-9641-4149b4f3c5b0)
![컬럼 옵션일 경우 disable, hide 옵션](https://github.com/user-attachments/assets/dc596e85-2803-4b2b-95af-e7c4f9149222)

## 테스트 가이드
- 그리드 옵션으로 false일 경우 컬럼 contextMenu에 해당 옵션이 안보이는지 확인해주세요
- 컬럼 옵션으로 false일 경우 컬럼 contextMenu에 해당 옵션이 disable 되는지 확인해주세요
- 해당 컬럼이 hide 옵션만 충족할 경우에도 컬럼을 클릭했을 시 contextMenu가 보이는지 확인해주세요

