### PR TITLE
[#1888] fix: Heatmap > data Color 기능 누락

### DIFF
--- a/docs/views/heatMap/example/Default.vue
+++ b/docs/views/heatMap/example/Default.vue
@@ -1,12 +1,12 @@
 <template>
   <ev-chart
-      :data="chartData"
-      :options="chartOptions"
+    :data="chartData"
+    :options="chartOptions"
   />
 </template>
 
 <script>
-import { onMounted, reactive } from 'vue';
+import { reactive } from 'vue';
 
   export default {
     setup() {
@@ -17,33 +17,35 @@ import { onMounted, reactive } from 'vue';
           },
         },
         labels: {
-          x: ['12a', '1a', '2a', '3a', '4a', '5a', '6a', '7a', '8a', '9a', '10a', '11a',
-              '12p', '1p', '2p', '3p', '4p', '5p', '6p', '7p', '8p', '9p', '10p', '11p'],
-          y: ['SUN', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'SAT'],
+          x: ['00:00', '06:00', '12:00', '18:00'],
+          y: ['1w', '2w', '3w'],
         },
         data: {
-          series1: [],
+          series1: [
+            { x: '00:00', y: '1w', value: 100 },
+            { x: '00:00', y: '2w', value: 80 },
+            { x: '00:00', y: '3w', value: 130 },
+            { x: '06:00', y: '1w', value: 20 },
+            { x: '06:00', y: '2w', value: 150 },
+            { x: '06:00', y: '3w', value: 115 },
+            { x: '12:00', y: '1w', value: 150 },
+            { x: '12:00', y: '2w', value: 80 },
+            { x: '12:00', y: '3w', value: 120 },
+            { x: '18:00', y: '1w', value: 0 },
+            { x: '18:00', y: '2w', value: 150 },
+            { x: '18:00', y: '3w', value: 90, color: '#D3D3D3' },
+          ],
         },
       });
 
 
       const chartOptions = {
         type: 'heatMap',
-        width: '100%',
-        title: {
-          text: 'Chart Title',
-          show: true,
-        },
-        indicator: {
-          use: true,
-        },
         axesX: [{
           type: 'step',
-          showGrid: false,
         }],
         axesY: [{
           type: 'step',
-          showGrid: false,
         }],
         heatMapColor: {
           min: '#FFC19E',
@@ -54,25 +56,6 @@ import { onMounted, reactive } from 'vue';
           use: true,
         },
       };
-
-      const createChartData = () => {
-        const labelX = chartData.labels.x;
-        const labelY = chartData.labels.y;
-        for (let ix = 0; ix < labelX.length; ix++) {
-          for (let iy = 0; iy < labelY.length; iy++) {
-            const randomCount = Math.floor(Math.random() * 500) + 1;
-            chartData.data.series1.push({
-              x: labelX[ix],
-              y: labelY[iy],
-              value: randomCount,
-            });
-          }
-        }
-      };
-
-      onMounted(() => {
-        createChartData();
-      });
 
       return {
         chartData,

--- a/docs/views/heatMap/example/Default.vue
+++ b/docs/views/heatMap/example/Default.vue
@@ -31,9 +31,9 @@ import { reactive } from 'vue';
             { x: '12:00', y: '1w', value: 150 },
             { x: '12:00', y: '2w', value: 80 },
             { x: '12:00', y: '3w', value: 120 },
-            { x: '18:00', y: '1w', value: 0 },
-            { x: '18:00', y: '2w', value: 150 },
-            { x: '18:00', y: '3w', value: 90, color: '#D3D3D3' },
+            { x: '18:00', y: '1w', value: 0, color: 'rgb(255, 255, 0)' },
+            { x: '18:00', y: '2w', value: 150, color: '#D3D3D3' },
+            { x: '18:00', y: '3w', value: 90, color: 'rgba(0,0,0,0.5)' },
           ],
         },
       });

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -279,8 +279,10 @@ class HeatMap {
             ? !selectedLabel?.label?.includes(this.getItemLabel(selectLabel, item))
             : false;
         }
