### PR TITLE
[#1801] timepicker placeholder 추가

### DIFF
--- a/docs/views/timePicker/api/timePicker.md
+++ b/docs/views/timePicker/api/timePicker.md
@@ -24,6 +24,7 @@ height: 35px;
 | clearable | Boolean | false | 시간 삭제가 가능한 [x]모양 버튼 사용 유무 | true, false|
 | disabled | Boolean | false | 시간 입력이 비활성화 여부 | true, false|
 | readonly | Boolean | false | 읽기 전용 사용 유무 | true, false|
+| placeholder | Array, String | undefined | placeholder 문구. 'range' 모드일 경우 시작시간과 종료시간의 placeholder 문구가 동일할 경우 String 타입으로 입력. 각 문구가 다를 경우 Array(['시작시간','끝시간']) 입력. 'single' 모드의 경우 String 타입으로 입력 |   |
 
 ### Event
 

--- a/docs/views/timePicker/api/timePicker.md
+++ b/docs/views/timePicker/api/timePicker.md
@@ -24,7 +24,7 @@ height: 35px;
 | clearable | Boolean | false | 시간 삭제가 가능한 [x]모양 버튼 사용 유무 | true, false|
 | disabled | Boolean | false | 시간 입력이 비활성화 여부 | true, false|
 | readonly | Boolean | false | 읽기 전용 사용 유무 | true, false|
-| placeholder | Array, String | undefined | placeholder 문구. 'range' 모드일 경우 시작시간과 종료시간의 placeholder 문구가 동일할 경우 String 타입으로 입력. 각 문구가 다를 경우 Array(['시작시간','끝시간']) 입력. 'single' 모드의 경우 String 타입으로 입력 |   |
+| placeholder | Array, String | undefined | placeholder 문구. 'range' 모드일 경우 시작시간과 종료시간의 placeholder 문구가 동일할 경우 String 타입으로 입력. 각 문구가 다를 경우 Array의 각 String 타입(['시작시간','끝시간'])으로 입력. 'single' 모드의 경우 String 타입으로 입력 |   |
 
 ### Event
 

--- a/docs/views/timePicker/example/Default.vue
+++ b/docs/views/timePicker/example/Default.vue
@@ -3,6 +3,7 @@
     <p class="case-title">Range</p>
     <ev-time-picker
       v-model="rangeTime"
+      :placeholder="['시작시간', '끝시간']"
       @change="changeTime"
     />
     <div class="description">
@@ -15,6 +16,7 @@
     <ev-time-picker
       v-model="commonTime"
       type="single"
+      placeholder="시간 입력"
     />
     <div class="description">
       <span class="badge">Time</span>

--- a/src/components/timePicker/TimePicker.vue
+++ b/src/components/timePicker/TimePicker.vue
@@ -18,7 +18,13 @@
           class="ev-input"
           :disabled="disabled"
           :readonly="readonly"
-          placeholder="start time"
+          :placeholder="
+            placeholder != undefined
+              ? typeof placeholder != 'string'
+                ? placeholder[0]
+                : placeholder
+              : 'start time'
+          "
           @focus="focusInputStartTime"
           @blur="blurInputStartTime"
           @change="changeStartTime"
@@ -49,7 +55,13 @@
           class="ev-input"
           :disabled="disabled"
           :readonly="readonly"
-          placeholder="end time"
+          :placeholder="
+            placeholder != undefined
+              ? typeof placeholder != 'string'
+                ? placeholder[1]
+                : placeholder
+              : 'end time'
+          "
           @focus="focusInputEndTime"
           @blur="blurInputEndTime"
           @change="changeEndTime"
@@ -84,7 +96,9 @@
           class="ev-input"
           :disabled="disabled"
           :readonly="readonly"
-          placeholder="Enter time"
+          :placeholder="
+            placeholder != undefined && typeof placeholder === 'string' ? placeholder : 'Enter time'
+          "
           @focus="focusInputTime"
           @blur="blurInputTime"
           @change="changeTime"
@@ -143,6 +157,11 @@ export default {
     readonly: {
       type: Boolean,
       default: false,
+    },
+    placeholder: {
+      type: [String, Array],
+      required: false,
+      default: undefined,
     },
   },
   emits: {

--- a/src/components/timePicker/TimePicker.vue
+++ b/src/components/timePicker/TimePicker.vue
@@ -20,7 +20,7 @@
           :readonly="readonly"
           :placeholder="
             placeholder != undefined
-              ? typeof placeholder != 'string'
+              ? typeof placeholder !== 'string'
                 ? placeholder[0]
                 : placeholder
               : 'start time'
@@ -57,7 +57,7 @@
           :readonly="readonly"
           :placeholder="
             placeholder != undefined
-              ? typeof placeholder != 'string'
+              ? typeof placeholder !== 'string'
                 ? placeholder[1]
                 : placeholder
               : 'end time'

--- a/src/components/timePicker/TimePicker.vue
+++ b/src/components/timePicker/TimePicker.vue
@@ -18,7 +18,7 @@
           class="ev-input"
           :disabled="disabled"
           :readonly="readonly"
-          :placeholder="getPlaceholder(placeholder, 0, 'start time')"
+          :placeholder="placeholders[0]"
           @focus="focusInputStartTime"
           @blur="blurInputStartTime"
           @change="changeStartTime"
@@ -49,7 +49,7 @@
           class="ev-input"
           :disabled="disabled"
           :readonly="readonly"
-          :placeholder="getPlaceholder(placeholder, 1, 'end time')"
+          :placeholder="placeholders[1]"
           @focus="focusInputEndTime"
           @blur="blurInputEndTime"
           @change="changeEndTime"
@@ -173,6 +173,18 @@ export default {
       },
     }); // <string | string[]>
 
