### PR TITLE
[#1975] Chart > RealTimeScatter > 범례 마우스 올려도 하이라이팅 안됨.

### DIFF
--- a/docs/views/scatterChart/example/RealTimeScatter.vue
+++ b/docs/views/scatterChart/example/RealTimeScatter.vue
@@ -48,14 +48,14 @@ export default {
     const series = {
       series1: {
         name: 'series1',
-        pointSize: 0.5,
+        pointSize: 1,
         color: '#DF6264',
         pointFill: '#DF6264',
         overflowColor: '#FF00FF',
       },
       series2: {
         name: 'series2',
-        pointSize: 0.5,
+        pointSize: 1,
         color: '#3CA0FF',
         pointFill: '#3CA0FF',
         overflowColor: '#A3D3FF',
@@ -112,7 +112,11 @@ export default {
         },
       }],
       legend: {
-        show: false,
+        show: true,
+        position: 'bottom',
+        padding: { top: 0, left: 0 },
+        height: 32,
+        virtualScroll: true,
       },
       displayOverflow: true,
       realTimeScatter: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.117",
+  "version": "3.4.118",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.scatter.js
+++ b/src/components/chart/element/element.scatter.js
@@ -155,12 +155,14 @@ class Scatter {
 
           if (item.xp !== null && item.yp !== null) {
             const overflowColor = item.y > minmaxY.graphMax && this.overflowColor;
-            const color = overflowColor || item.color || this.color;
+            const baseStrokeColor = overflowColor || item.color || this.color;
+            const baseFillColor = overflowColor || item.color || this.pointFill || this.color;
 
-            ctx.strokeStyle = color;
+            const strokeOpacity = this.getOpacity(param, baseStrokeColor, j);
+            const fillOpacity = this.getOpacity(param, baseFillColor, j);
 
-            const pointFillColor = overflowColor || item.color || this.pointFill || this.color;
-            ctx.fillStyle = pointFillColor;
+            ctx.strokeStyle = Util.colorStringToRgba(baseStrokeColor, strokeOpacity);
+            ctx.fillStyle = Util.colorStringToRgba(baseFillColor, fillOpacity);
 
             Canvas.drawPoint(ctx, pointStyle, pointSize, item.xp, item.yp);
           }

--- a/src/components/chart/element/element.scatter.js
+++ b/src/components/chart/element/element.scatter.js
@@ -112,22 +112,32 @@ class Scatter {
    * @returns {undefined}
    */
   defaultScatterDraw(param) {
-    const { ctx } = param;
+    const { ctx, axesSteps, duple, legendHitInfo } = param;
+    const minmaxY = axesSteps.y[this.yAxisIndex];
 
     this.data.forEach((item, idx) => {
-      this.calcItem(item, param);
+      const shouldDraw = legendHitInfo ? (legendHitInfo.sId === this.sId) : !duple.has(`${item.x}${item.y}`);
 
-      if (item.xp !== null && item.yp !== null) {
-        const color = item.dataColor || this.color;
-        ctx.strokeStyle = Util.colorStringToRgba(color, this.getOpacity(param, color, idx));
+      if (shouldDraw) {
+        if (!duple.has(`${item.x}${item.y}`)) {
+          duple.add(`${item.x}${item.y}`);
+        }
 
-        const pointFillColor = item.dataColor || this.pointFill;
-        ctx.fillStyle = Util.colorStringToRgba(
-          pointFillColor,
-          this.getOpacity(param, pointFillColor, idx),
-        );
+        this.calcItem(item, param);
 
-        Canvas.drawPoint(ctx, this.pointStyle, this.pointSize, item.xp, item.yp);
+        if (item.xp !== null && item.yp !== null) {
+          const overflowColor = item.y > minmaxY.graphMax && this.overflowColor;
+          const color = overflowColor || item.dataColor || this.color;
+          ctx.strokeStyle = Util.colorStringToRgba(color, this.getOpacity(param, color, idx));
+
+          const pointFillColor = item.dataColor || this.pointFill;
+          ctx.fillStyle = Util.colorStringToRgba(
+            pointFillColor,
+            this.getOpacity(param, pointFillColor, idx),
+          );
+
+          Canvas.drawPoint(ctx, this.pointStyle, this.pointSize, item.xp, item.yp);
+        }
       }
     });
   }
@@ -139,7 +149,7 @@ class Scatter {
    * @returns {undefined}
    */
   realTimeScatterDraw(param) {
-    const { ctx, axesSteps, duple } = param;
+    const { ctx, axesSteps, duple, legendHitInfo } = param;
     const minmaxY = axesSteps.y[this.yAxisIndex];
     const pointStyle = typeof this.pointStyle === 'string' ? this.pointStyle : this.pointStyle.value;
     const pointSize = typeof this.pointSize === 'number' ? this.pointSize : this.pointSize.value;
@@ -148,8 +158,12 @@ class Scatter {
       for (let j = 0; j < this.data[this.sId]?.dataGroup[i]?.data.length; j++) {
         const item = this.data[this.sId]?.dataGroup[i]?.data[j];
 
-        if (!duple.has(`${item.x}${item.y}`)) {
-          duple.add(`${item.x}${item.y}`);
+        const shouldDraw = legendHitInfo ? (legendHitInfo.sId === this.sId) : !duple.has(`${item.x}${item.y}`);
+
+        if (shouldDraw) {
+          if (!duple.has(`${item.x}${item.y}`)) {
+            duple.add(`${item.x}${item.y}`);
+          }
 
           this.calcItem(item, param);
 


### PR DESCRIPTION
# 변경 사항
- element.scatter.ts > Real Time Scatter 하이라이트 기능 추가
- 일반 스캐터도 duple(중복된 좌표 안그림) 적용

# 기존 동작
![before](https://github.com/user-attachments/assets/1c4fd8ff-c2d8-4997-a6c8-e956c0f7661c)

# 기대 동작
![after](https://github.com/user-attachments/assets/296316fb-72f8-4f64-838e-3aa94153374d)

## 스캐터 범례 하이라이트 방식이 다른 차트와 다른 이유
![reason](https://github.com/user-attachments/assets/d2a1d51e-9343-45a5-8ca8-171a04fdb5cb)
- 스캐터는 성능 향상을 위해 같은 좌표에 그린 점을 더 이상 안 그리게 되는데,
- 완전 같은 좌표가 아닌 미세하게 다른 좌표인 상황에서 매우 많은 점들이 겹쳐서 opacity가 적용되었음에도 이미지처럼 하이라이팅이 된것 처럼 보임.