### PR TITLE
[#1764] Chart > Time Axis > label Formatter > data parameter 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -150,7 +150,7 @@ const chartData = {
 | labelStyle     | Object   | ([상세](#labelstyle))  | 라벨의 폰트 스타일을 설정                                                                          |                                                                                          |
 | plotLines      | Array    | ([상세](#plotline))    | plot line(임계선 표시 용도) 설정                                                                   |                                                                                          |
 | plotBands      | Array    | ([상세](#plotband))    | plot band(임계영역 표시 용도) 설정                                                                 |                                                                                          |
-| formatter      | function | null                   | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용                                            | (value) => value + '%'                                                                   |
+| formatter      | function | null                | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용                   | (value, { prev, isDefaultMaxSameAsMin }) => value + '%' |
 | title          | Object   | ([상세](#title))       | 라벨의 폰트 스타일을 설정                                                                          |                                                                                          |
 
 ##### axesX

--- a/docs/views/barChart/example/Time.vue
+++ b/docs/views/barChart/example/Time.vue
@@ -37,8 +37,21 @@
           type: 'time',
           showGrid: false,
           categoryMode: true,
-          timeFormat: 'mm:ss',
-          interval: 'second',
+          timeFormat: 'DD HH:mm',
+          interval: 'hour',
+          formatter: (value, data) => {
+            if (data?.prev) {
+              const curr = dayjs(value).format('yy-MM-DD');
+              const prev = dayjs(data?.prev).format('yy-MM-DD');
+              if (curr === prev) {
+                return dayjs(value)
+                    .format('HH:mm');
+              }
+            }
+
+            return dayjs(value)
+                .format('DD HH:mm');
+          },
         }],
         axesY: [{
           type: 'linear',
@@ -76,7 +89,7 @@
           chartData.labels.shift();
         }
 
-        timeValue = dayjs(timeValue).add(1, 'second');
+        timeValue = dayjs(timeValue).add(1, 'hour');
         chartData.labels.push(dayjs(timeValue));
 
         Object.values(chartData.data).forEach((seriesData) => {
@@ -89,7 +102,7 @@
       };
 
       onMounted(() => {
-        for (let ix = 0; ix < 10; ix++) {
+        for (let ix = 0; ix < 60; ix++) {
           addRandomChartData();
         }
       });

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -83,22 +83,22 @@ const chartData =
   
 #### axesX axesY
 ##### type 공통
-  | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-  |------------ |-----------|---------|-------------------------|---------------------------------------------------|
+  | 이름 | 타입 | 디폴트 | 설명 | 종류(예시)                                               |
+  |------------ |-----------|---------|-------------------------|------------------------------------------------------|
   | type | String | | 축의 유형 | [time](#time-type)(categoryMode), [step](#step-type) |
-  | showAxis | Boolean | true | 축 표시 여부 | true / false | 
-  | startToZero | Boolean | false | 축의 시작을 0 부터 시작할지의 여부 | true / false |
-  | autoScaleRatio | Number | null | Axis의 Max Buffer를 위한 속성 | 0.1 ~ 0.9 |
-  | showGrid | Boolean | true | 차트 내부 그리드 표시 여부 | true / false |
-  | axisLineWidth  | Number | 1 | 축의 선 굵기 | 1 ~ |
-  | axisLineColor | String | '#C9CFDC' | 축의 색상 | | 
-  | gridLineColor | String | '#C9CFDC' | 그리드의 색상 | | 
-  | range | Array | null | 축에 표시할 값의 min, max  (autoScaleRatio = null, startToZero = false 이여야 정상 표현됩니다.) | [time](#time-type), [step](#step-type) |
-  | interval | String/number | | 축에 표시되는 값의 간격 단위 ( time: string / linear: number) | |
-  | labelStyle | Object | ([상세](#label-style)) | 라벨의 폰트 스타일을 설정 | |
-  | formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (value) => value + '%' |
-  | title | Object | ([상세](#axes-title)) | 라벨의 폰트 스타일을 설정 | |  
-  | scrollbar | Object | ([상세](#axes-scrollbar)) | 차트 축 스크롤 설정(range 옵션 설정되어 있어야 정상 동작합니다.) | |
+  | showAxis | Boolean | true | 축 표시 여부 | true / false                                         | 
+  | startToZero | Boolean | false | 축의 시작을 0 부터 시작할지의 여부 | true / false                                         |
+  | autoScaleRatio | Number | null | Axis의 Max Buffer를 위한 속성 | 0.1 ~ 0.9                                            |
+  | showGrid | Boolean | true | 차트 내부 그리드 표시 여부 | true / false                                         |
+  | axisLineWidth  | Number | 1 | 축의 선 굵기 | 1 ~                                                  |
+  | axisLineColor | String | '#C9CFDC' | 축의 색상 |                                                      | 
+  | gridLineColor | String | '#C9CFDC' | 그리드의 색상 |                                                      | 
+  | range | Array | null | 축에 표시할 값의 min, max  (autoScaleRatio = null, startToZero = false 이여야 정상 표현됩니다.) | [time](#time-type), [step](#step-type)               |
+  | interval | String/number | | 축에 표시되는 값의 간격 단위 ( time: string / linear: number) |                                                      |
+  | labelStyle | Object | ([상세](#label-style)) | 라벨의 폰트 스타일을 설정 |                                                      |
+  | formatter      | function | null                | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용                   | (value, { prev, isDefaultMaxSameAsMin }) => value + '%' |
+  | title | Object | ([상세](#axes-title)) | 라벨의 폰트 스타일을 설정 |                                                      |  
+  | scrollbar | Object | ([상세](#axes-scrollbar)) | 차트 축 스크롤 설정(range 옵션 설정되어 있어야 정상 동작합니다.) |                                                      |
 
 ##### time type
    - interval (Axis Label 표기를 위한 interval)

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -126,22 +126,22 @@ const chartData =
 
 ##### type 공통
 
-| 이름           | 타입     | 디폴트                | 설명                                                          | 종류(예시)             |
-| -------------- | -------- | --------------------- | ------------------------------------------------------------- | ---------------------- |
-| type           | String   |                       | 축의 유형                                                     | [time](#time-type)     |
-| showAxis       | Boolean  | true                  | 축 표시 여부                                                  | true / false           |
-| startToZero    | Boolean  | false                 | 축의 시작을 0 부터 시작할지의 여부                            | true / false           |
-| autoScaleRatio | Number   | null                  | Axis의 Max Buffer를 위한 속성                                 | 0.1 ~ 0.9              |
-| showGrid       | Boolean  | true                  | 차트 내부 그리드 표시 여부                                    | true / false           |
-| axisLineWidth  | Number   | 1                     | 축의 선 굵기                                                  | 1 ~                    |
-| axisLineColor  | String   | '#C9CFDC'             | 축의 색상                                                     |                        |
-| gridLineColor  | String   | '#C9CFDC'             | 그리드의 색상                                                 |                        |
-| interval       | String   | null                  | 축에 표시되는 값의 간격 단위 (ex. 'day', 'hour', 'minute'...) |
-| labelStyle     | Object   | ([상세](#labelstyle)) | 라벨의 폰트 스타일을 설정                                     |                        |
-| plotLines      | Array    | ([상세](#plotline))   | plot line(임계선 표시 용도) 설정                              |                        |
-| plotBands      | Array    | ([상세](#plotband))   | plot band(임계영역 표시 용도) 설정                            |                        |
-| formatter      | function | null                  | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용       | (value) => value + '%' |
-| title          | Object   | ([상세](#title))      | 라벨의 폰트 스타일을 설정                                     |                        |
+| 이름             | 타입       | 디폴트                 | 설명                                                | 종류(예시)                                                  |
+|----------------|----------|---------------------|---------------------------------------------------|---------------------------------------------------------|
+| type           | String   |                     | 축의 유형                                             | [time](#time-type)                                      |
+| showAxis       | Boolean  | true                | 축 표시 여부                                           | true / false                                            |
+| startToZero    | Boolean  | false               | 축의 시작을 0 부터 시작할지의 여부                              | true / false                                            |
+| autoScaleRatio | Number   | null                | Axis의 Max Buffer를 위한 속성                           | 0.1 ~ 0.9                                               |
+| showGrid       | Boolean  | true                | 차트 내부 그리드 표시 여부                                   | true / false                                            |
+| axisLineWidth  | Number   | 1                   | 축의 선 굵기                                           | 1 ~                                                     |
+| axisLineColor  | String   | '#C9CFDC'           | 축의 색상                                             |                                                         |
+| gridLineColor  | String   | '#C9CFDC'           | 그리드의 색상                                           |                                                         |
+| interval       | String   | null                | 축에 표시되는 값의 간격 단위 (ex. 'day', 'hour', 'minute'...) |
+| labelStyle     | Object   | ([상세](#labelstyle)) | 라벨의 폰트 스타일을 설정                                    |                                                         |
+| plotLines      | Array    | ([상세](#plotline))   | plot line(임계선 표시 용도) 설정                           |                                                         |
+| plotBands      | Array    | ([상세](#plotband))   | plot band(임계영역 표시 용도) 설정                          |                                                         |
+| formatter      | function | null                | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용                   | (value, { prev, isDefaultMaxSameAsMin }) => value + '%' |
+| title          | Object   | ([상세](#title))      | 라벨의 폰트 스타일을 설정                                    |                                                         |
 
 ##### axesX
 

--- a/docs/views/lineChart/example/Default.vue
+++ b/docs/views/lineChart/example/Default.vue
@@ -21,11 +21,11 @@
     setup() {
       const chartData = reactive({
         series: {
-          series1: { name: 'series#1' },
-          series2: { name: 'series#2' },
-          series3: { name: 'series#3' },
-          series4: { name: 'series#4' },
-          series5: { name: 'series#5' },
+          series1: { name: 'series#1', point: false },
+          series2: { name: 'series#2', point: false },
+          series3: { name: 'series#3', point: false },
+          series4: { name: 'series#4', point: false },
+          series5: { name: 'series#5', point: false },
         },
         labels: [],
         data: {
@@ -54,8 +54,21 @@
         },
         axesX: [{
           type: 'time',
-          timeFormat: 'HH:mm:ss',
-          interval: 'second',
+          timeFormat: 'DD HH:mm',
+          interval: 'hour',
+          formatter: (value, data) => {
+            if (data?.prev) {
+              const curr = dayjs(value).format('yy-MM-DD');
+              const prev = dayjs(data?.prev).format('yy-MM-DD');
+              if (curr === prev) {
+                return dayjs(value)
+                    .format('HH:mm');
+              }
+            }
+
+            return dayjs(value)
+                .format('DD HH:mm');
+          },
         }],
         axesY: [{
           type: 'linear',
@@ -74,7 +87,7 @@
           chartData.labels.shift();
         }
 
-        timeValue = dayjs(timeValue).add(1, 'second');
+        timeValue = dayjs(timeValue).add(1, 'hour');
         chartData.labels.push(dayjs(timeValue));
 
         Object.values(chartData.data).forEach((seriesData) => {

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -86,7 +86,7 @@ const chartData =
   | labelStyle | Object | ([상세](#labelstyle)) | 라벨의 폰트 스타일을 설정 | |
   | plotLines | Array | ([상세](#plotline)) | plot line(임계선 표시 용도) 설정 | |
   | plotBands | Array | ([상세](#plotband)) | plot band(임계영역 표시 용도) 설정 | |
-  | formatter | function | null | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용   | (value) => value + '%' |
+  | formatter      | function | null                | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용                   | (value, { prev, isDefaultMaxSameAsMin }) => value + '%' |
   | title | Object | ([상세](#title)) | 라벨의 폰트 스타일을 설정 | |  
 
 ##### axesX

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -355,7 +355,6 @@ class Scale {
               && options?.selectItem?.showLabelTip
               && hitInfo?.label
               && !this.options?.horizontal) {
-              debugger;
               const selectedLabel = this.getLabelFormat(
                 Math.min(axisMax, hitInfo.label + (0 * stepValue)),
               );

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -100,7 +100,9 @@ class Scale {
     }
 
     const minLabel = this.getLabelFormat(minValue);
-    const maxLabel = this.getLabelFormat(maxValue, isDefaultMaxSameAsMin);
+    const maxLabel = this.getLabelFormat(maxValue, {
+      isMaxValueSameAsMin: isDefaultMaxSameAsMin,
+    });
 
     return {
       min: minValue,
@@ -319,14 +321,18 @@ class Scale {
           ticks[ix] = axisMinForLabel + (ix * stepValue);
 
           linePosition = labelCenter + aliasPixel;
-          labelText = this.getLabelFormat(Math.min(axisMax, ticks[ix]));
+          labelText = this.getLabelFormat(Math.min(axisMax, ticks[ix]), {
+            prev: ticks[ix - 1] ?? '',
+          });
 
           const isBlurredLabel = this.options?.selectLabel?.use
             && this.options?.selectLabel?.useLabelOpacity
             && (this.options.horizontal === (this.type === 'y'))
             && selectLabelInfo?.dataIndex?.length
             && !selectLabelInfo?.label
-              .map(t => this.getLabelFormat(Math.min(axisMax, t))).includes(labelText);
+              .map((t, index) => this.getLabelFormat(Math.min(axisMax, t), {
+                prev: selectLabelInfo?.label[index - 1] ?? '',
+              })).includes(labelText);
 
           const labelColor = this.labelStyle.color;
           let defaultOpacity = 1;
@@ -349,6 +355,7 @@ class Scale {
               && options?.selectItem?.showLabelTip
               && hitInfo?.label
               && !this.options?.horizontal) {
+              debugger;
               const selectedLabel = this.getLabelFormat(
                 Math.min(axisMax, hitInfo.label + (0 * stepValue)),
               );

--- a/src/components/chart/scale/scale.linear.js
+++ b/src/components/chart/scale/scale.linear.js
@@ -5,13 +5,13 @@ class LinearScale extends Scale {
   /**
    * Transforming label by designated format
    * @param {number} value                   label value
-   * @param {boolean} isMaxValueSameAsMin    is default max value same as min value
+   * @param {object} data                   data for formatting
    *
    * @returns {string} formatted label
    */
-  getLabelFormat(value, isMaxValueSameAsMin) {
+  getLabelFormat(value, data = {}) {
     if (this.formatter) {
-      const formattedLabel = this.formatter(value, isMaxValueSameAsMin);
+      const formattedLabel = this.formatter(value, data);
 
       if (typeof formattedLabel === 'string') {
         return formattedLabel;

--- a/src/components/chart/scale/scale.logarithmic.js
+++ b/src/components/chart/scale/scale.logarithmic.js
@@ -33,7 +33,9 @@ class LogarithmicScale extends Scale {
     }
 
     const minLabel = this.getLabelFormat(minValue);
-    const maxLabel = this.getLabelFormat(maxValue, isDefaultMaxSameAsMin);
+    const maxLabel = this.getLabelFormat(maxValue, {
+      isMaxValueSameAsMin: isDefaultMaxSameAsMin,
+    });
 
     return {
       min: minValue,
@@ -99,13 +101,13 @@ class LogarithmicScale extends Scale {
   /**
    * Transforming label by designated format
    * @param {number} value                   label value
-   * @param {boolean} isMaxValueSameAsMin    is default max value same as min value
+   * @param {object} data                    data for formatting
    *
    * @returns {string} formatted label
    */
-  getLabelFormat(value, isMaxValueSameAsMin) {
+  getLabelFormat(value, data = {}) {
     if (this.formatter) {
-      const formattedLabel = this.formatter(value, isMaxValueSameAsMin);
+      const formattedLabel = this.formatter(value, data);
 
       if (typeof formattedLabel === 'string') {
         return formattedLabel;

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -347,12 +347,13 @@ class StepScale extends Scale {
    * Transforming label by designated format
    * @param {string} value       label value
    * @param {number} maxWidth    max width for each label
+   * @param {object} data        data for formatting
    *
    * @returns {string} formatted label
    */
-  getLabelFormat(value, maxWidth) {
+  getLabelFormat(value, maxWidth, data = {}) {
     if (this.formatter) {
-      const formattedLabel = this.formatter(value);
+      const formattedLabel = this.formatter(value, data);
 
       if (typeof formattedLabel === 'string') {
         return formattedLabel;

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -13,13 +13,13 @@ class TimeCategoryScale extends Scale {
   /**
    * Transforming label by designated format
    * @param {number} value                   label value
-   * @param {boolean} isMaxValueSameAsMin    is default max value same as min value
+   * @param {object} data                    data for formatting
    *
    * @returns {string} formatted label
    */
-  getLabelFormat(value, isMaxValueSameAsMin) {
+  getLabelFormat(value, data = {}) {
     if (this.formatter) {
-      const formattedLabel = this.formatter(value, isMaxValueSameAsMin);
+      const formattedLabel = this.formatter(value, data);
 
       if (typeof formattedLabel === 'string') {
         return formattedLabel;
@@ -187,14 +187,24 @@ class TimeCategoryScale extends Scale {
 
       labelCenter = Math.round(startPoint + (graphGap * ix));
       linePosition = labelCenter + aliasPixel;
-      labelText = this.getLabelFormat(Math.min(axisMax, ticks[ix]));
+
+      let prev;
+      for (let jx = 0; jx < ticks.length; jx++) {
+        if (ticks[jx] !== undefined && jx !== ix) {
+          prev = ticks[jx];
+        }
+      }
+
+      labelText = this.getLabelFormat(Math.min(axisMax, ticks[ix]), { prev });
 
       const isBlurredLabel = this.options?.selectLabel?.use
         && this.options?.selectLabel?.useLabelOpacity
         && (this.options.horizontal === (this.type === 'y'))
         && selectLabelInfo?.dataIndex?.length
         && !selectLabelInfo?.label
-          .map(t => this.getLabelFormat(Math.min(axisMax, t))).includes(labelText);
+          .map((t, index) => this.getLabelFormat(Math.min(axisMax, t), {
+            prev: selectLabelInfo?.label[index - 1] ?? '',
+          })).includes(labelText);
 
       const labelColor = this.labelStyle.color;
       let defaultOpacity = 1;

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -6,13 +6,13 @@ class TimeScale extends Scale {
   /**
    * Transforming label by designated format
    * @param {number} value                   label value
-   * @param {boolean} isMaxValueSameAsMin    is default max value same as min value
+   * @param {object} data                    data for formatting
    *
    * @returns {string} formatted label
    */
-  getLabelFormat(value, isMaxValueSameAsMin) {
+  getLabelFormat(value, data = {}) {
     if (this.formatter) {
-      const formattedLabel = this.formatter(value, isMaxValueSameAsMin);
+      const formattedLabel = this.formatter(value, data);
 
       if (typeof formattedLabel === 'string') {
         return formattedLabel;


### PR DESCRIPTION
### 요구사항
- Time Axis 에서 직전 label과 비교연산을 추가하고 싶음 

### 작업 내용
- formatter에 data parameter 추가
   - 기존 isDefaultMaxSameAsMin 변수는 data안으로 이동시킴
   - data에 prev(직전 label)
- line, bar 차트에 예제 코드 추가
- md 에 관련 내용 업데이트

### 결과
- ![image](https://github.com/user-attachments/assets/4af908f0-6c18-45d1-95d4-b03769545459)
- ![image](https://github.com/user-attachments/assets/6209c67a-7ce5-4c9e-a940-fd52dbccad68)

