### PR TITLE
[#1851] Grid > 칼럼 type이 StringNumber 일 때 콤마(,)가 포함되는 경우 정렬 안되는 버그

### DIFF
--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -281,6 +281,7 @@ export default {
       { caption: 'Name', field: 'userName', type: 'string', width: 80, fixed: true },
       { caption: 'Role', field: 'role', type: 'string', width: 80, hiddenDisplay: true },
       { caption: 'number', field: 'number', type: 'number', width: 80 },
+      { caption: 'string number', field: 'stringNumber', type: 'stringNumber', width: 80 },
       { caption: 'boolean', field: 'boolean', type: 'boolean', width: 80 },
       { caption: 'Phone', field: 'phone', type: 'string', sortable: false },
       { caption: 'Email', field: 'email', type: 'string', width: 80 },
@@ -310,6 +311,15 @@ export default {
       });
       clickedRowMV.value = clickedRow;
     };
+
+    const generateFormattedNumber = () => {
+      const randomValue = (Math.random() * 10000 + 1).toFixed(2);
+
+      return Number(randomValue).toLocaleString(undefined, {
+        maximumFractionDigits: 2,
+      });
+    };
+
     const getData = (count, startIndex) => {
       const temp = [];
       const roles = ['Common', 'Admin'];
@@ -319,6 +329,7 @@ export default {
           `user_${ix + 1}`,
           roles[ix % 2],
           ix,
+          generateFormattedNumber(),
           booleans[ix % 2],
           '010-0000-0000',
           'kmn0827@ex-em.com',

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -781,6 +781,33 @@ export const sortEvent = (params) => {
       return { aCol, bCol };
     };
 
+    const getSeparators = (str) => {
+      // 비숫자 문자(구분 기호)를 모두 찾기
+      const separators = str.match(/[^0-9]/g) || [];
+
+      // 구분 기호가 두 개 이상인 경우: 천 단위 구분자와 소수점 구분자 존재
+      const thousandSeparator = separators.length > 1 ? separators[0] : '';
+      const decimalSeparator = separators.length > 0 ? separators[separators.length - 1] : '.';
+
+      return { thousandSeparator, decimalSeparator };
+    };
+
+    const getNumberFromFormattedString = (str) => {
+      const { thousandSeparator, decimalSeparator } = getSeparators(str);
+
+      // 천 단위 구분 기호가 존재하는 경우 제거
+      let normalizedStr = thousandSeparator
+        ? str.replace(new RegExp(`\\${thousandSeparator}`, 'g'), '')
+        : str;
+
+      // 소수점 구분 기호를 점(.)으로 변환
+      if (decimalSeparator !== '.') {
+        normalizedStr = normalizedStr.replace(decimalSeparator, '.');
+      }
+
+      return parseFloat(normalizedStr);
+    };
+
     if (customSetAsc) {
       stores.store.sort((a, b) => {
         /*
@@ -810,8 +837,13 @@ export const sortEvent = (params) => {
         stores.store.sort((a, b) => {
           let { aCol, bCol } = getColumnValue(a, b);
           if (!aCol || typeof aCol === 'string' || typeof aCol === 'number') {
-            aCol = aCol === '' ? null : aCol;
-            bCol = bCol === '' ? null : bCol;
+            if (typeof aCol === 'string') {
+              aCol = aCol === '' ? null : getNumberFromFormattedString(aCol);
+              bCol = bCol === '' ? null : getNumberFromFormattedString(bCol);
+            } else {
+              aCol = aCol === '' ? null : aCol;
+              bCol = bCol === '' ? null : bCol;
+            }
             return numberSortFn(aCol ?? null, bCol ?? null);
           }
           return 0;


### PR DESCRIPTION
##################################
- 브라우저의 언어 및 지역 설정에 따라 천 단위 표기법이 다 다르기 때문에 콤마(,)가 포함되는 경우 뿐만 아니라 언어 설정에 따른 숫자 포맷 구분 함수 작성

- getSeparators
  - 비숫자 문자(구분기호)를 찾아서 천 단위 구분자와 소수점 구분자 확인
- getNumberFromFormattedString
  - 단위 구분 기호 존재하는 경우 제거
  - 소수점 구분 기호를 점으로 변환
- Default에 stringNumber 칼럼 추가