+    const placeholders = computed(() => {
+      const defaultValue = ['start time', 'end time'];
+      if (Array.isArray(props.placeholder)) {
+        return [
+          typeof props.placeholder[0] === 'string' ? props.placeholder[0] : defaultValue[0],
+          typeof props.placeholder[1] === 'string' ? props.placeholder[1] : defaultValue[1],
+        ];
+      }
+      if (typeof props.placeholder === 'string') return [props.placeholder, props.placeholder];
+      return defaultValue;
+    });
+
     const previousValue = ref(
       Array.isArray(time.value) ? [`${time.value[0]}`, `${time.value[1]}`] : `${time.value}`,
     ); // <string | string[]>
@@ -279,13 +291,6 @@ export default {
       isWrongType.single = true;
     };
 
-    const getPlaceholder = (placeholder, index, defaultText) => {
-      if (Array.isArray(placeholder)) {
-        return typeof placeholder[index] === 'string' ? placeholder[index] : defaultText;
-      }
-      return typeof placeholder === 'string' ? placeholder : defaultText;
-    };
-
     return {
       time,
       isWrongType,
@@ -302,7 +307,7 @@ export default {
       focusInputEndTime,
       blurInputEndTime,
       changeEndTime,
-      getPlaceholder,
+      placeholders,
     };
   },
 };

--- a/src/components/timePicker/TimePicker.vue
+++ b/src/components/timePicker/TimePicker.vue
@@ -18,13 +18,7 @@
           class="ev-input"
           :disabled="disabled"
           :readonly="readonly"
-          :placeholder="
-            !isNil(placeholder)
-              ? typeof placeholder !== 'string'
-                ? placeholder[0]
-                : placeholder
-              : 'start time'
-          "
+          :placeholder="getPlaceholder(placeholder, 0, 'start time')"
           @focus="focusInputStartTime"
           @blur="blurInputStartTime"
           @change="changeStartTime"
