### PR TITLE
[#1767]Tree Grid > 컬럼 정렬 sort column emit event 추가

### DIFF
--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -664,6 +664,7 @@ export default {
       useGridSetting,
       columnSettingInfo,
       setColumnHidden,
+      onSort,
     });
 
     const setGridSetting = (e) => {

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -306,6 +306,7 @@ import {
   onMounted,
   onUnmounted,
 } from 'vue';
+import { cloneDeep } from 'lodash-es';
 import TreeGridNode from './TreeGridNode';
 import Toolbar from './TreeGridToolbar';
 import GridPagination from '../grid/GridPagination';
@@ -433,6 +434,7 @@ export default {
       viewStore: [],
       filterStore: [],
       pagingStore: [],
+      originStore: [],
       showTreeStore: computed(() => stores.treeStore.filter(item => item.show)),
       searchStore: computed(() => stores.treeStore.filter(item => item.isFilter)),
       store: computed(() => (filterInfo.isSearch ? stores.searchStore : stores.treeStore)),
@@ -625,7 +627,9 @@ export default {
       handleExpand,
     } = treeEvent({ stores, onResize });
 
-    const { onSort } = sortEvent({ sortInfo, stores, updatePagingInfo });
+    const {
+        onSort,
+    } = sortEvent({ sortInfo, stores, updatePagingInfo, setTreeNodeStore, onResize });
 
     const {
       onSearch,
@@ -692,6 +696,7 @@ export default {
 
     onMounted(() => {
       stores.treeStore = setTreeNodeStore();
+      stores.originStore = cloneDeep(stores.treeStore);
       document.addEventListener('wheel', onMouseWheel, { capture: false });
       document.addEventListener('scroll', onMouseWheel, { capture: true });
     });

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -387,6 +387,7 @@ export default {
     'check-row': null,
     'check-all': null,
     'page-change': null,
+    'sort-column': null,
     'resize-column': ({ column, columns }) => ({ column, columns }),
     'change-column-status': ({ columns }) => ({ columns }),
     'change-column-info': ({ type, columns }) => ({ type, columns }),

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -88,26 +88,26 @@
                   @click.prevent="columnMenu.show"
                 >
                   {{ column.caption }}
-                    <!-- Sort Icon -->
+                <!-- Sort Icon -->
                 <span @click.stop="onSort(column)">
                   <template v-if="!!$slots.sortIcon">
                     <span
-                        v-if="column.sortable === undefined ? true : column.sortable"
-                        class="column-sort__icon column-sort__icon--basic"
-                        :style="{
-                            height: `${rowHeight}px`,
-                            'line-height': `${rowHeight}px`,
-                            }"
+                      v-if="column.sortable === undefined ? true : column.sortable"
+                      class="column-sort__icon column-sort__icon--basic"
+                      :style="{
+                        height: `${rowHeight}px`,
+                        'line-height': `${rowHeight}px`,
+                      }"
                     >
-                        <slot name="sortIcon" />
+                     <slot name="sortIcon" />
                     </span>
                     <span
                       v-if="isSortedColumn(column)"
                       :class="sortIconClass(column)"
                       :style="{
-                          height: `${rowHeight}px`,
-                          'line-height': `${rowHeight}px`,
-                          }"
+                        height: `${rowHeight}px`,
+                        'line-height': `${rowHeight}px`,
+                      }"
                     >
                       <slot :name="`sortIcon_${sortOrder}`" />
                     </span>
@@ -115,11 +115,11 @@
                   <template v-else>
                     <grid-sort-button
                       v-if="column.sortable === undefined ? true : column.sortable"
-                      lass="column-sort__icon column-sort__icon--basic"
+                      class="column-sort__icon column-sort__icon--basic"
                       :icon="'basic'"
                       :style="{
-                          height: `${rowHeight}px`,
-                          'line-height': `${rowHeight}px`,
+                        height: `${rowHeight}px`,
+                        'line-height': `${rowHeight}px`,
                       }"
                     />
                     <grid-sort-button
@@ -127,9 +127,9 @@
                       :class="sortIconClass(column)"
                       :icon="sortOrder"
                       :style="{
-                          height: `${rowHeight}px`,
-                          'line-height': `${rowHeight}px`,
-                          visibility: !!sortOrder ? column.hidden : true,
+                        height: `${rowHeight}px`,
+                        'line-height': `${rowHeight}px`,
+                        visibility: !!sortOrder ? column.hidden : true,
                       }"
                     />
                   </template>

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -92,44 +92,44 @@
                 <span @click.stop="onSort(column)">
                   <template v-if="!!$slots.sortIcon">
                     <span
