### PR TITLE
[#1784]Grid > row context menu 버튼이 항상 row 우측 끝에 위치하도록 수정

### DIFF
--- a/docs/views/treeGrid/example/CustomHeader.vue
+++ b/docs/views/treeGrid/example/CustomHeader.vue
@@ -27,7 +27,8 @@
           <div
             class="grid-custom-cell__content"
             :style="{
-              width: `${(item.data.customCell.toTime - item.data.customCell.fromTime) / totalRenderSec * 100}%`,
+              width: `${(item.data.customCell.toTime - item.data.customCell.fromTime)
+                / totalRenderSec * 100}%`,
               left: `${item.data.customCell.fromTime / totalRenderSec * 100}%`,
             }"
           />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.66",
+  "version": "3.4.67",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -473,10 +473,8 @@
                     'non-border': !!borderStyle,
                   }"
                   :style="{
-                    width: '30px',
-                    height: `${rowHeight}px`,
-                    'min-width': '30px',
-                    'line-height': `${rowHeight}px`,
+                    position: 'sticky',
+                    right: 0,
                   }"
                   :disabled="row[ROW_DISABLED_INDEX]"
                 >
@@ -485,8 +483,10 @@
                       class="row-contextmenu__btn"
                       :disabled="row[ROW_DISABLED_INDEX]"
                       :style="{
-                        position: 'absolute',
-                        right: 0,
+                        width: '30px',
+                        height: `${rowHeight}px`,
+                        'min-width': '30px',
+                        'line-height': `${rowHeight}px`,
                       }"
                       @click="onContextMenu($event)"
                     >
@@ -499,8 +499,10 @@
                       class="row-contextmenu__btn"
                       :disabled="row[ROW_DISABLED_INDEX]"
                       :style="{
-                        position: 'absolute',
-                        right: 0,
+                        width: '30px',
+                        height: `${rowHeight}px`,
+                        'min-width': '30px',
+                        'line-height': `${rowHeight}px`,
                       }"
                       @click="onContextMenu($event)"
                     />

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -480,31 +480,31 @@
                   }"
                   :disabled="row[ROW_DISABLED_INDEX]"
                 >
-                    <template v-if="$slots.contextmenuIcon">
-                      <span
-                        class="row-contextmenu__btn"
-                        :disabled="row[ROW_DISABLED_INDEX]"
-                        :style="{
-                          position: 'absolute',
-                          right: 0,
-                        }"
-                        @click="onContextMenu($event)"
-                      >
-                        <slot name="contextmenuIcon"></slot>
-                      </span>
-                    </template>
-                    <template v-else>
-                      <grid-option-button
-                        icon="ev-icon-warning2"
-                        class="row-contextmenu__btn"
-                        :disabled="row[ROW_DISABLED_INDEX]"
-                        :style="{
-                          position: 'absolute',
-                          right: 0,
-                        }"
-                        @click="onContextMenu($event)"
-                      />
-                    </template>
+                  <template v-if="$slots.contextmenuIcon">
+                    <span
+                      class="row-contextmenu__btn"
+                      :disabled="row[ROW_DISABLED_INDEX]"
+                      :style="{
+                        position: 'absolute',
+                        right: 0,
+                      }"
+                      @click="onContextMenu($event)"
+                    >
+                      <slot name="contextmenuIcon"></slot>
+                    </span>
+                  </template>
+                  <template v-else>
+                    <grid-option-button
+                      icon="ev-icon-warning2"
+                      class="row-contextmenu__btn"
+                      :disabled="row[ROW_DISABLED_INDEX]"
+                      :style="{
+                        position: 'absolute',
+                        right: 0,
+                      }"
+                      @click="onContextMenu($event)"
+                    />
+                  </template>
                 </td>
               </tr>
               <tr

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -480,17 +480,14 @@
                   }"
                   :disabled="row[ROW_DISABLED_INDEX]"
                 >
