### PR TITLE
1951 34 grid column width not a number

### DIFF
--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -804,6 +804,7 @@ export default {
         index,
         hiddenDisplay: false,
         ...column,
+        width: isFinite(column.width) ? column.width : undefined,
         sortOption: {
           sortType: column?.sortOption?.sortType || 'init',
         },

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -451,6 +451,7 @@ export default {
         index,
         hiddenDisplay: false,
         ...column,
+        width: isFinite(column.width) ? column.width : undefined,
         sortOption: {
            sortType: column?.sortOption?.sortType || 'init',
         },


### PR DESCRIPTION
# 이슈 내용
 - grid > column width 정보에 number 형 value가 아닌값으로 설정시 grid layout 깨지는 문제 발생

# 처리 내용
 - column 설정 초기화 할때 width가 숫자 형태가 아니면 설정값 제거
 - TreeGrid도 동일한 처리

PS) 처음 PR때 style 설정에서 쪽에 처리 했었는데, 초기 다른 auto(width 미설정 컬럼) 계산 및 resize 동작시에 지속적으로 영향을 주고 있어서 column 정보 읽을때 검증하고 기본값으로 설정되게 수정 했습니다.