### PR TITLE
[3.4] Chart > X Axis > 일부 텍스트 잘려보이는 현상 발생

### DIFF
--- a/docs/views/barChart/example/Horizontal.vue
+++ b/docs/views/barChart/example/Horizontal.vue
@@ -49,7 +49,7 @@
         horizontal: true,
         borderRadius: 15,
         axesX: [{
-          type: 'log',
+          type: 'linear',
           startToZero: true,
           autoScaleRatio: 0.1,
           showGrid: true,

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -171,47 +171,53 @@ class EvChart {
     this.drawSyncedIndicator({ horizontal, label, mousePosition });
   }
 
-  adjustYAxisWidth() {
+  adjustXAndYAxisWidth() {
     // fitWidth(maxWidth에 넘을 시 말줄임표 들어가는 기능)을 사용중인 step Axis인 경우에는 적용 제외
-    const isStepAxisUseFitWidth = this.options.axesY?.some(axisY => axisY.type === 'step' && axisY.labelStyle?.fitWidth);
+    const isStepXAxisUseFitWidth = this.options.axesX?.some(axisX => axisX.type === 'step' && axisX.labelStyle?.fitWidth);
+    const isStepYAxisUseFitWidth = this.options.axesY?.some(axisY => axisY.type === 'step' && axisY.labelStyle?.fitWidth);
 
-    if (
-        !this.axesY?.length
-        || !this.axesRange?.y
-        || !this.axesSteps?.y?.length
-        || isStepAxisUseFitWidth
-    ) {
-      return;
-    }
+    const getNotFormattedLabels = (axesSteps) => {
+      const { interval, graphMin, graphMax, steps = 0 } = axesSteps ?? {};
+      let result = [];
 
-    let notFormattedLabels = [];
-    const { interval, graphMin, graphMax, steps = 0 } = this.axesSteps?.y[0] ?? {};
-    if (interval) {
-      for (let i = 0; i < steps; i++) {
-        notFormattedLabels.push(graphMin + (i * interval));
+      if (interval) {
+        result = Array.from({ length: steps }, (_, i) => graphMin + i * interval);
+        result.push(graphMax);
+      } else {
+        const { labels } = this.data;
+        result = labels?.y ?? labels ?? [];
       }
-      notFormattedLabels.push(graphMax);
-    } else {
-      notFormattedLabels = this.data.labels?.y ?? this.data.labels ?? [];
-    }
 
-    const yMaxWidth = this.axesY[0]?.getLabelWidthHasMaxLength(notFormattedLabels);
-    if (yMaxWidth > 0) {
-      const adjustedRange = {
-        x: this.axesRange.x,
-        y: this.axesRange.y.map(value => ({
-          ...value,
-          size: {
-            width: yMaxWidth,
-            height: value.size.height,
-          },
-        })),
-      };
+      return result;
+    };
 
-      this.labelOffset = this.getLabelOffset(adjustedRange);
-      this.labelRange = this.getAxesLabelRange();
-      this.axesSteps = this.calculateSteps();
-    }
+    const notFormattedXLabels = getNotFormattedLabels(this.axesSteps?.x[0]);
+    const notFormattedYLabels = getNotFormattedLabels(this.axesSteps?.y[0]);
+
+    const xMaxWidth = this.axesX[0]?.getLabelWidthHasMaxLength(notFormattedXLabels);
+    const yMaxWidth = this.axesY[0]?.getLabelWidthHasMaxLength(notFormattedYLabels);
+
+    const adjustedRange = {
+      x: !isStepXAxisUseFitWidth ? this.axesRange?.x?.map(value => ({
+        ...value,
+        size: {
+          width: Math.max(xMaxWidth, value.size.width),
+          height: value.size.height,
+        },
+      })) : this.axesRange?.x,
+      y: !isStepYAxisUseFitWidth ? this.axesRange?.y?.map(value => ({
+        ...value,
+        size: {
+          width: Math.max(yMaxWidth, value.size.width),
+          height: value.size.height,
+        },
+      })) : this.axesRange?.y,
+    };
+
+    this.axesRange = adjustedRange;
+    this.labelOffset = this.getLabelOffset(adjustedRange);
+    this.labelRange = this.getAxesLabelRange();
+    this.axesSteps = this.calculateSteps();
   }
 
   /**
@@ -228,7 +234,7 @@ class EvChart {
     this.labelRange = this.getAxesLabelRange();
     this.axesSteps = this.calculateSteps();
 
-    this.adjustYAxisWidth();
+    this.adjustXAndYAxisWidth();
 
     this.drawAxis(hitInfo);
     this.drawSeries(hitInfo);


### PR DESCRIPTION
### 작업 배경 
- X축이 linear 타입일 때, 가장 너비가 긴 라벨을 찾는 로직이 **가장 큰 값**으로 되어있었습니다. 
   - `999` 와 `1000` 중  `1000`이  `1k`로 바뀌어서 짧아졌음에도 불구하고 `1k` 글자의 너비를 기준으로 라벨 간격을 산정함
- 사용자가 주입한 formatter 혹은 내부 formatter (ex. 1000 -> 1k) 를 적용하고 나서 가장 **긴 라벨**을 기준으로 계산 필요


### 변경 사항 요약
- #1905 에서 Y축만 다시 계산했던 로직을 X축도 포함되도록 로직 수정하였습니다. 
- Bar Chart > Horizontal 예제의 X축 타입을 log에서 linear로 변경하였습니다. 

### Before
<img width="712" height="487" alt="image" src="https://github.com/user-attachments/assets/55b4fb21-f2da-40e0-8812-56ab30593216" />

### After
<img width="698" height="335" alt="image" src="https://github.com/user-attachments/assets/26da5287-7e3d-4506-9682-2ae98a3d0599" />

### 테스트 가이드 
- X축을 linear타입으로 사용하는 차트에서 value의 값을 크게 하여 확인 
- Horizontal 예제에서도 테스트 가능
