### PR TITLE
[#1912] Chart > Custom Tooltip > 스크롤 이벤트 전달 필요 #1913

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.101",
+  "version": "3.4.102",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -354,7 +354,7 @@ const modules = {
 
     this.onWheel = (e) => {
       const isTooltipVisible = this.tooltipDOM?.style?.display === 'block';
-      const customTooltip = document.querySelector(this.options.tooltip.htmlScrollTarget);
+      const customTooltip = this.tooltipDOM?.querySelector(this.options.tooltip.htmlScrollTarget);
 
       if (isTooltipVisible
         || (customTooltip && customTooltip.scrollHeight > customTooltip.clientHeight)) {


### PR DESCRIPTION
https://github.com/ex-em/EVUI/pull/1913 에서 발생한 버그 수정을 위함

- 차트 툴팁을 미리 만들어두고 제거하지 않기에, document에서 찾으면 안되고 this.tooltipDOM에서 찾아야함.