### PR TITLE
바차트 스크롤 된 상태에서 클릭이벤트로 전달되는 dataIndex값 수정

### DIFF
--- a/docs/views/barChart/example/Scrollbar.vue
+++ b/docs/views/barChart/example/Scrollbar.vue
@@ -82,6 +82,11 @@
         v-model:selectedLabel
       </div>
       <div>{{ defaultSelectLabel }}</div>
+
+      <div class="badge yellow">
+        clicked dataIndex
+      </div>
+      <div>{{ clickedArgs?.dataIndex }}</div>
     </div>
   </div>
 </template>
@@ -96,8 +101,11 @@ export default {
     const chart = ref(null);
 
     const clickedLabel = ref();
-    const onClick = ({ selected }) => {
-      clickedLabel.value = selected;
+    const clickedArgs = ref();
+
+    const onClick = (args) => {
+      clickedLabel.value = args.selected;
+      clickedArgs.value = args;
     };
 
     const defaultSelectLabel = ref({
@@ -151,7 +159,30 @@ export default {
         'value9',
         'value10',
       ],
-      groups: [['series1', 'series2', 'series3', 'series4', 'series5', 'series6', 'series7', 'series8', 'series9', 'series10', 'series11', 'series12', 'series13', 'series14', 'series15', 'series16', 'series17', 'series18', 'series19', 'series20']],
+      groups: [
+        [
+          'series1',
+          'series2',
+          'series3',
+          'series4',
+          'series5',
+          'series6',
+          'series7',
+          'series8',
+          'series9',
+          'series10',
+          'series11',
+          'series12',
+          'series13',
+          'series14',
+          'series15',
+          'series16',
+          'series17',
+          'series18',
+          'series19',
+          'series20',
+        ],
+      ],
       data: {
         series1: [100, 150, 51, 150, 350, 100, 150, 51, 150, 350],
         series2: [100, 150, 51, 150, 450, 100, 150, 51, 150, 450],
@@ -211,7 +242,30 @@ export default {
         'value9',
         'value10',
       ],
-      groups: [['series1', 'series2', 'series3', 'series4', 'series5', 'series6', 'series7', 'series8', 'series9', 'series10', 'series11', 'series12', 'series13', 'series14', 'series15', 'series16', 'series17', 'series18', 'series19', 'series20']],
+      groups: [
+        [
+          'series1',
+          'series2',
+          'series3',
+          'series4',
+          'series5',
+          'series6',
+          'series7',
+          'series8',
+          'series9',
+          'series10',
+          'series11',
+          'series12',
+          'series13',
+          'series14',
+          'series15',
+          'series16',
+          'series17',
+          'series18',
+          'series19',
+          'series20',
+        ],
+      ],
       data: {
         series1: [100, 150, 51, 150, 350, 100, 150, 51, 150, 350],
         series2: [100, 150, 51, 150, 450, 100, 150, 51, 150, 450],
@@ -362,7 +416,7 @@ export default {
       },
     });
 
-    const getRandArr = count =>
+    const getRandArr = (count) =>
       Array(count)
         .fill(0)
         .map(() => Math.ceil(Math.random() * 100));
@@ -499,6 +553,8 @@ export default {
       chartOptions1,
       chartOptions2,
       defaultSelectLabel,
+      clickedLabel,
+      clickedArgs,
       updateData,
       updateDataWithDynamicRange,
       onClick,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.112",
+  "version": "3.4.113",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -337,7 +337,7 @@ class Bar {
 
       if ((sx <= xp) && (xp <= ex)) {
         item.data = gdata[m];
-        item.index = m;
+        item.index = gdata[m].index; // 원본 데이터 인덱스 사용
 
         if ((ey <= yp) && (yp <= sy)) {
           item.hit = true;
@@ -379,7 +379,7 @@ class Bar {
 
       if ((ey <= yp) && (yp <= sy)) {
         item.data = gdata[m];
-        item.index = m;
+        item.index = gdata[m].index; // 원본 데이터 인덱스 사용
 
         if ((sx <= xp) && (xp <= ex)) {
           item.hit = true;


### PR DESCRIPTION
### 문제 상황
hover 및 click 이벤트 발생에 대한 dataIndex값이 잘못된 값으로 전달되는 문제가 있었습니다.

### 수정 내용
스크롤 된 위치의 dataIndex가 아닌 원본 데이터 인덱스를 사용하도록 수정헀습니다.

### 기존 동작
![수정 전](https://github.com/user-attachments/assets/ab493c31-41bd-43c0-86c0-e22dd6d4b637)

### 수정 후 동작
![수정 후](https://github.com/user-attachments/assets/c07bf9cb-6ba9-4dbf-a2ad-21ece0911bda)