### PR TITLE
[#1792] Chart > Axis(step type) > Label Style >maxWidth 기능 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -212,15 +212,16 @@ const chartData = {
 
 ##### labelStyle
 
-| 이름       | 타입                        | 디폴트    | 설명                                               | 종류(예시)                             |
-| ---------- | --------------------------- | --------- | -------------------------------------------------- | -------------------------------------- |
-| show       | Boolean                     | true      | label 표시 여부                                    | true / false                           |
-| fontSize   | Number                      | 12        | 글자 크기                                          |                                        |
-| color      | Hex, RGB, RGBA Code(String) | '#25262E' | 글자 색상                                          |                                        |
-| fontFamily | String                      | 'Roboto'  | 폰트                                               |                                        |
-| fitWidth   | Boolean                     | false     | Label Text Ellipsis 처리                           |                                        |
-| fitDir     | String                      | 'right'   | Ellipsis 방향                                      | ( right => 'aaa...', left => '...aaa') |
-| padding    | Number                      | 0         | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0                                      |
+| 이름         | 타입                          | 디폴트       | 설명                                                       | 종류(예시)                             |
+|------------|-----------------------------|-----------|----------------------------------------------------------| -------------------------------------- |
+| show       | Boolean                     | true      | label 표시 여부                                              | true / false                           |
+| fontSize   | Number                      | 12        | 글자 크기                                                    |                                        |
+| color      | Hex, RGB, RGBA Code(String) | '#25262E' | 글자 색상                                                    |                                        |
+| fontFamily | String                      | 'Roboto'  | 폰트                                                       |                                        |
+| fitWidth   | Boolean                     | false     | Label Text Ellipsis 처리                                   |                                        |
+| maxWidth   | Number                      | undefined | fitWidth이 true일 때, maxWidth까지 영역을 확장하고 그 이후로 Ellipsis 처리 |                                        |
+| fitDir     | String                      | 'right'   | Ellipsis 방향                                              | ( right => 'aaa...', left => '...aaa') |
+| padding    | Number                      | 0         | (X축, linear, time타입에만 해당) label의 좌우 여백                   | 0                                      |
 
 ##### title
 

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -116,15 +116,16 @@ const chartData =
       - 축의 label의 minIndex, maxIndex 값을 array로 넘겨줌 ([0, 5])
 
 ##### label style
-| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
-|-----|------|-------|-----|-----|
-| show | Boolean | true | label 표시 여부 | true / false |
-| fontSize | Number | 12 | 글자 크기 | |
-| color | Hex, RGB, RGBA Code(String) | '#25262E' | 글자 색상 | |
-| fontFamily | String | 'Roboto' | 폰트 | |
-| fitWidth | Boolean | false | Label Text Ellipsis 처리 | |
-| fitDir | String | 'right' | Ellipsis 방향 | ( right => 'aaa...', left => '...aaa') |
-| alignToGridLine | Boolean | false | 축 line에 표시할지의 여부 | |
+| 이름              | 타입                          | 디폴트       | 설명 | 종류(예시) |
+|-----------------|-----------------------------|-----------|-----|-----|
+| show            | Boolean                     | true      | label 표시 여부 | true / false |
+| fontSize        | Number                      | 12        | 글자 크기 | |
+| color           | Hex, RGB, RGBA Code(String) | '#25262E' | 글자 색상 | |
+| fontFamily      | String                      | 'Roboto'  | 폰트 | |
+| fitWidth        | Boolean                     | false     | Label Text Ellipsis 처리 | |
+| maxWidth        | Number                      | undefined | fitWidth이 true일 때, maxWidth까지 영역을 확장하고 그 이후로 Ellipsis 처리 | |
+| fitDir          | String                      | 'right'   | Ellipsis 방향 | ( right => 'aaa...', left => '...aaa') |
+| alignToGridLine | Boolean                     | false     | 축 line에 표시할지의 여부 | |
 
 ##### axes title
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -163,15 +163,16 @@ const chartData =
 
 ##### labelStyle
 
-| 이름       | 타입                        | 디폴트    | 설명                                               | 종류(예시)                             |
-| ---------- | --------------------------- | --------- | -------------------------------------------------- | -------------------------------------- |
-| show       | Boolean                     | true      | label 표시 여부                                    | true / false                           |
-| fontSize   | Number                      | 12        | 글자 크기                                          |                                        |
-| color      | Hex, RGB, RGBA Code(String) | '#25262E' | 글자 색상                                          |                                        |
-| fontFamily | String                      | 'Roboto'  | 폰트                                               |                                        |
-| fitWidth   | Boolean                     | false     | Label Text Ellipsis 처리                           |                                        |
+| 이름       | 타입                        | 디폴트    | 설명                                               | 종류(예시)                                |
+| ---------- | --------------------------- | --------- | -------------------------------------------------- |---------------------------------------|
+| show       | Boolean                     | true      | label 표시 여부                                    | true / false                          |
+| fontSize   | Number                      | 12        | 글자 크기                                          |                                       |
+| color      | Hex, RGB, RGBA Code(String) | '#25262E' | 글자 색상                                          |                                       |
+| fontFamily | String                      | 'Roboto'  | 폰트                                               |                                       |
+| fitWidth   | Boolean                     | false     | Label Text Ellipsis 처리                           |                                       |
+| maxWidth   | Number                      | undefined | fitWidth이 true일 때, maxWidth까지 영역을 확장하고 그 이후로 Ellipsis 처리 |                                       |
 | fitDir     | String                      | 'right'   | Ellipsis 방향                                      | ( right => 'aaa...', left => '...aaa') |
-| padding    | Number                      | 0         | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0                                      |
+| padding    | Number                      | 0         | (X축, linear, time타입에만 해당) label의 좌우 여백 | 0                                     |
 
 ##### title
 

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -40,7 +40,7 @@ class StepScale extends Scale {
       }
     }
 
