### PR TITLE
[#1776] Grid, TreeGrid > 커스텀 헤더

### DIFF
--- a/docs/views/grid/api/grid.md
+++ b/docs/views/grid/api/grid.md
@@ -111,6 +111,7 @@
 | summaryDecimal | Number | Summary 계산 타입 중 'sum', 'average'를 선택한 경우 소수점 표현 자리수 | ex) 0~20 (디폴트: 3 ) | N |
 | summaryRenderer | String | Summary 에 표시할 텍스트 또는 계산 값 | ex) 'Sum: {0}' | N |
 | summaryData | Array | Summary 할 대상 추가 시 summaryRenderer 와 함께 사용 | ex) '{0}({1}%)' | N |
+| customHeader | Boolean | 커스텀 헤더 사용 여부 | Boolean | N |
 
 ### Event
 | 이름 | 파라미터                        | 설명                                                                  |

--- a/docs/views/grid/example/CustomHeader.vue
+++ b/docs/views/grid/example/CustomHeader.vue
@@ -1,0 +1,155 @@
+<template>
+  <div class="case">
+    <ev-grid
+      :columns="columns"
+      :rows="tableData"
+      :height="400"
+      :option="{
+        adjust: true,
+      }"
+    >
+      <template #customHeader>
+        <div class="grid-custom-header">
+          <div
+            v-for="item in customHeaderData"
+            :key="item.type"
+            :style="{
+              left: `${item.fromTime / totalRenderSec * 100}%`,
+              width: `${(item.toTime - item.fromTime) / totalRenderSec * 100}%`,
+              backgroundColor: item.color
+            }"
+            :class="`grid-custom-header__content grid-custom-header__content--${item.type}`"
+          />
+        </div>
+      </template>
+      <template #customCell="{ item }">
+        <div class="grid-custom-cell">
+          <div
+            class="grid-custom-cell__content"
+            :style="{
+              width: `${(item.row[2][3].toTime - item.row[2][3].fromTime) / totalRenderSec * 100}%`,
+              left: `${item.row[2][3].fromTime / totalRenderSec * 100}%`,
+            }"
+          />
+        </div>
+      </template>
+    </ev-grid>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const tableData = ref([]);
+    const columns = ref([
+      { caption: 'Name', field: 'userName', type: 'string', width: 80, fixed: true },
+      { caption: 'number', field: 'number', type: 'number', width: 80 },
+      { caption: 'boolean', field: 'boolean', type: 'boolean', width: 80 },
+      { caption: '', field: 'customCell', type: 'string', width: 300, customHeader: true },
+    ]);
+    const totalRenderSec = 5000;
+    const customHeaderData = [
+      {
+        type: 'attr1',
+        color: '#00BEB8',
+        fromTime: 0,
+        toTime: 894,
+      },
+      {
+        type: 'attr2',
+        color: '#C02CD3',
+        fromTime: 895,
+        toTime: 1031,
+      },
+      {
+        type: 'attr3',
+        color: '#0273D7',
+        fromTime: 1032,
+        toTime: 1246,
+      },
+      {
+        type: 'attr4',
+        color: '#6DD790',
+        fromTime: 1247,
+        toTime: 1832,
+      },
+      {
+        type: 'attr5',
+        color: '#FFC032',
+        fromTime: 3703,
+        toTime: totalRenderSec,
+      },
+    ];
+    let initSec = 0;
+    const getData = (count, startIndex) => {
+      const temp = [];
+      const booleans = [true, false];
+      for (let ix = startIndex; ix < startIndex + count; ix++) {
+        const fromAccTime = !ix ? 0 : Math.floor(Math.random() * 200);
+        const fromTimeRange = initSec + fromAccTime;
+        let fromRenderTime;
+        if (fromTimeRange > totalRenderSec) {
+          fromRenderTime = totalRenderSec;
+          initSec = totalRenderSec;
+        } else {
+          initSec = fromTimeRange;
+          fromRenderTime = fromTimeRange;
+        }
+        const toAccTime = Math.floor(Math.random() * 4000);
+        const toTimeRange = fromRenderTime + toAccTime;
+        const toRenderTime = toTimeRange > totalRenderSec ? totalRenderSec : toTimeRange;
+        temp.push([
+          `user_${ix + 1}`,
+          ix,
+          booleans[ix % 2],
+          {
+            fromTime: fromRenderTime,
+            toTime: toRenderTime,
+          },
+        ]);
+      }
+      return temp;
+    };
+
+    tableData.value = getData(20, 0);
+
+    return {
+      columns,
+      tableData,
+      customHeaderData,
+      totalRenderSec,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.grid-custom-header {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background-color: #EEEEEE;
+  &__content {
+    position: absolute;
+    height: 100%;
+  }
+}
+:deep(.customCell) {
+  padding: 0;
+  & > div {
+    height: 100%;
+  }
+}
+.grid-custom-cell {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  &__content {
+    position: absolute;
+    height: 100%;
+    background-color: #087AED;
+  }
+}
+</style>

--- a/docs/views/grid/props.js
+++ b/docs/views/grid/props.js
@@ -18,6 +18,8 @@ import ColumnEvent from './example/ColumnEvent.vue';
 import ColumnEventRaw from '!!raw-loader!./example/ColumnEvent.vue';
 import Disabled from './example/Disabled.vue';
 import DisabledRaw from '!!raw-loader!./example/Disabled.vue';
+import CustomHeader from './example/CustomHeader.vue';
+import CustomHeaderRaw from '!!raw-loader!./example/CustomHeader.vue';
 
 export default {
   mdText,
@@ -58,6 +60,10 @@ export default {
     Disabled: {
       component: Disabled,
       parsedData: parseComponent(DisabledRaw),
+    },
+    'Custom Table Header': {
+      component: CustomHeader,
+      parsedData: parseComponent(CustomHeaderRaw),
     },
   },
 };

--- a/docs/views/treeGrid/api/treeGrid.md
+++ b/docs/views/treeGrid/api/treeGrid.md
@@ -114,6 +114,7 @@
 | summaryRenderer | String  | Summary 에 표시할 텍스트 또는 계산 값                          | ex) 'Sum: {0}'                                   | N |
 | summaryData     | Array   | Summary 할 대상 추가 시 summaryRenderer 와 함께 사용          | ex) '{0}({1}%)'                                  | N |
 | expandColumn    | Boolean | 트리그리드를 확장하는데 사용하는 컬럼을 의미, 설정하지 않으면 자동으로 첫번째 컬럼에 적용 | ex) 'expandColumn: true'                         | N |
