### PR TITLE
[#1997] 3.4 > chart > Scale.time > y값이 null일 경우, 차트에 그려지지 않음

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.200",
+  "version": "3.4.201",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -418,8 +418,8 @@ const modules = {
       const position = isHorizontal ? baseData?.x : baseData?.y;
 
       const baseValue = baseData?.o;
-      const isPassingValue = !Util.isNullOrUndefined(baseSeries.passingValue)
-      && baseSeries.passingValue === baseValue;
+      const isPassingValue = !Util.isNullOrUndefined(baseSeries?.passingValue)
+      && baseSeries?.passingValue === baseValue;
       const isSameSign = (curr >= 0 && baseValue >= 0) || (curr < 0 && baseValue < 0);
 
       if (isPassingValue || position == null || !isSameSign || !baseSeries.show) {

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -418,7 +418,8 @@ const modules = {
       const position = isHorizontal ? baseData?.x : baseData?.y;
 
       const baseValue = baseData?.o;
-      const isPassingValue = baseSeries.passingValue === baseValue;
+      const isPassingValue = Util.isNullOrUndefined(baseSeries.passingValue)
+      && baseSeries.passingValue === baseValue;
       const isSameSign = (curr >= 0 && baseValue >= 0) || (curr < 0 && baseValue < 0);
 
       if (isPassingValue || position == null || !isSameSign || !baseSeries.show) {
@@ -598,21 +599,23 @@ const modules = {
     const isHorizontal = this.options.horizontal;
 
     if (data.length) {
+      const usePassingValue = !Util.isNullOrUndefined(passingValue);
+
       return data.reduce((acc, p, index) => {
         const minmax = acc;
         const px = p.x?.value || p.x;
         const py = p.y?.value || p.y;
         const po = p.o?.value || p.o;
 
-        if (po !== passingValue && px <= minmax.minX) {
+        if ((usePassingValue ? (po !== passingValue && px <= minmax.minX) : px <= minmax.minX)) {
           minmax.minX = (px === null) ? 0 : px;
         }
 
-        if (po !== passingValue && py <= minmax.minY) {
+        if ((usePassingValue ? (po !== passingValue && py <= minmax.minY) : py <= minmax.minY)) {
           minmax.minY = (py === null) ? 0 : py;
         }
 
-        if (po !== passingValue && px >= minmax.maxX) {
+        if ((usePassingValue ? (po !== passingValue && px >= minmax.maxX) : px >= minmax.maxX)) {
           minmax.maxX = (px === null) ? 0 : px;
 
           if (isHorizontal && px !== null) {
@@ -621,7 +624,7 @@ const modules = {
           }
         }
 
-        if (po !== passingValue && py >= minmax.maxY) {
+        if ((usePassingValue ? (po !== passingValue && py >= minmax.maxY) : py >= minmax.maxY)) {
           minmax.maxY = (py === null) ? 0 : py;
 
           if (!isHorizontal && py !== null) {

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -418,7 +418,7 @@ const modules = {
       const position = isHorizontal ? baseData?.x : baseData?.y;
 
       const baseValue = baseData?.o;
-      const isPassingValue = Util.isNullOrUndefined(baseSeries.passingValue)
+      const isPassingValue = !Util.isNullOrUndefined(baseSeries.passingValue)
       && baseSeries.passingValue === baseValue;
       const isSameSign = (curr >= 0 && baseValue >= 0) || (curr < 0 && baseValue < 0);
 


### PR DESCRIPTION
### 이슈 내용 
- passingValue를 사용하지 않을 때, 차트의 값이 null일 경우, passingValue와 동일 취급되어 차트에 표시되지 않음

### 수정 내용 
- psassingValue 검사 로직 강화 

### 수정 전
<img width="1212" height="344" alt="image" src="https://github.com/user-attachments/assets/71440725-b9df-4550-b10d-2e3ba0d42897" />

### 수정 후
<img width="1351" height="400" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/4a6c9297-2c09-407e-966c-07917c8bad51" />