@@ -55,12 +49,7 @@
           class="ev-input"
           :disabled="disabled"
           :readonly="readonly"
-          :placeholder="!isNil(placeholder)
-              ? typeof placeholder !== 'string'
-                ? placeholder[1]
-                : placeholder
-              : 'end time'
-          "
+          :placeholder="getPlaceholder(placeholder, 1, 'end time')"
           @focus="focusInputEndTime"
           @blur="blurInputEndTime"
           @change="changeEndTime"
@@ -95,9 +84,7 @@
           class="ev-input"
           :disabled="disabled"
           :readonly="readonly"
-          :placeholder="
-            !isNil(placeholder) && typeof placeholder === 'string' ? placeholder : 'Enter time'
-          "
+          :placeholder="typeof placeholder === 'string' ? placeholder : 'Enter time'"
           @focus="focusInputTime"
           @blur="blurInputTime"
           @change="changeTime"
@@ -292,6 +279,13 @@ export default {
       isWrongType.single = true;
     };
 
+    const getPlaceholder = (placeholder, index, defaultText) => {
+      if (Array.isArray(placeholder)) {
+        return typeof placeholder[index] === 'string' ? placeholder[index] : defaultText;
+      }
+      return typeof placeholder === 'string' ? placeholder : defaultText;
+    };
+
     return {
       time,
       isWrongType,
@@ -308,6 +302,7 @@ export default {
       focusInputEndTime,
       blurInputEndTime,
       changeEndTime,
+      getPlaceholder,
     };
   },
 };

--- a/src/components/timePicker/TimePicker.vue
+++ b/src/components/timePicker/TimePicker.vue
@@ -19,7 +19,7 @@
           :disabled="disabled"
           :readonly="readonly"
           :placeholder="
-            placeholder != undefined
+            !isNil(placeholder)
               ? typeof placeholder !== 'string'
                 ? placeholder[0]
                 : placeholder
@@ -55,8 +55,7 @@
           class="ev-input"
           :disabled="disabled"
           :readonly="readonly"
-          :placeholder="
-            placeholder != undefined
+          :placeholder="!isNil(placeholder)
               ? typeof placeholder !== 'string'
                 ? placeholder[1]
                 : placeholder
@@ -97,7 +96,7 @@
           :disabled="disabled"
           :readonly="readonly"
           :placeholder="
-            placeholder != undefined && typeof placeholder === 'string' ? placeholder : 'Enter time'
+            !isNil(placeholder) && typeof placeholder === 'string' ? placeholder : 'Enter time'
           "
           @focus="focusInputTime"
           @blur="blurInputTime"


### PR DESCRIPTION
## 작업 배경
timepicker에 placeholder 문구를 변경할 수 없음

## 변경 사항 요약
docs의 해당 설명 추가
timepicker에 placeholder 옵션 추가
- 'range' 모드일 경우 시작 시간과 종료 시간의 문구가 동일할 경우 string타입으로 각 문구가 다를 경우 string[]으로 입력
- 'single' 모드일 경우 string타입으로 입력
- placeholder 옵션이 없을 경우 default 문구 

## 이전 동작
![image](https://github.com/user-attachments/assets/be395eb8-c701-49ae-a78a-784d81934f39)
![image](https://github.com/user-attachments/assets/ab32fb52-6436-4cd0-9a9e-4fcd163681be)
![image](https://github.com/user-attachments/assets/ab424622-2032-4a04-96b5-6574e441b9e9)

## 기대 동작
![image](https://github.com/user-attachments/assets/a1522856-373f-46a4-8746-b5257f193717)
![image](https://github.com/user-attachments/assets/e00a1672-162b-499c-b859-b6de8ac4f7fb)
![image](https://github.com/user-attachments/assets/484ceeb7-4481-4d1f-98de-8e3e9d5e5800)

## 테스트 가이드
timepicker의 placeholder 옵션이 잘 동작하는지 확인해주세요

