### PR TITLE
[#1896] Chart > Axis > type: Step > AlignToGridLine > 데이터가 소수점일 때 화면에 정상적으로 표시되지 않음

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.96",
+  "version": "3.4.97",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -265,28 +265,27 @@ class StepScale extends Scale {
 
       if (alignToGridLine && index >= this.labels.length) {
         const cellInterval = bnMinus(+labels[1], +labels[0]);
-        let labelLastText = bnPlus(+labels[labels.length - 1], cellInterval);
+        const lastLabelValue = bnPlus(+labels[labels.length - 1], cellInterval);
         if (
-            indexInterval !== 1
-            && bnMinus(labelLastText, drawnLabels[drawnLabels.length - 1]) <= cellInterval
+            isNaN(lastLabelValue)
+            || (indexInterval !== 1
+            && bnMinus(lastLabelValue, drawnLabels[drawnLabels.length - 1]) <= cellInterval)
         ) {
           return;
         }
 
-        if (isNaN(labelLastText)) {
-          labelLastText = 'Max';
-        }
         labelCenter = Math.round(startPoint + (labelGap * labels.length));
         linePosition = labelCenter + aliasPixel;
 
+        const lastLabelText = this.getLabelFormat(`${lastLabelValue}`, maxWidth);
         if (this.type === 'x') {
-          ctx.fillText(labelLastText, labelCenter, labelPoint);
+          ctx.fillText(lastLabelText, labelCenter, labelPoint);
           if (this.showGrid) {
             ctx.moveTo(linePosition, offsetPoint);
             ctx.lineTo(linePosition, offsetCounterPoint);
           }
         } else {
-          ctx.fillText(labelLastText, labelPoint, labelCenter);
+          ctx.fillText(lastLabelText, labelPoint, labelCenter);
           if (this.showGrid) {
             ctx.moveTo(offsetPoint, linePosition);
             ctx.lineTo(offsetCounterPoint, linePosition);


### PR DESCRIPTION
### 작업내용
1. 마지막으로 붙이는 label에대해 사용자 정의 formatter누락되있던 부분 수정

### Before
![image](https://github.com/user-attachments/assets/fc78680d-1e94-44cb-8d8b-be8b7193f428)
### After
![image](https://github.com/user-attachments/assets/7b5634b3-221c-4e57-b096-02dca82dcbe9)


