### PR TITLE
[fix] 차트 더블클릭이벤트로 전달받은 value값이 해당 위치의 max값으로 전달되는 문제를 해결했습니다.

### DIFF
--- a/docs/views/lineChart/example/SelectSeries.vue
+++ b/docs/views/lineChart/example/SelectSeries.vue
@@ -54,9 +54,15 @@
         <br>
         <br>
         <div class="badge yellow">
-          더블클릭 이벤트 데이터 (selected)
+          더블클릭 이벤트 데이터 (seriesId)
         </div>
         {{ dblclickedSeries }}
+        <br>
+        <br>
+        <div class="badge yellow">
+          더블클릭 이벤트 데이터 (value)
+        </div>
+        {{ dblclickedValue }}
         <br>
         <br>
       </div>
@@ -169,8 +175,10 @@ export default {
     };
 
     const dblclickedSeries = ref();
+    const dblclickedValue = ref();
     const onDblClick = (e) => {
       dblclickedSeries.value = e.seriesId;
+      dblclickedValue.value = e.value;
     };
 
     const defaultSelectSeries = ref({
@@ -246,6 +254,7 @@ export default {
       chartOptions2,
       clickedSeries,
       dblclickedSeries,
+      dblclickedValue,
       defaultSelectSeries,
       isLive,
       onClick,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.106",
+  "version": "3.4.107",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -134,19 +134,26 @@ const modules = {
       }
 
       const setSelectedItemInfo = () => {
-        const hitInfo = this.getItemByPosition(offset, false);
+        const hitInfo = this.findHitItem(offset);
 
-        ({
-          label: args.label,
-          value: args.value,
-          sId: args.seriesId,
-          maxIndex: args.dataIndex,
-          acc: args.acc,
-        } = hitInfo);
+        // 실제 클릭된 아이템의 정보 추출 (hitId가 있으면 해당 아이템, 없으면 첫 번째 아이템)
+        const hitItemId = hitInfo.hitId || Object.keys(hitInfo.items)[0];
+        const hitItem = hitInfo.items[hitItemId];
+
+        if (hitItem) {
+          args.label = hitItem.data?.x || hitItem.data?.y;
+          args.value = hitItem.data?.o;
+          args.seriesId = hitItemId;
+          args.dataIndex = hitItem.index;
+          args.acc = hitItem.data?.acc;
+        }
       };
 
       const setSelectedLabelInfo = (targetAxis) => {
-        const itemHitInfo = this.getItemByPosition(offset, false);
+        const hitInfo = this.findHitItem(offset);
+        const hitItemId = hitInfo.hitId || Object.keys(hitInfo.items)[0];
+        const hitItem = hitInfo.items[hitItemId];
+
         const {
           labelIndex: clickedLabelIndex,
         } = this.getLabelInfoByPosition(offset, targetAxis);
@@ -157,24 +164,31 @@ const modules = {
 
         this.defaultSelectInfo = this.getSelectedLabelInfoWithLabelData(dataIndexList, targetAxis);
 
-        args.label = itemHitInfo.label;
-        args.seriesId = itemHitInfo.sId;
-        args.value = itemHitInfo.value;
-        args.acc = itemHitInfo.acc;
-        args.dataIndex = itemHitInfo.maxIndex;
+        if (hitItem) {
+          args.label = hitItem.data?.x || hitItem.data?.y;
+          args.seriesId = hitItemId;
+          args.value = hitItem.data?.o;
+          args.acc = hitItem.data?.acc;
+          args.dataIndex = hitItem.index;
+        }
       };
 
       const setSelectedSeriesInfo = () => {
-        const itemHitInfo = this.getItemByPosition(offset, false);
-        const hitInfo = this.getSeriesInfoByPosition(offset);
-        if (hitInfo.sId !== null) {
-          const allSelectedList = this.updateSelectedSeriesInfo(hitInfo.sId, true);
+        const hitInfo = this.findHitItem(offset);
+        const hitItemId = hitInfo.hitId || Object.keys(hitInfo.items)[0];
+        const hitItem = hitInfo.items[hitItemId];
 
-          args.label = itemHitInfo.label;
-          args.value = itemHitInfo.value;
-          args.seriesId = allSelectedList.seriesId?.at(0);
-          args.acc = itemHitInfo.acc;
-          args.dataIndex = itemHitInfo.maxIndex;
+        const seriesHitInfo = this.getSeriesInfoByPosition(offset);
+        if (seriesHitInfo.sId !== null) {
+          const allSelectedList = this.updateSelectedSeriesInfo(seriesHitInfo.sId, true);
+
+          if (hitItem) {
+            args.label = hitItem.data?.x || hitItem.data?.y;
+            args.value = hitItem.data?.o;
+            args.seriesId = allSelectedList.seriesId?.at(0);
+            args.acc = hitItem.data?.acc;
+            args.dataIndex = hitItem.index;
+          }
         }
       };
 


### PR DESCRIPTION
# 기존 동작
더블클릭으로 전달받은 value값이 항상 max값으로만 옵니다.
![evui수정전](https://github.com/user-attachments/assets/31019661-4b5b-4f74-9ca5-6f3c2468fa96)

# 기대 동작
더블클릭으로 전달받은 value값이 이벤트가 발생한 정확한 위치의 값으로 옵니다.
![evui수정후](https://github.com/user-attachments/assets/2e1a3247-de4a-428a-8b13-598852450e9d)

close #1925

