### PR TITLE
[#1855]Common > HTMLCollection Type에서 forEach를 사용한 경우 제거 (3.5.0-rc.1 버전 필수)

### DIFF
--- a/src/components/chart/plugins/plugins.legend.gradient.js
+++ b/src/components/chart/plugins/plugins.legend.gradient.js
@@ -260,7 +260,7 @@ const modules = {
 
       const thumbDOM = targetDOM.getElementsByClassName('ev-chart-legend-thumb')[0];
       const labels = thumbDOM.children;
-      labels.forEach((labelDOM) => {
+      [...labels]?.forEach?.((labelDOM) => {
         labelDOM.style.opacity = 1;
       });
     }
@@ -310,7 +310,7 @@ const modules = {
     const thumbDOM = targetDOM?.getElementsByClassName('ev-chart-legend-thumb')[0];
     if (thumbDOM) {
       const labels = thumbDOM.children;
-      labels.forEach((labelDOM) => {
+      [...labels]?.forEach?.((labelDOM) => {
         labelDOM.style.opacity = 0.2;
       });
     }

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -165,7 +165,7 @@ const modules = {
     this.updateStartEndRowIndex();
 
     const elementsToRemove = this.legendBoxDOM.querySelectorAll('.ev-chart-legend-container');
-    elementsToRemove.forEach(element => element.remove());
+    [...elementsToRemove]?.forEach?.(element => element.remove());
 
     const totalScrollHeight = this.totalRowCount * this.legendItemHeight;
     const top = this.startRowIndex * this.legendItemHeight;
@@ -190,7 +190,7 @@ const modules = {
       useLegendSeries = Object.entries(this.seriesList)
       .filter(([, series]) => series.showLegend);
     }
-    useLegendSeries.slice(startIndex, endIndex).forEach(([, series]) => {
+    useLegendSeries?.slice(startIndex, endIndex)?.forEach(([, series]) => {
       this.addLegend(series);
     });
   },
@@ -231,8 +231,8 @@ const modules = {
    * @returns {undefined}
    */
   addLegendForGroups(groups, seriesList, useTable) {
-    groups.forEach((group) => {
-      group.slice().reverse().forEach((sId) => {
+    groups?.forEach?.((group) => {
+      group?.slice()?.reverse()?.forEach((sId) => {
         const series = seriesList[sId];
         if (series && series.showLegend) {
           this.addLegendBasedOnType(series, useTable);
@@ -407,7 +407,7 @@ const modules = {
         colorDOM.style.backgroundColor = inactiveColor;
         colorDOM.style.borderColor = inactiveColor;
         nameDOM.style.color = inactiveColor;
-        valueDOMList?.forEach((dom) => {
+        [...valueDOMList]?.forEach?.((dom) => {
           dom.style.color = inactiveColor;
         });
       } else {
@@ -429,7 +429,7 @@ const modules = {
         }
 
         nameDOM.style.color = opt.color;
-        valueDOMList?.forEach((dom) => {
+        [...valueDOMList]?.forEach?.((dom) => {
           const style = opt.table?.columns[dom.dataset.type]?.style;
           dom.style.color = style?.color ? style.color : opt.color;
         });
@@ -691,10 +691,10 @@ const modules = {
     const aggregations = this.getAggregations();
     const rowDOMList = this.legendBoxDOM?.getElementsByClassName('ev-chart-legend--table__row');
 
-    rowDOMList.forEach((row) => {
+    [...rowDOMList]?.forEach?.((row) => {
       const valueDOMList = row?.getElementsByClassName('ev-chart-legend--table__value');
 
-      valueDOMList.forEach((dom) => {
+      [...valueDOMList]?.forEach?.((dom) => {
         const key = dom.dataset.type;
         if (key === 'name') {
           return;


### PR DESCRIPTION
### 이슈 내용 
- vue-cli 에서 vite로 변경됨에 따라 `HTMLCollection`에 자동으로 forEach를 지원하는 기능이 사라지면서 에러 발생 
   - Chart 공통 - Legend 클릭 기능
   - Heatmap - gradient legend - 마우스 호버 시 label이 표시되는 기능


### 처리 내용
- HTMLCollection type을 대상으로 forEach를 사용한 로직에 배열 벼환 로직 추가