### PR TITLE
[#1868]textField byte 제한 조건 추가

### DIFF
--- a/docs/views/textField/api/textField.md
+++ b/docs/views/textField/api/textField.md
@@ -35,6 +35,7 @@ height: 100px;
 | readonly      | Boolean        | false    | 읽기 전용 여부 | true, false                                                  |
 | placeholder   | String         |          | Input / Textarea의 placeholder 값 |                                                              |
 | maxLength     | Number         | Infinity | value 의 최대길이 제한 길이 |                                                              |
+| maxUnit       | String         | 'count'  | maxLength unit을 설정 | 'count', 'byte', 
 | showMaxLength | Boolean        | false    | maxLength 및 입력 value의 길이값 표현 여부. maxLength 설정되어 있어야 표현 가능 | true, false                                                  |
 | autocomplete  | String         | off      | 자동완성을 허용할 양식 입력 필드를 지정 | on, name, email, username, new-password, current-password 등  |
 | errorMsg      | String         |          | Error 표현을 위한 메시지 |                                                              |

--- a/docs/views/textField/example/Default.vue
+++ b/docs/views/textField/example/Default.vue
@@ -64,10 +64,31 @@
     </div>
   </div>
 
+    <div class="case">
+    <p class="case-title">Max Length  & maxUnit</p>
+    <div style="display: flex;">
+      <ev-text-field
+        v-model="modelValue6"
+        placeholder="Please enter the content"
+        type="text"
+        :max-length="3"
+        max-unit="byte"
+      />
+      <ev-text-field
+        v-model="modelValue6"
+        placeholder="Please enter the content"
+        type="text"
+        :max-length="3"
+        show-max-length
+        max-unit="byte"
+      />
+    </div>
+  </div>
+
   <div class="case">
     <p class="case-title">Error Message</p>
     <ev-text-field
-      v-model="modelValue6"
+      v-model="modelValue7"
       placeholder="Please enter the content"
       type="text"
       :error-msg="errMsg"
@@ -86,11 +107,12 @@ export default {
     const modelValue3 = ref('Disabled Content');
     const modelValue4 = ref();
     const modelValue5 = ref();
-    const modelValue6 = ref('1234가나다');
+    const modelValue6 = ref();
+    const modelValue7 = ref('1234가나다');
     const errMsg = ref();
     const checkValid = () => {
       const regexp = /^[0-9]*$/;
-      if (!regexp.test(modelValue6.value)) {
+      if (!regexp.test(modelValue7.value)) {
         errMsg.value = '숫자만 입력 가능!';
       } else {
         errMsg.value = '';
@@ -104,6 +126,7 @@ export default {
       modelValue4,
       modelValue5,
       modelValue6,
+      modelValue7,
       checkValid,
       errMsg,
     };

--- a/docs/views/textField/example/Textarea.vue
+++ b/docs/views/textField/example/Textarea.vue
@@ -53,6 +53,27 @@
       />
     </div>
   </div>
+
+    <div class="case">
+    <p class="case-title">Max Length  & maxUnit</p>
+    <div style="display: flex;">
+      <ev-text-field
+        v-model="modelValue5"
+        placeholder="Please enter the content"
+        type="textarea"
+        :max-length="10"
+        max-unit="byte"
+      />
+      <ev-text-field
+        v-model="modelValue5"
+        placeholder="Please enter the content"
+        type="textarea"
+        :max-length="10"
+        show-max-length
+        max-unit="byte"
+      />
+    </div>
+  </div>
 </template>
 
 <script>
@@ -64,12 +85,14 @@ export default {
     const modelValue2 = ref('Read Only Content');
     const modelValue3 = ref('Disabled Content');
     const modelValue4 = ref();
+    const modelValue5 = ref();
 
     return {
       modelValue1,
       modelValue2,
       modelValue3,
       modelValue4,
+      modelValue5,
     };
   },
 };

--- a/src/components/textField/TextField.vue
+++ b/src/components/textField/TextField.vue
@@ -26,7 +26,6 @@
           :placeholder="placeholder"
           :disabled="disabled"
           :readonly="readonly"
-          :maxlength="maxLength"
           :autocomplete="autocomplete"
           @focus="focusInput"
           @blur="blurInput"
@@ -42,7 +41,6 @@
           :placeholder="placeholder"
           :disabled="disabled"
           :readonly="readonly"
-          :maxlength="maxLength"
           :autocomplete="autocomplete"
           @focus="focusInput"
           @blur="blurInput"
@@ -95,15 +93,15 @@
     <div
       v-if="maxLength && showMaxLength"
       class="ev-text-field-maxlength"
-      :class="{ max: mv?.length > maxLength }"
+      :class="{ max: currentLength > maxLength }"
     >
-      <span class="curr-length">{{ mv ? mv.length : 0 }}</span> / {{ maxLength }}
+      <span class="curr-length">{{ currentLength }}</span> / {{ maxLength }}{{ maxUnit === 'byte' ? ' Bytes' : '' }}
     </div>
   </div>
 </template>
 
 <script>
-import { ref, computed, nextTick } from 'vue';
+import { ref, computed } from 'vue';
 
 export default {
   name: 'EvTextField',
@@ -139,6 +137,10 @@ export default {
     maxLength: {
       type: Number,
       default: null,
+    },
+    maxUnit: {
+      type: String,
+      default: 'count',
     },
     showMaxLength: {
       type: Boolean,
@@ -206,18 +208,36 @@ export default {
     const blurInput = (e) => {
       emit('blur', e);
     };
+
+    const getByteLength = (text) => new TextEncoder().encode(text).length;
+
+    const currentLength = computed(() => 
+      props.maxUnit === 'byte'
+        ? getByteLength(mv.value || '')
+        : (mv.value || '').length
+    );
+
     const inputMv = (e) => {
-      const inputValue = e.target.value;
-      if (mv.value !== inputValue) {
-        mv.value = inputValue;
-      }
-      nextTick(() => {
-        emit('input', mv.value, e);
-      });
-    };
-    const changeMv = (e) => {
-      emit('change', mv.value, e);
-    };
+        let value = e.target.value;
+
+        if (props.maxLength) {
+            if (props.maxUnit === 'byte') {
+                while (getByteLength(value) > props.maxLength) {
+                    value = value.slice(0, -1);
+                }
+            } else {
+                if (value.length > props.maxLength) {
+                    value = value.slice(0, props.maxLength);
+                }
+            }
+        }
+
+        e.target.value = value;  
+        mv.value = value;      
+        emit('input', value, e);  
+    }
+
+    const changeMv = (e) => emit('change', mv.value, e);
 
     return {
       mv,
@@ -231,6 +251,7 @@ export default {
       blurInput,
       inputMv,
       changeMv,
+      currentLength,
     };
   },
 };
@@ -342,7 +363,7 @@ $icon-width: 14px !default;
       }
     }
   }
-}
+  }
 @include state('error') {
   .ev-text-field-error {
     float: left;
@@ -352,7 +373,7 @@ $icon-width: 14px !default;
 
     @include evThemify() {
       color: evThemed('error');
-    }
+  }
   }
 }
 @include state('ev-text-field-suffix') {
@@ -363,7 +384,7 @@ $icon-width: 14px !default;
     font-size: 15px;
     cursor: default;
   }
