### PR TITLE
[#1923] 차트의 click과 dblClick을 통해 전달받은 seriesId가 다른 문제를 해결했습니다.

### DIFF
--- a/docs/views/lineChart/example/SelectSeries.vue
+++ b/docs/views/lineChart/example/SelectSeries.vue
@@ -170,8 +170,8 @@ export default {
 
     const dblclickedSeries = ref();
     const onDblClick = (e) => {
-      clickedSeries.value = { eventTarget: 'series', seriesId: e.sId };
-      dblclickedSeries.value = e.sId;
+      clickedSeries.value = { eventTarget: 'series', seriesId: e.seriesId };
+      dblclickedSeries.value = e.seriesId;
     };
 
     const defaultSelectSeries = ref({

--- a/docs/views/lineChart/example/SelectSeries.vue
+++ b/docs/views/lineChart/example/SelectSeries.vue
@@ -170,7 +170,7 @@ export default {
 
     const dblclickedSeries = ref();
     const onDblClick = (e) => {
-      clickedSeries.value = { eventTarget: 'series', seriesId: e.seriesId };
+      clickedSeries.value = { eventTarget: 'series', seriesId: e.seriesId ? [e.seriesId] : [] };
       dblclickedSeries.value = e.seriesId;
     };
 

--- a/docs/views/lineChart/example/SelectSeries.vue
+++ b/docs/views/lineChart/example/SelectSeries.vue
@@ -170,7 +170,6 @@ export default {
 
     const dblclickedSeries = ref();
     const onDblClick = (e) => {
-      clickedSeries.value = { eventTarget: 'series', seriesId: e.seriesId ? [e.seriesId] : [] };
       dblclickedSeries.value = e.seriesId;
     };
 

--- a/docs/views/lineChart/example/SelectSeries.vue
+++ b/docs/views/lineChart/example/SelectSeries.vue
@@ -5,12 +5,14 @@
       :data="chartData1"
       :options="chartOptions1"
       @click="onClick"
+      @dbl-click="onDblClick"
     />
     <ev-chart
       v-model:selectedSeries="defaultSelectSeries"
       :data="chartData2"
       :options="chartOptions2"
       @click="onClick"
+      @dbl-click="onDblClick"
     />
     <div class="description">
       <ev-toggle v-model="isLive" />
@@ -49,6 +51,12 @@
           클릭 이벤트 데이터 (selected)
         </div>
         {{ clickedSeries }}
+        <br>
+        <br>
+        <div class="badge yellow">
+          더블클릭 이벤트 데이터 (selected)
+        </div>
+        {{ dblclickedSeries }}
         <br>
         <br>
       </div>
@@ -122,7 +130,7 @@ export default {
       }],
       selectSeries: {
         use: true,
-        limit: 2,
+        limit: 1,
         useDeselectOverflow: true,
       },
     });
@@ -150,7 +158,7 @@ export default {
       }],
       selectSeries: {
         use: true,
-        limit: 2,
+        limit: 1,
         useDeselectOverflow: true,
       },
     });
