### PR TITLE
[#1983] [3.4] Chart > time Axis > formatter 가 적용되어 있을 경우, selectLabel > useLabelOpacity가 정상동작하지 않음

### DIFF
--- a/docs/views/comboChart/example/LineBarSelectLabel.vue
+++ b/docs/views/comboChart/example/LineBarSelectLabel.vue
@@ -53,9 +53,18 @@
         },
         axesX: [{
           type: 'time',
-          timeFormat: 'mm:ss',
-          interval: 'second',
+          timeFormat: 'HH:mm',
+          interval: 'hour',
           categoryMode: true,
+          formatter: (value, data) => {
+            const curr = dayjs(value).format('YY-MM-DD');
+            const prev = data?.prev ? dayjs(data.prev).format('YY-MM-DD') : '';
+            if (curr !== prev) {
+              return dayjs(value).format('DD HH:mm');
+            }
+
+            return dayjs(value).format('HH:mm');
+          },
         }],
         axesY: [{
           type: 'linear',
@@ -88,7 +97,7 @@
       let timeValue = dayjs().format('YYYY-MM-DD HH:mm:ss');
 
       const addRandomChartData = () => {
-        timeValue = dayjs(timeValue).add(1, 'second');
+        timeValue = dayjs(timeValue).add(1, 'hour');
         chartData.labels.push(dayjs(timeValue));
 
         Object.values(chartData.data).forEach((seriesData) => {

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -349,8 +349,8 @@ class Scale {
             && (this.options.horizontal === (this.type === 'y'))
             && selectLabelInfo?.dataIndex?.length
             && !selectLabelInfo?.label
-              .map((t, index) => this.getLabelFormat(Math.min(axisMax, t), {
-                prev: selectLabelInfo?.label[index - 1] ?? '',
+              .map(t => this.getLabelFormat(Math.min(axisMax, t), {
+                prev: ticks[ix - 1] ?? '',
               })).includes(labelText);
 
           const labelColor = this.labelStyle.color;

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -205,8 +205,8 @@ class TimeCategoryScale extends Scale {
         && (this.options.horizontal === (this.type === 'y'))
         && selectLabelInfo?.dataIndex?.length
         && !selectLabelInfo?.label
-          .map((t, index) => this.getLabelFormat(Math.min(axisMax, t), {
-            prev: selectLabelInfo?.label[index - 1] ?? '',
+          .map(t => this.getLabelFormat(Math.min(axisMax, t), {
+            prev,
           })).includes(labelText);
 
       const labelColor = this.labelStyle.color;


### PR DESCRIPTION
### 문제 상황 
- formatter를 사용하는 축 일경우, selectLabel > useLabelOpacity가 true라면 모든 라벨이 흐리게 보이는 현상 발생
<img width="1504" height="381" alt="image" src="https://github.com/user-attachments/assets/af961d9a-3d3a-4062-92df-259abf28d113" />

### 문제 원인
- 직전 라벨의 값을 확인하는 prev 변수를 확인하는 formatter일 경우, prev값이 formatter에 제대로 전달되지 않아 매칭되는 label이 아니라고 판단함

### 해결
<img width="1528" height="413" alt="image" src="https://github.com/user-attachments/assets/885da6fd-c016-409d-8388-08cc0b9d7004" />