-                  <div
-                    class="row-contextmenu__btn-wrapper"
-                    :style="{
-                      position: 'absolute',
-                      right: 0,
-                    }"
-                  >
                     <template v-if="$slots.contextmenuIcon">
                       <span
                         class="row-contextmenu__btn"
                         :disabled="row[ROW_DISABLED_INDEX]"
+                        :style="{
+                          position: 'absolute',
+                          right: 0,
+                        }"
                         @click="onContextMenu($event)"
                       >
                         <slot name="contextmenuIcon"></slot>
@@ -501,10 +498,13 @@
                         icon="ev-icon-warning2"
                         class="row-contextmenu__btn"
                         :disabled="row[ROW_DISABLED_INDEX]"
+                        :style="{
+                          position: 'absolute',
+                          right: 0,
+                        }"
                         @click="onContextMenu($event)"
                       />
                     </template>
-                  </div>
                 </td>
               </tr>
               <tr

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -486,8 +486,6 @@
                     <span
                       class="row-contextmenu__btn"
                       :disabled="row[ROW_DISABLED_INDEX]"
-                      :style="{
-                      }"
                       @click="onContextMenu($event)"
                     >
                       <slot name="contextmenuIcon"></slot>
@@ -498,8 +496,6 @@
                       icon="ev-icon-warning2"
                       class="row-contextmenu__btn"
                       :disabled="row[ROW_DISABLED_INDEX]"
-                      :style="{
-                      }"
                       @click="onContextMenu($event)"
                     />
                   </template>

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -473,8 +473,6 @@
                     'non-border': !!borderStyle,
                   }"
                   :style="{
-                    position: 'sticky',
-                    right: 0,
                     width: '30px',
                     height: `${rowHeight}px`,
                     'min-width': '30px',
@@ -482,23 +480,31 @@
                   }"
                   :disabled="row[ROW_DISABLED_INDEX]"
                 >
-                  <template v-if="$slots.contextmenuIcon">
-                    <span
-                      class="row-contextmenu__btn"
-                      :disabled="row[ROW_DISABLED_INDEX]"
-                      @click="onContextMenu($event)"
-                    >
-                      <slot name="contextmenuIcon"></slot>
-                    </span>
-                  </template>
-                  <template v-else>
-                    <grid-option-button
-                      icon="ev-icon-warning2"
-                      class="row-contextmenu__btn"
-                      :disabled="row[ROW_DISABLED_INDEX]"
-                      @click="onContextMenu($event)"
-                    />
-                  </template>
+                  <div
+                    class="row-contextmenu__btn-wrapper"
+                    :style="{
+                      position: 'absolute',
+                      right: 0,
+                    }"
+                  >
+                    <template v-if="$slots.contextmenuIcon">
+                      <span
+                        class="row-contextmenu__btn"
+                        :disabled="row[ROW_DISABLED_INDEX]"
+                        @click="onContextMenu($event)"
+                      >
+                        <slot name="contextmenuIcon"></slot>
+                      </span>
+                    </template>
+                    <template v-else>
+                      <grid-option-button
+                        icon="ev-icon-warning2"
+                        class="row-contextmenu__btn"
+                        :disabled="row[ROW_DISABLED_INDEX]"
+                        @click="onContextMenu($event)"
+                      />
+                    </template>
+                  </div>
                 </td>
               </tr>
               <tr

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -475,6 +475,10 @@
                   :style="{
                     position: 'sticky',
                     right: 0,
+                    width: '30px',
+                    height: `${rowHeight}px`,
+                    'min-width': '30px',
+                    'line-height': `${rowHeight}px`,
                   }"
                   :disabled="row[ROW_DISABLED_INDEX]"
                 >
@@ -483,10 +487,6 @@
                       class="row-contextmenu__btn"
                       :disabled="row[ROW_DISABLED_INDEX]"
                       :style="{
-                        width: '30px',
-                        height: `${rowHeight}px`,
-                        'min-width': '30px',
-                        'line-height': `${rowHeight}px`,
                       }"
                       @click="onContextMenu($event)"
                     >