-        return isDownplay ? 0.1 : 1;
+
+        return isDownplay ? 0.1 : opacity;
       }
+
       return opacity;
     };
 
@@ -303,7 +305,12 @@ class HeatMap {
           isHighlight,
         } = this.getItemInfo(value);
 
-        const itemOpacity = getOpacity(item, opacity, index);
+        let originalOpacity = opacity;
+        if (opacity === 1 && Util.getColorStringType(item.dataColor) === 'RGBA') {
+          originalOpacity = Util.getOpacity(item.dataColor);
+        }
+
+        const itemOpacity = getOpacity(item, originalOpacity, index);
 
         if (!item.dataColor) {
           item.dataColor = dataColor;
@@ -487,13 +494,19 @@ class HeatMap {
     } else {
       isShow = this.colorState.find(({ id }) => id === cId)?.show;
     }
+
     ctx.save();
     ctx.shadowOffsetX = 0;
     ctx.shadowOffsetY = 0;
     ctx.shadowBlur = 4;
 
     if (x !== null && y !== null && isShow) {
-      const color = Util.colorStringToRgba(gdata.dataColor);
+      let highlightOpacity = 1;
+      if (Util.getColorStringType(gdata.dataColor) === 'RGBA') {
+        highlightOpacity = Util.getOpacity(item.dataColor);
+      }
+
+      const color = Util.colorStringToRgba(gdata.dataColor, highlightOpacity);
       ctx.shadowColor = Util.colorStringToRgba('#959494');
       ctx.strokeStyle = color;
       ctx.fillStyle = color;

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -305,7 +305,10 @@ class HeatMap {
 
         const itemOpacity = getOpacity(item, opacity, index);
 
-        item.dataColor = dataColor;
+        if (!item.dataColor) {
+          item.dataColor = dataColor;
+        }
+
         item.cId = id;
         ctx.save();
 

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -33,6 +33,10 @@ export default {
    * @returns {string} color type
    */
   getColorStringType(colorStr) {
+    if (!colorStr) {
+      return '';
+    }
+
     const noneWhiteSpaceColorStr = colorStr.replace(/ /g, '');
     const isHEX = /^#(?:[A-Fa-f0-9]{3}){1,2}$/.exec(noneWhiteSpaceColorStr);
     const isRGB = /^rgb[(](?:\s*0*(?:\d\d?(?:\.\d+)?(?:\s*%)?|\.\d+\s*%|100(?:\.0*)?\s*%|(?:1\d\d|2[0-4]\d|25[0-5])(?:\.\d+)?)\s*(?:,(?![)])|(?=[)]))){3}[)]$/.exec(noneWhiteSpaceColorStr);

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -496,7 +496,7 @@ const modules = {
    * @returns {array} data info added position and etc
    */
   addSeriesDSForHeatMap(data) {
-    return data.map(({ x, y, value }) => ({
+    return data.map(({ x, y, value, color = null }) => ({
       x,
       y,
       o: value,
@@ -504,7 +504,7 @@ const modules = {
       yp: null,
       w: null,
       h: null,
-      dataColor: null,
+      dataColor: color,
       cId: null,
     }));
   },


### PR DESCRIPTION
## 이슈 내용
- heatmap 차트에 dataColor기능 없음

### dataColor 기능이란
- ![image](https://github.com/user-attachments/assets/9b2b1ad5-5565-4237-bbb6-fc0c7f6807c3)
- series color에 관계없이 특정 데이터 전용 color를 부여할 때 사용

## 처리 내용
- dataColor 기능 추가 
- Heatmap > Default 예제 단순화 
   - dataGenerator 로직 제거 
   - dataColor예제 추가
   - ![image](https://github.com/user-attachments/assets/f7d60a2c-464e-4269-96ca-b5eb5ed3dd79)

