### PR TITLE
[#1826] Grid > GridColumnSetting 에서 최초 칼럼이 1개인 경우, 해당 칼럼 체크 해지 가능한 버그

### DIFF
--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -277,14 +277,15 @@ export default {
         value: 'rows',
       },
     ]);
+    // TODO: 머지 직전 삭제할 예정입니다.
     const columns = ref([
-      { caption: 'Name', field: 'userName', type: 'string', width: 80, fixed: true },
-      { caption: 'Role', field: 'role', type: 'string', width: 80, hiddenDisplay: true },
-      { caption: 'number', field: 'number', type: 'number', width: 80 },
-      { caption: 'boolean', field: 'boolean', type: 'boolean', width: 80 },
-      { caption: 'Phone', field: 'phone', type: 'string', sortable: false },
-      { caption: 'Email', field: 'email', type: 'string', width: 80 },
-      { caption: 'Last Login', field: 'lastLogin', type: 'string' },
+      { caption: 'Name', field: 'userName', type: 'string', width: 80 },
+      // { caption: 'Role', field: 'role', type: 'string', width: 80, hiddenDisplay: true },
+      // { caption: 'number', field: 'number', type: 'number', width: 80 },
+      // { caption: 'boolean', field: 'boolean', type: 'boolean', width: 80 },
+      // { caption: 'Phone', field: 'phone', type: 'string', sortable: false },
+      // { caption: 'Email', field: 'email', type: 'string', width: 80 },
+      // { caption: 'Last Login', field: 'lastLogin', type: 'string' },
     ]);
     const resetBorderStyle = () => {
       borderMV.value = '';

--- a/src/components/grid/GridColumnSetting.vue
+++ b/src/components/grid/GridColumnSetting.vue
@@ -140,7 +140,7 @@ export default {
         lastCheckedColumn = columns[0];
       } else if (columns?.length < 1) { // 최소 한개 컬럼은 선택되도록
         if (lastCheckedColumn == null) {
-          lastCheckedColumn = originColumnList.value?.[0]?.text;
+          lastCheckedColumn = originColumnList.value[0]?.text;
         }
         checkColumnGroup.value.push(lastCheckedColumn);
       }

--- a/src/components/grid/GridColumnSetting.vue
+++ b/src/components/grid/GridColumnSetting.vue
@@ -138,7 +138,10 @@ export default {
     const onCheckColumn = (columns) => {
       if (columns?.length === 1) {
         lastCheckedColumn = columns[0];
-      } else if (columns?.length < 1 && lastCheckedColumn !== null) { // 최소 한개 컬럼은 선택되도록
+      } else if (columns?.length < 1) { // 최소 한개 컬럼은 선택되도록
+        if (lastCheckedColumn == null) {
+          lastCheckedColumn = originColumnList.value?.[0]?.text;
+        }
         checkColumnGroup.value.push(lastCheckedColumn);
       }
     };


### PR DESCRIPTION
## as-is
최초 칼럼이 1개인 경우, 해당 칼럼 체크 해지 가능.
![gird-one-col-check](https://github.com/user-attachments/assets/579594ab-aac8-44c6-9296-3de3a36e793a)

- (참고) 최초 칼럼이 2개 이상인 경우,  마지막 남은 1개의 칼럼은 체크 해지 불가능

## to-be 
최초 칼럼이 1개인 경우, 해당 칼럼 체크 해지 불가능.
![gird-one-col-check-2](https://github.com/user-attachments/assets/ade8be8d-62bf-4d30-9823-39c89230df05)