@@ -499,10 +499,6 @@
                       class="row-contextmenu__btn"
                       :disabled="row[ROW_DISABLED_INDEX]"
                       :style="{
-                        width: '30px',
-                        height: `${rowHeight}px`,
-                        'min-width': '30px',
-                        'line-height': `${rowHeight}px`,
                       }"
                       @click="onContextMenu($event)"
                     />
@@ -512,18 +508,21 @@
               <tr
                 v-if="useRowDetail && $slots?.rowDetail && row[4]"
               >
-              <div
-                :style="{
-                  height: `${detailRowHeight}px`,
-                  'min-height': `${detailRowHeight}px`,
-                  'max-height': `${detailRowHeight}px`
-                }">
-
-                <slot
-                  name="rowDetail"
-                  :item="{ row }"
-                />
-              </div>
+                <td :colspan="row.length">
+                  <div
+                    :style="{
+                      width: '100%',
+                      height: `${detailRowHeight}px`,
+                      'min-height': `${detailRowHeight}px`,
+                      'max-height': `${detailRowHeight}px`
+                    }"
+                  >
+                    <slot
+                      name="rowDetail"
+                      :item="{ row }"
+                    />
+                  </div>
+                </td>
               </tr>
             </template>
             <tr v-if="!viewStore.length">

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -35,8 +35,9 @@
   .row-contextmenu__btn {
     display: none;
     position: absolute;
-    right: 0;
+    right: 10px;
     vertical-align: middle;
+    transform: translate(0, -50%);
   }
 }
 

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -34,6 +34,8 @@
   }
   .row-contextmenu__btn {
     display: none;
+    position: absolute;
+    right: 0;
     vertical-align: middle;
   }
 }
@@ -148,7 +150,6 @@
     }
   }
   .row {
-    position: relative;
     color: inherit;
     white-space: nowrap;
 
@@ -180,12 +181,6 @@
       }
     }
   }
-  .row-contextmenu {
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-  }
-
   .cell {
     display: inline-block;
     padding: 0 10px;
@@ -203,7 +198,10 @@
       text-overflow: ellipsis;
     }
     &.row-checkbox {
+      display: inline-flex;
       padding: 0;
+      justify-content: center;
+      align-items: center;
       .ev-checkbox {
         display: inline-flex;
         width: 100%;

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -148,6 +148,7 @@
     }
   }
   .row {
+    position: relative;
     color: inherit;
     white-space: nowrap;
 


### PR DESCRIPTION
## 이슈 현상
- 마지막 컬럼 끝나는 지점이 그리드 전체 너비보다 작은 경우 row context menu 버튼이 row 중간에 위치하는 것으로 보여짐
![image](https://github.com/user-attachments/assets/7cceb01d-1d78-4004-a97a-e5d83f306c2b)

## 작업 내용
- https://github.com/ex-em/EVUI/pull/1785 에서 픽스했으나 컨텍스트 메뉴 위치가 row 기준 우측이 아니라 보여지는 영역 기준 우측 끝이라 재수정
- 기존에 그렇게 되어있었으나 [row detail 영역 추가](https://github.com/ex-em/EVUI/pull/1541/files#diff-28e53691ea0423e79230f0755b6246dd2274f59f0ac11328122372ab69cd3d54) 하면서 detail 패널의 배경색이 전부 안칠해지는 현상으로 수정되면서 발생하게 된 이슈로 해당 부분 관련 개선
![image](https://github.com/user-attachments/assets/83ecbeae-40b7-40b5-a0d4-a6ca05e56ce3)


## 테스트 가이드
- 마지막 컬럼 끝지점이 그리드 중간에 있거나 또는 그리드 내 가로 스크롤이 생겼을 때 컨텍스트메뉴 버튼의 위치가 보여지는 영역의 우측 끝에 위치하는지 확인 (여백이 있어도 항상 우측에 위치, 스크롤이 생겨도 항상 보여야함.)
- row detail 패널 열었을 경우 배경색이 다 칠해지는지 확인