-                            v-if="column.sortable === undefined ? true : column.sortable"
-                            class="column-sort__icon column-sort__icon--basic"
-                            :style="{
-                        height: `${rowHeight}px`,
-                        'line-height': `${rowHeight}px`,
-                      }"
+                        v-if="column.sortable === undefined ? true : column.sortable"
+                        class="column-sort__icon column-sort__icon--basic"
+                        :style="{
+                            height: `${rowHeight}px`,
+                            'line-height': `${rowHeight}px`,
+                            }"
                     >
-                      <slot name="sortIcon" />
+                        <slot name="sortIcon" />
                     </span>
                     <span
-                            v-if="isSortedColumn(column)"
-                            :class="sortIconClass(column)"
-                            :style="{
-                        height: `${rowHeight}px`,
-                        'line-height': `${rowHeight}px`,
-                      }"
+                      v-if="isSortedColumn(column)"
+                      :class="sortIconClass(column)"
+                      :style="{
+                          height: `${rowHeight}px`,
+                          'line-height': `${rowHeight}px`,
+                          }"
                     >
                       <slot :name="`sortIcon_${sortOrder}`" />
                     </span>
                   </template>
                   <template v-else>
                     <grid-sort-button
-                            v-if="column.sortable === undefined ? true : column.sortable"
-                            class="column-sort__icon column-sort__icon--basic"
-                            :icon="'basic'"
-                            :style="{
-                        height: `${rowHeight}px`,
-                        'line-height': `${rowHeight}px`,
+                      v-if="column.sortable === undefined ? true : column.sortable"
+                      lass="column-sort__icon column-sort__icon--basic"
+                      :icon="'basic'"
+                      :style="{
+                          height: `${rowHeight}px`,
+                          'line-height': `${rowHeight}px`,
                       }"
                     />
                     <grid-sort-button
-                            v-if="isSortedColumn(column)"
-                            :class="sortIconClass(column)"
-                            :icon="sortOrder"
-                            :style="{
-                        height: `${rowHeight}px`,
-                        'line-height': `${rowHeight}px`,
-                        visibility: !!sortOrder ? column.hidden : true,
+                      v-if="isSortedColumn(column)"
+                      :class="sortIconClass(column)"
+                      :icon="sortOrder"
+                      :style="{
+                          height: `${rowHeight}px`,
+                          'line-height': `${rowHeight}px`,
+                          visibility: !!sortOrder ? column.hidden : true,
                       }"
                     />
                   </template>
@@ -177,7 +177,7 @@
           <tbody>
             <tree-grid-node
               v-for="(node, idx) in viewStore"
-              :key="node['id'] || idx"
+              :key="idx"
               :selected-data="selectedRow"
               :node-data="node"
               :use-checkbox="useCheckbox"

--- a/src/components/treeGrid/style/treeGrid.scss
+++ b/src/components/treeGrid/style/treeGrid.scss
@@ -79,6 +79,26 @@
       align-items: center;
     }
   }
+  .column-sort__icon {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    width: 24px;
+    height: 24px;
+    background-size: contain;
+    transform: translateY(-50%);
+    &:hover {
+      cursor: pointer;
+    }
+    &--basic {
+      visibility: hidden;
+    }
+  }
+  :hover {
+    .column-sort__icon--basic {
+      visibility: visible;
+    }
+  }
 }
 
 .column-name {

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -1042,6 +1042,45 @@ export const sortEvent = ({ sortInfo, stores, updatePagingInfo }) => {
     }
   };
 
