### PR TITLE
[#1900] Chart > Tooltip > textBaseline warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.97",
+  "version": "3.4.98",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -357,7 +357,7 @@ const modules = {
 
       // 2. Draw series name
       ctx.fillStyle = typeof opt.fontColor.label === 'function' ? opt.fontColor.label(curTooltipInfo) : opt.fontColor.label ?? opt.fontColor;
-      ctx.textBaseline = 'Bottom';
+
       const seriesNameSpaceWidth = opt.maxWidth - Math.round(ctx.measureText(maxValue).width)
         - boxPadding.l - boxPadding.r - seriesColorMarginRight - VALUE_MARGIN;
       const xPos = itemX + seriesColorMarginRight;
@@ -492,7 +492,7 @@ const modules = {
 
     // 2. Draw value y names
     ctx.fillStyle = typeof opt.fontColor.label === 'function' ? opt.fontColor.label(curTooltipInfo) : opt.fontColor.label ?? opt.fontColor;
-    ctx.textBaseline = 'Bottom';
+
     if (this.axesY.length) {
       ctx.fillText(
         this.axesY[hitAxis.y].getLabelFormat(hitItem.y),
@@ -612,7 +612,7 @@ const modules = {
 
       // 2. Draw series name
       ctx.fillStyle = typeof opt.fontColor.label === 'function' ? opt.fontColor.label(curTooltipInfo) : opt.fontColor.label ?? opt.fontColor;
-      ctx.textBaseline = 'Bottom';
+
       const seriesNameSpaceWidth = opt.maxWidth - Math.round(ctx.measureText(maxValue).width)
         - boxPadding.l - boxPadding.r - seriesColorMarginRight - VALUE_MARGIN;
       const xPos = itemX + seriesColorMarginRight;


### PR DESCRIPTION
# 현상
- 콘솔 경고 발생
![Image](https://github.com/user-attachments/assets/775a72ac-11e0-41d8-b79f-3afff9c1fbfe)

# 변경 내용
- `Bottom`을 원래 의도했던 `bottom`으로 변경할 경우 아래 이미지와 같아지기 때문에(_색상 아이콘과 글자가 틀어져보임_),  
   `Bottom`이였을 때 기본값으로 인식됐던 `alphabetic`으로 인식시키기 위해 textBaseline 삭제
![image](https://github.com/user-attachments/assets/5a886e6d-3598-4c07-8a8d-fe12c506073f)
<details>
<summary>기존 툴팁 형태</summary>

![image](https://github.com/user-attachments/assets/c6a67a00-1a21-4eac-a650-275efc9426e5)
</details>
