### PR TITLE
feat: bar chart thickness option에 px 추가 

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -113,7 +113,7 @@ const chartData = {
 | type         | String          | ''                                        | series 별로 type값을 지정하지 않을 경우 일괄 적용될 차트의 타입                                                                                                                        | 'bar', 'pie', 'line', 'scatter' |
 | width        | String / Number | '100%'                                    | 차트의 너비                                                                                                                                                                            | '100%', '150px', 150            |
 | height       | String / Number | '100%'                                    | 차트의 높이                                                                                                                                                                            | '100%', '150px', 150            |
-| thickness    | Number          | 1                                         | 차트 막대의 너비                                                                                                                                                                       | 0.1 ~ 1                         |
+| thickness    | Number \| `'${number}px'` | 1                                         | 차트 막대의 너비, 최대치를 넘지 않음                                                                                                                                                                      | 0.1 ~ 1 \| '10px'               |
 | cPadRatio    | Number          | 0                                         | 카테고리(각 라벨간)내부 padding 영역의 비율                                                                                                                                            | 0 ~ 0.99 (1 미만)               |
 | borderRadius | Number          | 0                                         | 막대 가장자리 부분의 border-radius 값.                                                                                                                                                 | 0 ~                             |
 | horizontal   | Boolean         | false                                     | 차트 막대의 방향 - 수평 전환 여부                                                                                                                                                      | true, false                     |
@@ -135,7 +135,7 @@ const chartData = {
 
 | 이름           | 타입     | 디폴트                 | 설명                                                                                               | 종류(예시)                                                                               |
 | -------------- | -------- | ---------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| type           | String   |                        | 축의 유형                                                                                          | [linear](#linear-type), [time](#time-type), [log](#Logarithmic-type), [step](#step-type) |
+| type           | String   |                        | 축의 유형                                                                                          | [linear](#linear-type), [time](#time-type), [log](#logarithmic-type), [step](#step-type) |
 | showAxis       | Boolean  | true                   | 축 표시 여부                                                                                       | true / false                                                                             |
 | startToZero    | Boolean  | false                  | 축의 시작을 0 부터 시작할지의 여부                                                                 | true / false                                                                             |
 | autoScaleRatio | Number   | null                   | Axis의 Max Buffer를 위한 속성                                                                      | 0.1 ~ 0.9                                                                                |
@@ -383,7 +383,7 @@ const chartOptions = {
 | indicatorColor | Hex, RGB, RGBA Code(String) | '#000000'           | indicator 색상                |            |
 | tipStyle       | Object                      | ([상세](#tipstyle)) | tip 스타일을 설정             |
 
-##### etc.
+##### etc
 
 | 이름          | 타입                        | 디폴트    | 설명             | 종류(예시) |
 | ------------- | --------------------------- | --------- | ---------------- | ---------- |
@@ -407,7 +407,7 @@ const chartOptions = {
 | indicatorColor      | Hex, RGB, RGBA Code(String) | '#000000'           | indicator 색상                                                             |                 |
 | tipStyle            | Object                      | ([상세](#tipstyle)) | tip 스타일을 설정                                                          |
 
-##### etc.
+##### etc
 
 | 이름          | 타입                        | 디폴트    | 설명             | 종류(예시) |
 | ------------- | --------------------------- | --------- | ---------------- | ---------- |

--- a/docs/views/barChart/example/AxisControl.vue
+++ b/docs/views/barChart/example/AxisControl.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="case">
+
+  <ev-chart
+    :data="chartData"
+    :options="chartOptions"
+  />
+  <div class="description">
+      <div class="hover-options">
+        <span>axisXShow</span>
+        <ev-toggle v-model="axisXShow" />
+        <span>axisYShow</span>
+        <ev-toggle v-model="axisYShow" />
+        <span>gridXShow</span>
+        <ev-toggle v-model="gridXShow" />
+        <span>gridYShow</span>
+        <ev-toggle v-model="gridYShow" />
+        <span>formatterApply: () => ''</span>
+        <ev-toggle v-model="formatterApply" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { computed, ref } from 'vue';
+
+  export default {
+    setup() {
+      const chartData = {
+        series: {
+          series1: { name: '시리즈 이름' },
+        },
+        labels: ['가나다라', '마바사', '아자차', '카타', '파하'],
+        data: {
+          series1: [100, 150, 51, 150, 350],
+        },
+      };
+
+      const axisXShow = ref(true);
+      const axisYShow = ref(true);
+      const gridXShow = ref(true);
+      const gridYShow = ref(true);
+      const formatterApply = ref(false);
+
+      const chartOptions = computed(() => ({
+        type: 'bar',
+        cPadRatio: 0.1,
+        axesX: [{
+          type: 'step',
+          showAxis: axisXShow.value,
+          showGrid: gridXShow.value,
+        }],
+        axesY: [{
+          showAxis: axisYShow.value,
+          showGrid: gridYShow.value,
+          type: 'linear',
+          startToZero: true,
+          autoScaleRatio: 0.1,
+          formatter: formatterApply.value ? () => '' : undefined,
+        }],
+      }));
+
+      return {
+        chartData,
+        chartOptions,
+        axisXShow,
+        axisYShow,
+        gridXShow,
+        gridYShow,
+        formatterApply,
+      };
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/docs/views/barChart/example/Default.vue
+++ b/docs/views/barChart/example/Default.vue
@@ -21,7 +21,7 @@
       const chartOptions = {
         type: 'bar',
         cPadRatio: 0.1,
-        thickness: '10px',
+        thickness: 1,
         axesX: [{
           type: 'step',
         }],

--- a/docs/views/barChart/example/Default.vue
+++ b/docs/views/barChart/example/Default.vue
@@ -21,6 +21,7 @@
       const chartOptions = {
         type: 'bar',
         cPadRatio: 0.1,
+        thickness: '10px',
         axesX: [{
           type: 'step',
         }],

--- a/docs/views/barChart/example/Stack.vue
+++ b/docs/views/barChart/example/Stack.vue
@@ -31,7 +31,7 @@
         type: 'bar',
         width: '100%',
         height: '100%',
-        thickness: 1,
+        thickness: '20px',
         title: {
           text: 'Title Test',
           show: true,

--- a/docs/views/barChart/props.js
+++ b/docs/views/barChart/props.js
@@ -22,6 +22,8 @@ import Overlapping from './example/Overlapping';
 import OverlappingRaw from '!!raw-loader!./example/Overlapping';
 import HoverWithGroup from './example/HoverWithGroup';
 import HoverWithGroupRaw from '!!raw-loader!./example/HoverWithGroup';
+import AxisControl from './example/AxisControl';
+import AxisControlRaw from '!!raw-loader!./example/AxisControl';
 
 export default {
   mdText,
@@ -82,6 +84,11 @@ export default {
       description: '',
       component: HoverWithGroup,
       parsedData: parseComponent(HoverWithGroupRaw),
+    },
+    AxisControl: {
+      description: 'axis control',
+      component: AxisControl,
+      parsedData: parseComponent(AxisControlRaw),
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.84",
+  "version": "3.4.85",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -97,7 +97,16 @@ class Bar {
     bArea = cArea > (cPad * 2) ? (cArea - (cPad * 2)) : cArea;
     bArea = this.isExistGrp ? bArea : bArea / showSeriesCount;
 
-    const size = Math.ceil(bArea * thickness);
+    const getSize = () => {
+      if (typeof thickness === 'string' && thickness?.endsWith('px')) {
+        return Math.min(bArea, parseInt(thickness, 10));
+      }
+      if (typeof thickness === 'number' && thickness <= 1 && thickness >= 0) {
+        return Math.ceil(bArea * thickness);
+      }
+      return bArea;
+    };
+    const size = getSize();
 
     w = isHorizontal ? null : size;
     h = isHorizontal ? size : null;

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -98,8 +98,8 @@ class Bar {
     bArea = this.isExistGrp ? bArea : bArea / showSeriesCount;
 
     const getSize = () => {
-      if (typeof thickness === 'string' && thickness?.endsWith('px')) {
-        return Math.min(bArea, parseInt(thickness, 10));
+      if (typeof thickness === 'string' && /[0-9]+px/.test(thickness)) {
+        return Math.min(bArea, Number(thickness.replace('px', '')));
       }
       if (typeof thickness === 'number' && thickness <= 1 && thickness >= 0) {
         return Math.ceil(bArea * thickness);

--- a/src/components/chart/element/element.bar.time.js
+++ b/src/components/chart/element/element.bar.time.js
@@ -47,7 +47,16 @@ class TimeBar extends Bar {
       bArea = (cArea - (cPad * 2)) / showSeriesCount;
     }
 
-    const size = Math.ceil(bArea * thickness);
+    const getSize = () => {
+      if (typeof thickness === 'string' && thickness?.endsWith('px')) {
+        return Math.min(bArea, parseInt(thickness, 10));
+      }
+      if (typeof thickness === 'number' && thickness <= 1 && thickness >= 0) {
+        return Math.ceil(bArea * thickness);
+      }
+      return bArea;
+    };
+    const size = getSize();
 
     let w = isHorizontal ? null : size;
     let subW = isHorizontal ? null : size;

--- a/src/components/chart/element/element.bar.time.js
+++ b/src/components/chart/element/element.bar.time.js
@@ -48,8 +48,8 @@ class TimeBar extends Bar {
     }
 
     const getSize = () => {
-      if (typeof thickness === 'string' && thickness?.endsWith('px')) {
-        return Math.min(bArea, parseInt(thickness, 10));
+      if (typeof thickness === 'string' && /[0-9]+px/.test(thickness)) {
+        return Math.min(bArea, Number(thickness.replace('px', '')));
       }
       if (typeof thickness === 'number' && thickness <= 1 && thickness >= 0) {
         return Math.ceil(bArea * thickness);


### PR DESCRIPTION
기존 바 너비와 px값 중 `Math.min`값을 사용함

![image](https://github.com/user-attachments/assets/28c8d754-0cb5-4509-9eb6-2e44430a5d03)


![image](https://github.com/user-attachments/assets/df51e510-ce5d-4cba-bb67-8adad467e619)
