### PR TITLE
[#1822] Scatter > RealTimeScatter > 포인트 개별 fill 컬러 설정이 안됨.

### DIFF
--- a/docs/views/scatterChart/example/RealTimeScatter.vue
+++ b/docs/views/scatterChart/example/RealTimeScatter.vue
@@ -48,14 +48,14 @@ export default {
     const series = {
       series1: {
         name: 'series1',
-        pointSize: 4,
+        pointSize: 0.5,
         color: '#DF6264',
         pointFill: '#DF6264',
         overflowColor: '#FF00FF',
       },
       series2: {
         name: 'series2',
-        pointSize: 4,
+        pointSize: 0.5,
         color: '#3CA0FF',
         pointFill: '#3CA0FF',
         overflowColor: '#A3D3FF',
@@ -158,10 +158,10 @@ export default {
       series2 = [];
 
       if (isInit) {
-        data = generateData(100);
+        data = generateData(10000);
         isInit = false;
       } else {
-        data = generateData(10);
+        data = generateData(100);
       }
 
       for (let i = 0; i < data.length; i++) {
@@ -173,13 +173,11 @@ export default {
           series1.push({
             x: dataX,
             y: dataY / 1000,
-            color: '#FF0000',
           });
         } else {
           series2.push({
             x: dataX,
             y: dataY / 1000,
-            color: '#0000FF',
           });
         }
       }

--- a/docs/views/scatterChart/example/RealTimeScatter.vue
+++ b/docs/views/scatterChart/example/RealTimeScatter.vue
@@ -48,14 +48,14 @@ export default {
     const series = {
       series1: {
         name: 'series1',
-        pointSize: 0.5,
+        pointSize: 4,
         color: '#DF6264',
         pointFill: '#DF6264',
         overflowColor: '#FF00FF',
       },
       series2: {
         name: 'series2',
-        pointSize: 0.5,
+        pointSize: 4,
         color: '#3CA0FF',
         pointFill: '#3CA0FF',
         overflowColor: '#A3D3FF',
@@ -158,10 +158,10 @@ export default {
       series2 = [];
 
       if (isInit) {
-        data = generateData(10000);
+        data = generateData(100);
         isInit = false;
       } else {
-        data = generateData(100);
+        data = generateData(10);
       }
 
       for (let i = 0; i < data.length; i++) {
@@ -173,11 +173,13 @@ export default {
           series1.push({
             x: dataX,
             y: dataY / 1000,
+            color: '#FF0000',
           });
         } else {
           series2.push({
             x: dataX,
             y: dataY / 1000,
+            color: '#0000FF',
           });
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.80",
+  "version": "3.4.81",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.scatter.js
+++ b/src/components/chart/element/element.scatter.js
@@ -159,7 +159,7 @@ class Scatter {
 
             ctx.strokeStyle = color;
 
-            const pointFillColor = overflowColor || this.pointFill || item.color || this.color;
+            const pointFillColor = overflowColor || item.color || this.pointFill || this.color;
             ctx.fillStyle = pointFillColor;
 
             Canvas.drawPoint(ctx, pointStyle, pointSize, item.xp, item.yp);


### PR DESCRIPTION
[현상]
- 각각의 데이터에 `color`를 변경하여도 pointFIll 컬러가 변경되지 않음 (테두리 색만 변함)
![image](https://github.com/user-attachments/assets/05fd9fc2-682b-4569-b0fd-15ec53d05e96)


[개선]
- realTimeScatter > pointFillColor를 받는 조건 수정
![image](https://github.com/user-attachments/assets/c84b88f7-89f3-4a28-a119-4a5042b6dfa7)

- 머지하기전에 RealTimeScatter.vue 원상복구 예정입니다.