### PR TITLE
fix #1837 grid eventListener 제거

### DIFF
--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -1077,8 +1077,8 @@ export default {
     });
 
     onUnmounted(() => {
-      document.removeEventListener('wheel', onMouseWheel);
-      document.removeEventListener('scroll', onMouseWheel);
+      document.removeEventListener('wheel', onMouseWheel, { capture: false });
+      document.removeEventListener('scroll', onMouseWheel, { capture: true });
     });
 
     onActivated(() => {


### PR DESCRIPTION
> While addEventListener() will let you add the same listener more than once for the same type if the options are different, the only option removeEventListener() checks is the capture/useCapture flag. Its value must match for removeEventListener() to match, but the other values don't.

capture 옵션이 다를 경우 콜백이 같아도 이벤트가 제대로 지워지지 않습니다.