### PR TITLE
[#1766] Chart > HeatMap > Drag 이후 label 클릭 시 Drag Select 해제 bug fix

### DIFF
--- a/docs/views/heatMap/example/Event.vue
+++ b/docs/views/heatMap/example/Event.vue
@@ -144,6 +144,7 @@ import { onMounted, reactive, ref, watch } from 'vue';
       const selectionRange = ref({});
       const clickedSelectLabel = ref({
         dataIndex: [],
+        targetAxis: 'xAxis',
       });
 
       const onDragSelect = ({ data, range }) => {

--- a/docs/views/heatMap/example/Event.vue
+++ b/docs/views/heatMap/example/Event.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="case">
     <ev-chart
+      v-model:selectedLabel="clickedSelectLabel"
       :data="chartData"
       :options="chartOptions"
       @drag-select="onDragSelect"
@@ -8,6 +9,15 @@
       @dbl-click="onDblClick"
     />
     <div class="description">
+      <div class="one-row">
+        <p class="badge yellow">label 클릭 여부</p>
+        <ev-toggle
+          v-model="useSelectLabel"
+        />
+        <div v-if="useSelectLabel">
+          {{ clickedSelectLabel }}
+        </div>
+      </div>
       <div class="one-row">
         <p class="badge yellow">
           선택 영역 내 데이터
@@ -60,11 +70,13 @@
 </div></template>
 
 <script>
-import { onMounted, reactive, ref } from 'vue';
+import { onMounted, reactive, ref, watch } from 'vue';
   import dayjs from 'dayjs';
 
   export default {
     setup() {
+      const useSelectLabel = ref(false);
+
       const chartData = reactive({
         series: {
           series1: {
@@ -81,7 +93,7 @@ import { onMounted, reactive, ref } from 'vue';
       });
 
 
-      const chartOptions = {
+      const chartOptions = reactive({
         type: 'heatMap',
         width: '100%',
         title: {
@@ -109,6 +121,11 @@ import { onMounted, reactive, ref } from 'vue';
         selectItem: {
           use: true,
         },
+        selectLabel: {
+          use: true,
+          useClick: useSelectLabel.value,
+          useApproximateValue: true,
+        },
         heatMapColor: {
           min: '#A1CDF9',
           max: '#336fe9',
@@ -121,10 +138,13 @@ import { onMounted, reactive, ref } from 'vue';
         tooltip: {
           use: true,
         },
-      };
+      });
 
       const selectionItems = ref([]);
       const selectionRange = ref({});
+      const clickedSelectLabel = ref({
+        dataIndex: [],
+      });
 
       const onDragSelect = ({ data, range }) => {
         selectionItems.value = data;
@@ -162,6 +182,7 @@ import { onMounted, reactive, ref } from 'vue';
           if (randomValue > 4500) {
             randomValue = -1;
           }
+
           const item = {
             x: timeValue,
             y: yValue,
@@ -186,11 +207,18 @@ import { onMounted, reactive, ref } from 'vue';
         }
       });
 
+      watch(useSelectLabel, (newValue) => {
+        clickedSelectLabel.value.dataIndex = [];
+        chartOptions.selectLabel.useClick = newValue;
+      });
+
       return {
+        useSelectLabel,
         chartData,
         chartOptions,
         selectionItems,
         selectionRange,
+        clickedSelectLabel,
         dblClickedInfo,
         clickedInfo,
         onDragSelect,

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -2,6 +2,7 @@ import { numberWithComma } from '@/common/utils';
 import throttle from '@/common/utils.throttle';
 import { cloneDeep, defaultsDeep, inRange, isEqual } from 'lodash-es';
 import dayjs from 'dayjs';
+import { target } from 'vue-router/dist/vue-router.cjs.prod';
 
 const modules = {
   /**
@@ -346,10 +347,19 @@ const modules = {
 
       const useSelectLabel = selectLabelOpt?.use && selectLabelOpt?.useClick;
       const useKeepDisplay = dragSelectionOpt?.keepDisplay;
+      const useBothAxis = selectLabelOpt?.useBothAxis;
 
       if (location === 'xAxis' || location === 'yAxis') {
         if (useSelectLabel) {
-          this.removeSelectionArea();
+          if (useBothAxis) {
+            this.removeSelectionArea();
+          } else {
+            const { targetAxis } = this.defaultSelectInfo;
+
+            if (targetAxis) {
+              this.removeSelectionArea();
+            }
+          }
         }
       } else if (useKeepDisplay) {
         if (location !== 'canvas') {
@@ -474,22 +484,14 @@ const modules = {
       }
 
       if (type === 'heatMap') {
-        const { selectLabel: selectLabelOpt, dragSelection: dragSelectionOpt } = this.options;
-        const { targetAxis } = this.defaultSelectInfo;
-
         const offset = this.getMousePosition(e);
         const location = this.getCurMouseLocation(offset);
 
-        const useSelectLabel = selectLabelOpt?.use && selectLabelOpt?.useClick;
-        const useKeepDisplay = dragSelectionOpt?.keepDisplay;
-
-        if (useKeepDisplay && location === 'canvas') {
+        if (location !== 'chartBackground') {
           return;
         }
 
-        if (!useSelectLabel && (location === 'xAxis' || location === 'yAxis')) {
-          return;
-        }
+        const { targetAxis } = this.defaultSelectInfo;
 
         if (targetAxis) {
           this.clearSelectedLabelInfo();

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -247,13 +247,29 @@ const modules = {
               this.clearSelectedItemInfo();
               args.deselected = { eventTarget: 'item' };
 
-              if (!useBothAxis) {
-                const selectLabelAxis = isHorizontal ? 'yAxis' : 'xAxis';
-                if (location !== selectLabelAxis) {
-                  return;
+              if (useSelectLabel) {
+                if ((location === 'yAxis' || location === 'xAxis') && !useBothAxis) {
+                  const selectLabelAxis = isHorizontal ? 'yAxis' : 'xAxis';
+                  if (location !== selectLabelAxis) {
+                    return;
+                  }
                 }
+
+                this.removeSelectionArea();
+
+                if (location !== 'canvas') {
+                  setSelectedLabelInfo(location);
+                }
+              } else {
+                if (!useBothAxis) {
+                  const selectLabelAxis = isHorizontal ? 'yAxis' : 'xAxis';
+                  if (location !== selectLabelAxis) {
+                    return;
+                  }
+                }
+
+                setSelectedLabelInfo(location);
               }
-              setSelectedLabelInfo(location);
             }
           } else if (useSelectItem) {
             setSelectedItemInfo();

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -475,6 +475,7 @@ const modules = {
 
       if (type === 'heatMap') {
         const { selectLabel: selectLabelOpt, dragSelection: dragSelectionOpt } = this.options;
+        const { targetAxis } = this.defaultSelectInfo;
 
         const offset = this.getMousePosition(e);
         const location = this.getCurMouseLocation(offset);
@@ -488,6 +489,11 @@ const modules = {
 
         if (!useSelectLabel && (location === 'xAxis' || location === 'yAxis')) {
           return;
+        }
+
+        if (targetAxis) {
+          this.clearSelectedLabelInfo();
+          this.render();
         }
 
         const rangeInfo = { xcp, xep, ycp, yep, range: aRange };

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -338,11 +338,40 @@ const modules = {
      *
      * @returns {undefined}
      */
+    this.onMouseDownHeatMap = (e) => {
+      const { selectLabel: selectLabelOpt, dragSelection: dragSelectionOpt } = this.options;
+
+      const offset = this.getMousePosition(e);
+      const location = this.getCurMouseLocation(offset);
+
+      const useSelectLabel = selectLabelOpt?.use && selectLabelOpt?.useClick;
+      const useKeepDisplay = dragSelectionOpt?.keepDisplay;
+
+      if (location === 'xAxis' || location === 'yAxis') {
+        if (useSelectLabel) {
+          this.removeSelectionArea();
+        }
+      } else if (useKeepDisplay) {
+        if (location !== 'canvas') {
+          this.removeSelectionArea();
+        }
+      } else {
+        this.removeSelectionArea();
+      }
+    };
+
     this.onMouseDown = (e) => {
       const { dragSelection, type } = this.options;
 
       if (dragSelection.use && (type === 'scatter' || type === 'line' || type === 'heatMap')) {
-        this.removeSelectionArea();
+        switch (type) {
+          case 'heatMap':
+            this.onMouseDownHeatMap(e);
+            break;
+          default:
+            this.removeSelectionArea();
+        }
+
         this.dragStart(e, type);
       }
     };
@@ -445,6 +474,22 @@ const modules = {
       }
 
       if (type === 'heatMap') {
+        const { selectLabel: selectLabelOpt, dragSelection: dragSelectionOpt } = this.options;
+
+        const offset = this.getMousePosition(e);
+        const location = this.getCurMouseLocation(offset);
+
+        const useSelectLabel = selectLabelOpt?.use && selectLabelOpt?.useClick;
+        const useKeepDisplay = dragSelectionOpt?.keepDisplay;
+
+        if (useKeepDisplay && location === 'canvas') {
+          return;
+        }
+
+        if (!useSelectLabel && (location === 'xAxis' || location === 'yAxis')) {
+          return;
+        }
+
         const rangeInfo = { xcp, xep, ycp, yep, range: aRange };
         const { xsp, ysp, width, height } = this.getDragInfoForHeatMap(rangeInfo);
         dragInfo.xsp = xsp;

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -2,7 +2,6 @@ import { numberWithComma } from '@/common/utils';
 import throttle from '@/common/utils.throttle';
 import { cloneDeep, defaultsDeep, inRange, isEqual } from 'lodash-es';
 import dayjs from 'dayjs';
-import { target } from 'vue-router/dist/vue-router.cjs.prod';
 
 const modules = {
   /**


### PR DESCRIPTION
##################################
# Chart > HeatMap label 클릭시 Drag Select 해제 현상 발생
## 작업 내역
- onMouseDown, onDragMove 이벤트에 type이 heatMap일 경우 분기처리
- location: 클릭한 영역 / drag selection: 드래그한 영역 / canvas: background, x축, y축이 아닌 영역

## 세부 사항
- location이 x축, y축일 경우 + label select가 가능한 경우 => drag selection 해제 
- location이 x축, y축일 경우 + label select가 불가한 경우 => drag selection 해제X 
- location이 canvas (background, x축, y축이 아닌 영역) + keepDisplay가 true인 경우 => drag selection 해제X 
- 그 외 => drag selection 해제

## 테스트
- heatMap > event에서 확인할 수 있도록 수정