### PR TITLE
[#1800] legend 업데이트됐을때 scroll 높이 재계산

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.71",
+  "version": "3.4.72",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -737,8 +737,8 @@ const modules = {
       }
       this.setLegendColumnHeader();
     } else if (this.options.legend.virtualScroll) {
-      const elementsToRemove = this.legendBoxDOM.querySelectorAll('.ev-chart-legend-container');
-      elementsToRemove.forEach(element => element.remove());
+      this.updateVisibleRowCount();
+      this.renderVisibleLegends();
     } else {
       while (legendBoxDOM.hasChildNodes()) {
         legendBoxDOM.removeChild(legendBoxDOM.firstChild);


### PR DESCRIPTION
범례 리스트가 업데이트되었을때 가상 스크롤 관련 값들이 다시 계산되도록 수정했습니다.

close #1800 