### PR TITLE
[3.4] Chart > series, data 오브젝트의 series Id (key) 가 뒤늦게 할당되는 경우 차트 그려지지 않음

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.118",
+  "version": "3.4.119",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -47,10 +47,12 @@ const modules = {
           seriesIDs.forEach((seriesID) => {
             const series = this.seriesList[seriesID];
 
-            const hasPassingValueInData = data[seriesID].some(item => item === series.passingValue);
+            const hasPassingValueInData = data?.[seriesID]
+            ?.some(item => item === series.passingValue);
+
             series.hasPassingValueInData = hasPassingValueInData;
 
-            const sData = data[seriesID].map((item) => {
+            const sData = data?.[seriesID]?.map((item) => {
               if (series.interpolation === 'zero' && !item) {
                 return 0;
               }


### PR DESCRIPTION
### 문제 상황 
chartData : { series : {}, data: {}, labels: [] } 에서 data가 빈 오브젝트일 경우 에러메시지가 발생하며 차트가 동작하지 않음 
<img width="836" height="330" alt="image" src="https://github.com/user-attachments/assets/f22b6181-eef4-4eda-bb2f-827608e9ff87" />

### 해결 
옵셔널 체이닝을 추가하여 값이 있을 경우에만 이후 로직을 수행하고 에러를 표시하지 않도록 함

### 기타 
EVUI version update

