### PR TITLE
[#1824] Grid > 검색 시 컬럼 데이터가 타입이 배열인 경우 에러

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.81",
+  "version": "3.4.82",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1074,7 +1074,9 @@ export const filterEvent = (params) => {
             let columnValue = rowData[column.index] ?? null;
             column.type = column.type || 'string';
             if (columnValue !== null) {
-              if (typeof columnValue === 'object') {
+              if (columnValue instanceof Array) {
+                columnValue = JSON.stringify(columnValue);
+              } else if (typeof columnValue === 'object') {
                 columnValue = columnValue[column.field];
               }
               if (!column.hide && (column?.searchable === undefined || column?.searchable)) {


### PR DESCRIPTION
## 수정 전
값이 배열인 데이터가 존재하는 경우, 검색 시 에러 발생
![image](https://github.com/user-attachments/assets/1973d529-5075-481e-a13b-c59db3fcd217)

## 수정 후
값이 배열인 데이터가 존재할 때에도 정상적으로 검색 문자열로 필터링
![스크린샷 2024-12-02 오전 10 57 34](https://github.com/user-attachments/assets/18128720-9a39-421b-91c3-c03a0c71de88)

close #1824 

