### PR TITLE
[#1992] Chart > Scatter > 중복체크 하는 로직 변경 필요

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -258,6 +258,35 @@ class EvChart {
   }
 
   /**
+   * Collect duplicate point keys for scatter overlap detection
+   * @param {Map<string, string>} duple
+   * @param {string[]} chartTypeSet
+   *
+   * @returns {undefined}
+   */
+  collectDuplicatePoints(duple, chartTypeSet) {
+    for (let jx = chartTypeSet.length - 1; jx >= 0; jx--) {
+      const series = this.seriesList[chartTypeSet[jx]];
+      if (this.options.realTimeScatter?.use) {
+        const seriesDatas = series.data[series.sId].dataGroup;
+        for (let i = 0; i < seriesDatas.length; i++) {
+          const dataItems = seriesDatas[i]?.data || [];
+          for (let j = 0; j < dataItems.length; j++) {
+            const item = dataItems[j];
+            duple.set(`${item.x}${item.y}`, series.sId);
+          }
+        }
+      } else {
+        const seriesDatas = this.data.data[chartTypeSet[jx]];
+        for (let i = 0; i < seriesDatas.length; i++) {
+          const item = seriesDatas[i];
+          duple.set(`${item.x}${item.y}`, series.sId);
+        }
+      }
+    }
+  }
+
+  /**
    * Draw each series
    * @param {any} [hitInfo=undefined]   legend mouseover callback (object or undefined)
    *
@@ -296,12 +325,21 @@ class EvChart {
       }
     });
 
-    const duple = new Set();
+    /**
+     * new Map<`${x}${y}`, seriesID>
+     */
+    const duple = new Map();
 
     const chartKeys = Object.keys(this.seriesInfo.charts);
+
     for (let ix = 0; ix < chartKeys.length; ix++) {
       const chartType = chartKeys[ix];
       const chartTypeSet = this.seriesInfo.charts[chartType];
+
+      // 중복 데이터를 여기서 쌓아놓기.
+      if (chartType === 'scatter') {
+        this.collectDuplicatePoints(duple, chartTypeSet);
+      }
 
       for (let jx = 0; jx < chartTypeSet.length; jx++) {
         let series = this.seriesList[chartTypeSet[jx]];
@@ -385,9 +423,7 @@ class EvChart {
               }
             }
 
-            if (this.options.realTimeScatter?.use) {
-              series = this.seriesList[chartTypeSet.at(-1 - jx)];
-            }
+            series = this.seriesList[chartTypeSet.at(-1 - jx)];
 
             series.draw({
               legendHitInfo,

--- a/src/components/chart/element/element.scatter.js
+++ b/src/components/chart/element/element.scatter.js
@@ -115,14 +115,13 @@ class Scatter {
     const { ctx, axesSteps, duple, legendHitInfo } = param;
     const minmaxY = axesSteps.y[this.yAxisIndex];
 
-    this.data.forEach((item, idx) => {
-      const shouldDraw = legendHitInfo ? (legendHitInfo.sId === this.sId) : !duple.has(`${item.x}${item.y}`);
+    // Adjusted because Real Time Scatter is drawn from the back.
+    for (let i = this.data.length - 1; i >= 0; i--) {
+      const item = this.data[i];
+      const idx = i;
+      const shouldDraw = legendHitInfo ? (legendHitInfo.sId === this.sId) : duple.get(`${item.x}${item.y}`) === this.sId;
 
       if (shouldDraw) {
-        if (!duple.has(`${item.x}${item.y}`)) {
-          duple.add(`${item.x}${item.y}`);
-        }
-
         this.calcItem(item, param);
 
         if (item.xp !== null && item.yp !== null) {
@@ -139,7 +138,7 @@ class Scatter {
           Canvas.drawPoint(ctx, this.pointStyle, this.pointSize, item.xp, item.yp);
         }
       }
-    });
+    }
   }
 
   /**
@@ -158,13 +157,9 @@ class Scatter {
       for (let j = 0; j < this.data[this.sId]?.dataGroup[i]?.data.length; j++) {
         const item = this.data[this.sId]?.dataGroup[i]?.data[j];
 
-        const shouldDraw = legendHitInfo ? (legendHitInfo.sId === this.sId) : !duple.has(`${item.x}${item.y}`);
+        const shouldDraw = legendHitInfo ? (legendHitInfo.sId === this.sId) : duple.get(`${item.x}${item.y}`) === this.sId;
 
         if (shouldDraw) {
-          if (!duple.has(`${item.x}${item.y}`)) {
-            duple.add(`${item.x}${item.y}`);
-          }
-
           this.calcItem(item, param);
 
           if (item.xp !== null && item.yp !== null) {


### PR DESCRIPTION
# 변경 사항
- 중복 로직 변경 사항
  - 기존엔 그리면서 중복 리스트를 할당하였음.
  - 애초에 중복 리스트를 만들고 key값을 데이터, value를 seriesId로 설정
  - 그릴 때 seriesId가 일치하면 그림.

- 그럼 이전과 뭐가 다른지?
  - 이전엔 첫번째 그려지는 시리즈가 중복데이터를 가지고 있으면 그 뒤의 시리즈는 전부 해당 좌표에 데이터를 못 그렸고,
  - 이제는 중복 데이터를 가지고 있는 마지막 시리즈가 그려지게 됨.

# 기존
- 데이터 100만개가 그려져서 중복데이터가 많을 경우, 먼저 그려지는 series2만 보임
<img width="963" height="500" alt="before" src="https://github.com/user-attachments/assets/39927216-cc56-4b99-9722-097add728a82" />

# 기대
- 가장 나중에 그려지는 series1만 보임
<img width="956" height="497" alt="after" src="https://github.com/user-attachments/assets/2f1410d9-ad1c-4766-9723-52e63f1841ad" />
