### PR TITLE
[#1808]Tree Grid > sorting 기능 임시 잠금 -- column width변경 시 외부 sorting 정보 누락

### DIFF
--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -114,7 +114,7 @@
                   </template>
                   <template v-else>
                     <grid-sort-button
-                      v-if="column.sortable === undefined ? true : column.sortable"
+                      v-if="column.sortable === undefined ? false : column.sortable"
                       class="column-sort__icon column-sort__icon--basic"
                       :icon="'basic'"
                       :style="{

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -1028,7 +1028,11 @@ export const sortEvent = ({ sortInfo, stores }) => {
 
 
   const setSortInfo = (columns, emitTriggered = true) => {
-    const sortByColumn = columns?.find(col => col?.sortOption?.sortType && col.sortOption.sortType !== 'init');
+    const sortByColumnIndex = columns?.findIndex(col => col?.sortOption?.sortType && col.sortOption.sortType !== 'init');
+    const sortByColumn = columns[sortByColumnIndex];
+    if (sortByColumnIndex > -1) {
+      sortByColumn.index = sortByColumnIndex;
+    }
     const { sortType } = sortByColumn?.sortOption || {};
 
     sortInfo.sortColumn = sortByColumn;


### PR DESCRIPTION
- evui version update (3.4.74 -> 3.4.75)
- sortable 옵션이 true가 아니면 sort아이콘이 안보이도록 함
- sorting 정보 셋팅 시 index값이 없어 column 정보를 바꾸지 않던 현상 수정