+  const compareValues = (nodeA, nodeB) => {
+    const valueA = nodeA.data[sortInfo.sortField];
+    const valueB = nodeB.data[sortInfo.sortField];
+
+    if (valueA === valueB) return 0;
+
+    const isAscending = sortInfo.sortOrder === 'asc';
+
+    if (isAscending) return valueA > valueB ? 1 : -1;
+
+    return valueA < valueB ? 1 : -1;
+  };
+
+  const sortTree = (nodes, depth = 0) => {
+    const groupedNodes = {};
+
+    nodes.forEach((node) => {
+      const nodeDepth = node.level || depth;
+      if (!groupedNodes[nodeDepth]) {
+        groupedNodes[nodeDepth] = [];
+      }
+      groupedNodes[nodeDepth].push(node);
+    });
+
+    Object.keys(groupedNodes).forEach((key) => {
+      groupedNodes[key].sort(compareValues);
+    });
+
+    nodes.length = 0;
+    Object.values(groupedNodes).forEach((group) => {
+      group.forEach((node) => {
+        nodes.push(node);
+        if (node.hasChild) {
+          sortTree(node.children, node.level + 1);
+        }
+      });
+    });
+  };
+
   const onSort = (column, sortOrder) => {
     const sortable = column.sortable === undefined ? true : column.sortable;
     if (sortable) {
@@ -1079,48 +1118,9 @@ export const sortEvent = ({ sortInfo, stores, updatePagingInfo }) => {
         columns: updatedColumInfo,
       });
 
-      const sortTree = (nodes, depth = 0) => {
-        const groupedNodes = {};
-
-        nodes.forEach((node) => {
-          const nodeDepth = node.level || depth;
-          if (!groupedNodes[nodeDepth]) {
-            groupedNodes[nodeDepth] = [];
-          }
-          groupedNodes[nodeDepth].push(node);
-        });
-
-        Object.keys(groupedNodes).forEach((key) => {
-          groupedNodes[key].sort(compareValues);
-        });
-
-        nodes.length = 0;
-        Object.values(groupedNodes).forEach((group) => {
-          group.forEach((node) => {
-            nodes.push(node);
-            if (node.hasChild) {
-              sortTree(node.children, node.level + 1);
-            }
-          });
-        });
-      };
       sortTree(stores.treeRows);
       stores.treeStore = stores.treeRows;
     }
   };
-
-  const compareValues = (nodeA, nodeB) => {
-    const valueA = nodeA.data[sortInfo.sortField];
-    const valueB = nodeB.data[sortInfo.sortField];
-
-    if (valueA === valueB) return 0;
-
-    const isAscending = sortInfo.sortOrder === 'asc';
-
-    if (isAscending) return valueA > valueB ? 1 : -1;
-
-    return valueA < valueB ? 1 : -1;
-  };
-
   return { onSort, setSortInfo };
 };

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -635,7 +635,7 @@ export const contextMenuEvent = (params) => {
     contextInfo.contextMenuItems = menuItems;
   };
   const onColumnContextMenu = (event, column) => {
-    if (event.target.className.includes('column-name--click')) {
+    if (event.target.className.includes('column-name')) {
       const sortable = column.sortable === undefined ? true : column.sortable;
       contextInfo.columnMenuItems = [
         {
@@ -993,8 +993,7 @@ export const pagingEvent = (params) => {
   return { getPagingData, updatePagingInfo, changePage };
 };
 
-export const sortEvent = (params) => {
-  const { sortInfo, stores, updatePagingInfo } = params;
+export const sortEvent = ({ sortInfo, stores, updatePagingInfo }) => {
   const { emit } = getCurrentInstance();
 
   const getDefaultSortType = (includeInit = true) => (includeInit ? ['asc', 'desc', 'init'] : ['asc', 'desc']);
@@ -1080,20 +1079,6 @@ export const sortEvent = (params) => {
         columns: updatedColumInfo,
       });
 
-      const compareValues = (nodeA, nodeB) => {
-        const valueA = nodeA.data[sortInfo.sortField];
-        const valueB = nodeB.data[sortInfo.sortField];
-
-        if (valueA === valueB) return 0;
-
-        const isAscending = sortInfo.sortOrder === 'asc';
-
-        if (isAscending) return valueA > valueB ? 1 : -1;
-
-        return valueA < valueB ? 1 : -1;
-      };
-
-
       const sortTree = (nodes, depth = 0) => {
         const groupedNodes = {};
 
@@ -1122,6 +1107,19 @@ export const sortEvent = (params) => {
       sortTree(stores.treeRows);
       stores.treeStore = stores.treeRows;
     }
+  };
+
+  const compareValues = (nodeA, nodeB) => {
+    const valueA = nodeA.data[sortInfo.sortField];
+    const valueB = nodeB.data[sortInfo.sortField];
+
+    if (valueA === valueB) return 0;
+
+    const isAscending = sortInfo.sortOrder === 'asc';
+
+    if (isAscending) return valueA > valueB ? 1 : -1;
+
+    return valueA < valueB ? 1 : -1;
   };
 
   return { onSort, setSortInfo };


### PR DESCRIPTION
## 작업 배경
Tree Grid에 칼럼 정렬 event가 없음
![image](https://github.com/user-attachments/assets/74974208-178e-4f71-a916-2377c3b5758b)

## 변경 사항 요약
- sort column 이벤트 추가
- sort button 추가

## 기대 동작
![image](https://github.com/user-attachments/assets/aac474f4-ed72-42fb-ac63-d38842fb04bc)

## 테스트 가이드
- 동일한 뎁스별로 칼럼 정렬이 잘 되는지 확인해주세요.
- sort type에 따라 sort button이 함께 보이는지 확인해주세요.
- sort button으로 칼럼 정렬이 잘 되는지 확인해주세요.