-    const maxWidth = chartRect.chartWidth / (labelCount + 2);
+    const maxWidth = this.labelStyle?.maxWidth ?? chartRect.chartWidth / (labelCount + 2);
 
     return {
       min: minValue,
@@ -126,7 +126,7 @@ class StepScale extends Scale {
     const endPoint = aPos[this.units.rectEnd];
     const offsetPoint = aPos[this.units.rectOffset(this.position)];
     const offsetCounterPoint = aPos[this.units.rectOffsetCounter(this.position)];
-    const maxWidth = chartRect.chartWidth / (steps + 2);
+    const maxWidth = this.labelStyle?.maxWidth ?? chartRect.chartWidth / (steps + 2);
 
     this.drawAxisTitle(chartRect, labelOffset);
 


### PR DESCRIPTION
### 관련 옵션 설명
- LabelStyle > fitWidth
   - false(default) : label을 자르지 않고 최대 길이를 가진 label의 너비만 큼 영역을 계산하여 말줄임표 없이 full text를 표시함
   - true :  내부 로직에 따라 영역의 너비를 결정하며 넘치는 부분에서는 말줄임표를 붙여 표시함

### 작업 내용
- fitWidth이 true일때 `내부 로직에 따라 영역의 너비를 결정하며` -> `maxWidth까지는 영역을 잡고 너비를 결정하며` 로 변경
- 단 maxWidth이 undefined인 경우 내부 로직에 따름 

### 변경 사항
1. Axis(Step) > LabelStyle > maxWidth옵션 (default: undefined) 추가 
2. 관련 설명 추가


### 결과 
**1. fitWidth : false (default)** 
   -  ![image](https://github.com/user-attachments/assets/ab4f3bb1-925a-497a-abaa-cce6138b9861)

**3. fitWidth: true**
   - ![image](https://github.com/user-attachments/assets/dd0624af-19bb-4b3a-ab35-dcd121fa492d)

**5. fitWidth: true + maxWidth** 
   -  ![image](https://github.com/user-attachments/assets/5cd26336-f373-495f-adbc-565d5817395b)
   - ![image](https://github.com/user-attachments/assets/17197468-c507-4b6d-89c1-98be37fbdb77)


