### PR TITLE
[#1991][3.4.120] Chart > Heatmap > 빈 공간 드래그했을 때 드래그한 범위 밖에 데이터 조회됨

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.123",
+  "version": "3.4.124",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -483,10 +483,7 @@ class HeatMap {
       const y1 = yp;
       const y2 = yp + h;
 
-      return ((x1 >= xsp && x1 <= xep) && (y1 >= ysp && y1 <= yep))
-         || ((x1 >= xsp && x1 <= xep) && (y2 >= ysp && y2 <= yep))
-         || ((x2 >= xsp && x2 <= xep) && (y1 >= ysp && y1 <= yep))
-        || ((x2 >= xsp && x2 <= xep) && (y2 >= ysp && y2 <= yep));
+      return ((x1 >= xsp && x2 <= xep) && (y1 >= ysp && y2 <= yep));
     });
   }
 
@@ -695,8 +692,8 @@ class HeatMap {
         y: { steps: yCurrentCount, min: yMin, max: yMax },
       } = this.currentLabelInfo;
 
-      const labelXCount = xCurrentCount || labelX.x.length;
-      const labelYCount = yCurrentCount || labelY.y.length;
+      const labelXCount = xCurrentCount || labelX.length;
+      const labelYCount = yCurrentCount || labelY.length;
       const gapX = (x2 - x1) / labelXCount;
       const gapY = (y2 - y1) / labelYCount;
 


### PR DESCRIPTION
이슈
빈 공간에 드래그했을 때 드래그한 범위 밖에 데이터가 조회됨

![Sep-03-2025 18-22-07](https://github.com/user-attachments/assets/a5c8bcd5-f086-48c5-af31-acf1773223fb)


수정 내용
x2값이 xep 값과 같을 때 생기는 이슈로 조건식에서 '=' 제거
selectionRange 구할 때 labelX.x 로 오타 있는 부분 수정

![Sep-03-2025 18-18-28](https://github.com/user-attachments/assets/626dd51c-6928-42e8-b3e2-1cd8a5ef5a5e)

테스트 방법
Event 예제에서 heatmapColor 옵션에 stroke show: false로 변경
빈 공간 드래그했을 때 데이터가 나오는지 확인
데이터가 있는 공간을 드래그햇을 때 드래그 범위에 맞는 데이터가 반환되는지 확인