### PR TITLE
[#1800] legend 가상 스크롤 가로형으로 세팅시 아래 영역 안보이거나 진동 발생하는 문제 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.72",
+  "version": "3.4.73",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -150,7 +150,7 @@ const modules = {
   updateStartEndRowIndex() {
     const index = Math.max(Math.floor(this.legendBoxDOM.scrollTop / this.legendItemHeight), 0);
     this.startRowIndex = Math.min(index, this.totalRowCount - this.visibleRowCount);
-    this.endRowIndex = this.startRowIndex + this.visibleRowCount;
+    this.endRowIndex = this.startRowIndex + this.visibleRowCount + 1;
   },
 
   /**

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -149,7 +149,7 @@ const modules = {
    */
   updateStartEndRowIndex() {
     const index = Math.max(Math.floor(this.legendBoxDOM.scrollTop / this.legendItemHeight), 0);
-    this.startRowIndex = index > this.totalRowCount - 1 ? 0 : index;
+    this.startRowIndex = Math.min(index, this.totalRowCount - this.visibleRowCount);
     this.endRowIndex = this.startRowIndex + this.visibleRowCount;
   },
 

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -149,7 +149,7 @@ const modules = {
    */
   updateStartEndRowIndex() {
     const index = Math.max(Math.floor(this.legendBoxDOM.scrollTop / this.legendItemHeight), 0);
-    this.startRowIndex = Math.min(index, this.totalRowCount - this.visibleRowCount);
+    this.startRowIndex = Math.min(index, Math.max(this.totalRowCount - this.visibleRowCount, 0));
     this.endRowIndex = this.startRowIndex + this.visibleRowCount + 1;
   },
 


### PR DESCRIPTION
# 기존 동작
![Nov-08-2024 01-20-04](https://github.com/user-attachments/assets/d8ad671e-608a-4384-8a4c-c73a941378d4)
legend virtualScroll 적용 후 position: 'top' 또는 position: 'bottom'일때 스크롤 마우스를 통해 바로 아래 영역으로 내리면 보이지 않는 문제가 있고, 아래영역에서 스크롤을 좀 더 아래로 내렸을때 진동이 발생하는 문제가 있었습니다.
# 수정 후 동작
![Nov-08-2024 01-22-56](https://github.com/user-attachments/assets/d26d039b-c481-4d44-a6ec-77330cf33b5a)
기존 동작의 에러가 발생하지 않습니다.
# 테스트 방법
lineChart의 VirtualLegendScroll에서 legend option을 top 또는 bottom으로 변경 후 스크롤을 내렸을때 진동이 발생하거나 legend가 잘리는 현상이 발생하지 않는지 확인해주세요.