-}
+  }
 @include state('ev-text-field-prefix') {
   .ev-input {
     padding: 0 $input-default-padding 0 calc($input-default-padding + $icon-width);

--- a/src/components/textField/TextField.vue
+++ b/src/components/textField/TextField.vue
@@ -27,6 +27,7 @@
           :disabled="disabled"
           :readonly="readonly"
           :autocomplete="autocomplete"
+          :maxlength="maxUnit === 'byte' ? null : maxLength"
           @focus="focusInput"
           @blur="blurInput"
           @input="inputMv"
@@ -42,6 +43,7 @@
           :disabled="disabled"
           :readonly="readonly"
           :autocomplete="autocomplete"
+          :maxlength="maxUnit === 'byte' ? null : maxLength"
           @focus="focusInput"
           @blur="blurInput"
           @input="inputMv"
@@ -95,7 +97,8 @@
       class="ev-text-field-maxlength"
       :class="{ max: currentLength > maxLength }"
     >
-      <span class="curr-length">{{ currentLength }}</span> / {{ maxLength }}{{ maxUnit === 'byte' ? ' Bytes' : '' }}
+      <span class="curr-length">{{ currentLength }}</span> / {{ maxLength
+       }}{{ maxUnit === 'byte' ? ' Bytes' : '' }}
     </div>
   </div>
 </template>
@@ -209,35 +212,29 @@ export default {
       emit('blur', e);
     };
 
-    const getByteLength = (text) => new TextEncoder().encode(text).length;
+    const getByteLength = text => new TextEncoder().encode(text).length;
 
-    const currentLength = computed(() => 
-      props.maxUnit === 'byte'
+    const currentLength = computed(() =>
+      (props.maxUnit === 'byte'
         ? getByteLength(mv.value || '')
-        : (mv.value || '').length
+        : (mv.value || '').length),
     );
 
     const inputMv = (e) => {
-        let value = e.target.value;
+      let value = e.target.value;
 
-        if (props.maxLength) {
-            if (props.maxUnit === 'byte') {
-                while (getByteLength(value) > props.maxLength) {
-                    value = value.slice(0, -1);
-                }
-            } else {
-                if (value.length > props.maxLength) {
-                    value = value.slice(0, props.maxLength);
-                }
-            }
+      if (props.maxLength && props.maxUnit === 'byte') {
+        while (getByteLength(value) > props.maxLength) {
+          value = value.slice(0, -1);
         }
+        e.target.value = value;
+      }
 
-        e.target.value = value;  
-        mv.value = value;      
-        emit('input', value, e);  
-    }
+      mv.value = value;
+      emit('input', value, e);
+    };
 
-    const changeMv = (e) => emit('change', mv.value, e);
+    const changeMv = e => emit('change', mv.value, e);
 
     return {
       mv,
@@ -363,7 +360,7 @@ $icon-width: 14px !default;
       }
     }
   }
-  }
+}
 @include state('error') {
   .ev-text-field-error {
     float: left;
@@ -373,7 +370,7 @@ $icon-width: 14px !default;
 
     @include evThemify() {
       color: evThemed('error');
-  }
+    }
   }
 }
 @include state('ev-text-field-suffix') {
@@ -384,7 +381,7 @@ $icon-width: 14px !default;
     font-size: 15px;
     cursor: default;
   }
-  }
+}
 @include state('ev-text-field-prefix') {
   .ev-input {
     padding: 0 $input-default-padding 0 calc($input-default-padding + $icon-width);


### PR DESCRIPTION
## 작업 배경
textField 길이 제한 조건이 글자 수 이외에도 byte 조건이 필요하여 해당 요소 추가
기존 textField 사용 호환성을 위해 maxUnit을 추가하여 기본은 count(글자수)로 계산하고 maxUnit이 byte인 경우 byte를 계산합니다

## 변경 사항 요약
- maxUnit 추가(maxUnit이 byte일 경우 길이 제한 조건을 byte로 계산)
- textfield md에 maxUnit 설명 추가
- textfield maxUnit 예시 추가

## 기대 동작
[default]
![default](https://github.com/user-attachments/assets/02451174-8bc3-4b2c-97c4-c55367b46815)

[textarea]
![textField](https://github.com/user-attachments/assets/a0a6a056-c5b1-4d2b-a08d-9800c4d8d464)

## 테스트 가이드
maxUnit이 byte일 경우 byte 제한 조건에 맞게 제한되는지 확인해주세요
기존 textField에 문제가 없는지 확인해주세요