+| customHeader    | Boolean | 커스텀 헤더 사용 여부 | Boolean                         | N |
 
 ### Event
 | 이름 | 파라미터 | 설명 |

--- a/docs/views/treeGrid/example/CustomHeader.vue
+++ b/docs/views/treeGrid/example/CustomHeader.vue
@@ -1,0 +1,277 @@
+<template>
+  <div class="case">
+    <ev-tree-grid
+      :columns="gridColumns"
+      :rows="tableData"
+      :height="400"
+      :option="{
+        adjust: true,
+      }"
+    >
+      <template #customHeader>
+        <div class="grid-custom-header">
+          <div
+            v-for="item in customHeaderData"
+            :key="item.type"
+            :style="{
+              left: `${item.fromTime / totalRenderSec * 100}%`,
+              width: `${(item.toTime - item.fromTime) / totalRenderSec * 100}%`,
+              backgroundColor: item.color
+            }"
+            :class="`grid-custom-header__content grid-custom-header__content--${item.type}`"
+          />
+        </div>
+      </template>
+      <template #customCell="{ item }">
+        <div class="grid-custom-cell">
+          <div
+            class="grid-custom-cell__content"
+            :style="{
+              width: `${(item.data.customCell.toTime - item.data.customCell.fromTime) / totalRenderSec * 100}%`,
+              left: `${item.data.customCell.fromTime / totalRenderSec * 100}%`,
+            }"
+          />
+        </div>
+      </template>
+    </ev-tree-grid>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const tableData = ref([]);
+    const totalRenderSec = 5000;
+    const customHeaderData = [
+      {
+        type: 'attr1',
+        color: '#00BEB8',
+        fromTime: 0,
+        toTime: 894,
+      },
+      {
+        type: 'attr2',
+        color: '#C02CD3',
+        fromTime: 895,
+        toTime: 1031,
+      },
+      {
+        type: 'attr3',
+        color: '#0273D7',
+        fromTime: 1032,
+        toTime: 1246,
+      },
+      {
+        type: 'attr4',
+        color: '#6DD790',
+        fromTime: 1247,
+        toTime: 1832,
+      },
+      {
+        type: 'attr5',
+        color: '#FFC032',
+        fromTime: 3703,
+        toTime: totalRenderSec,
+      },
+    ];
+    const getData = () => {
+      tableData.value = [
+        {
+          id: 'Exem 0',
+          date: '2016-05-01',
+          name: '1111',
+          customCell: {
+            fromTime: 0,
+            toTime: 125,
+          },
+          expand: true,
+        },
+        {
+          id: 'Exem 1',
+          date: '2016-05-01',
+          name: '2222',
+          value: 123,
+          customCell: {
+            fromTime: 13,
+            toTime: 2152,
+          },
+          expand: true,
+          children: [{
+            id: 'Exem 2',
+            date: '2016-05-02',
+            name: '2',
+            value: 222,
+            customCell: {
+              fromTime: 13,
+              toTime: 1879,
+            },
+            expand: false,
+            children: [{
+              id: 'Exem 3',
+              date: '2016-05-02',
+              name: '3',
+              value: 3333,
+              customCell: {
+                fromTime: 13,
+                toTime: 871,
+              },
+              uncheckable: true,
+            }, {
+              id: 'Exem 4',
+              date: '2016-05-02',
+              name: '4',
+              customCell: {
+                fromTime: 37,
+                toTime: 529,
+              },
+              expand: false,
+              uncheckable: true,
+              children: [{
+                id: 'Exem 5',
+                date: '2016-05-02',
+                name: '5',
+                customCell: {
+                  fromTime: 37,
+                  toTime: 476,
+                },
+                children: [{
+                  id: 'Exem 51',
+                  date: '2016-05-02',
+                  name: '1251',
+                  customCell: {
+                    fromTime: 37,
+                    toTime: 378,
+                  },
+                  children: [{
+                    id: 'Exem 52',
+                    date: '2016-05-02',
+                    name: '20000',
+                    customCell: {
+                      fromTime: 186,
+                      toTime: 476,
+                    },
+                  }],
+                }],
+              }, {
+                id: 'Exem 6',
+                date: '2016-05-02',
+                name: '6',
+                customCell: {
+                  fromTime: 317,
+                  toTime: 529,
+                },
+              }],
+            }],
+          }, {
+            id: 'Exem 7',
+            date: '2016-05-03',
+            name: '7',
+            customCell: {
+              fromTime: 487,
+              toTime: 3474,
+            },
+            children: [{
+              id: 'Exem 8',
+              date: '2016-05-03',
+              name: '8',
+              value: 333,
+              customCell: {
+                fromTime: 487,
+                toTime: 1951,
+              },
+            }, {
+              id: 'Exem 9',
+              date: '2016-05-03',
+              name: '9',
+              customCell: {
+                fromTime: 762,
+                toTime: 2145,
+              },
+            }, {
+              id: 'Exem 10',
+              date: '2016-05-03',
+              name: '10',
+              customCell: {
+                fromTime: 861,
+                toTime: 2368,
+              },
+            }],
+          }, {
+            id: 'Exem 11',
+            date: '2016-05-04',
+            name: '11',
+            customCell: {
+              fromTime: 2384,
+              toTime: 3474,
+            },
+          }],
+        },
+      ];
+    };
+    const gridColumns = ref([
+      { caption: 'ID', field: 'id', type: 'number' },
+      { caption: 'Date', field: 'date', type: 'string' },
+      {
+        caption: 'Name',
+        field: 'name',
+        type: 'float',
+        summaryType: 'sum',
+        summaryOnlyTopParent: true,
+        summaryRenderer: 'Sum: {0} 최상위 부모만 summary',
+        decimal: 1,
+      },
+      {
+        caption: 'Value',
+        field: 'value',
+        type: 'number',
+        summaryType: 'sum',
+        summaryRenderer: 'Sum: {0} 모든 row summary',
+        decimal: 1,
+      },
+      { caption: 't', field: 'customCell', type: 'string', width: 300, customHeader: true },
+    ]);
+
+    getData();
+    return {
+      gridColumns,
+      tableData,
+      customHeaderData,
+      totalRenderSec,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.grid-custom-header {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background-color: #EEEEEE;
+  &__content {
+    position: absolute;
+    height: 100%;
+  }
+}
+:deep(.customCell) {
+  padding: 0 !important;
+  & > div {
+    height: 100%;
+  }
+  .td-content {
+    height: 100%;
+  }
+}
+.grid-custom-cell {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  &__content {
+    position: absolute;
+    height: 100%;
+    background-color: #087AED;
+  }
+}
+</style>

--- a/docs/views/treeGrid/example/CustomHeader.vue
+++ b/docs/views/treeGrid/example/CustomHeader.vue
@@ -230,7 +230,7 @@ export default {
         summaryRenderer: 'Sum: {0} 모든 row summary',
         decimal: 1,
       },
-      { caption: 't', field: 'customCell', type: 'string', width: 300, customHeader: true },
+      { caption: '', field: 'customCell', type: 'string', width: 300, customHeader: true },
     ]);
 
     getData();

