### PR TITLE
[#1790] Slider > 값이 0일 때 슬라이더 위치가 이동하지 않는 버그

### DIFF
--- a/src/components/slider/uses.js
+++ b/src/components/slider/uses.js
@@ -1,5 +1,5 @@
 import { ref, reactive, watch, computed, onMounted, getCurrentInstance } from 'vue';
-import { isEqual } from 'lodash-es';
+import { isEqual, isNumber } from 'lodash-es';
 import { convertToPercent } from '@/common/utils';
 import { getValueCloseToStep } from '@/components/inputNumber/uses';
 
@@ -138,7 +138,8 @@ export const useModel = () => {
   };
 
   watch(() => props.modelValue, (curr, prev) => {
-    if (curr
+    if (isNumber(curr)
+      && curr >= 0
       && !isEqual(curr, prev)
       && !state.dragging
     ) {


### PR DESCRIPTION
## as-is

![Oct-23-2024 16-22-13](https://github.com/user-attachments/assets/4c29290a-d240-4123-a5f9-5b47185d2bc1)

- 외부에서 값이 변경될 때, 다른 값의 경우 슬라이더 핸들의 위치가 정상적으로 변경되지만 값이 0일 경우 슬라이더가 해당 값 변화를 감지하지 못해 핸들이 움직이지 않습니다
- watch 내부 조건문에서 curr (현재 modelValue) = 0 일 경우 falsy 한 값으로 판단하여 핸들을 조정하는 함수 `setHandleValue` 가 호출되지 않기 때문으로, 해당 조건문 수정했습니다

## to-be

![Oct-23-2024 16-22-34](https://github.com/user-attachments/assets/01e318ad-3261-4f8a-8581-a900808dfb89)

- modelValue 가 0이 되어도 핸들 정상적으로 이동