### PR TITLE
[#1771]Chart > Tooltip > formatter 옵션 사용 시 Tooltip 무한 증가 현상 발생

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.63",
+  "version": "3.4.64",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -825,7 +825,10 @@ class EvChart {
     // Tooltip Update
     if (updateTooltipFormatter) {
       this.tooltipDOM.innerHTML = '';
-      this.createTooltipDOM();
+
+      if (!options.tooltip?.formatter?.html) {
+        this.setDefaultTooltipLayout();
+      }
     }
 
     this.chartRect = this.getChartRect();

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -32,9 +32,7 @@ const modules = {
     this.tooltipDOM.style.display = 'none';
 
     if (!this.options.tooltip?.formatter?.html) {
-      this.tooltipBodyDOM.appendChild(this.tooltipCanvas);
-      this.tooltipDOM.appendChild(this.tooltipHeaderDOM);
-      this.tooltipDOM.appendChild(this.tooltipBodyDOM);
+      this.setDefaultTooltipLayout();
     }
 
     document.body.appendChild(this.tooltipDOM);
@@ -48,6 +46,12 @@ const modules = {
         this.tooltipDOM.style.display = 'none';
       };
     }
+  },
+
+  setDefaultTooltipLayout() {
+    this.tooltipBodyDOM.appendChild(this.tooltipCanvas);
+    this.tooltipDOM.appendChild(this.tooltipHeaderDOM);
+    this.tooltipDOM.appendChild(this.tooltipBodyDOM);
   },
 
   /**

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -355,7 +355,6 @@ class Scale {
               && options?.selectItem?.showLabelTip
               && hitInfo?.label
               && !this.options?.horizontal) {
-              debugger;
               const selectedLabel = this.getLabelFormat(
                 Math.min(axisMax, hitInfo.label + (0 * stepValue)),
               );

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -355,6 +355,7 @@ class Scale {
               && options?.selectItem?.showLabelTip
               && hitInfo?.label
               && !this.options?.horizontal) {
+              debugger;
               const selectedLabel = this.getLabelFormat(
                 Math.min(axisMax, hitInfo.label + (0 * stepValue)),
               );


### PR DESCRIPTION
## 이슈 내용 
- tooltip > Formatter옵션을 동적으로 변경할 때 마다 Tooltip DOM이 새로 추가되는 현상 발생 
- ![evui_1771_before](https://github.com/user-attachments/assets/980fa5d2-e5b6-4e6f-886b-9c84372a5094)


## 처리 내용 
- createTooltipDOM 호출 로직 삭제
- html formatter에서 일반 Tooltip으로 변경할 경우 일반 Tooltip을 구성하는 dom을 append하는 로직 추가

- ![evui_1771_after](https://github.com/user-attachments/assets/41c16c41-b53c-4fb1-83ee-5d954e996cae)

