### PR TITLE
[#1902] TreeGrid > Row Expand Emit 추가

### DIFF
--- a/docs/views/treeGrid/api/treeGrid.md
+++ b/docs/views/treeGrid/api/treeGrid.md
@@ -119,12 +119,13 @@
 | customHeader    | Boolean | 커스텀 헤더 사용 여부 | Boolean                         | N |
 
 ### Event
-| 이름 | 파라미터 | 설명 |
-| ---- | ------- | ---- |
-| check-row | event, row, index | row의 체크박스가 체크 되었을때 호출된다. |
-| check-all | event, rows | 헤더의 체크박스가 체크 되었을때 호출 된다. 전체 row의 체크박스를 체크한다. |
-| click-row | event, row | row가 클릭 되었을 때 호출된다. |
-| dblclick-row | event, row | row가 더블 클릭 되었을 때 호출된다. |
-| page-change | event | page 정보가 변경되었을 때 호출된다. |
-| resize-column | column, columns             | column의 width가 resize 됐을때 호출된다.                                     | |
-| change-column-status | columns             | column의 상태(column Show/Hide)가 변경되었을 때 호출된다. |
+| 이름                   | 파라미터              | 설명                                                                   |
+|----------------------|-------------------|----------------------------------------------------------------------|
+| check-row            | event, row, index | row의 체크박스가 체크 되었을때 호출된다.                                             |
+| check-all            | event, rows       | 헤더의 체크박스가 체크 되었을때 호출 된다. 전체 row의 체크박스를 체크한다.                         |
+| click-row            | event, row        | row가 클릭 되었을 때 호출된다.                                                  |
+| dblclick-row         | event, row        | row가 더블 클릭 되었을 때 호출된다.                                               |
+| page-change          | event             | page 정보가 변경되었을 때 호출된다.                                               |
+| resize-column        | column, columns   | column의 width가 resize 됐을때 호출된다.                                      | |
+| change-column-status | columns           | column의 상태(column Show/Hide)가 변경되었을 때 호출된다.                          |
+| toggle-row           | row, isExpand     | row의 토글버튼이 클릭 되었을 때 호출된다. |

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -40,6 +40,7 @@
       @check-all="onCheckedRow"
       @click-row="onClickRow"
       @dblclick-row="onDoubleClickRow"
+      @toggle-row="onToggledRow"
     >
     </ev-tree-grid>
     <div class="description">
@@ -208,6 +209,18 @@
       <div class="form-rows">
         <div class="form-row">
           <span class="badge yellow">
+            Toggled Row
+          </span>
+          <ev-text-field
+            v-model="toggledRowMV"
+            type="textarea"
+            readonly
+          />
+        </div>
+      </div>
+      <div class="form-rows">
+        <div class="form-row">
+          <span class="badge yellow">
             Highlight
           </span>
           <ev-input-number
@@ -299,6 +312,7 @@ export default {
     const headerCheckMV = ref(true);
     const checkedRowsMV = ref();
     const clickedRowMV = ref();
+    const toggledRowMV = ref();
     const DbClickedRowsMV = ref();
     const expandColumnMV = ref(0);
     const useGridSettingMV = ref(true);
@@ -410,6 +424,10 @@ export default {
       const rowData = e.rowData.data;
       clickedRowMV.value = JSON.stringify(rowData);
     };
+    const onToggledRow = ({ row, isExpand }) => {
+      console.log('=> here!');
+      toggledRowMV.value = `Expand : ${isExpand}\nrow : ${JSON.stringify(row.data)}`;
+    };
     const getData = () => {
       tableData.value = [
         {
@@ -489,7 +507,7 @@ export default {
       ];
     };
     const columns = ref([
-      { caption: 'ID', field: 'id', type: 'number', fixed: true },
+      { caption: 'ID', field: 'id', type: 'number' },
       { caption: 'Date', field: 'date', type: 'string' },
       {
         caption: 'Name',
@@ -558,6 +576,7 @@ export default {
       checkedRowsMV,
       clickedRowMV,
       DbClickedRowsMV,
+      toggledRowMV,
       menuItems,
       highlightMV,
       borderMV,
@@ -581,6 +600,7 @@ export default {
       onCheckedRow,
       onDoubleClickRow,
       onClickRow,
+      onToggledRow,
       resetBorderStyle,
       resetTreeIcon,
       resetDataIcon,

--- a/docs/views/treeGrid/example/Default.vue
+++ b/docs/views/treeGrid/example/Default.vue
@@ -425,7 +425,6 @@ export default {
       clickedRowMV.value = JSON.stringify(rowData);
     };
     const onToggledRow = ({ row, isExpand }) => {
-      console.log('=> here!');
       toggledRowMV.value = `Expand : ${isExpand}\nrow : ${JSON.stringify(row.data)}`;
     };
     const getData = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.98",
+  "version": "3.4.99",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -395,6 +395,7 @@ export default {
     'check-all': null,
     'page-change': null,
     'sort-column': null,
+    'toggle-row': null,
     'resize-column': ({ column, columns }) => ({ column, columns }),
     'change-column-status': ({ columns }) => ({ columns }),
     'change-column-info': ({ type, columns }) => ({ type, columns }),

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -741,6 +741,7 @@ export const contextMenuEvent = (params) => {
 };
 
 export const treeEvent = (params) => {
+  const { emit } = getCurrentInstance();
   const { stores, onResize } = params;
   const setTreeNodeStore = () => {
     let nodeIndex = 0;
@@ -834,9 +835,11 @@ export const treeEvent = (params) => {
     });
   };
   const handleExpand = (node) => {
+    const isExpand = !node.expand;
     const data = node;
     data.expand = !data.expand;
     setExpandNode(data.children, data.expand, data.isFilter);
+    emit('toggle-row', { row: data, isExpand });
     onResize();
   };
   return { setTreeNodeStore, handleExpand };


### PR DESCRIPTION
# 변경 사항 요약

- TreeGrid의 Expand 대상 컬럼에서 Toggle 발생 시 row-toggle Emit을 추가했습니다.
- toggle-row 이벤트 발생 시 row 데이터와 expand 여부가 전달됩니다.
    
    ```jsx
    emit('toggle-row', { row: data, isExpand })
    ```

![image](https://github.com/user-attachments/assets/f7fc3548-257a-4e89-b3e6-417e3fb4127f)
