### PR TITLE
[#1989] fix: 항상 undefined 할당 하는 버그 수정

### DIFF
--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -895,8 +895,8 @@ export default {
     );
     watch(
       () => [props.width, props.height, props.option.columnWidth],
-      (value) => {
-        resizeInfo.columnWidth = value[3];
+      () => {
+        if (props.option.columnWidth != null) resizeInfo.columnWidth = props.option.columnWidth;
         stores.orderedColumns.map((column) => {
           const item = column;
 


### PR DESCRIPTION
### 문제
 - 트리그리드에서 컬럼과 cell width가 서로 다르게 설정되는 문제
 
<img width="343" height="384" alt="image" src="https://github.com/user-attachments/assets/973e027f-124c-4428-8814-0a2e08d30647" />

### 수정
 - default 값에 항상 undefined 할당 하는 코드 수정

### 테스트
tree grid option > adjust - false 일때만 발생