### PR TITLE
[#1865] ev-window > ESC 키 이벤트 작동 시 emit 이벤트 추가

### DIFF
--- a/src/components/window/Window.vue
+++ b/src/components/window/Window.vue
@@ -172,6 +172,7 @@ export default {
     'mousedown-mousemove',
     'resize',
     'expand',
+    'keydown-esc',
   ],
   setup() {
     const {

--- a/src/components/window/uses.js
+++ b/src/components/window/uses.js
@@ -703,7 +703,7 @@ const getActiveWindowsOrderByZIndexAsc = () => {
 };
 
 const useEscCloseAndFocusable = ({ closeWin, windowRef }) => {
-  const { props } = getCurrentInstance();
+  const { props, emit } = getCurrentInstance();
 
   let sequence = null;
   let timer = null;
@@ -735,6 +735,8 @@ const useEscCloseAndFocusable = ({ closeWin, windowRef }) => {
     // 예시 상황) Nested에서 외부 Window의 escClose는 true이고, 내부 Window의 escClose는 false인 경우,
     // esc 눌러도 외부 Window는 닫히지 않고, 가장 상단에 있는 내부 Window가 수동으로 닫힌 후에 닫히도록 하기 위해
     if (!topActiveWindow.escClose) return;
+
+    emit('keydown-esc');
 
     topActiveWindow.closeWin();
   };


### PR DESCRIPTION
## 작업 배경
![Image](https://github.com/user-attachments/assets/32d91f1e-b5c3-48db-b3e1-0cf86b59c7ba)

엑셈원 화면에서 ev-window를 사용하는 모달창이 ESC 키를 입력하여 모달창이 닫힐 때<br>저장되지 않은 데이터들을 초기화하기 위해서 emit 이벤트가 필요하였습니다.