@@ -158,6 +166,12 @@ export default {
     const clickedSeries = ref();
     const onClick = (e) => {
       clickedSeries.value = e.selected;
+    };
+
+    const dblclickedSeries = ref();
+    const onDblClick = (e) => {
+      clickedSeries.value = { eventTarget: 'series', seriesId: e.sId };
+      dblclickedSeries.value = e.sId;
     };
 
     const defaultSelectSeries = ref({
@@ -232,9 +246,11 @@ export default {
       chartOptions1,
       chartOptions2,
       clickedSeries,
+      dblclickedSeries,
       defaultSelectSeries,
       isLive,
       onClick,
+      onDblClick,
       changeSelectedSeries,
     };
   },

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -193,8 +193,6 @@ const modules = {
         }
       }
 
-      ({ label: args.label, value: args.value, sId: args.seriesId, acc: args.acc } = hitInfo);
-
       if (typeof this.listeners['dbl-click'] === 'function') {
         this.listeners['dbl-click'](args);
       }

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -150,7 +150,6 @@ const modules = {
 
         args.label = itemHitInfo.label;
         args.value = itemHitInfo.value;
-        args.seriesId = this.defaultSelectInfo.seriesId;
         args.acc = itemHitInfo.acc;
       };
 
@@ -159,10 +158,10 @@ const modules = {
         const hitInfo = this.getSeriesInfoByPosition(offset);
         if (hitInfo.sId !== null) {
           const allSelectedList = this.updateSelectedSeriesInfo(hitInfo.sId);
-          
+
           args.label = itemHitInfo.label;
           args.value = itemHitInfo.value;
-          args.seriesId = allSelectedList.seriesId;
+          args.seriesId = allSelectedList.seriesId?.at(0);
           args.acc = itemHitInfo.acc;
         }
       };
@@ -857,7 +856,7 @@ const modules = {
               seriesId: sId,
               seriesName: series.name,
               itemData: item.data,
-             });
+            });
             const sw = ctx ? ctx.measureText(formattedSeriesName).width : 1;
 
             item.id = series.id;

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -157,6 +157,7 @@ const modules = {
         this.defaultSelectInfo = this.getSelectedLabelInfoWithLabelData(dataIndexList, targetAxis);
 
         args.label = itemHitInfo.label;
+        args.seriesId = itemHitInfo.sId;
         args.value = itemHitInfo.value;
         args.acc = itemHitInfo.acc;
       };

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -140,6 +140,7 @@ const modules = {
           label: args.label,
           value: args.value,
           sId: args.seriesId,
+          maxIndex: args.dataIndex,
           acc: args.acc,
         } = hitInfo);
       };
