### PR TITLE
[#1796] Line chart > Stack > color 값이 rgba 형태로 들어올 때 legend box 내부 색상이 하얘짐

### DIFF
--- a/docs/views/lineChart/example/Stack.vue
+++ b/docs/views/lineChart/example/Stack.vue
@@ -13,7 +13,7 @@
       const time = dayjs().format('YYYY-MM-DD HH:mm:ss');
       const chartData = {
         series: {
-          series1: { name: 'series#1', fill: true, point: true },
+          series1: { name: 'series#1', fill: true, point: true, color: 'rgba(239, 58, 58, 0.5)' },
           series2: { name: 'series#2', fill: true, point: true },
           series3: { name: 'series#3', fill: true, point: true },
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.68",
+  "version": "3.4.69",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -367,4 +367,26 @@ export default {
   isNullOrUndefined(value) {
     return value === null || value === undefined;
   },
+
+  rgbaAdjustHalfOpacity(color) {
+    const rgbRegex = /^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/;
+    const rgbaRegex = /^rgba\((\d+),\s*(\d+),\s*(\d+),\s*([\d.]+)\)$/;
+
+    if (rgbRegex.test(color)) {
+      const [, r, g, b] = color.match(rgbRegex);
+      return `rgba(${r}, ${g}, ${b}, 0.5)`;
+    }
+
+    if (rgbaRegex.test(color)) {
+      const [, r, g, b, a] = color.match(rgbaRegex);
+      const newOpacity = (parseFloat(a) / 2).toFixed(2);
+      return `rgba(${r}, ${g}, ${b}, ${newOpacity})`;
+    }
+
+    if (color.startsWith('#') && color.length > 7) {
+      return color;
+    }
+
+    return `${color}80`;
+  },
 };

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -281,7 +281,7 @@ const modules = {
 
         if (series.type === 'line' && series.fill) {
           colorDOM.style.height = '8px';
-          colorDOM.style.backgroundColor = `${seriesColor}80`;
+          colorDOM.style.backgroundColor = Util.rgbaAdjustHalfOpacity(seriesColor);
           colorDOM.style.border = `1px solid ${seriesColor}`;
         } else {
           colorDOM.style.backgroundColor = seriesColor;
@@ -653,7 +653,8 @@ const modules = {
 
     if (series.type === 'line' && series.fill) {
       colorDOM.style.height = '8px';
-      colorDOM.style.backgroundColor = series.show ? `${seriesColor}80` : opt.inactive;
+      colorDOM.style.backgroundColor = series.show
+        ? Util.rgbaAdjustHalfOpacity(seriesColor) : opt.inactive;
       colorDOM.style.border = `1px solid ${seriesColor}`;
     } else {
       colorDOM.style.backgroundColor = seriesColor;
@@ -730,7 +731,7 @@ const modules = {
     switch (series.type) {
       case 'line': {
         if (series.fill) {
-          colorDOM.style.backgroundColor = `${seriesColor}80`;
+          colorDOM.style.backgroundColor = Util.rgbaAdjustHalfOpacity(seriesColor);
           colorDOM.style.border = `1px solid ${seriesColor}`;
         } else {
           if (series.point) {
@@ -754,7 +755,8 @@ const modules = {
 
     if (series.type === 'line' && series.fill) {
       colorDOM.style.height = '8px';
-      colorDOM.style.backgroundColor = series.show ? `${seriesColor}80` : opt.inactive;
+      colorDOM.style.backgroundColor = series.show
+        ? Util.rgbaAdjustHalfOpacity(seriesColor) : opt.inactive;
       colorDOM.style.border = `1px solid ${seriesColor}`;
     } else {
       colorDOM.style.backgroundColor = seriesColor;


### PR DESCRIPTION
## 문제
![image](https://github.com/user-attachments/assets/ae34caa6-b635-4b73-bc0f-4d879718f488)

![image](https://github.com/user-attachments/assets/ab21c3a4-a701-441c-86b2-76c803e485c3)
series color가 rgba로 들어올 경우 legend box의 색상이 하얘짐

## 변경사항
- rgb, rgba, hex로 들어오는 값을 opacity를 1/2로 하여 재계산 해주는 Util 생성

![image](https://github.com/user-attachments/assets/c6143bb5-87ec-4f84-ba8b-573cb61ff4af)