--- a/docs/views/treeGrid/props.js
+++ b/docs/views/treeGrid/props.js
@@ -10,6 +10,8 @@ import ColumnEvent from './example/ColumnEvent.vue';
 import ColumnEventRaw from '!!raw-loader!./example/ColumnEvent.vue';
 import ColumnSetting from './example/ColumnSetting.vue';
 import ColumnSettingRaw from '!!raw-loader!./example/ColumnSetting.vue';
+import CustomHeader from './example/CustomHeader.vue';
+import CustomHeaderRaw from '!!raw-loader!./example/CustomHeader.vue';
 
 export default {
   mdText,
@@ -34,6 +36,10 @@ export default {
     'Custom Column List': {
       component: ColumnSetting,
       parsedData: parseComponent(ColumnSettingRaw),
+    },
+    'Custom Table Header': {
+      component: CustomHeader,
+      parsedData: parseComponent(CustomHeaderRaw),
     },
   },
 };

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -248,69 +248,75 @@
               @dragover="onDragOver"
               @drop="onDrop"
             >
-              <!-- Column Name -->
-              <span
-                :title="column.caption"
-                class="column-name"
-                @click="onColumnContextMenu($event, column)"
-                @click.prevent="columnMenu.show"
-              >
-                {{ column.caption }}
-                <!-- Sort Icon -->
-                <span @click.stop="onSort(column)">
-                  <template v-if="!!$slots.sortIcon">
-                    <span
-                      v-if="column.sortable === undefined ? true : column.sortable"
-                      class="column-sort__icon column-sort__icon--basic"
-                      :style="{
-                        height: `${rowHeight}px`,
-                        'line-height': `${rowHeight}px`,
-                      }"
-                    >
-                      <slot name="sortIcon" />
-                    </span>
-                    <span
-                      v-if="sortField === column.field"
-                      :class="[{
-                        'column-sort__icon': true,
-                        'column-sort__icon--asc': sortOrder === 'asc',
-                        'column-sort__icon--desc': sortOrder === 'desc',
-                      }]"
-                      :style="{
-                        height: `${rowHeight}px`,
-                        'line-height': `${rowHeight}px`,
-                      }"
-                    >
-                      <slot :name="`sortIcon_${sortOrder}`" />
-                    </span>
-                  </template>
-                  <template v-else>
-                    <grid-sort-button
-                      v-if="column.sortable === undefined ? true : column.sortable"
-                      class="column-sort__icon column-sort__icon--basic"
-                      :icon="'basic'"
-                      :style="{
-                        height: `${rowHeight}px`,
-                        'line-height': `${rowHeight}px`,
-                      }"
-                    />
-                    <grid-sort-button
-                      v-if="sortField === column.field"
-                      :class="[{
-                        'column-sort__icon': true,
-                        'column-sort__icon--asc': sortOrder === 'asc',
-                        'column-sort__icon--desc': sortOrder === 'desc',
-                      }]"
-                      :icon="sortOrder"
-                      :style="{
-                        height: `${rowHeight}px`,
-                        'line-height': `${rowHeight}px`,
-                        visibility: !!sortOrder ? column.hidden : true,
-                      }"
-                    />
-                  </template>
+              <!-- Custom Header -->
+              <template v-if="column.customHeader && !!$slots.customHeader">
+                <slot name="customHeader" />
+              </template>
+              <template v-else>
+                <!-- Column Name -->
+                <span
+                  :title="column.caption"
+                  class="column-name"
+                  @click="onColumnContextMenu($event, column)"
+                  @click.prevent="columnMenu.show"
+                >
+                  {{ column.caption }}
+                  <!-- Sort Icon -->
+                  <span @click.stop="onSort(column)">
+                    <template v-if="!!$slots.sortIcon">
+                      <span
+                        v-if="column.sortable === undefined ? true : column.sortable"
+                        class="column-sort__icon column-sort__icon--basic"
+                        :style="{
+                          height: `${rowHeight}px`,
+                          'line-height': `${rowHeight}px`,
+                        }"
+                      >
+                        <slot name="sortIcon" />
+                      </span>
+                      <span
+                        v-if="sortField === column.field"
+                        :class="[{
+                          'column-sort__icon': true,
+                          'column-sort__icon--asc': sortOrder === 'asc',
+                          'column-sort__icon--desc': sortOrder === 'desc',
+                        }]"
+                        :style="{
+                          height: `${rowHeight}px`,
+                          'line-height': `${rowHeight}px`,
+                        }"
+                      >
+                        <slot :name="`sortIcon_${sortOrder}`" />
+                      </span>
+                    </template>
+                    <template v-else>
+                      <grid-sort-button
+                        v-if="column.sortable === undefined ? true : column.sortable"
+                        class="column-sort__icon column-sort__icon--basic"
+                        :icon="'basic'"
+                        :style="{
+                          height: `${rowHeight}px`,
+                          'line-height': `${rowHeight}px`,
+                        }"
+                      />
+                      <grid-sort-button
+                        v-if="sortField === column.field"
+                        :class="[{
+                          'column-sort__icon': true,
+                          'column-sort__icon--asc': sortOrder === 'asc',
+                          'column-sort__icon--desc': sortOrder === 'desc',
+                        }]"
+                        :icon="sortOrder"
+                        :style="{
+                          height: `${rowHeight}px`,
+                          'line-height': `${rowHeight}px`,
+                          visibility: !!sortOrder ? column.hidden : true,
+                        }"
+                      />
+                    </template>
+                  </span>
                 </span>
