### PR TITLE
feat: add SCSS preprocessor options for modern API in Vite configuration

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -12,5 +12,12 @@ export default defineConfig({
       docs: path.join(__dirname, 'docs/'),
     },
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: 'modern',
+      },
+    },
+  },
   base: '/EVUI/',
 });

--- a/vite.config.lib.js
+++ b/vite.config.lib.js
@@ -1,4 +1,3 @@
-
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import path from 'path';
@@ -17,6 +16,13 @@ export default defineConfig({
         globals: {
           vue: 'Vue',
         },
+      },
+    },
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: 'modern',
       },
     },
   },


### PR DESCRIPTION
sass 버전이 업데이트 되면서  api가 바꼈습니다. 해당 컨피그를 수정했습니다.

fix #1857 