### PR TITLE
Autofix: [#1800] legend 가상 스크롤 가로형으로 세팅시 아래 영역 안보이거나 진동 발생하는 문제 해결

### DIFF
--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -124,7 +124,7 @@ const modules = {
    *
    * @returns {undefined}
    */
-  updateVisibleRowCount() {
+  updateVisibleRowCount(forceUpdate = false) {
     const isLeftOrRight = this.options.legend.position === 'right' || this.options.legend.position === 'left';
     const legendBoxHeight = this.legendBoxDOM.clientHeight;
     const legendBoxWidth = this.legendBoxDOM.clientWidth;
@@ -136,8 +136,12 @@ const modules = {
 
     this.itemsPerRow = isLeftOrRight ? 1 : Math.floor(legendBoxWidth / itemWidth);
     this.totalRowCount = Math.ceil(useLegendSeriesCount / this.itemsPerRow);
-    this.visibleRowCount = legendBoxHeight > this.legendItemHeight
+    const newVisibleRowCount = legendBoxHeight > this.legendItemHeight
       ? Math.round(legendBoxHeight / this.legendItemHeight) + 1 : this.totalRowCount;
+    if (forceUpdate || newVisibleRowCount !== this.visibleRowCount) {
+      this.visibleRowCount = newVisibleRowCount;
+      this.renderVisibleLegends();
+    }
   },
 
   /**
@@ -161,8 +165,13 @@ const modules = {
    *
    * @returns {undefined}
    */
-  renderVisibleLegends() {
+  renderVisibleLegends(forceUpdate = false) {
     this.updateStartEndRowIndex();
+    if (!forceUpdate && this.prevStartRowIndex === this.startRowIndex && this.prevEndRowIndex === this.endRowIndex) {
+      return;
+    }
+    this.prevStartRowIndex = this.startRowIndex;
+    this.prevEndRowIndex = this.endRowIndex;
 
     const elementsToRemove = this.legendBoxDOM.querySelectorAll('.ev-chart-legend-container');
     elementsToRemove.forEach(element => element.remove());
@@ -495,8 +504,10 @@ const modules = {
     this.legendBoxDOM.addEventListener('mouseleave', this.onLegendBoxLeave);
 
     if (this.options.legend.virtualScroll && !this.useTable) {
-      this.legendBoxDOM.addEventListener('resize', this.updateVisibleRowCount);
-      this.legendBoxDOM.addEventListener('scroll', this.renderVisibleLegends.bind(this));
+      this.legendBoxDOM.addEventListener('resize', () => this.updateVisibleRowCount(true));
+      this.legendBoxDOM.addEventListener('scroll', () => {
+        requestAnimationFrame(() => this.renderVisibleLegends(true));
+      });
     }
 
     this.initResizeEvent();


### PR DESCRIPTION
Addressed the issue where legends with virtualScroll enabled would disappear or vibrate when scrolling for top or bottom positions. Modified the rendering logic to ensure smooth scrolling and proper display of legend items. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    