### PR TITLE
[#1860] Select > 다중 선택 > 아이템 클릭 시 model value 변화 감지하지 못함

### DIFF
--- a/src/components/select/uses.js
+++ b/src/components/select/uses.js
@@ -315,6 +315,7 @@ export const useDropdown = (param) => {
       mv.value.splice(idx, 1);
     }
     allCheck.value = mv.value.length === filteredItems.value.filter(item => !item.disabled).length;
+    mv.value = [...mv.value];
     changeMv();
   };
   const clickItem = !props.multiple ? singleClickItem : multipleClickItem;


### PR DESCRIPTION
이슈
-
- 아이템 클릭 시 체크박스의 부모요소를 클릭 햇을 때 emit 이벤트가 발생하지 않음
- 컴포넌트 외부에서 model value에 watch를 걸 경우 정상적으로 동작하지 않으므로 수정 필요

![Image](https://github.com/user-attachments/assets/d6885107-a0de-4d6c-8984-10d39f8acd0e)

발생 원인
-
item 클릭 시 호출하는 함수 내에서 mv value 배열 주소값이 변경되지 않아 computed에서 변화 감지하지 못함

해결
-
item 클릭 시 호출하는 함수내에서 mv 변수의 배열 요소 수정 후 mv 변수를 새로운 배열 주소값으로 바인딩

![stat_indicator_issue](https://github.com/user-attachments/assets/9b4ec4ed-32e0-435e-af06-6ca9cb4b1099)
