### PR TITLE
[#1907]Chart > HeatMap > 차트영역 바깥쪽에서 안으로 드래그했을 때 범위값 이상 (3.0)

### DIFF
--- a/docs/views/heatMap/example/Event.vue
+++ b/docs/views/heatMap/example/Event.vue
@@ -61,7 +61,7 @@ v-for="(item, itemIdx) in row.items"
 </div></template>
 
 <script>
-import { onMounted, reactive, ref, computed } from 'vue';
+import { onMounted, reactive, ref } from 'vue';
   import dayjs from 'dayjs';
 
   export default {
@@ -81,13 +81,8 @@ import { onMounted, reactive, ref, computed } from 'vue';
         },
       });
 
-      const xRange = computed(() => (chartData.labels.x.length
-        ? [chartData.labels.x[0], chartData.labels.x[7]] : null));
-      const yRange = computed(() => (chartData.labels.y.length
-        ? [0, 3] : null));
 
-
-      const chartOptions = reactive({
+      const chartOptions = {
         type: 'heatMap',
         width: '100%',
         title: {
@@ -107,30 +102,10 @@ import { onMounted, reactive, ref, computed } from 'vue';
           interval: 'second',
           categoryMode: true,
           showGrid: false,
-          range: xRange,
-          scrollbar: {
-            use: true,
-            showButton: true,
-            background: '#E0E1DD',
-            thumbStyle: {
-              background: '#415A77',
-              radius: 2,
-            },
-          },
         }],
         axesY: [{
           type: 'step',
           showGrid: false,
-          range: yRange,
-          scrollbar: {
-            use: true,
-            showButton: true,
-            background: '#E0E1DD',
-            thumbStyle: {
-              background: '#415A77',
-              radius: 2,
-            },
-          },
         }],
         selectItem: {
           use: true,
@@ -147,7 +122,7 @@ import { onMounted, reactive, ref, computed } from 'vue';
         tooltip: {
           use: true,
         },
-      });
+      };
 
       const selectionItems = ref([]);
       const selectionRange = ref({});

--- a/docs/views/heatMap/example/Event.vue
+++ b/docs/views/heatMap/example/Event.vue
@@ -61,7 +61,7 @@ v-for="(item, itemIdx) in row.items"
 </div></template>
 
 <script>
-import { onMounted, reactive, ref } from 'vue';
+import { onMounted, reactive, ref, computed } from 'vue';
   import dayjs from 'dayjs';
 
   export default {
@@ -81,8 +81,13 @@ import { onMounted, reactive, ref } from 'vue';
         },
       });
 
+      const xRange = computed(() => (chartData.labels.x.length
+        ? [chartData.labels.x[0], chartData.labels.x[7]] : null));
+      const yRange = computed(() => (chartData.labels.y.length
+        ? [0, 3] : null));
 
-      const chartOptions = {
+
+      const chartOptions = reactive({
         type: 'heatMap',
         width: '100%',
         title: {
@@ -102,10 +107,30 @@ import { onMounted, reactive, ref } from 'vue';
           interval: 'second',
           categoryMode: true,
           showGrid: false,
+          range: xRange,
+          scrollbar: {
+            use: true,
+            showButton: true,
+            background: '#E0E1DD',
+            thumbStyle: {
+              background: '#415A77',
+              radius: 2,
+            },
+          },
         }],
         axesY: [{
           type: 'step',
           showGrid: false,
+          range: yRange,
+          scrollbar: {
+            use: true,
+            showButton: true,
+            background: '#E0E1DD',
+            thumbStyle: {
+              background: '#415A77',
+              radius: 2,
+            },
+          },
         }],
         selectItem: {
           use: true,
@@ -122,7 +147,7 @@ import { onMounted, reactive, ref } from 'vue';
         tooltip: {
           use: true,
         },
-      };
+      });
 
       const selectionItems = ref([]);
       const selectionRange = ref({});

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -26,6 +26,19 @@ class HeatMap {
       h: 0,
     };
     this.type = 'heatMap';
