### PR TITLE
[#1878] Chart > Tooltip > fontColor function으로 받을 수 있게, formatter > label function으로 받을 수 있게 추가 필요

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -333,7 +333,7 @@ const chartData = {
 | maxWidth            | Number                      |                                            | 툴팁의 최대 너비                                        |                                                                     |
 | textOverflow        | String                      | 'wrap'                                     | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis                                                   |
 | fontFamily          | String                      | 'Roboto'                                   | 툴팁에 표시될 폰트                                      | 'Roboto', 'serif                                                    |
-| fontColor           | Hex code (string), Object   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                                 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontColor           | Hex code (string), Object, Function   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                                 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
 | fontSize            | Object                      | { title: 16, contents: 14 }                | 툴팁에 표시될 폰트 사이즈                               |                                                                     |
 | colorShape          | String                      | 'rect'                                     | 툴팁에 표시될 series color의 모양                       | 'rect', 'circle'                                                    |
 | rowPadding          | Object                      | { top: 0, bottom: 3, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값                   |                                                                     |

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -217,7 +217,7 @@ const chartData =
 | maxWidth            | Number                      |                                            | 툴팁의 최대 너비                                        |                                                                     |
 | textOverflow        | String                      | 'wrap'                                     | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis                                                   |
 | fontFamily          | String                      | 'Roboto'                                   | 툴팁에 표시될 폰트                                      | 'Roboto', 'serif                                                    |
-| fontColor           | Hex code (string), Object   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                                 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontColor           | Hex code (string), Object, Function   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                                 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
 | fontSize            | Object                      | { title: 16, contents: 14 }                | 툴팁에 표시될 폰트 사이즈                               |                                                                     |
 | colorShape          | String                      | 'rect'                                     | 툴팁에 표시될 series color의 모양                       | 'rect', 'circle'                                                    |
 | rowPadding          | Object                      | { top: 0, bottom: 3, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값                   |                                                                     |

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -284,7 +284,7 @@ const chartData =
 | maxWidth            | Number                      |                                            | 툴팁의 최대 너비                                        |                                                                     |
 | textOverflow        | String                      | 'wrap'                                     | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis                                                   |
 | fontFamily          | String                      | 'Roboto'                                   | 툴팁에 표시될 폰트                                      | 'Roboto', 'serif'                                                   |
-| fontColor           | Hex code (string), Object   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                                 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontColor           | Hex code (string), Object, Function   | '#000000'                                  | 툴팁에 표시될 폰트 컬러                                 | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
 | fontSize            | Object                      | { title: 16, contents: 14 }                | 툴팁에 표시될 폰트 사이즈                               |                                                                     |
 | colorShape          | String                      | 'rect'                                     | 툴팁에 표시될 series color의 모양                       | 'rect', 'circle'                                                    |
 | rowPadding          | Object                      | { top: 0, bottom: 3, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값                   |                                                                     |

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -216,7 +216,7 @@ const chartData =
 | maxWidth            | Number                      |           | 툴팁의 최대 너비                            |                                                                     |
 | textOverflow        | String                      | 'wrap'    | 툴팁에 표시될 텍스트가 maxWidth 값을 넘길 경우 의 처리  | 'wrap', 'ellipsis'                                                  |
 | fontFamily          | String                      | 'Roboto'  | 툴팁에 표시될 폰트                           | 'Roboto', 'serif'                                                   |
-| fontColor           | Hex code (string), Object   | '#000000' | 툴팁에 표시될 폰트 컬러                        | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
+| fontColor           | Hex code (string), Object, Function   | '#000000' | 툴팁에 표시될 폰트 컬러                        | '#FFFFFF', { label: '#FFFFFF', value: '#FFFFFF', 'title: #FFFFFF' } |
 | fontSize            | Object                      | { title: 16, contents: 14 } | 툴팁에 표시될 폰트 사이즈  | |
 | colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean                     | false     | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -770,16 +770,23 @@ const modules = {
           }
 
           if (gdata !== null && gdata !== undefined) {
-            const sName = series.name;
-            const sw = ctx ? ctx.measureText(sName).width : 1;
+            const formattedSeriesName = this.getFormattedTooltipLabel({
+              dataId: series.id,
+              seriesId: sId,
+              seriesName: series.name,
+              itemData: item.data,
+             });
+            const sw = ctx ? ctx.measureText(formattedSeriesName).width : 1;
 
-            item.name = sName;
+            item.id = series.id;
+            item.name = formattedSeriesName;
             item.axis = { x: series.xAxisIndex, y: series.yAxisIndex };
             items[sId] = item;
 
             const formattedTxt = this.getFormattedTooltipValue({
+              dataId: series.id,
               seriesId: sId,
-              seriesName: sName,
+              seriesName: formattedSeriesName,
               value: gdata,
               itemData: item.data,
             });
@@ -787,7 +794,7 @@ const modules = {
             item.data.formatted = formattedTxt;
 
             if (maxsw < sw) {
-              maxs = sName;
+              maxs = formattedSeriesName;
               maxsw = sw;
             }
 
@@ -815,14 +822,41 @@ const modules = {
   },
 
   /**
+   * get formatted label for tooltip
+   * @param dataId
+   * @param seriesId
+   * @param seriesName
+   * @param itemData
+   * @returns {string}
+   */
+  getFormattedTooltipLabel({ dataId, seriesId, seriesName, itemData }) {
+    const opt = this.options;
+    const tooltipOpt = opt.tooltip;
+    const tooltipLabelFormatter = tooltipOpt?.formatter?.label;
+
+    let formattedLabel = seriesName;
+    if (tooltipLabelFormatter) {
+      formattedLabel = tooltipLabelFormatter({
+        dataId,
+        seriesId,
+        seriesName,
+        itemData,
+      });
+    }
+
+    return formattedLabel;
+  },
+
+  /**
    * get formatted value for tooltip
+   * @param dataId
    * @param seriesId
    * @param seriesName
    * @param value
    * @param itemData
    * @returns {string}
    */
-  getFormattedTooltipValue({ seriesId, seriesName, value, itemData }) {
+  getFormattedTooltipValue({ dataId, seriesId, seriesName, value, itemData }) {
     const opt = this.options;
     const isHorizontal = !!opt.horizontal;
     const tooltipOpt = opt.tooltip;
@@ -838,6 +872,7 @@ const modules = {
           name: seriesName,
           percentage: itemData?.percentage,
           seriesId,
+          dataId,
         });
       } else if (opt.type === 'heatMap') {
         formattedTxt = tooltipValueFormatter({
@@ -845,6 +880,7 @@ const modules = {
           y: itemData?.y,
           value: value > -1 ? value : 'error',
           seriesId,
+          dataId,
         });
       } else {
         formattedTxt = tooltipValueFormatter({
@@ -852,6 +888,7 @@ const modules = {
           y: isHorizontal ? itemData?.y : value,
           name: seriesName,
           seriesId,
+          dataId,
         });
       }
     }
@@ -893,9 +930,17 @@ const modules = {
           ),
         );
 
-        const formattedValue = this.getFormattedTooltipValue({
+        const formattedSeriesName = this.getFormattedTooltipLabel({
+          dataId: series.id,
           seriesId: sId,
           seriesName: series.name,
+          itemData: hasData,
+         });
+
+        const formattedValue = this.getFormattedTooltipValue({
+          dataId: series.id,
+          seriesId: sId,
+          seriesName: formattedSeriesName,
           value: hasData?.o,
           itemData: hasData,
         });
@@ -904,7 +949,7 @@ const modules = {
           const item = {};
           item.color = series.color;
           item.hit = false;
-          item.name = series.name;
+          item.name = formattedSeriesName;
           item.axis = { x: series.xAxisIndex, y: series.yAxisIndex };
           item.index = isHorizontal ? series.yAxisIndex : series.xAxisIndex;
           item.data = hasData;
@@ -914,9 +959,9 @@ const modules = {
         }
 
         const maxSeriesNameWidth = ctx ? ctx.measureText(maxSeriesName).width : 1;
-        const seriesNameWidth = ctx ? ctx.measureText(series.name).width : 1;
+        const seriesNameWidth = ctx ? ctx.measureText(formattedSeriesName).width : 1;
         if (maxSeriesNameWidth < seriesNameWidth) {
-          maxSeriesName = series.name;
+          maxSeriesName = formattedSeriesName;
         }
 
         const maxValueWidth = ctx ? ctx.measureText(maxValueTxt).width : 1;

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -293,9 +293,11 @@ const modules = {
     const seriesList = [];
     seriesKeys.forEach((seriesName) => {
       seriesList.push({
+        id: seriesName,
         data: items[seriesName].data,
         color: items[seriesName].color,
         name: items[seriesName].name,
+        dataId: items[seriesName].id,
       });
     });
 
@@ -342,11 +344,18 @@ const modules = {
         ctx.fillStyle = color;
       }
 
+      const curTooltipInfo = {
+        id: seriesList[ix].id,
+        name: seriesList[ix].name,
+        value: valueText,
+        dataId: seriesList[ix].dataId,
+      };
+
       // 1. Draw series color
       this.drawSeriesColorShape(ctx, opt.colorShape, { x: itemX, y: itemY });
 
       // 2. Draw series name
-      ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
+      ctx.fillStyle = typeof opt.fontColor.label === 'function' ? opt.fontColor.label(curTooltipInfo) : opt.fontColor.label ?? opt.fontColor;
       ctx.textBaseline = 'Bottom';
       const seriesNameSpaceWidth = opt.maxWidth - Math.round(ctx.measureText(maxValue).width)
         - boxPadding.l - boxPadding.r - seriesColorMarginRight - VALUE_MARGIN;
@@ -381,7 +390,7 @@ const modules = {
       ctx.save();
 
       // 3. Draw value
-      ctx.fillStyle = opt.fontColor?.value ?? opt.fontColor;
+      ctx.fillStyle = typeof opt.fontColor.value === 'function' ? opt.fontColor.value(curTooltipInfo) : opt.fontColor.value ?? opt.fontColor;
       ctx.textAlign = 'right';
       ctx.fillText(valueText, this.tooltipDOM.offsetWidth - boxPadding.r, itemY);
       ctx.restore();
@@ -470,11 +479,18 @@ const modules = {
       ctx.fillStyle = hitColor;
     }
 
+    const curTooltipInfo = {
+      id: hitInfo.hitId,
+      name: hitItem.y,
+      value: valueText,
+      dataId: items[sId].id,
+    };
+
     // 1. Draw value color
     this.drawSeriesColorShape(ctx, opt.colorShape, { x: itemX, y: itemY });
 
     // 2. Draw value y names
-    ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
+    ctx.fillStyle = typeof opt.fontColor.label === 'function' ? opt.fontColor.label(curTooltipInfo) : opt.fontColor.label ?? opt.fontColor;
     ctx.textBaseline = 'Bottom';
     if (this.axesY.length) {
       ctx.fillText(
@@ -485,6 +501,7 @@ const modules = {
 
     // 3. Draw value
     ctx.textAlign = 'right';
+    ctx.fillStyle = typeof opt.fontColor.value === 'function' ? opt.fontColor.value(curTooltipInfo) : opt.fontColor.value ?? opt.fontColor;
     ctx.fillText(valueText, this.tooltipDOM.offsetWidth - boxPadding.r, itemY);
     ctx.closePath();
   },
@@ -582,11 +599,18 @@ const modules = {
         ctx.fillStyle = color;
       }
 
+      const curTooltipInfo = {
+        id: hitInfo.hitId,
+        name: seriesList[ix].name,
+        value: valueText,
+        dataId: seriesList[ix].dataId,
+      };
+
       // 1. Draw series color
       this.drawSeriesColorShape(ctx, opt.colorShape, { x: itemX, y: itemY });
 
       // 2. Draw series name
-      ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
+      ctx.fillStyle = typeof opt.fontColor.label === 'function' ? opt.fontColor.label(curTooltipInfo) : opt.fontColor.label ?? opt.fontColor;
       ctx.textBaseline = 'Bottom';
       const seriesNameSpaceWidth = opt.maxWidth - Math.round(ctx.measureText(maxValue).width)
         - boxPadding.l - boxPadding.r - seriesColorMarginRight - VALUE_MARGIN;
@@ -622,6 +646,7 @@ const modules = {
 
       // 3. Draw value
       ctx.textAlign = 'right';
+      ctx.fillStyle = typeof opt.fontColor.value === 'function' ? opt.fontColor.value(curTooltipInfo) : opt.fontColor.value ?? opt.fontColor;
       ctx.fillText(valueText, this.tooltipDOM.offsetWidth - boxPadding.r, itemY);
       ctx.restore();
       ctx.closePath();


### PR DESCRIPTION
## 변경 사항
![after](https://github.com/user-attachments/assets/4034b37b-7a90-4828-a6e6-8aca96b51a68)
- Tooltip > fontColor(label, value)에 조건을 태울 수 있도록 수정
- Tooltip > formatter > label도 함수로 받을 수 있도록 수정
* docs. md파일 수정
* fix. Tooltip.vue 원상복구, series에 id를 추가하여 dataId로 받을 수 있도록 수정

https://github.com/ex-em/EVUI/pull/1879 와 동일합니다.