### PR TITLE
[#1788] Chart > legend 타입이 table 일 경우, 리렌더링이 발생했을 때 내용물이 사라지는 버그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.67",
+  "version": "3.4.68",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -583,8 +583,15 @@ const modules = {
       return;
     }
 
-    while (legendBoxDOM.hasChildNodes()) {
-      legendBoxDOM.removeChild(legendBoxDOM.firstChild);
+    if (this.useTable) {
+      const legendTableDOM = this.legendTableDOM;
+      while (legendTableDOM.hasChildNodes()) {
+        legendTableDOM.removeChild(legendTableDOM.firstChild);
+      }
+    } else {
+      while (legendBoxDOM.hasChildNodes()) {
+        legendBoxDOM.removeChild(legendBoxDOM.firstChild);
+      }
     }
 
     this.seriesInfo.count = 0;

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -588,6 +588,7 @@ const modules = {
       while (legendTableDOM.hasChildNodes()) {
         legendTableDOM.removeChild(legendTableDOM.firstChild);
       }
+      this.setLegendColumnHeader();
     } else {
       while (legendBoxDOM.hasChildNodes()) {
         legendBoxDOM.removeChild(legendBoxDOM.firstChild);


### PR DESCRIPTION
## 이슈 

- `plugins.legend.ts` 의 `updateLegend` > `resetLegend` 호출 시 legend 를 초기화하면서 legendBoxDOM 의 내용물을  전부 removeChild 를 통해 비워주고 있습니다
- legendBoxDOM 의 내용물이 div 형식일 경우 (ev-chart-legend--container) 따로 부모 노드를 갖지 않는 리스트 형식이라 전부 `removeChild` 를 수행해도 다시 append 가 되지만, 내부 내용물이 table 형식일 경우 (useTable: true일 경우, ev-chart-legend--table) legendBoxDOM 과 legendTableDOM 노드 간의 부모 - 자식 관계가 끊어지면서 테이블이 다시 그려지지 않습니다
- `addLegendWithValues` 에서 legendTableDOM 의 내용물을 변경하고 있으나, legendBoxDOM 에서 legendTableDOM 이 제거되었기 때문에 실제 화면에 반영되지 않고 legend 가 출력되지 않는 버그가 발생합니다
- 정적인 화면에서는 한번 렌더링이 수행되고 resetLegend 가 호출되지 않기 때문에 이상이 없으나, 차트 데이터가 지속적으로 변경될 경우 legend 가 사라져 문제가 되고 있습니다

## 해결책

- useTable 이 true 일 경우 (테이블 형식으로 legend 를 출력할 경우) legendBoxDOM 의 자식 대신 legendTableDOM 의 자식을 삭제하는 방식으로 resetLegend 수행하도록 조건문 수정

## as-is

![Oct-22-2024 21-10-33](https://github.com/user-attachments/assets/cab7fb5a-8181-42fb-a90e-9e23f09e175b)

![스크린샷 2024-10-22 오후 9 10 55](https://github.com/user-attachments/assets/b81cbb6f-6424-4c48-a152-af8b1ce6d71d)

`ev-chart-legend` 의 자식 노드가 사라지고 업데이트가 되지 않아 legend 가 아예 사라지는 모습

## to-be

![Oct-22-2024 21-08-41](https://github.com/user-attachments/assets/8a5ecafd-afb6-4d94-b569-bc5d97cf0f0e)

`ev-chart-legend` 의 자식 노드로 `ev-chart-legend--table` 이 유지되어 row 가 변경되어도 정상적으로 출력됩니다


