### PR TITLE
[#1793] TreeGrid > hiddenColumnMenuItem 옵션 적용

### DIFF
--- a/docs/views/treeGrid/api/treeGrid.md
+++ b/docs/views/treeGrid/api/treeGrid.md
@@ -70,6 +70,7 @@
 |  | customContextMenuClass |                       | 우클릭시 보여지는 컨텍스트 메뉴의 클래스를 설정한다.                                                                  | String |
 |  | customContextMenu | []                 | 우클릭시 보여지는 컨텍스트 메뉴를 설정한다.                |                           |
 |  |                  | menuItems          | 컨텍스트 메뉴                                 |                           |
+|  | hiddenColumnMenuItem | {}                      | 그리드 헤더 클릭시 보여지는 컨텍스트 메뉴 각 아이템의 표시 여부를 설정한다. (`true`: 숨김 / `false`: 노출 / Default: `false`) |  |
 |  | page             | {}                 | 페이지 설정                                  |                           |
 |  |                  | use                | 페이지 사용 여부                               | Boolean                   |
 |  |                  | isInfinite         | Infinite Scroll 사용 여부                   | Boolean                   |

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -525,6 +525,7 @@ export default {
       columnMenu: null,
       columnMenuItems: [],
       columnMenuTextInfo: props.option.columnMenuText || {},
+      hiddenColumnMenuItem: props.option.hiddenColumnMenuItem || {},
       customContextMenu: props.option.customContextMenu || [],
       gridSettingMenu: null,
       gridSettingContextMenuItems: [],

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -643,6 +643,7 @@ export const contextMenuEvent = (params) => {
           text: contextInfo.columnMenuTextInfo?.hide ?? 'Hide',
           iconClass: 'ev-icon-visibility-off',
           disabled: !useGridSetting.value || stores.orderedColumns.length === 1,
+          hidden: contextInfo.hiddenColumnMenuItem?.hide || !useGridSetting.value,
           click: () => {
             setColumnHidden(column.field);
             emit('change-column-status', {


### PR DESCRIPTION
### 작업 배경
- TreeGrid >  hiddenColumnMenuItem 관련 값이 정렬 쪽에 추가되었는데 미동작
- grid와 같은 스펙을 유지하기 위하여 숨김및 관련 옵션이 적용될 수 있도록 처리

### 작업 내용
- hiddenColumnMenuItem 값이 추가 되어야 하는 곳에 추가
- grid 와 같은 스펙으로만 적용