-              </span>
+              </template>
               <!-- Column Resize -->
               <span
                 class="column-resize"

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -81,9 +81,9 @@
                 <span
                   :title="column.caption"
                   :class="[
-                  'column-name',
-                  { 'column-name--click' : useGridSetting }
-                ]"
+                    'column-name',
+                    { 'column-name--click' : useGridSetting }
+                  ]"
                   @click="onColumnContextMenu($event, column)"
                   @click.prevent="columnMenu.show"
                 >

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -72,18 +72,24 @@
               :class="getColumnClass(column)"
               :style="getColumnStyle(column, index)"
             >
-              <!-- Column Name -->
-              <span
-                :title="column.caption"
-                :class="[
+              <!-- Custom Header -->
+              <template v-if="column.customHeader && !!$slots.customHeader">
+                <slot name="customHeader" />
+              </template>
+              <template v-else>
+                <!-- Column Name -->
+                <span
+                  :title="column.caption"
+                  :class="[
                   'column-name',
                   { 'column-name--click' : useGridSetting }
                 ]"
-                @click="onColumnContextMenu($event, column)"
-                @click.prevent="columnMenu.show"
-              >
-                {{ column.caption }}
-              </span>
+                  @click="onColumnContextMenu($event, column)"
+                  @click.prevent="columnMenu.show"
+                >
+                  {{ column.caption }}
+                </span>
+              </template>
               <!-- Column Resize -->
               <span
                 class="column-resize"
@@ -886,6 +892,7 @@ export default {
         column: true,
         render,
         'non-border': !!styleInfo.borderStyle,
+        [column.field]: column.field,
       };
     };
     const getColumnStyle = (column, index) => {

--- a/src/components/treeGrid/TreeGridNode.vue
+++ b/src/components/treeGrid/TreeGridNode.vue
@@ -256,6 +256,7 @@ export default {
       'tree-td': cellIndex === 0,
       [column.type]: column.type,
       [column.align]: column.align,
+      [column.field]: column.field,
       'non-border': !!props.borderStyle,
     });
     const getColumnStyle = (column, cellIndex) => ({


### PR DESCRIPTION
# 작업 내용
- Grid, TreeGrid에 커스텀하게 표현할 수 있는 커스텀 헤더 추가
- TreeGrid 컬럼 class에 field명 누락되어있어 추가 
- column 옵션에 customHeader 추가
- customHeader slot 추가
- docs 에 사용예제 참고

![image](https://github.com/user-attachments/assets/b8cb5393-34e2-4b98-b777-98d4176b46e6)
![image](https://github.com/user-attachments/assets/0bdace07-ad11-4139-b842-f590b04d3ec8)

