### PR TITLE
[#1977] Chart > 데이터 업데이트 도중 범례 하이라이트 기능 풀림

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -96,6 +96,8 @@ class EvChart {
 
     this.defaultSelectItemInfo = defaultSelectItemInfo;
     this.defaultSelectInfo = defaultSelectInfo;
+
+    this.legendHover = null;
   }
 
   /**
@@ -897,7 +899,13 @@ class EvChart {
 
     this.initDefaultSelectInfo();
 
-    this.render(updateInfo?.hitInfo);
+
+    let renderHitInfo = updateInfo?.hitInfo;
+    if (!renderHitInfo?.legend && this.legendHover?.sId) {
+      renderHitInfo = { ...(renderHitInfo || {}), legend: this.legendHover };
+    }
+
+    this.render(renderHitInfo);
 
     const isDragMove = this.dragInfo && this.drawSelectionArea;
     if (isDragMove) {

--- a/src/components/chart/plugins/plugins.legend.gradient.js
+++ b/src/components/chart/plugins/plugins.legend.gradient.js
@@ -169,6 +169,8 @@ const modules = {
         return;
       }
 
+      this.legendHover = { sId: 'gradient', type: this.options.type };
+
       this.update({
         updateSeries: false,
         updateSelTip: { update: false, keepDomain: false },
@@ -182,6 +184,8 @@ const modules = {
      */
     this.onLegendBoxLeave = () => {
       this.legendDragInfo.dragging = false;
+
+      this.legendHover = null;
 
       this.clearOverlay();
 

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -148,7 +148,7 @@ const modules = {
    * @returns {undefined}
    */
   updateStartEndRowIndex() {
-    const index = Math.max(Math.floor(this.legendBoxDOM.scrollTop / this.legendItemHeight), 0);
+    const index = Math.max(Math.floor(this.legendBoxDOM?.scrollTop / this.legendItemHeight), 0);
     this.startRowIndex = Math.min(index, Math.max(this.totalRowCount - this.visibleRowCount, 0));
     this.endRowIndex = this.startRowIndex + this.visibleRowCount + 1;
   },
@@ -466,6 +466,8 @@ const modules = {
       const targetId = targetDOM?.series?.sId;
       const legendHitInfo = { sId: targetId, type: this.options.type };
 
+      this.legendHover = legendHitInfo;
+
       this.update({
         updateSeries: false,
         updateSelTip: { update: false, keepDomain: false },
@@ -481,6 +483,8 @@ const modules = {
      * @returns {undefined}
      */
     this.onLegendBoxLeave = () => {
+      this.legendHover = null;
+
       this.update({
         updateSeries: false,
         updateSelTip: { update: false, keepDomain: false },
@@ -581,6 +585,8 @@ const modules = {
       const targetId = targetDOM?.series?.cId;
       const legendHitInfo = { sId: targetId, type: this.options.type };
 
+      this.legendHover = legendHitInfo;
+
       series.colorState.forEach((colorItem) => {
         colorItem.state = colorItem.id === targetId ? 'highlight' : 'downplay';
       });
@@ -600,6 +606,8 @@ const modules = {
      * @returns {undefined}
      */
     this.onLegendBoxLeave = () => {
+      this.legendHover = null;
+
       const series = Object.values(this.seriesList)[0];
       series.colorState.forEach((item) => {
         item.state = 'normal';

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -460,6 +460,15 @@ const modules = {
     this.onLegendBoxOver = (e) => {
       const targetDOM = this.getContainerDOM(e);
       if (!targetDOM) {
+        this.legendHover = null;
+
+        this.update({
+          updateSeries: false,
+          updateSelTip: { update: false, keepDomain: false },
+          hitInfo: {
+            legend: null,
+          },
+        });
         return;
       }
 
@@ -579,6 +588,15 @@ const modules = {
 
       const targetDOM = this.getContainerDOM(e);
       if (!targetDOM) {
+        this.legendHover = null;
+
+        this.update({
+          updateSeries: false,
+          updateSelTip: { update: false, keepDomain: false },
+          hitInfo: {
+            legend: null,
+          },
+        });
         return;
       }
 

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -453,6 +453,23 @@ const modules = {
     };
 
     /**
+     * callback for mouseleave event on legendBoxDOM
+     *
+     * @returns {undefined}
+     */
+    this.onLegendBoxLeave = () => {
+      this.legendHover = null;
+
+      this.update({
+        updateSeries: false,
+        updateSelTip: { update: false, keepDomain: false },
+        hitInfo: {
+          legend: null,
+        },
+      });
+    };
+
+    /**
      * callback for legendBoxDOM hovering
      *
      * @returns {undefined}
@@ -460,15 +477,7 @@ const modules = {
     this.onLegendBoxOver = (e) => {
       const targetDOM = this.getContainerDOM(e);
       if (!targetDOM) {
-        this.legendHover = null;
-
-        this.update({
-          updateSeries: false,
-          updateSelTip: { update: false, keepDomain: false },
-          hitInfo: {
-            legend: null,
-          },
-        });
+        this.onLegendBoxLeave();
         return;
       }
 
@@ -482,23 +491,6 @@ const modules = {
         updateSelTip: { update: false, keepDomain: false },
         hitInfo: {
           legend: legendHitInfo,
-        },
-      });
-    };
-
-    /**
-     * callback for mouseleave event on legendBoxDOM
-     *
-     * @returns {undefined}
-     */
-    this.onLegendBoxLeave = () => {
-      this.legendHover = null;
-
-      this.update({
-        updateSeries: false,
-        updateSelTip: { update: false, keepDomain: false },
-        hitInfo: {
-          legend: null,
         },
       });
     };
@@ -579,6 +571,25 @@ const modules = {
     };
 
     /**
+     * callback for mouseleave event on legendBoxDOM
+     *
+     * @returns {undefined}
+     */
+    this.onLegendBoxLeave = () => {
+      this.legendHover = null;
+
+      const series = Object.values(this.seriesList)[0];
+      series.colorState.forEach((item) => {
+        item.state = 'normal';
+      });
+
+      this.update({
+        updateSeries: false,
+        updateSelTip: { update: false, keepDomain: false },
+      });
+    };
+
+    /**
      * callback for legendBoxDOM hovering
      *
      * @returns {undefined}
@@ -588,15 +599,7 @@ const modules = {
 
       const targetDOM = this.getContainerDOM(e);
       if (!targetDOM) {
-        this.legendHover = null;
-
-        this.update({
-          updateSeries: false,
-          updateSelTip: { update: false, keepDomain: false },
-          hitInfo: {
-            legend: null,
-          },
-        });
+        this.onLegendBoxLeave();
         return;
       }
 
@@ -615,25 +618,6 @@ const modules = {
         hitInfo: {
           legend: legendHitInfo,
         },
-      });
-    };
-
-    /**
-     * callback for mouseleave event on legendBoxDOM
-     *
-     * @returns {undefined}
-     */
-    this.onLegendBoxLeave = () => {
-      this.legendHover = null;
-
-      const series = Object.values(this.seriesList)[0];
-      series.colorState.forEach((item) => {
-        item.state = 'normal';
-      });
-
-      this.update({
-        updateSeries: false,
-        updateSelTip: { update: false, keepDomain: false },
       });
     };
 


### PR DESCRIPTION
# 변경 사항
- this.legendHover 추가하여 마우스오버 기능 유지
- onLegendBoxOver에서 해당 DOM이 없으면 초기화되도록 수정

# 기존 동작
![before](https://github.com/user-attachments/assets/e48d4c0b-767e-46cc-a041-69f50123daf0)

# 기대 동작
![after](https://github.com/user-attachments/assets/1306e429-8e82-4c06-aec4-a0610d69c5bb)
