### PR TITLE
line/bar chart > click event param으로 clicked time 값 전달 

### DIFF
--- a/docs/views/barChart/example/SelectItem.vue
+++ b/docs/views/barChart/example/SelectItem.vue
@@ -307,7 +307,6 @@ export default {
       chartOptions4,
       clickedLabel,
       defaultSelectItem,
-      defaultSelectItem,
       onClick,
       updateData,
     };

--- a/docs/views/barChart/example/SelectItem.vue
+++ b/docs/views/barChart/example/SelectItem.vue
@@ -1,0 +1,327 @@
+<template>
+  <div class="case">
+    <ev-chart
+      ref="chart"
+      v-model:selectedItem="defaultSelectItem"
+      :data="chartData1"
+      :options="chartOptions1"
+      @click="onClick"
+    />
+    <ev-chart
+      v-model:selectedItem="defaultSelectItem"
+      :data="chartData2"
+      :options="chartOptions2"
+      @click="onClick"
+    />
+    <ev-chart
+      v-model:selectedItem="defaultSelectItem"
+      :data="chartData3"
+      :options="chartOptions3"
+      @click="onClick"
+    />
+    <ev-chart
+      v-model:selectedItem="defaultSelectItem"
+      :data="chartData4"
+      :options="chartOptions4"
+      @click="onClick"
+    />
+    <div class="description">
+      <ev-toggle v-model="isFixedPosTop" />
+      <span class="left">
+        tip 위치를 최상단에 고정
+      </span>
+      <br>
+      <br>
+      <ev-button @click="updateData">
+        Update Data
+      </ev-button>
+      <span class="left">
+        차트 데이터를 변경하면 팁의 위치만 변경, 라벨은 고정
+      </span>
+      <br>
+      <br>
+      <div>
+        <div class="badge yellow">
+          v-model:selectedItem
+        </div>
+        {{ defaultSelectItem }}
+        <br>
+        <br>
+        <div class="badge yellow">
+          클릭 이벤트 데이터 (selected)
+        </div>
+        {{ clickedLabel }}
+        <br>
+        <br>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  components: {},
+
+  setup() {
+    const chart = ref(null);
+
+    const chartData1 = ref({
+      series: {
+        series1: { name: 'series#1' },
+        series2: { name: 'series#2' },
+      },
+      labels: ['value1', 'value2', 'value3', 'value4', 'value5'],
+      data: {
+        series1: [100, 150, 51, 150, 350],
+        series2: [100, 150, 51, 150, 450],
+      },
+    });
+    const chartData2 = ref({
+      series: {
+        series1: { name: 'series#1' },
+        series2: { name: 'series#2' },
+      },
+      labels: ['value1', 'value2', 'value3', 'value4', 'value5'],
+      groups: [['series1', 'series2']],
+      data: {
+        series1: [100, 150, 51, 150, 350],
+        series2: [100, 150, 51, 150, 450],
+      },
+    });
+    const chartData3 = ref({
+      series: {
+        series1: { name: 'series#1' },
+        series2: { name: 'series#2' },
+      },
+      labels: ['value1', 'value2', 'value3', 'value4', 'value5'],
+      data: {
+        series1: [100, 150, 51, 150, 350],
+        series2: [100, 150, 51, 150, 450],
+      },
+    });
+    const chartData4 = ref({
+      series: {
+        series1: { name: 'series#1' },
+        series2: { name: 'series#2' },
+      },
+      labels: ['value1', 'value2', 'value3', 'value4', 'value5'],
+      groups: [['series1', 'series2']],
+      data: {
+        series1: [100, 150, 51, 150, 350],
+        series2: [100, 150, 51, 150, 450],
+      },
+    });
+
+    const isFixedPosTop = ref(false);
+
+    const chartOptions1 = ref({
+      type: 'bar',
+      thickness: 0.8,
+      width: '100%',
+      horizontal: false,
+      title: {
+        show: false,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesX: [{
+        type: 'step',
+        showGrid: false,
+        labelStyle: {
+          fitWidth: true,
+          fitDir: 'left',
+        },
+      }],
+      axesY: [{
+        showAxis: true,
+        type: 'linear',
+        startToZero: true,
+        autoScaleRatio: 0.1,
+        showGrid: false,
+      }],
+      selectItem: {
+        use: true,
+        useClick: true,
+      },
+      maxTip: {
+        use: true,
+        showTextTip: true,
+        tipStyle: {
+          background: '#FF0000',
+        },
+      },
+    });
+    const chartOptions2 = ref({
+      type: 'bar',
+      thickness: 0.8,
+      width: '100%',
+      horizontal: false,
+      title: {
+        show: false,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesX: [{
+        type: 'step',
+        showGrid: false,
+        labelStyle: {
+          fitWidth: true,
+          fitDir: 'left',
+        },
+      }],
+      axesY: [{
+        showAxis: true,
+        type: 'linear',
+        startToZero: true,
+        autoScaleRatio: 0.1,
+        showGrid: false,
+      }],
+      selectItem: {
+        use: true,
+        useClick: true,
+      },
+      maxTip: {
+        use: true,
+        showTextTip: true,
+        tipStyle: {
+          background: '#FF0000',
+        },
+      },
+    });
+    const chartOptions3 = ref({
+      type: 'bar',
+      thickness: 0.8,
+      width: '100%',
+      horizontal: true,
+      title: {
+        show: false,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesY: [{
+        type: 'step',
+        showGrid: false,
+        labelStyle: {
+          fitWidth: true,
+          fitDir: 'left',
+        },
+      }],
+      axesX: [{
+        showAxis: true,
+        type: 'linear',
+        startToZero: true,
+        autoScaleRatio: 0.1,
+        showGrid: false,
+      }],
+      selectItem: {
+        use: true,
+        useClick: true,
+      },
+      maxTip: {
+        use: true,
+        showTextTip: true,
+        tipStyle: {
+          background: '#FF0000',
+        },
+      },
+    });
+    const chartOptions4 = ref({
+      type: 'bar',
+      thickness: 0.8,
+      width: '100%',
+      horizontal: true,
+      title: {
+        show: false,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesY: [{
+        type: 'step',
+        showGrid: false,
+        labelStyle: {
+          fitWidth: true,
+          fitDir: 'left',
+        },
+      }],
+      axesX: [{
+        showAxis: true,
+        type: 'linear',
+        startToZero: true,
+        autoScaleRatio: 0.1,
+        showGrid: false,
+      }],
+      selectItem: {
+        use: true,
+        useClick: true,
+      },
+      maxTip: {
+        use: true,
+        showTextTip: true,
+        tipStyle: {
+          background: '#FF0000',
+        },
+      },
+    });
+
+    const clickedLabel = ref();
+    const onClick = ({ selected }) => {
+      clickedLabel.value = selected;
+    };
+
+    const defaultSelectItem = ref();
+
+    const updateData = () => {
+      const getRandArr = count => Array(count)
+        .fill(0).map(() => Math.ceil(Math.random() * 100));
+
+      const chartList = [chartData1, chartData2, chartData3, chartData4];
+      chartList.forEach((c) => {
+        const seriesList = ['series1', 'series2'];
+        seriesList.forEach((sId) => {
+          c.value.data[sId] = getRandArr(5);
+        });
+      });
+    };
+
+
+    return {
+      chart,
+      chartData1,
+      chartData2,
+      chartData3,
+      chartData4,
+      isFixedPosTop,
+      chartOptions1,
+      chartOptions2,
+      chartOptions3,
+      chartOptions4,
+      clickedLabel,
+      defaultSelectItem,
+      defaultSelectItem,
+      onClick,
+      updateData,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+  .description {
+    position: relative;
+  }
+  .left {
+    position: absolute;
+    left: 160px;
+    padding-top: 10px;
+  }
+</style>

--- a/docs/views/barChart/props.js
+++ b/docs/views/barChart/props.js
@@ -12,6 +12,8 @@ import Time from './example/Time';
 import TimeRaw from '!!raw-loader!./example/Time';
 import Event from './example/Event';
 import EventRaw from '!!raw-loader!./example/Event';
+import SelectItem from './example/SelectItem';
+import SelectItemRaw from '!!raw-loader!./example/SelectItem';
 import SelectLabel from './example/SelectLabel';
 import SelectLabelRaw from '!!raw-loader!./example/SelectLabel';
 import Gradient from './example/Gradient';
@@ -64,6 +66,11 @@ export default {
       description: 'Click, Double Click 등 이벤트 등록이 가능합니다.',
       component: Event,
       parsedData: parseComponent(EventRaw),
+    },
+    'Select Item': {
+      description: '차트 전체에서 선택한 라벨 내 모든 아이템이 하이라이트 되는 기능입니다.',
+      component: SelectItem,
+      parsedData: parse(SelectItemRaw).descriptor,
     },
     'Select Label': {
       description: '차트 전체에서 선택한 라벨 내 모든 아이템이 하이라이트 되는 기능입니다.',

--- a/docs/views/barChart/props.js
+++ b/docs/views/barChart/props.js
@@ -68,7 +68,7 @@ export default {
       parsedData: parseComponent(EventRaw),
     },
     'Select Item': {
-      description: '차트 전체에서 선택한 라벨 내 모든 아이템이 하이라이트 되는 기능입니다.',
+      description: '차트에서 선택한 series에 대한 정보를 추출할 수 있는 기능입니다.',
       component: SelectItem,
       parsedData: parse(SelectItemRaw).descriptor,
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.90",
+  "version": "3.4.91",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -855,14 +855,24 @@ const modules = {
             if (ldata !== null && ldata !== undefined) {
               const g = isHorizontal ? data.o || data.x : data.o || data.y;
 
-              if (series.stackIndex) {
+              if (series.stackIndex != null) {
                 acc += !isNaN(data.o) ? data.o : 0;
                 useStack = true;
               } else {
                 acc += data.y;
               }
 
-              if (maxValue === null || maxValue <= g) {
+
+              if (maxType === 'bar' && useStack) {
+                if (item.hit) {
+                  maxValue = g;
+                  maxSeriesID = seriesID;
+                  maxIndex = index;
+                  maxLabel = ldata;
+                  maxValuePos = lp;
+                  maxType = series.type;
+                }
+              } else if (maxValue === null || maxValue <= g) {
                 maxValue = g;
                 maxSeriesID = seriesID;
                 maxLabel = ldata;

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -177,6 +177,7 @@ const modules = {
       };
 
       const setSelectedLabelInfo = (targetAxis) => {
+        const itemHitInfo = this.getItemByPosition(offset, false);
         const {
           labelIndex: clickedLabelIndex,
         } = this.getLabelInfoByPosition(offset, targetAxis);
@@ -195,10 +196,14 @@ const modules = {
           eventTarget: 'label',
           ...cloneDeep(this.defaultSelectInfo),
         };
+        args.label = itemHitInfo.label;
+        args.dataIndex = itemHitInfo.maxIndex;
       };
 
       const setSelectedSeriesInfo = () => {
+        const itemHitInfo = this.getItemByPosition(offset, false);
         const hitInfo = this.getSeriesInfoByPosition(offset);
+
         if (hitInfo.sId !== null) {
           const allSelectedList = this.updateSelectedSeriesInfo(hitInfo.sId);
           this.defaultSelectInfo.seriesId = allSelectedList.seriesId;
@@ -207,6 +212,8 @@ const modules = {
             eventTarget: 'series',
             ...cloneDeep(this.defaultSelectInfo),
           };
+          args.label = itemHitInfo.label;
+          args.dataIndex = itemHitInfo.maxIndex;
         }
       };
 

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -114,17 +114,15 @@ const modules = {
       const selectItem = this.options.selectItem;
       const args = { e };
 
-      if (selectItem.use) {
-        const offset = this.getMousePosition(e);
-        const hitInfo = this.getItemByPosition(offset, selectItem.useApproximateValue);
+      const offset = this.getMousePosition(e);
+      const hitInfo = this.getItemByPosition(offset, selectItem.useApproximateValue);
 
 
-        if (hitInfo.label !== null) {
-          this.render(hitInfo);
-        }
-
-        ({ label: args.label, value: args.value, sId: args.seriesId, acc: args.acc } = hitInfo);
+      if (hitInfo.label !== null) {
+        this.render(hitInfo);
       }
+
+      ({ label: args.label, value: args.value, sId: args.seriesId, acc: args.acc } = hitInfo);
 
       if (typeof this.listeners['dbl-click'] === 'function') {
         this.listeners['dbl-click'](args);


### PR DESCRIPTION
### 내용
chartOption 세팅값에 상관없이 click event의 param값으로 label과 dataIndex가 전달되도록 수정했습니다.
bar 차트를 stacked로 사용할 때 selectItem 값이 클릭이벤트가 발생한 위치의 series가 담기도록 수정했습니다.

### 테스트 방법
barChart example에 SelectItem 을 추가해두었습니다.
각 시리즈별로 click event를 발생시켜보고 click event가 발생된 series가 잘 세팅되는지 확인해주세요.

close #1867 