### PR TITLE
[#1832] Grid > 모든 데이터가 uncheckable, disabledRows 일 때 헤더 전체 체크되는 버그 수정

### DIFF
--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1329,6 +1329,10 @@ export const storeEvent = (params) => {
         const disabled = props.disabledRows.includes(row);
         store.push([idx, checked, row, selected, expanded, uncheckable, disabled]);
       });
+
+      if (rows.length === props.uncheckable?.length || rows.length === props.disabledRows?.length) {
+        hasUnChecked = true;
+      }
       checkInfo.isHeaderChecked = rows.length > 0 ? !hasUnChecked : false;
       checkInfo.isHeaderIndeterminate = hasUnChecked && !!checkInfo.checkedRows.length;
       checkInfo.isHeaderUncheckable = rows.every(row => props.uncheckable.includes(row)

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1330,7 +1330,9 @@ export const storeEvent = (params) => {
         store.push([idx, checked, row, selected, expanded, uncheckable, disabled]);
       });
 
-      if (rows.length === props.uncheckable?.length || rows.length === props.disabledRows?.length) {
+      if (rows.length !== props.checked.length
+        && (rows.length === props.uncheckable?.length || rows.length === props.disabledRows?.length)
+      ) {
         hasUnChecked = true;
       }
       checkInfo.isHeaderChecked = rows.length > 0 ? !hasUnChecked : false;


### PR DESCRIPTION
#### 작업 배경
일부 화면에서 그리드의 모든 데이터가 uncheckable 일 경우, 헤더 영역의 전체 체크박스 체크됨

#### 변경 사항
[AS-IS]
그리드 모든 데이터가 uncheckable / disabledRows 일 경우 헤더 영역의 전체 체크박스 체크됨
![image](https://github.com/user-attachments/assets/b29fe068-9038-4f3d-bf3e-37e46782c893)


[TO-BE]
그리드 모든 데이터가 uncheckable / disabledRows 일 경우 헤더 전체 체크 해지되도록 예외 추가
![image](https://github.com/user-attachments/assets/8030e9d9-ef08-4f83-ab05-8f6b28849a34)

모든 데이터 checked + uncheckable or disabledRows 일 경우 헤더 전체 체크
![image](https://github.com/user-attachments/assets/45ea7881-e113-4bcc-8500-309563372aaa)