@@ -160,6 +161,7 @@ const modules = {
         args.seriesId = itemHitInfo.sId;
         args.value = itemHitInfo.value;
         args.acc = itemHitInfo.acc;
+        args.dataIndex = itemHitInfo.maxIndex;
       };
 
       const setSelectedSeriesInfo = () => {
@@ -172,6 +174,7 @@ const modules = {
           args.value = itemHitInfo.value;
           args.seriesId = allSelectedList.seriesId?.at(0);
           args.acc = itemHitInfo.acc;
+          args.dataIndex = itemHitInfo.maxIndex;
         }
       };
 

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -125,6 +125,14 @@ const modules = {
       const useSelectLabel = selectLabelOpt?.use && selectLabelOpt?.useClick;
       const useSelectSeries = selectSeriesOpt?.use && selectSeriesOpt?.useClick;
 
+      if (useSelectItem) {
+        args.eventTarget = 'item';
+      } else if (useSelectLabel) {
+        args.eventTarget = 'label';
+      } else if (useSelectSeries) {
+        args.eventTarget = 'series';
+      }
+
       const setSelectedItemInfo = () => {
         const hitInfo = this.getItemByPosition(offset, false);
 

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -111,15 +111,87 @@ const modules = {
      * @returns {undefined}
      */
     this.onDblClick = (e) => {
-      const selectItem = this.options.selectItem;
       const args = { e };
-
       const offset = this.getMousePosition(e);
-      const hitInfo = this.getItemByPosition(offset, selectItem.useApproximateValue);
 
+      const {
+        type: chartType,
+        selectItem: selectItemOpt,
+        selectLabel: selectLabelOpt,
+        selectSeries: selectSeriesOpt,
+      } = this.options;
 
-      if (hitInfo.label !== null) {
-        this.render(hitInfo);
+      const useSelectItem = selectItemOpt?.use && selectItemOpt?.useClick;
+      const useSelectLabel = selectLabelOpt?.use && selectLabelOpt?.useClick;
+      const useSelectSeries = selectSeriesOpt?.use && selectSeriesOpt?.useClick;
+
+      const setSelectedItemInfo = () => {
+        const hitInfo = this.getItemByPosition(offset, false);
+
+        ({
+          label: args.label,
+          value: args.value,
+          sId: args.seriesId,
+          maxIndex: args.dataIndex,
+          acc: args.acc,
+        } = hitInfo);
+      };
+
+      const setSelectedLabelInfo = (targetAxis) => {
+        const itemHitInfo = this.getItemByPosition(offset, false);
+        const {
+          labelIndex: clickedLabelIndex,
+        } = this.getLabelInfoByPosition(offset, targetAxis);
+
+        const {
+          dataIndex: dataIndexList,
+        } = this.regulateSelectedLabelInfo(clickedLabelIndex, targetAxis);
+
+        this.defaultSelectInfo = this.getSelectedLabelInfoWithLabelData(dataIndexList, targetAxis);
+
+        args.label = itemHitInfo.label;
+        args.dataIndex = itemHitInfo.maxIndex;
+        args.acc = itemHitInfo.acc;
+        args.sId = this.defaultSelectInfo.seriesId;
+      };
+
+      const setSelectedSeriesInfo = () => {
+        const itemHitInfo = this.getItemByPosition(offset, false);
+        const hitInfo = this.getSeriesInfoByPosition(offset);
+        if (hitInfo.sId !== null) {
+          const allSelectedList = this.updateSelectedSeriesInfo(hitInfo.sId);
+
+          args.label = itemHitInfo.label;
+          args.dataIndex = itemHitInfo.maxIndex;
+          args.sId = allSelectedList.seriesId;
+          args.acc = itemHitInfo.acc;
+        }
+      };
+
+      switch (chartType) {
+        case 'bar': {
+          if (useSelectItem) {
+            setSelectedItemInfo();
+          } else if (useSelectLabel) {
+            setSelectedLabelInfo(this.options.horizontal ? 'yAxis' : 'xAxis');
+          }
+          break;
+        }
+
+        case 'line': {
+          if (useSelectItem) {
+            setSelectedItemInfo();
+          } else if (useSelectLabel) {
+            setSelectedLabelInfo();
+          } else if (useSelectSeries) {
+            setSelectedSeriesInfo();
+          }
+          break;
+        }
+        default: {
+          setSelectedItemInfo();
+          break;
+        }
       }
 
       ({ label: args.label, value: args.value, sId: args.seriesId, acc: args.acc } = hitInfo);

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1202,6 +1202,11 @@ const modules = {
   updateSelectedSeriesInfo(seriesId) {
     const option = this.options?.selectSeries ?? {};
     const before = this.defaultSelectInfo ?? { seriesId: [] };
+
+    if (typeof before.seriesId === 'string') {
+      before.seriesId = [before.seriesId];
+    }
+
     const after = cloneDeep(before);
 
     if (before.seriesId.includes(seriesId)) {

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -177,10 +177,10 @@ const modules = {
 
       switch (chartType) {
         case 'bar': {
-          if (useSelectItem) {
-            setSelectedItemInfo();
-          } else if (useSelectLabel) {
+          if (useSelectLabel) {
             setSelectedLabelInfo(this.options.horizontal ? 'yAxis' : 'xAxis');
+          } else {
+            setSelectedItemInfo();
           }
           break;
         }

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -165,7 +165,7 @@ const modules = {
         const itemHitInfo = this.getItemByPosition(offset, false);
         const hitInfo = this.getSeriesInfoByPosition(offset);
         if (hitInfo.sId !== null) {
-          const allSelectedList = this.updateSelectedSeriesInfo(hitInfo.sId);
+          const allSelectedList = this.updateSelectedSeriesInfo(hitInfo.sId, true);
 
           args.label = itemHitInfo.label;
           args.value = itemHitInfo.value;
@@ -279,7 +279,7 @@ const modules = {
         const hitInfo = this.getSeriesInfoByPosition(offset);
 
         if (hitInfo.sId !== null) {
-          const allSelectedList = this.updateSelectedSeriesInfo(hitInfo.sId);
+          const allSelectedList = this.updateSelectedSeriesInfo(hitInfo.sId, false);
           this.defaultSelectInfo.seriesId = allSelectedList.seriesId;
 
           args.selected = {
@@ -1197,9 +1197,10 @@ const modules = {
   /**
    * Add or delete selected series Index,according to policy and option
    * @param seriesId {number}
+   * @param keepSelection {boolean}
    * @returns after {number[]}  '[0, 1 ...]' result series Id List
    */
-  updateSelectedSeriesInfo(seriesId) {
+  updateSelectedSeriesInfo(seriesId, keepSelection) {
     const option = this.options?.selectSeries ?? {};
     const before = this.defaultSelectInfo ?? { seriesId: [] };
 
@@ -1210,8 +1211,10 @@ const modules = {
     const after = cloneDeep(before);
 
     if (before.seriesId.includes(seriesId)) {
-      const idx = before.seriesId.indexOf(seriesId);
-      after.seriesId.splice(idx, 1);
+      if (!keepSelection) {
+        const idx = before.seriesId.indexOf(seriesId);
+        after.seriesId.splice(idx, 1);
+      }
     } else if (seriesId) {
       after.seriesId.push(seriesId);
       if (option.limit > 0 && option.limit < after.seriesId.length) {

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -132,7 +132,6 @@ const modules = {
           label: args.label,
           value: args.value,
           sId: args.seriesId,
-          maxIndex: args.dataIndex,
           acc: args.acc,
         } = hitInfo);
       };
@@ -150,9 +149,9 @@ const modules = {
         this.defaultSelectInfo = this.getSelectedLabelInfoWithLabelData(dataIndexList, targetAxis);
 
         args.label = itemHitInfo.label;
-        args.dataIndex = itemHitInfo.maxIndex;
+        args.value = itemHitInfo.value;
+        args.seriesId = this.defaultSelectInfo.seriesId;
         args.acc = itemHitInfo.acc;
-        args.sId = this.defaultSelectInfo.seriesId;
       };
 
       const setSelectedSeriesInfo = () => {
@@ -160,10 +159,10 @@ const modules = {
         const hitInfo = this.getSeriesInfoByPosition(offset);
         if (hitInfo.sId !== null) {
           const allSelectedList = this.updateSelectedSeriesInfo(hitInfo.sId);
-
+          
           args.label = itemHitInfo.label;
-          args.dataIndex = itemHitInfo.maxIndex;
-          args.sId = allSelectedList.seriesId;
+          args.value = itemHitInfo.value;
+          args.seriesId = allSelectedList.seriesId;
           args.acc = itemHitInfo.acc;
         }
       };

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -333,7 +333,7 @@ export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
     'dbl-click': async (e) => {
       await nextTick();
       emit('dbl-click', e);
-      emit('update:selectedSeries', { seriesId: e.sId });
+      emit('update:selectedSeries', { seriesId: e.seriesId });
     },
     'drag-select': async (e) => {
       await nextTick();

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -333,7 +333,15 @@ export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
     'dbl-click': async (e) => {
       await nextTick();
       emit('dbl-click', e);
-      emit('update:selectedSeries', { seriesId: e.seriesId });
+      const { eventTarget } = e;
+      switch (eventTarget) {
+        case 'series': {
+          emit('update:selectedSeries', { seriesId: e.seriesId });
+          break;
+        }
+        default:
+          break;
+      }
     },
     'drag-select': async (e) => {
       await nextTick();

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -374,7 +374,7 @@ export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
         const { eventTarget } = e;
         switch (eventTarget) {
           case 'series': {
-            emit('update:selectedSeries', { seriesId: e.seriesId });
+            emit('update:selectedSeries', { seriesId: e.seriesId ? [e.seriesId] : [] });
             break;
           }
           default:

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -254,6 +254,40 @@ const DEFAULT_DATA = {
   data: {},
 };
 
+const useWidgetClickEvent = () => {
+  let timer = null;
+  let clickCount = 0;
+  const Delay = 200;
+
+  const clickEventCallback = (callback) => {
+    clickCount++;
+
+    if (clickCount === 1) {
+      timer = setTimeout(() => {
+        if (clickCount === 1) {
+          callback();
+        }
+        clickCount = 0;
+      }, Delay);
+    }
+  };
+
+  const dblClickEventCallback = (callback) => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    callback();
+    clickCount = 0;
+  };
+
+  return {
+    clickEventCallback,
+    dblClickEventCallback,
+  };
+};
+
+
 export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
   const { props, emit } = getCurrentInstance();
 
@@ -281,67 +315,73 @@ export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
   const selectLabelInfo = cloneDeep(props.selectedLabel ?? injectGroupSelectedLabel?.value);
   const selectSeriesInfo = cloneDeep(props.selectedSeries);
 
+  const { clickEventCallback, dblClickEventCallback } = useWidgetClickEvent();
+
   const eventListeners = {
     click: async (e) => {
       await nextTick();
-      const { seriesId, dataIndex, eventTarget, targetAxis } = e?.selected ?? {};
-      const { eventTarget: deselectedEventTarget } = e?.deselected ?? {};
+      clickEventCallback(() => {
+        const { seriesId, dataIndex, eventTarget, targetAxis } = e?.selected ?? {};
+        const { eventTarget: deselectedEventTarget } = e?.deselected ?? {};
 
-      switch (eventTarget) {
-        case 'item': {
-          if (seriesId !== null) {
-            emit('update:selectedItem', {
-              seriesID: seriesId,
-              dataIndex,
-            });
-            if (deselectedEventTarget === 'label') {
-              emit('update:selectedLabel', { dataIndex: [] });
-            }
-          } else {
-            emit('update:selectedItem', null);
-          }
-          break;
-        }
-
-        case 'label': {
-          if (injectGroupSelectedLabel?.value) {
-            injectGroupSelectedLabel.value.dataIndex = dataIndex;
-          } else {
-            emit('update:selectedLabel', {
-              dataIndex,
-              targetAxis,
-            });
-
-            if (deselectedEventTarget === 'item') {
+        switch (eventTarget) {
+          case 'item': {
+            if (seriesId !== null) {
+              emit('update:selectedItem', {
+                seriesID: seriesId,
+                dataIndex,
+              });
+              if (deselectedEventTarget === 'label') {
+                emit('update:selectedLabel', { dataIndex: [] });
+              }
+            } else {
               emit('update:selectedItem', null);
             }
+            break;
           }
-          break;
+
+          case 'label': {
+            if (injectGroupSelectedLabel?.value) {
+              injectGroupSelectedLabel.value.dataIndex = dataIndex;
+            } else {
+              emit('update:selectedLabel', {
+                dataIndex,
+                targetAxis,
+              });
+
+              if (deselectedEventTarget === 'item') {
+                emit('update:selectedItem', null);
+              }
+            }
+            break;
+          }
+
+          case 'series': {
+            emit('update:selectedSeries', { seriesId });
+            break;
+          }
+
+          default:
+            break;
         }
 
-        case 'series': {
-          emit('update:selectedSeries', { seriesId });
-          break;
-        }
-
-        default:
-          break;
-      }
-
-      emit('click', e);
+        emit('click', e);
+      });
     },
     'dbl-click': async (e) => {
       await nextTick();
-      emit('dbl-click', e);
-      const { eventTarget } = e;
-      switch (eventTarget) {
-        case 'series': {
-          emit('update:selectedSeries', { seriesId: e.seriesId });
-          break;
+      dblClickEventCallback(() => {
+        const { eventTarget } = e;
+        switch (eventTarget) {
+          case 'series': {
+            emit('update:selectedSeries', { seriesId: e.seriesId });
+            break;
+          }
+          default:
+            break;
         }
-        default:
-          break;
-      }
+        emit('dbl-click', e);
+      });
     },
     'drag-select': async (e) => {
       await nextTick();

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -333,6 +333,7 @@ export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
     'dbl-click': async (e) => {
       await nextTick();
       emit('dbl-click', e);
+      emit('update:selectedSeries', { seriesId: e.sId });
     },
     'drag-select': async (e) => {
       await nextTick();


### PR DESCRIPTION
# 문제 상황
selectSeries use: true 옵션을 사용할 때 차트의 click event를 통해 전달받은 seriesId값과 동일한 위치에서 더블클릭이벤트로 전달받은 arg.sId값이 다른 문제가 있었습니다.

# 코드 변경 사항
더블클릭이벤트 발생시 sId 구하는 로직을 click event 발생시 구하는 로직과 동일하게 적용했습니다.

# 변경 전
selectSeries use : true 옵션일 때 선택된 seriesId값이 dblclick event의 param에 포함되지않았습니다.

# 변경 후
![seriesId 수정후](https://github.com/user-attachments/assets/44e0e828-1e3d-45e6-ae1d-f00a5b8d1f5b)
