### PR TITLE
[#1878] Chart > Tooltip > fontColor function으로 받을 수 있게, formatter > label function으로 받을 수 있게 추가 필요

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -333,7 +333,7 @@ const chartData = {
 | maxWidth            | Number                      |                                            | 툴팁의 최대 너비                                        |                                                                     |
 | textOverflow        | String                      | 'wrap'                                     | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis                                                   |
 | fontFamily          | String                      | 'Roboto'                                   | 툴팁에 표시될 폰트                                      | 'Roboto', 'serif                                                    |
-| fontColor           | Hex code (string), Object   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                                 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontColor           | Hex code (string), Object, Function   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                                 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
 | fontSize            | Object                      | { title: 16, contents: 14 }                | 툴팁에 표시될 폰트 사이즈                               |                                                                     |
 | colorShape          | String                      | 'rect'                                     | 툴팁에 표시될 series color의 모양                       | 'rect', 'circle'                                                    |
 | rowPadding          | Object                      | { top: 0, bottom: 3, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값                   |                                                                     |

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -217,7 +217,7 @@ const chartData =
 | maxWidth            | Number                      |                                            | 툴팁의 최대 너비                                        |                                                                     |
 | textOverflow        | String                      | 'wrap'                                     | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis                                                   |
 | fontFamily          | String                      | 'Roboto'                                   | 툴팁에 표시될 폰트                                      | 'Roboto', 'serif                                                    |
-| fontColor           | Hex code (string), Object   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                                 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontColor           | Hex code (string), Object, Function   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                                 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
 | fontSize            | Object                      | { title: 16, contents: 14 }                | 툴팁에 표시될 폰트 사이즈                               |                                                                     |
 | colorShape          | String                      | 'rect'                                     | 툴팁에 표시될 series color의 모양                       | 'rect', 'circle'                                                    |
 | rowPadding          | Object                      | { top: 0, bottom: 3, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값                   |                                                                     |

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -285,7 +285,7 @@ const chartData =
 | maxWidth            | Number                      |                                            | 툴팁의 최대 너비                                        |                                                                     |
 | textOverflow        | String                      | 'wrap'                                     | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis                                                   |
 | fontFamily          | String                      | 'Roboto'                                   | 툴팁에 표시될 폰트                                      | 'Roboto', 'serif'                                                   |
-| fontColor           | Hex code (string), Object   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                                 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontColor           | Hex code (string), Object, Function   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                                 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
 | fontSize            | Object                      | { title: 16, contents: 14 }                | 툴팁에 표시될 폰트 사이즈                               |                                                                     |
 | colorShape          | String                      | 'rect'                                     | 툴팁에 표시될 series color의 모양                       | 'rect', 'circle'                                                    |
 | rowPadding          | Object                      | { top: 0, bottom: 3, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값                   |                                                                     |

--- a/docs/views/lineChart/example/Tooltip.vue
+++ b/docs/views/lineChart/example/Tooltip.vue
@@ -340,30 +340,13 @@
           textOverflow,
           formatter: {
             title: ({ x }) => dayjs(x).format('YYYY-MM-DD HH:mm:ss'),
-            label: ({ seriesName }) => {
-              if (seriesName === 'series#1') {
-                 return `ⓒ ${seriesName}`;
-              }
-
-              return seriesName;
-            },
             value: ({ y }) => `${y.toFixed(2)}`,
           },
           colorShape,
           fontColor: {
             title: titleFontColor,
-            label: ({ id }) => {
-              if (id === 'series1') {
-                return '#FF0000';
-              }
-              return labelFontColor.value;
-            },
-            value: ({ value }) => {
-              if (+value > 0.9) {
-                return '#FF0000';
-              }
-              return valueFontColor.value;
-            },
+            label: labelFontColor,
+            value: valueFontColor,
           },
           fontSize: {
             title: titleFontSize,

--- a/docs/views/lineChart/example/Tooltip.vue
+++ b/docs/views/lineChart/example/Tooltip.vue
@@ -340,13 +340,30 @@
           textOverflow,
           formatter: {
             title: ({ x }) => dayjs(x).format('YYYY-MM-DD HH:mm:ss'),
+            label: ({ seriesName }) => {
+              if (seriesName === 'series#1') {
+                 return `ⓒ ${seriesName}`;
+              }
+
+              return seriesName;
+            },
             value: ({ y }) => `${y.toFixed(2)}`,
           },
           colorShape,
           fontColor: {
             title: titleFontColor,
-            label: labelFontColor,
-            value: valueFontColor,
+            label: ({ id }) => {
+              if (id === 'series1') {
+                return '#FF0000';
+              }
+              return labelFontColor.value;
+            },
+            value: ({ value }) => {
+              if (+value > 0.9) {
+                return '#FF0000';
+              }
+              return valueFontColor.value;
+            },
           },
           fontSize: {
             title: titleFontSize,

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -216,7 +216,7 @@ const chartData =
 | maxWidth            | Number                      |           | 툴팁의 최대 너비                            |                                                                     |
 | textOverflow        | String                      | 'wrap'    | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis'                                                  |
 | fontFamily          | String                      | 'Roboto'  | 툴팁에 표시될 폰트                           | 'Roboto', 'serif'                                                   |
-| fontColor           | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러                        | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontColor           | Hex code (string), Object, Function   | '#000000' | 툴팁에 표시될 폰트 컬러                        | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
 | fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
 | colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean                     | false     | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -770,16 +770,20 @@ const modules = {
           }
 
           if (gdata !== null && gdata !== undefined) {
-            const sName = series.name;
-            const sw = ctx ? ctx.measureText(sName).width : 1;
+            const formattedSeriesName = this.getFormattedTooltipLabel({
+              seriesId: sId,
+              seriesName: series.name,
+              itemData: item.data,
+             });
+            const sw = ctx ? ctx.measureText(formattedSeriesName).width : 1;
 
-            item.name = sName;
+            item.name = formattedSeriesName;
             item.axis = { x: series.xAxisIndex, y: series.yAxisIndex };
             items[sId] = item;
 
             const formattedTxt = this.getFormattedTooltipValue({
               seriesId: sId,
-              seriesName: sName,
+              seriesName: formattedSeriesName,
               value: gdata,
               itemData: item.data,
             });
@@ -787,7 +791,7 @@ const modules = {
             item.data.formatted = formattedTxt;
 
             if (maxsw < sw) {
-              maxs = sName;
+              maxs = formattedSeriesName;
               maxsw = sw;
             }
 
@@ -812,6 +816,30 @@ const modules = {
     const maxHighlight = maxg !== null ? [maxSID, maxg] : null;
 
     return { items, hitId, maxTip: [maxs, maxv], maxHighlight };
+  },
+
+  /**
+   * get formatted label for tooltip
+   * @param seriesId
+   * @param seriesName
+   * @param itemData
+   * @returns {string}
+   */
+  getFormattedTooltipLabel({ seriesId, seriesName, itemData }) {
+    const opt = this.options;
+    const tooltipOpt = opt.tooltip;
+    const tooltipLabelFormatter = tooltipOpt?.formatter?.label;
+
+    let formattedLabel = seriesName;
+    if (tooltipLabelFormatter) {
+      formattedLabel = tooltipLabelFormatter({
+        seriesId,
+        seriesName,
+        itemData,
+      });
+    }
+
+    return formattedLabel;
   },
 
   /**
@@ -893,9 +921,16 @@ const modules = {
           ),
         );
 
-        const formattedValue = this.getFormattedTooltipValue({
+      
+        const formattedSeriesName = this.getFormattedTooltipLabel({
           seriesId: sId,
           seriesName: series.name,
+          itemData: hasData,
+         });
+
+        const formattedValue = this.getFormattedTooltipValue({
+          seriesId: sId,
+          seriesName: formattedSeriesName,
           value: hasData?.o,
           itemData: hasData,
         });
@@ -904,7 +939,7 @@ const modules = {
           const item = {};
           item.color = series.color;
           item.hit = false;
-          item.name = series.name;
+          item.name = formattedSeriesName;
           item.axis = { x: series.xAxisIndex, y: series.yAxisIndex };
           item.index = isHorizontal ? series.yAxisIndex : series.xAxisIndex;
           item.data = hasData;
@@ -914,9 +949,9 @@ const modules = {
         }
 
         const maxSeriesNameWidth = ctx ? ctx.measureText(maxSeriesName).width : 1;
-        const seriesNameWidth = ctx ? ctx.measureText(series.name).width : 1;
+        const seriesNameWidth = ctx ? ctx.measureText(formattedSeriesName).width : 1;
         if (maxSeriesNameWidth < seriesNameWidth) {
-          maxSeriesName = series.name;
+          maxSeriesName = formattedSeriesName;
         }
 
         const maxValueWidth = ctx ? ctx.measureText(maxValueTxt).width : 1;

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -921,7 +921,6 @@ const modules = {
           ),
         );
 
-      
         const formattedSeriesName = this.getFormattedTooltipLabel({
           seriesId: sId,
           seriesName: series.name,

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -771,17 +771,20 @@ const modules = {
 
           if (gdata !== null && gdata !== undefined) {
             const formattedSeriesName = this.getFormattedTooltipLabel({
+              dataId: series.id,
               seriesId: sId,
               seriesName: series.name,
               itemData: item.data,
              });
             const sw = ctx ? ctx.measureText(formattedSeriesName).width : 1;
 
+            item.id = series.id;
             item.name = formattedSeriesName;
             item.axis = { x: series.xAxisIndex, y: series.yAxisIndex };
             items[sId] = item;
 
             const formattedTxt = this.getFormattedTooltipValue({
+              dataId: series.id,
               seriesId: sId,
               seriesName: formattedSeriesName,
               value: gdata,
@@ -820,12 +823,13 @@ const modules = {
 
   /**
    * get formatted label for tooltip
+   * @param dataId
    * @param seriesId
    * @param seriesName
    * @param itemData
    * @returns {string}
    */
-  getFormattedTooltipLabel({ seriesId, seriesName, itemData }) {
+  getFormattedTooltipLabel({ dataId, seriesId, seriesName, itemData }) {
     const opt = this.options;
     const tooltipOpt = opt.tooltip;
     const tooltipLabelFormatter = tooltipOpt?.formatter?.label;
@@ -833,6 +837,7 @@ const modules = {
     let formattedLabel = seriesName;
     if (tooltipLabelFormatter) {
       formattedLabel = tooltipLabelFormatter({
+        dataId,
         seriesId,
         seriesName,
         itemData,
@@ -844,13 +849,14 @@ const modules = {
 
   /**
    * get formatted value for tooltip
+   * @param dataId
    * @param seriesId
    * @param seriesName
    * @param value
    * @param itemData
    * @returns {string}
    */
-  getFormattedTooltipValue({ seriesId, seriesName, value, itemData }) {
+  getFormattedTooltipValue({ dataId, seriesId, seriesName, value, itemData }) {
     const opt = this.options;
     const isHorizontal = !!opt.horizontal;
     const tooltipOpt = opt.tooltip;
@@ -866,6 +872,7 @@ const modules = {
           name: seriesName,
           percentage: itemData?.percentage,
           seriesId,
+          dataId,
         });
       } else if (opt.type === 'heatMap') {
         formattedTxt = tooltipValueFormatter({
@@ -873,6 +880,7 @@ const modules = {
           y: itemData?.y,
           value: value > -1 ? value : 'error',
           seriesId,
+          dataId,
         });
       } else {
         formattedTxt = tooltipValueFormatter({
@@ -880,6 +888,7 @@ const modules = {
           y: isHorizontal ? itemData?.y : value,
           name: seriesName,
           seriesId,
+          dataId,
         });
       }
     }
@@ -922,12 +931,14 @@ const modules = {
         );
 
         const formattedSeriesName = this.getFormattedTooltipLabel({
+          dataId: series.id,
           seriesId: sId,
           seriesName: series.name,
           itemData: hasData,
          });
 
         const formattedValue = this.getFormattedTooltipValue({
+          dataId: series.id,
           seriesId: sId,
           seriesName: formattedSeriesName,
           value: hasData?.o,

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -297,6 +297,7 @@ const modules = {
         data: items[seriesName].data,
         color: items[seriesName].color,
         name: items[seriesName].name,
+        dataId: items[seriesName].id,
       });
     });
 
@@ -347,6 +348,7 @@ const modules = {
         id: seriesList[ix].id,
         name: seriesList[ix].name,
         value: valueText,
+        dataId: seriesList[ix].dataId,
       };
 
       // 1. Draw series color
@@ -481,6 +483,7 @@ const modules = {
       id: hitInfo.hitId,
       name: hitItem.y,
       value: valueText,
+      dataId: items[sId].id,
     };
 
     // 1. Draw value color
@@ -600,6 +603,7 @@ const modules = {
         id: hitInfo.hitId,
         name: seriesList[ix].name,
         value: valueText,
+        dataId: seriesList[ix].dataId,
       };
 
       // 1. Draw series color

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -293,6 +293,7 @@ const modules = {
     const seriesList = [];
     seriesKeys.forEach((seriesName) => {
       seriesList.push({
+        id: seriesName,
         data: items[seriesName].data,
         color: items[seriesName].color,
         name: items[seriesName].name,
@@ -342,11 +343,17 @@ const modules = {
         ctx.fillStyle = color;
       }
 
+      const curTooltipInfo = {
+        id: seriesList[ix].id,
+        name: seriesList[ix].name,
+        value: valueText,
+      };
+
       // 1. Draw series color
       this.drawSeriesColorShape(ctx, opt.colorShape, { x: itemX, y: itemY });
 
       // 2. Draw series name
-      ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
+      ctx.fillStyle = typeof opt.fontColor.label === 'function' ? opt.fontColor.label(curTooltipInfo) : opt.fontColor.label ?? opt.fontColor;
       ctx.textBaseline = 'Bottom';
       const seriesNameSpaceWidth = opt.maxWidth - Math.round(ctx.measureText(maxValue).width)
         - boxPadding.l - boxPadding.r - seriesColorMarginRight - VALUE_MARGIN;
@@ -381,7 +388,7 @@ const modules = {
       ctx.save();
 
       // 3. Draw value
-      ctx.fillStyle = opt.fontColor?.value ?? opt.fontColor;
+      ctx.fillStyle = typeof opt.fontColor.value === 'function' ? opt.fontColor.value(curTooltipInfo) : opt.fontColor.value ?? opt.fontColor;
       ctx.textAlign = 'right';
       ctx.fillText(valueText, this.tooltipDOM.offsetWidth - boxPadding.r, itemY);
       ctx.restore();
@@ -470,11 +477,17 @@ const modules = {
       ctx.fillStyle = hitColor;
     }
 
+    const curTooltipInfo = {
+      id: hitInfo.hitId,
+      name: hitItem.y,
+      value: valueText,
+    };
+
     // 1. Draw value color
     this.drawSeriesColorShape(ctx, opt.colorShape, { x: itemX, y: itemY });
 
     // 2. Draw value y names
-    ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
+    ctx.fillStyle = typeof opt.fontColor.label === 'function' ? opt.fontColor.label(curTooltipInfo) : opt.fontColor.label ?? opt.fontColor;
     ctx.textBaseline = 'Bottom';
     if (this.axesY.length) {
       ctx.fillText(
@@ -485,6 +498,7 @@ const modules = {
 
     // 3. Draw value
     ctx.textAlign = 'right';
+    ctx.fillStyle = typeof opt.fontColor.value === 'function' ? opt.fontColor.value(curTooltipInfo) : opt.fontColor.value ?? opt.fontColor;
     ctx.fillText(valueText, this.tooltipDOM.offsetWidth - boxPadding.r, itemY);
     ctx.closePath();
   },
@@ -582,11 +596,17 @@ const modules = {
         ctx.fillStyle = color;
       }
 
+      const curTooltipInfo = {
+        id: hitInfo.hitId,
+        name: seriesList[ix].name,
+        value: valueText,
+      };
+
       // 1. Draw series color
       this.drawSeriesColorShape(ctx, opt.colorShape, { x: itemX, y: itemY });
 
       // 2. Draw series name
-      ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
+      ctx.fillStyle = typeof opt.fontColor.label === 'function' ? opt.fontColor.label(curTooltipInfo) : opt.fontColor.label ?? opt.fontColor;
       ctx.textBaseline = 'Bottom';
       const seriesNameSpaceWidth = opt.maxWidth - Math.round(ctx.measureText(maxValue).width)
         - boxPadding.l - boxPadding.r - seriesColorMarginRight - VALUE_MARGIN;
@@ -622,6 +642,7 @@ const modules = {
 
       // 3. Draw value
       ctx.textAlign = 'right';
+      ctx.fillStyle = typeof opt.fontColor.value === 'function' ? opt.fontColor.value(curTooltipInfo) : opt.fontColor.value ?? opt.fontColor;
       ctx.fillText(valueText, this.tooltipDOM.offsetWidth - boxPadding.r, itemY);
       ctx.restore();
       ctx.closePath();


### PR DESCRIPTION
## 변경 사항
![after](https://github.com/user-attachments/assets/4034b37b-7a90-4828-a6e6-8aca96b51a68)
- Tooltip > fontColor(label, value)에 조건을 태울 수 있도록 수정
- Tooltip > formatter > label도 함수로 받을 수 있도록 수정

Merge 전 Tooltip.vue에서 수정한 내용은 롤백할 예정입니다.