### PR TITLE
[#1912] Chart > Custom Tooltip > 스크롤 이벤트 전달 필요

### DIFF
--- a/docs/views/lineChart/example/CustomTooltip.vue
+++ b/docs/views/lineChart/example/CustomTooltip.vue
@@ -21,17 +21,19 @@ import dayjs from 'dayjs';
 export default {
   setup() {
     const chartData = reactive({
-      series: {
-        series1: { name: 'series#1', point: false },
-        series2: { name: 'series#2', point: false },
-        series3: { name: 'series#3', point: false },
-      },
+      series: Object.fromEntries(
+        Array.from({ length: 100 }, (_, i) => {
+          const seriesId = `series${i + 1}`;
+          return [seriesId, { name: `series#${i + 1}`, point: false }];
+        }),
+      ),
       labels: [],
-      data: {
-        series1: [],
-        series2: [],
-        series3: [],
-      },
+      data: Object.fromEntries(
+        Array.from({ length: 100 }, (_, i) => {
+          const seriesId = `series${i + 1}`;
+          return [seriesId, []];
+        }),
+      ),
     });
 
     const useHtml = ref(true);
@@ -83,6 +85,8 @@ export default {
       }],
       tooltip: {
         use: true,
+        useScrollbar: true,
+        htmlScrollTarget: '.ev-chart-tooltip-custom__body',
       },
     });
 
@@ -120,3 +124,10 @@ export default {
   },
 };
 </script>
+
+<style lang="scss">
+.ev-chart-tooltip-custom__body {
+  max-height: 400px;
+  overflow-y: auto !important;
+}
+</style>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.100",
+  "version": "3.4.101",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -354,10 +354,18 @@ const modules = {
 
     this.onWheel = (e) => {
       const isTooltipVisible = this.tooltipDOM?.style?.display === 'block';
+      const customTooltip = document.querySelector(this.options.tooltip.htmlScrollTarget);
 
-      if (isTooltipVisible) {
+      if (isTooltipVisible
+        || (customTooltip && customTooltip.scrollHeight > customTooltip.clientHeight)) {
         e.preventDefault();
-        this.tooltipBodyDOM.scrollTop += e.deltaY;
+
+        if (isTooltipVisible) {
+          this.tooltipBodyDOM.scrollTop += e.deltaY;
+        }
+        if (customTooltip) {
+          customTooltip.scrollTop += e.deltaY;
+        }
       }
     };
 

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -711,6 +711,7 @@ const modules = {
           data: hitInfoItems[sId].data,
           color: hitInfoItems[sId].color,
           name: hitInfoItems[sId].name,
+          dataId: hitInfoItems[sId].id,
         });
       });
 


### PR DESCRIPTION
# 이슈
![Image](https://github.com/user-attachments/assets/2427b3ad-06b1-49c9-99fe-4cc4813f7c32)

- 기존 tooltip처럼 마우스 휠 동작을 할 때 툴팁 내부의 스크롤이 되게끔 변경 필요

# 변경 사항
![after](https://github.com/user-attachments/assets/dc9807e3-a8d2-44fd-8761-54b83ba3e680)
- tooltip option에 `htmlScrollTarget`을 추가하여 해당 DOM 스크롤로 대체할 수 있게 수정
- 기존 tooltip처럼 id 값 전달할 수 있게 수정