### PR TITLE
[#1784]Grid > row context menu 버튼이 항상 row 우측 끝에 위치하도록 수정

### DIFF
--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -473,6 +473,8 @@
                     'non-border': !!borderStyle,
                   }"
                   :style="{
+                    position: 'sticky',
+                    right: 0,
                     width: '30px',
                     height: `${rowHeight}px`,
                     'min-width': '30px',
@@ -484,10 +486,6 @@
                     <span
                       class="row-contextmenu__btn"
                       :disabled="row[ROW_DISABLED_INDEX]"
-                      :style="{
-                        position: 'absolute',
-                        right: 0,
-                      }"
                       @click="onContextMenu($event)"
                     >
                       <slot name="contextmenuIcon"></slot>
@@ -498,10 +496,6 @@
                       icon="ev-icon-warning2"
                       class="row-contextmenu__btn"
                       :disabled="row[ROW_DISABLED_INDEX]"
-                      :style="{
-                        position: 'absolute',
-                        right: 0,
-                      }"
                       @click="onContextMenu($event)"
                     />
                   </template>
@@ -510,18 +504,21 @@
               <tr
                 v-if="useRowDetail && $slots?.rowDetail && row[4]"
               >
-              <div
-                :style="{
-                  height: `${detailRowHeight}px`,
-                  'min-height': `${detailRowHeight}px`,
-                  'max-height': `${detailRowHeight}px`
-                }">
-
-                <slot
-                  name="rowDetail"
-                  :item="{ row }"
-                />
-              </div>
+                <td :colspan="row.length">
+                  <div
+                    :style="{
+                      width: '100%',
+                      height: `${detailRowHeight}px`,
+                      'min-height': `${detailRowHeight}px`,
+                      'max-height': `${detailRowHeight}px`
+                    }"
+                  >
+                    <slot
+                      name="rowDetail"
+                      :item="{ row }"
+                    />
+                  </div>
+                </td>
               </tr>
             </template>
             <tr v-if="!viewStore.length">

--- a/src/components/grid/style/grid.scss
+++ b/src/components/grid/style/grid.scss
@@ -34,7 +34,10 @@
   }
   .row-contextmenu__btn {
     display: none;
+    position: absolute;
+    right: 10px;
     vertical-align: middle;
+    transform: translate(0, -50%);
   }
 }
 
@@ -180,11 +183,6 @@
       }
     }
   }
-  .row-contextmenu {
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-  }
 
   .cell {
     display: inline-block;
@@ -203,7 +201,10 @@
       text-overflow: ellipsis;
     }
     &.row-checkbox {
+      display: inline-flex;
       padding: 0;
+      justify-content: center;
+      align-items: center;
       .ev-checkbox {
         display: inline-flex;
         width: 100%;


### PR DESCRIPTION
## 이슈 현상
- 마지막 컬럼 끝나는 지점이 그리드 전체 너비보다 작은 경우 row context menu 버튼이 row 중간에 위치하는 것으로 보여짐
![image](https://github.com/user-attachments/assets/7cceb01d-1d78-4004-a97a-e5d83f306c2b)

## 작업 내용
- https://github.com/ex-em/EVUI/pull/1785 에서 픽스했으나 컨텍스트 메뉴 위치가 row 기준 우측이 아니라 보여지는 영역 기준 우측 끝이라 재수정
- 기존에 그렇게 되어있었으나 [row detail 영역 추가](https://github.com/ex-em/EVUI/pull/1541/files#diff-28e53691ea0423e79230f0755b6246dd2274f59f0ac11328122372ab69cd3d54) 하면서 detail 패널의 배경색이 전부 안칠해지는 현상으로 수정되면서 발생하게 된 이슈로 해당 부분 관련 개선
![image](https://github.com/user-attachments/assets/83ecbeae-40b7-40b5-a0d4-a6ca05e56ce3)


## 테스트 가이드
- 마지막 컬럼 끝지점이 그리드 중간에 있거나 또는 그리드 내 가로 스크롤이 생겼을 때 컨텍스트메뉴 버튼의 위치가 보여지는 영역의 우측 끝에 위치하는지 확인 (여백이 있어도 항상 우측에 위치, 스크롤이 생겨도 항상 보여야함.)
- row detail 패널 열었을 경우 배경색이 다 칠해지는지 확인
