### PR TITLE
[#1743]Chart 내 최대값에 단위 변환 적용

### DIFF
--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -92,9 +92,11 @@ const modules = {
 
       if (maxTipOpt.use && maxArgs) {
         if (tooltipValueFormatter) {
-          maxArgs.text = isHorizontal
-            ? tooltipValueFormatter({ x: maxArgs.value })
-            : tooltipValueFormatter({ y: maxArgs.value });
+          maxArgs.text = tooltipValueFormatter({
+            seriesId: seriesInfo.sId,
+            x: isHorizontal ? maxArgs.value : undefined,
+            y: !isHorizontal ? maxArgs.value : undefined,
+          });
         } else {
           maxArgs.text = numberWithComma(maxArgs.value);
         }


### PR DESCRIPTION
## 작업 배경
formatt함수에 seriesId 정보가 필요한데 현재는 값만 있어 원하는 formatt이 적용되지 않음

## 변경 사항 요약
- seriesId값을 사용할수 있도록 seriesId: seriesInfo.sId 추가

## 이전 동작
![image](https://github.com/user-attachments/assets/16fa8c31-f51d-47d4-ab5a-2bdec823b283)

## 기대 동작
![image](https://github.com/user-attachments/assets/9056f59c-2554-41ab-b0e9-e5f063dec055)

## 테스트 가이드
seriesId 정보가 필요한 경우에 seriesId의 값이 fromatt함수에 들어와 잘 동작하는지 확인해주세요

