### PR TITLE
[#1827]Chart > Axis > time > interval : month 값 조정

### DIFF
--- a/src/components/chart/helpers/helpers.constant.js
+++ b/src/components/chart/helpers/helpers.constant.js
@@ -206,7 +206,7 @@ export const TIME_INTERVALS = {
   },
   month: {
     common: true,
-    size: 2.628e9,
+    size: 2.6784e9,
     steps: [1, 2, 3],
   },
   quarter: {

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -183,7 +183,7 @@ class TimeCategoryScale extends Scale {
     let labelPoint;
     let ix;
     for (ix = 0; ix < oriSteps; ix += count) {
-      ticks[ix] = axisMin + (ix * stepValue);
+      ticks[ix] = dayjs(axisMin).valueOf() + (ix * stepValue);
 
       labelCenter = Math.round(startPoint + (graphGap * ix));
       linePosition = labelCenter + aliasPixel;


### PR DESCRIPTION
### 이슈 내용 
```
- axis Type : 'time'
- interval: 'month'
- category: true
- timeFormat: 'YYYY-MM'
```
일 때 사용자 예상과 다르게 월이 표시되는 현상 발생

### 처리내용
-  `month`의 interval size(ms)를 30.42일 -> 31일 로 변경
- interval 계산하는 로직 date, dayjs 값이 들어와도 계산 될 수 있도록 valueOf 추가


### Before / After
![image](https://github.com/user-attachments/assets/1c4c83bb-45f0-438e-8a89-6885b017f378)
