### PR TITLE
[#1928] Chart > Realtime Scatter > 미래시로 들어올 경우 앞부분이 점진적으로 사라짐

### DIFF
--- a/docs/views/scatterChart/example/RealTimeScatter.vue
+++ b/docs/views/scatterChart/example/RealTimeScatter.vue
@@ -135,7 +135,7 @@ export default {
         let randomX = 0;
         let randomY = 0;
         if (!isInit) {
-          randomX = floor(Date.now() + getRandomInt(-3000, 0)); // -3초 ~ 현재
+          randomX = floor(Date.now() + getRandomInt(+1000, 0)); // -3초 ~ 현재
           randomY = floor(getRandomInt(3000, 95000));
         } else {
           randomX = floor(Date.now() + getRandomInt(-300000, 0)); // -5분 ~ 현재
@@ -195,12 +195,12 @@ export default {
 
     const tick = () => {
       setDataHandler();
-      timeoutId = setTimeout(tick, 3000);
+      timeoutId = setTimeout(tick, 100);
     };
 
     watch(() => isRealTime.value, () => {
       if (isRealTime.value) {
-        timeoutId = setTimeout(tick, 3000);
+        timeoutId = setTimeout(tick, 100);
       } else {
         clearTimeout(timeoutId);
       }

--- a/docs/views/scatterChart/example/RealTimeScatter.vue
+++ b/docs/views/scatterChart/example/RealTimeScatter.vue
@@ -135,7 +135,7 @@ export default {
         let randomX = 0;
         let randomY = 0;
         if (!isInit) {
-          randomX = floor(Date.now() + getRandomInt(+1000, 0)); // -3초 ~ 현재
+          randomX = floor(Date.now() + getRandomInt(-3000, 0)); // -3초 ~ 현재
           randomY = floor(getRandomInt(3000, 95000));
         } else {
           randomX = floor(Date.now() + getRandomInt(-300000, 0)); // -5분 ~ 현재
@@ -195,12 +195,12 @@ export default {
 
     const tick = () => {
       setDataHandler();
-      timeoutId = setTimeout(tick, 100);
+      timeoutId = setTimeout(tick, 3000);
     };
 
     watch(() => isRealTime.value, () => {
       if (isRealTime.value) {
-        timeoutId = setTimeout(tick, 100);
+        timeoutId = setTimeout(tick, 3000);
       } else {
         clearTimeout(timeoutId);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.107",
+  "version": "3.4.108",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -101,9 +101,6 @@ const modules = {
       }
 
       this.dataSet[key].length = this.options.realTimeScatter.range || 300;
-      this.dataSet[key].toTime = Math.floor(Date.now() / 1000) * 1000;
-      this.dataSet[key].fromTime = this.dataSet[key].toTime - this.dataSet[key].length * 1000;
-      this.dataSet[key].endIndex = this.dataSet[key].length - 1;
 
       for (let i = 0; i < storeLength; i++) {
         const item = data[i];
@@ -114,6 +111,14 @@ const modules = {
       }
 
       lastTime = Math.floor(lastTime / 1000) * 1000;
+
+      const dataGroupLastTime = this.dataSet[key].dataGroup.at(-1)?.data?.at(-1)?.x || Date.now();
+
+      this.dataSet[key].toTime = lastTime
+        || (dataGroupLastTime ? Math.floor(dataGroupLastTime / 1000) * 1000 : 0);
+      this.dataSet[key].fromTime = this.dataSet[key].toTime - this.dataSet[key].length * 1000;
+      this.dataSet[key].endIndex = this.dataSet[key].length - 1;
+
       if (
         (this.dataSet[key].toTime - lastTime) / 1000
         > this.dataSet[key].length && key === ''


### PR DESCRIPTION
## 현상
클라이언트 시간과 서버 시간이 안맞아서 클라이언트보다 미래 시간의 데이터가 들어올 경우 아래 이미지 처럼 데이터가 점진적으로 사라짐

## 변경 사항
- 실시간 스캐터 차트 시간 계산 로직 개선   
  `Date.now`말고 데이터 마지막 시간을 우선 사용하여 데이터 잘림 현상 방지

## 기존 동작
![Image](https://github.com/user-attachments/assets/60ced001-4333-477e-9991-14174bc36789)

## 기대 동작
![after](https://github.com/user-attachments/assets/7dddaac1-619b-4b4e-922e-58ca483643f4)

## 테스트
현재 RealTimeScatter.vue에 미래 시간으로 들어오게끔 설정해놨습니다.

## TODO
RealTimeScatter.vue 테스트를 위한 코드 롤백 예정