### PR TITLE
fix: 마지막 컬럼 너비 계산 로직 수정

### DIFF
--- a/docs/views/grid/example/Default.vue
+++ b/docs/views/grid/example/Default.vue
@@ -284,7 +284,7 @@ export default {
       { caption: 'boolean', field: 'boolean', type: 'boolean', width: 80 },
       { caption: 'Phone', field: 'phone', type: 'string', sortable: false },
       { caption: 'Email', field: 'email', type: 'string', width: 80 },
-      { caption: 'Last Login', field: 'lastLogin', type: 'string' },
+      { caption: 'Last Login', field: 'lastLogin', type: 'string', hide: true },
     ]);
     const resetBorderStyle = () => {
       borderMV.value = '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.98",
+  "version": "3.4.102",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",
-  "engines": {
-    "node": "<=12.0.0"
-  },
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.102",
+  "version": "3.4.103",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -689,6 +689,20 @@ export default {
       type: [Array],
       default: () => [],
     },
+    /**
+     * @type {Object}
+     * @property {number} columnWidth 컬럼 너비 minWidth
+     * @property {number} scrollWidth 스크롤 너비
+     * @property {number} rowHeight 행 높이
+     * @property {number} gridWidth 그리드 너비 width
+     * @property {number} gridHeight 그리드 높이
+     * @property {boolean} adjust 컬럼 너비 조정 여부
+     * @property {boolean} useGridSetting 그리드 설정 사용 여부
+     * @property {number} gridWidth 그리드 너비 width
+     * @property {number} gridHeight 그리드 높이
+     * @property {boolean} adjust 컬럼 너비 조정 여부
+     * @property {boolean} useGridSetting 그리드 설정 사용 여부
+     */
     option: {
       type: Object,
       default: () => ({}),

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -291,9 +291,14 @@ export const resizeEvent = (params) => {
 
       columnWidth = elWidth - result.totalWidth;
       if (columnWidth > 0) {
-        remainWidth = columnWidth
-          - (Math.floor(columnWidth / result.emptyCount) * result.emptyCount);
-        columnWidth = Math.floor(columnWidth / result.emptyCount);
+        const sharePerEmptyCount = result.emptyCount === 0
+            ? 0
+            : Math.floor(columnWidth / result.emptyCount);
+
+        remainWidth = columnWidth - (sharePerEmptyCount * result.emptyCount);
+        columnWidth = result.emptyCount !== 0
+          ? sharePerEmptyCount
+          : columnWidth;
       } else {
         columnWidth = resizeInfo.columnWidth;
       }
@@ -302,22 +307,20 @@ export const resizeEvent = (params) => {
       resizeInfo.columnWidth = columnWidth;
     }
 
-    stores.orderedColumns.forEach((column) => {
-      const item = column;
-      const minWidth = isRenderer(column) ? resizeInfo.rendererMinWidth : resizeInfo.minWidth;
-      if (item.width && item.width < minWidth) {
-        item.width = minWidth;
+    stores.orderedColumns.forEach((col) => {
+      const minWidth = isRenderer(col) ? resizeInfo.rendererMinWidth : resizeInfo.minWidth;
+      if (col.width && col.width < minWidth) {
+        col.width = minWidth;
       }
-      if (!item.width && !item.hide) {
-        item.width = columnWidth;
+      if (!col.width && !col.hide) {
+        col.width = columnWidth;
       }
-      return item;
     });
 
     if (remainWidth) {
       let index = stores.orderedColumns.length - 1;
       let lastColumn = stores.orderedColumns[index];
-      while (lastColumn.hide) {
+      while (lastColumn.hide || lastColumn.hiddenDisplay) {
         index -= 1;
         lastColumn = stores.orderedColumns[index];
       }

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -320,6 +320,9 @@ export const resizeEvent = (params) => {
     if (remainWidth) {
       let index = stores.orderedColumns.length - 1;
       let lastColumn = stores.orderedColumns[index];
+
+      // orderedColumns에 hiddenDisplay === true 컬럼은 포함되어 있지 않다.
+      // 하지만 hide === true 컬럼은 포함되어 있다. 그래서 hiddenDisplay 조건은 필요없지만 조건을 추가해서 코드 가독성과 안정성을 높였다.
       while (lastColumn.hide || lastColumn.hiddenDisplay) {
         index -= 1;
         lastColumn = stores.orderedColumns[index];

--- a/src/components/treeGrid/uses.js
+++ b/src/components/treeGrid/uses.js
@@ -236,9 +236,14 @@ export const resizeEvent = (params) => {
 
       columnWidth = elWidth - result.totalWidth;
       if (columnWidth > 0) {
-        remainWidth = columnWidth
-          - (Math.floor(columnWidth / result.emptyCount) * result.emptyCount);
-        columnWidth = Math.floor(columnWidth / result.emptyCount);
+        const sharePerEmptyCount = result.emptyCount === 0
+            ? 0
+            : Math.floor(columnWidth / result.emptyCount);
+
+        remainWidth = columnWidth - (sharePerEmptyCount * result.emptyCount);
+        columnWidth = result.emptyCount !== 0
+          ? sharePerEmptyCount
+          : columnWidth;
       } else {
         columnWidth = resizeInfo.columnWidth;
       }
@@ -247,22 +252,23 @@ export const resizeEvent = (params) => {
       resizeInfo.columnWidth = columnWidth;
     }
 
-    stores.orderedColumns.forEach((column) => {
-      const item = column;
-      const minWidth = isRenderer(column) ? resizeInfo.rendererMinWidth : resizeInfo.minWidth;
-      if (item.width && item.width < minWidth) {
-        item.width = minWidth;
+    stores.orderedColumns.forEach((col) => {
+      const minWidth = isRenderer(col) ? resizeInfo.rendererMinWidth : resizeInfo.minWidth;
+      if (col.width && col.width < minWidth) {
+        col.width = minWidth;
       }
-      if (!item.width && !item.hide) {
-        item.width = columnWidth;
+      if (!col.width && !col.hide) {
+        col.width = columnWidth;
       }
-      return item;
     });
 
     if (remainWidth) {
       let index = stores.orderedColumns.length - 1;
       let lastColumn = stores.orderedColumns[index];
-      while (lastColumn.hide) {
+
+      // orderedColumns에 hiddenDisplay === true 컬럼은 포함되어 있지 않다.
+      // 하지만 hide === true 컬럼은 포함되어 있다. 그래서 hiddenDisplay 조건은 필요없지만 조건을 추가해서 코드 가독성과 안정성을 높였다.
+      while (lastColumn.hide || lastColumn.hiddenDisplay) {
         index -= 1;
         lastColumn = stores.orderedColumns[index];
       }


### PR DESCRIPTION
대부분의 로직이 이미 존재 하는 상태였고, 버그로 인해 
```ts
remainWidth = columnWidth - (Math.floor(columnWidth / result.emptyCount) * result.emptyCount);
```
에서 `result.emptyCount`가 0일때 로직이 의도대로 동작하지 않아 발생하는 버그였습니다.

단 옵션의 adjust가 true여야만 작동합니다.

### 기대 동작
![May-28-2025 13-53-04](https://github.com/user-attachments/assets/cf609179-b153-4347-b302-86201e0237e5)


### 기존
![image](https://github.com/user-attachments/assets/f2ad7812-80e4-4b2a-93cd-2ffc7e650977)

