### PR TITLE
fix: 점선스타일 ctx 반영후 복구 안하는 문제 수정

### DIFF
--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -478,8 +478,6 @@ class Scale {
         const mergedPlotLineOpt = defaultsDeep({}, plotLine, PLOT_LINE_OPTION);
         const { value, label: labelOpt } = mergedPlotLineOpt;
 
-        this.setPlotLineStyle(mergedPlotLineOpt);
-
         let dataPos;
         if (this.type === 'x') {
           dataPos = Canvas.calculateX(value, axisMin, axisMax, xArea, minX);
@@ -488,6 +486,7 @@ class Scale {
             return;
           }
 
+          this.setPlotLineStyle(mergedPlotLineOpt);
           this.drawXPlotLine(dataPos, minX, maxX, minY, maxY);
         } else {
           dataPos = Canvas.calculateY(value, axisMin, axisMax, yArea, maxY);
@@ -496,6 +495,7 @@ class Scale {
             return;
           }
 
+          this.setPlotLineStyle(mergedPlotLineOpt);
           this.drawYPlotLine(dataPos, minX, maxX, minY, maxY);
         }
 


### PR DESCRIPTION
# 변경 사항
- ctx 상태 변경 위치를 변경해서 restore 되게 수정

# 기존 동작
![chrome-capture-2025-8-22](https://github.com/user-attachments/assets/d5580095-ba4d-4d82-ac33-0177ae2f74ea)

# 기대 동작
y axis plot line 에 점선(segments)스타일 설정 하고  y axis 최대 값을 넘어가는 값으로 설정해도 다른 line 들이 점선으로 변경되지 않음
