### PR TITLE
[#1917] Chart > Time Axis > Category Mode > label이 2개이상 표시되도록 함

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.101",
+  "version": "3.4.102",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -185,7 +185,7 @@ class TimeCategoryScale extends Scale {
     let labelPoint;
     let ix;
     const maxIndex = oriSteps === count ? oriSteps : oriSteps - 1;
-    for (ix = 0; maxIndex; ix += count) {
+    for (ix = 0; ix <= maxIndex; ix += count) {
       ticks[ix] = dayjs(axisMin).valueOf() + (ix * stepValue);
 
       labelCenter = Math.round(startPoint + (graphGap * ix));

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -184,7 +184,8 @@ class TimeCategoryScale extends Scale {
     let labelText;
     let labelPoint;
     let ix;
-    for (ix = 0; oriSteps === count ? ix <= oriSteps : ix < oriSteps; ix += count) {
+    const maxIndex = oriSteps === count ? oriSteps : oriSteps - 1;
+    for (ix = 0; maxIndex; ix += count) {
       ticks[ix] = dayjs(axisMin).valueOf() + (ix * stepValue);
 
       labelCenter = Math.round(startPoint + (graphGap * ix));

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -126,7 +126,9 @@ class TimeCategoryScale extends Scale {
     const axisMax = stepInfo.graphMax;
     const stepValue = stepInfo.rawInterval;
     const oriSteps = stepInfo.oriSteps;
-    const count = Math.round(oriSteps / steps);
+
+    // 2개 이하일 경우, 첫번째와 마지막 라벨만 표시
+    const count = steps <= 2 ? oriSteps : Math.round(oriSteps / steps);
 
     let startPoint = aPos[this.units.rectStart];
     const endPoint = aPos[this.units.rectEnd];
@@ -182,7 +184,7 @@ class TimeCategoryScale extends Scale {
     let labelText;
     let labelPoint;
     let ix;
-    for (ix = 0; ix < oriSteps; ix += count) {
+    for (ix = 0; oriSteps === count ? ix <= oriSteps : ix < oriSteps; ix += count) {
       ticks[ix] = dayjs(axisMin).valueOf() + (ix * stepValue);
 
       labelCenter = Math.round(startPoint + (graphGap * ix));


### PR DESCRIPTION
### 이슈 내용
- ![image](https://github.com/user-attachments/assets/69d3e218-7cc5-45ad-bfda-24abbbd69c42)
   - Axis Type : 'time'
   - categoryMode: true
- 위와 같은 옵션으로 차트 너비가 좁을 때 x축 label이 1개만 표시됨 

### 처리 내용 
- label이 최소 2개는 나오도록 함
- ![image](https://github.com/user-attachments/assets/a4dbbde3-7740-4555-9ac0-6ebea9d85c2c)

### 테스트 가이드 
- Docs > Bar > Time 예제에서 차트의 너비를 줄여 확인 
- Docs > Combo > 모든 예제에서 차트의 너비를 출여 확인 
- Docs > Heatmap > Step Axis, Time, Event 예제에서 차트의 너비를 줄여 확인 