+
+    this.filteredRange = {
+      x: {
+        steps: 0,
+        min: 0,
+        max: 0,
+      },
+      y: {
+        steps: 0,
+        min: 0,
+        max: 0,
+      },
+    };
   }
 
   /**
@@ -250,7 +263,7 @@ class HeatMap {
     this.size.w = xArea / minmaxX.oriSteps;
     this.size.h = yArea / minmaxY.oriSteps;
 
-    this.filteredRange = {
+    this.currentLabelInfo = {
       x: {
         steps: minmaxX.oriSteps,
         min: minmaxX.graphMin,
@@ -565,8 +578,8 @@ class HeatMap {
     };
 
     if (labels.x.length && labels.y.length) {
-      const labelXCount = this.filteredRange?.x?.steps ?? labels.x.length;
-      const labelYCount = this.filteredRange?.y?.steps ?? labels.y.length;
+      const labelXCount = this.currentLabelInfo.x.steps || labels.x.length;
+      const labelYCount = this.currentLabelInfo.y.steps || labels.y.length;
 
       const { x1, x2, y1, y2 } = range;
       const gapX = (x2 - x1) / labelXCount;
@@ -625,8 +638,8 @@ class HeatMap {
     const { x: labelX, y: labelY } = this.labels;
 
     if (labelX.length && labelY.length) {
-      const labelXCount = this.filteredRange?.x?.steps ?? labelX.length;
-      const labelYCount = this.filteredRange?.y?.steps ?? labelY.length;
+      const labelXCount = this.currentLabelInfo.x.steps || labelX.x.length;
+      const labelYCount = this.currentLabelInfo.y.steps || labelY.y.length;
       const gapX = (x2 - x1) / labelXCount;
       const gapY = (y2 - y1) / labelYCount;
 
@@ -645,15 +658,17 @@ class HeatMap {
         max: lastIndexY - Math.floor((ysp - y1) / gapY),
       };
 
-      const { min: xMin, max: xMax } = this.filteredRange.x;
-      const { min: yMin, max: yMax } = this.filteredRange.y;
+      const getFilteredLabel = (dir) => {
+        const list = dir === 'x' ? labelX : labelY;
+        const count = dir === 'x' ? labelXCount : labelYCount;
+        const { min, max } = this.currentLabelInfo[dir];
+        return list.length === count
+          ? list.filter(label => min <= label && label <= max)
+          : list;
+      };
 
-      const filteredLabelX = labelXCount !== labelX.length
-        ? labelX.filter(item => xMin <= item && item <= xMax)
-        : labelX;
-      const filteredLabelY = labelYCount !== labelY.length
-        ? labelY.filter(item => yMin <= item && item <= yMax)
-        : labelY;
+      const filteredLabelX = getFilteredLabel('x');
+      const filteredLabelY = getFilteredLabel('y');
 
       selectionRange = {
         xMin: filteredLabelX[xIndex.min],

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -629,6 +629,12 @@ class HeatMap {
     return blockRange;
   }
 
+  getFilteredLabel(labels, count, min, max) {
+    return labels.length !== count
+      ? labels.filter(label => min <= label && label <= max)
+      : labels;
+  }
+
   findSelectionRange(rangeInfo) {
     const { xsp, ycp, width, height, range } = rangeInfo;
 
@@ -638,8 +644,13 @@ class HeatMap {
     const { x: labelX, y: labelY } = this.labels;
 
     if (labelX.length && labelY.length) {
-      const labelXCount = this.currentLabelInfo.x.steps || labelX.x.length;
-      const labelYCount = this.currentLabelInfo.y.steps || labelY.y.length;
+      const {
+        x: { steps: xCurrentCount, min: xMin, max: xMax },
+        y: { steps: yCurrentCount, min: yMin, max: yMax },
+      } = this.currentLabelInfo;
+
+      const labelXCount = xCurrentCount || labelX.x.length;
+      const labelYCount = yCurrentCount || labelY.y.length;
       const gapX = (x2 - x1) / labelXCount;
       const gapY = (y2 - y1) / labelYCount;
 
@@ -658,17 +669,8 @@ class HeatMap {
         max: lastIndexY - Math.floor((ysp - y1) / gapY),
       };
 
-      const getFilteredLabel = (dir) => {
-        const list = dir === 'x' ? labelX : labelY;
-        const count = dir === 'x' ? labelXCount : labelYCount;
-        const { min, max } = this.currentLabelInfo[dir];
-        return list.length === count
-          ? list.filter(label => min <= label && label <= max)
-          : list;
-      };
-
-      const filteredLabelX = getFilteredLabel('x');
-      const filteredLabelY = getFilteredLabel('y');
+      const filteredLabelX = this.getFilteredLabel(labelX, labelXCount, xMin, xMax);
+      const filteredLabelY = this.getFilteredLabel(labelY, labelYCount, yMin, yMax);
 
       selectionRange = {
         xMin: filteredLabelX[xIndex.min],

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -27,7 +27,7 @@ class HeatMap {
     };
     this.type = 'heatMap';
 
-    this.filteredRange = {
+    this.currentLabelInfo = {
       x: {
         steps: 0,
         min: 0,

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -250,9 +250,17 @@ class HeatMap {
     this.size.w = xArea / minmaxX.oriSteps;
     this.size.h = yArea / minmaxY.oriSteps;
 
-    this.filterdCount = {
-      x: minmaxX.oriSteps,
-      y: minmaxY.oriSteps,
+    this.filteredRange = {
+      x: {
+        steps: minmaxX.oriSteps,
+        min: minmaxX.graphMin,
+        max: minmaxX.graphMax,
+      },
+      y: {
+        steps: minmaxY.oriSteps,
+        min: minmaxY.graphMin,
+        max: minmaxY.graphMax,
+      },
     };
 
     const getOpacity = (item, opacity, index) => {
@@ -557,8 +565,8 @@ class HeatMap {
     };
 
     if (labels.x.length && labels.y.length) {
-      const labelXCount = this.filterdCount?.x ?? labels.x.length;
-      const labelYCount = this.filterdCount?.y ?? labels.y.length;
+      const labelXCount = this.filteredRange?.x?.steps ?? labels.x.length;
+      const labelYCount = this.filteredRange?.y?.steps ?? labels.y.length;
 
       const { x1, x2, y1, y2 } = range;
       const gapX = (x2 - x1) / labelXCount;
@@ -609,7 +617,7 @@ class HeatMap {
   }
 
   findSelectionRange(rangeInfo) {
-    const { xcp, ycp, width, height, range } = rangeInfo;
+    const { xsp, ycp, width, height, range } = rangeInfo;
 
     let selectionRange = null;
 
@@ -617,30 +625,41 @@ class HeatMap {
     const { x: labelX, y: labelY } = this.labels;
 
     if (labelX.length && labelY.length) {
-      const gapX = (x2 - x1) / labelX.length;
-      const gapY = (y2 - y1) / labelY.length;
+      const labelXCount = this.filteredRange?.x?.steps ?? labelX.length;
+      const labelYCount = this.filteredRange?.y?.steps ?? labelY.length;
+      const gapX = (x2 - x1) / labelXCount;
+      const gapY = (y2 - y1) / labelYCount;
 
-      const xsp = xcp;
-      const xep = xcp + width;
+      const xep = xsp + width;
       const ysp = ycp;
-      const yep = ycp + height;
+      const yep = ysp + height;
 
       const xIndex = {
         min: Math.floor((xsp - x1) / gapX),
         max: Math.floor((xep - x1 - gapX) / gapX),
       };
 
-      const lastIndexY = labelY.length - 1;
+      const lastIndexY = labelYCount - 1;
       const yIndex = {
         min: lastIndexY - Math.floor((yep - y1 - gapY) / gapY),
         max: lastIndexY - Math.floor((ysp - y1) / gapY),
       };
 
+      const { min: xMin, max: xMax } = this.filteredRange.x;
+      const { min: yMin, max: yMax } = this.filteredRange.y;
+
+      const filteredLabelX = labelXCount !== labelX.length
+        ? labelX.filter(item => xMin <= item && item <= xMax)
+        : labelX;
+      const filteredLabelY = labelYCount !== labelY.length
+        ? labelY.filter(item => yMin <= item && item <= yMax)
+        : labelY;
+
       selectionRange = {
-        xMin: labelX[xIndex.min],
-        xMax: labelX[xIndex.max],
-        yMin: labelY[yIndex.min],
-        yMax: labelY[yIndex.max],
+        xMin: filteredLabelX[xIndex.min],
+        xMax: filteredLabelX[xIndex.max],
+        yMin: filteredLabelY[yIndex.min],
+        yMax: filteredLabelY[yIndex.max],
       };
     }
 

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -347,7 +347,7 @@ const modules = {
 
       // 2. Draw series name
       ctx.fillStyle = opt.fontColor?.label ?? opt.fontColor;
-      ctx.textBaseline = 'Bottom';
+      ctx.textBaseline = 'bottom';
       const seriesNameSpaceWidth = opt.maxWidth - Math.round(ctx.measureText(maxValue).width)
         - boxPadding.l - boxPadding.r - seriesColorMarginRight - VALUE_MARGIN;
       const xPos = itemX + seriesColorMarginRight;


### PR DESCRIPTION
### 이슈
1. 차트 바깥쪽에서 안으로 드래그했을 때 범위값이 x값의 시작값으로 나옴

![Image](https://github.com/user-attachments/assets/e45e3cc9-4dcd-4fc5-9376-307c579a18ba)

2. 히트맵 스크롤 옵션 사용시 드래그한 범위가 다른 범위로 나옴

![heatmap_drag_issue2](https://github.com/user-attachments/assets/f29dc347-eb20-4229-8f25-553f8453f0b3)


### 기대상황
1. drag한 범위의 최솟값이 나와야함
2. 스크롤 사용할 때도 드래그한 범위가 정상적으로 나와야함

### 실제상황
1. x값의 시작값으로 나옴
2. 스크롤 사용시 드래그한 범위가 비정상적으로 나옴

### 수정 내용
- 드래그한 범위의 x 시작점을 계산할 때 xcp가 아닌 xsp 변수 사용
- 스크롤 사용할 때 filteredRange 변수로 x, y의 steps, min,max 값 property 가지고 있도록 수정
- 드래그한 범위 계산할 때 min,max 값으로 현재 스크롤하여 보여지고 있는 범위에서 x, y 범위값 계산하도록 로직 수정

![heatmap_drag_issue_fix](https://github.com/user-attachments/assets/faedf5ae-6a8b-405d-8428-33c38059df51)

![heatmap_drag_issue_fix2](https://github.com/user-attachments/assets/8db05820-69ed-4bb7-9513-384374886b10)


