### PR TITLE
[#1999] Chart > Tooltip > 툴팁 데이터를 가지고 외부 컴포넌트에 활용할 수 있도록 수정 필요.

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -354,8 +354,9 @@ const chartData = {
 | showAllValueInRange | Boolean                             | false                                      | 동일한 axes값을 가진 전체 series를 Tooltip에 표시       |
 | showHeader          | Boolean                             | true                                       | Tooltip의 Header 영역 표시 여부                         |
 | formatter           | function / Object                   | null                                       | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용 | (아래 코드 참고)                                                    |
+| returnValue         | function                    | null                                       | 외부 컴포넌트 커스텀 툴팁을 구현할 때 사용하는 함수                 | (아래 코드 참고)                                                    |
 
-```
+```ts
 const chartOptions = {
     tooltip: {
         // 이전 버전 호환용으로 valueFormatter를 이전버전과 같이 사용 가능
@@ -375,9 +376,34 @@ const chartOptions = {
         formatter: {
             html: (seiresList) =>  `<div class="customClass">${seriesList[0].name} : ${seriesList[0].data.y}</div>`
         }
+
+        // returnValue function
+        // return type : void
+        // 커스텀 툴팁을 구현할 때 사용하는 함수
+        returnValue: (seriesList, event) => {
+            // seriesList: Array<SeriesItem>
+            // event: MouseEvent
+        }
     },
 }
 ```
+
+#### returnValue
+
+| 이름 | 타입 | 설명 | 종류(예시) |
+| --- | --- | --- | --- |
+| seriesList | Array<SeriesItem> | 마우스 위치에 해당하는 시리즈 데이터 배열 | |
+| event | MouseEvent | 마우스 이벤트 객체 | |
+
+  - SeriesItem  
+    | 이름 | 타입 | 설명 | 종류(예시) |
+    | --- | --- | --- | --- |
+    | sId | String | 시리즈 ID | 'series1' |
+    | data | Object | 시리즈 데이터 | { x: Date, y: Number, xp: Number, yp: Number, o: Number } |
+    | color | String | 시리즈 색상 | '#2b99f0' |
+    | name | String | 시리즈 이름 | 'Series 1' |
+    | dataId | String | 데이터 ID | 'data_1' |
+    | index | Number | 데이터 인덱스 | 0 |
 
 #### indicator
 

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -241,6 +241,7 @@ const chartData =
 | rowPadding          | Object                              | { top: 0, bottom: 3, right: 20, left: 16 } | 툴팁에 표시될 series Row의 padding 값                   |                                                                     |
 | showAllValueInRange | Boolean                             | false                                      | 동일한 axes값을 가진 전체 series를 Tooltip에 표시       |
 | formatter           | function / Object                   | null                                       | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용 | (아래 코드 참고)                                                    |
+| returnValue         | function                    | null                                       | 외부 컴포넌트 커스텀 툴팁을 구현할 때 사용하는 함수                 | (아래 코드 참고)                                                    |
 
 ```
 const chartOptions = {
@@ -262,9 +263,34 @@ const chartOptions = {
         formatter: {
             html: ([item]) =>  `<div class="customClass">${item.name} : ${item.data.y}</div>`
         }
+
+        // returnValue function
+        // return type : void
+        // 커스텀 툴팁을 구현할 때 사용하는 함수
+        returnValue: (seriesList, event) => {
+            // seriesList: Array<SeriesItem>
+            // event: MouseEvent
+        }
     },
 }
 ```
+
+#### returnValue
+
+| 이름 | 타입 | 설명 | 종류(예시) |
+| --- | --- | --- | --- |
+| seriesList | Array<SeriesItem> | 마우스 위치에 해당하는 시리즈 데이터 배열 | |
+| event | MouseEvent | 마우스 이벤트 객체 | |
+
+  - SeriesItem  
+    | 이름 | 타입 | 설명 | 종류(예시) |
+    | --- | --- | --- | --- |
+    | sId | String | 시리즈 ID | 'series1' |
+    | data | Object | 시리즈 데이터 | { x: Date, y: Number, xp: Number, yp: Number, o: Number } |
+    | color | String | 시리즈 색상 | '#2b99f0' |
+    | name | String | 시리즈 이름 | 'Series 1' |
+    | dataId | String | 데이터 ID | 'data_1' |
+    | index | Number | 데이터 인덱스 | 0 |
 
 #### heatmap color
 

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -294,8 +294,9 @@ const chartData =
 | showAllValueInRange | Boolean                     | false                                      | 동일한 axes값을 가진 전체 series를 Tooltip에 표시       |
 | showHeader          | Boolean                     | true                                       | Tooltip의 Header 영역 표시 여부                         |
 | formatter           | function / Object           | null                                       | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용 | (아래 코드 참고)                                                    |
+| returnValue         | function                    | null                                       | 외부 컴포넌트 커스텀 툴팁을 구현할 때 사용하는 함수                 | (아래 코드 참고)                                                    |
 
-```
+```ts
 const chartOptions = {
     tooltip: {
         // 이전 버전 호환용으로 valueFormatter를 이전버전과 같이 사용 가능
@@ -315,9 +316,34 @@ const chartOptions = {
         formatter: {
             html: (seiresList) =>  `<div class="customClass">${seriesList[0].name} : ${seriesList[0].data.y}</div>`
         }
+
+        // returnValue function
+        // return type : void
+        // 커스텀 툴팁을 구현할 때 사용하는 함수
+        returnValue: (seriesList, event) => {
+            // seriesList: Array<SeriesItem>
+            // event: MouseEvent
+        }
     },
 }
 ```
+
+#### returnValue
+
+| 이름 | 타입 | 설명 | 종류(예시) |
+| --- | --- | --- | --- |
+| seriesList | Array<SeriesItem> | 마우스 위치에 해당하는 시리즈 데이터 배열 | |
+| event | MouseEvent | 마우스 이벤트 객체 | |
+
+  - SeriesItem  
+    | 이름 | 타입 | 설명 | 종류(예시) |
+    | --- | --- | --- | --- |
+    | sId | String | 시리즈 ID | 'series1' |
+    | data | Object | 시리즈 데이터 | { x: Date, y: Number, xp: Number, yp: Number, o: Number } |
+    | color | String | 시리즈 색상 | '#2b99f0' |
+    | name | String | 시리즈 이름 | 'Series 1' |
+    | dataId | String | 데이터 ID | 'data_1' |
+    | index | Number | 데이터 인덱스 | 0 |
 
 #### indicator
 

--- a/docs/views/lineChart/example/ExternalTooltip.vue
+++ b/docs/views/lineChart/example/ExternalTooltip.vue
@@ -1,0 +1,158 @@
+<template>
+  <div class="case" @mouseleave="hideExternalTooltip" @wheel="onReplaceScroll">
+    <ev-chart :data="chartData" :options="chartOptions" />
+
+    <div
+      v-show="tooltip.items.length"
+      class="ev-chart-tooltip"
+      :style="{
+        position: 'fixed',
+        left: `${tooltip.x + 12}px`,
+        top: `${tooltip.y + 12}px`,
+      }"
+    >
+      <div class="ev-chart-tooltip-custom">
+        <div class="ev-chart-tooltip-custom__header">
+          {{
+            typeof tooltip.time === 'number' || typeof tooltip.time === 'string'
+              ? tooltip.time
+              : tooltip.time
+          }}
+        </div>
+        <div class="ev-chart-tooltip-custom__body">
+          <div
+            v-for="s in tooltip.items"
+            :key="s.sId + ':' + s.index"
+            class="row"
+          >
+            <span class="color-circle" :style="{ backgroundColor: s.color }" />
+            <span class="series-name">{{ s.name }}</span>
+            <span class="value">{{ s.data?.y }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { onMounted, reactive } from 'vue';
+import dayjs from 'dayjs';
+
+export default {
+  setup() {
+    const chartData = reactive({
+      series: Object.fromEntries(
+        Array.from({ length: 100 }, (_, i) => {
+          const seriesId = `series${i + 1}`;
+          return [seriesId, { name: `series#${i + 1}`, point: false }];
+        }),
+      ),
+      labels: [],
+      data: Object.fromEntries(
+        Array.from({ length: 100 }, (_, i) => {
+          const seriesId = `series${i + 1}`;
+          return [seriesId, []];
+        }),
+      ),
+    });
+
+    const tooltip = reactive({ show: false, x: 0, y: 0, time: '', items: [] });
+
+    const chartOptions = reactive({
+      type: 'line',
+      width: '100%',
+      height: '80%',
+      title: {
+        text: 'Chart Title',
+        show: true,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesX: [
+        {
+          type: 'time',
+          timeFormat: 'HH:mm:ss',
+          interval: 'second',
+        },
+      ],
+      axesY: [
+        {
+          type: 'linear',
+          showGrid: true,
+          autoScaleRatio: 0.1,
+        },
+      ],
+      tooltip: {
+        use: true,
+        useScrollbar: true,
+        htmlScrollTarget: '.ev-chart-tooltip-custom__body',
+        returnValue: (seriesList, e) => {
+          tooltip.items = seriesList;
+          tooltip.x = e.clientX;
+          tooltip.y = e.clientY;
+          tooltip.time = dayjs(seriesList?.[0]?.data?.x).format('HH:mm:ss');
+          tooltip.show = true;
+        },
+      },
+    });
+
+    let timeValue = dayjs().format('YYYY-MM-DD HH:mm:ss');
+    const addRandomChartData = () => {
+      timeValue = dayjs(timeValue).add(1, 'second');
+      chartData.labels.push(dayjs(timeValue));
+
+      Object.values(chartData.data).forEach((seriesData) => {
+        seriesData.push(Math.floor(Math.random() * 10) + 1);
+      });
+    };
+
+    const onReplaceScroll = (e) => {
+      const scrollElement = document.querySelector(
+        '.ev-chart-tooltip-custom__body',
+      );
+
+      if (scrollElement && scrollElement.scrollHeight > scrollElement.clientHeight) {
+        e.preventDefault();
+
+        if (scrollElement) {
+          scrollElement.scrollTop += e.deltaY;
+        }
+      }
+    };
+
+    onMounted(() => {
+      for (let ix = 0; ix < 60; ix++) {
+        addRandomChartData();
+      }
+    });
+
+    const hideExternalTooltip = () => {
+      tooltip.show = false;
+    };
+
+    return {
+      chartData,
+      chartOptions,
+      tooltip,
+      onReplaceScroll,
+      hideExternalTooltip,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.ev-chart-tooltip {
+  background-color: rgb(76, 76, 76);
+  border: 1px solid rgb(102, 102, 102);
+  color: #FFFFFF;
+
+  &__body {
+    max-height: 400px;
+    overflow-y: auto !important;
+  }
+}
+</style>

--- a/docs/views/lineChart/props.js
+++ b/docs/views/lineChart/props.js
@@ -14,6 +14,8 @@ import Tooltip from './example/Tooltip';
 import TooltipRaw from '!!raw-loader!./example/Tooltip';
 import CustomTooltip from './example/CustomTooltip';
 import CustomTooltipRaw from '!!raw-loader!./example/CustomTooltip';
+import ExternalTooltip from './example/ExternalTooltip';
+import ExternalTooltipRaw from '!!raw-loader!./example/ExternalTooltip';
 import PlotLine from './example/PlotLine';
 import PlotLineRaw from '!!raw-loader!./example/PlotLine';
 import SelectLabel from './example/SelectLabel';
@@ -78,6 +80,11 @@ export default {
       description: 'Tooltip의 내용을 HTML로 가공하여 구성할 수 있습니다.',
       component: CustomTooltip,
       parsedData: parseComponent(CustomTooltipRaw),
+    },
+    'External Tooltip': {
+      description: 'Tooltip의 내용을 외부에서 제어할 수 있습니다.',
+      component: ExternalTooltip,
+      parsedData: parseComponent(ExternalTooltipRaw),
     },
     'Plot line & Plot band': {
       description: '차트 배경에 선 및 영역을 표시할 수 있습니다.',

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -148,8 +148,9 @@ const chartData =
 | showAllValueInRange | Boolean                     | false                                      | 동일한 axes값을 가진 전체 series를 Tooltip에 표시       |
 | showHeader          | Boolean                     | true                                       | Tooltip의 Header 영역 표시 여부                         |
 | formatter           | function / Object           | null                                       | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용 | (아래 코드 참고)                                                    |
+| returnValue         | function                    | null                                       | 외부 컴포넌트 커스텀 툴팁을 구현할 때 사용하는 함수                 | (아래 코드 참고)                                                    |
 
-```
+```ts
 const chartOptions = {
     tooltip: {
         // 이전 버전 호환용으로 valueFormatter를 이전버전과 같이 사용 가능
@@ -168,9 +169,34 @@ const chartOptions = {
         formatter: {
             html: ([item]) =>  `<div class="customClass">${item.name} : ${item.data.o} (${item.data.percentage})</div>`
         }
+
+        // returnValue function
+        // return type : void
+        // 커스텀 툴팁을 구현할 때 사용하는 함수
+        returnValue: (seriesList, event) => {
+            // seriesList: Array<SeriesItem>
+            // event: MouseEvent
+        }
     },
 }
 ```
+
+#### returnValue
+
+| 이름 | 타입 | 설명 | 종류(예시) |
+| --- | --- | --- | --- |
+| seriesList | Array<SeriesItem> | 마우스 위치에 해당하는 시리즈 데이터 배열 | |
+| event | MouseEvent | 마우스 이벤트 객체 | |
+
+  - SeriesItem  
+    | 이름 | 타입 | 설명 | 종류(예시) |
+    | --- | --- | --- | --- |
+    | sId | String | 시리즈 ID | 'series1' |
+    | data | Object | 시리즈 데이터 | { x: Date, y: Number, xp: Number, yp: Number, o: Number } |
+    | color | String | 시리즈 색상 | '#2b99f0' |
+    | name | String | 시리즈 이름 | 'Series 1' |
+    | dataId | String | 데이터 ID | 'data_1' |
+    | index | Number | 데이터 인덱스 | 0 |
 
 #### selectItem
 

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -221,7 +221,9 @@ const chartData =
 | colorShape | String | 'rect' | 툴팁에 표시될 series color의 모양 | 'rect', 'circle' |
 | showAllValueInRange | Boolean                     | false     | 동일한 axes값을 가진 전체 series를 Tooltip에 표시 |
 | formatter           | function / Object           | null      | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용      | (아래 코드 참고)                                                          |
-```
+| returnValue         | function                    | null                                       | 외부 컴포넌트 커스텀 툴팁을 구현할 때 사용하는 함수                 | (아래 코드 참고)                                                    |
+
+```ts
 const chartOptions = {
     tooltip: {
         // 이전 버전 호환용으로 valueFormatter를 이전버전과 같이 사용 가능
@@ -240,9 +242,34 @@ const chartOptions = {
         formatter: {
             html: (seiresList) =>  `<div class="customClass">${seriesList[0].name} : ${seriesList[0].data.y}</div>`
         }
+
+        // returnValue function
+        // return type : void
+        // 커스텀 툴팁을 구현할 때 사용하는 함수
+        returnValue: (seriesList, event) => {
+            // seriesList: Array<SeriesItem>
+            // event: MouseEvent
+        }
     },
 }
 ```
+
+#### returnValue
+
+| 이름 | 타입 | 설명 | 종류(예시) |
+| --- | --- | --- | --- |
+| seriesList | Array<SeriesItem> | 마우스 위치에 해당하는 시리즈 데이터 배열 | |
+| event | MouseEvent | 마우스 이벤트 객체 | |
+
+  - SeriesItem  
+    | 이름 | 타입 | 설명 | 종류(예시) |
+    | --- | --- | --- | --- |
+    | sId | String | 시리즈 ID | 'series1' |
+    | data | Object | 시리즈 데이터 | { x: Date, y: Number, xp: Number, yp: Number, o: Number } |
+    | color | String | 시리즈 색상 | '#2b99f0' |
+    | name | String | 시리즈 이름 | 'Series 1' |
+    | dataId | String | 데이터 ID | 'data_1' |
+    | index | Number | 데이터 인덱스 | 0 |
 
 #### selectItem
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -37,7 +37,22 @@ const modules = {
         if (tooltip.use && this.isInitTooltip) {
           this.drawItemsHighlight(hitInfo, ctx);
 
-          if (tooltip?.formatter?.html) {
+          if (typeof tooltip?.returnValue === 'function') {
+            const seriesList = [];
+            Object.keys(hitInfo.items).forEach((sId) => {
+              seriesList.push({
+                sId,
+                data: hitInfo.items[sId].data,
+                color: hitInfo.items[sId].color,
+                name: hitInfo.items[sId].name,
+                dataId: hitInfo.items[sId].id,
+                index: hitInfo.items[sId].index,
+              });
+            });
+
+            this.hideTooltipDOM();
+            tooltip.returnValue(seriesList, e);
+          } else if (tooltip?.formatter?.html) {
             this.drawCustomTooltip(hitInfo?.items);
             this.setCustomTooltipLayoutPosition(hitInfo, e);
           } else {
@@ -52,6 +67,10 @@ const modules = {
           }
         }
       } else if (tooltip.use && this.isInitTooltip) {
+        if (typeof tooltip?.returnValue === 'function') {
+          tooltip.returnValue([], e);
+        }
+
         this.hideTooltipDOM();
       }
 
@@ -88,7 +107,7 @@ const modules = {
      * @returns {undefined}
      */
 
-    this.onMouseLeave = () => {
+    this.onMouseLeave = (e) => {
       const { tooltip, dragSelection } = this.options;
 
       if (tooltip.throttledMove) {
@@ -100,6 +119,10 @@ const modules = {
       }
 
       if (tooltip.use && this.isInitTooltip) {
+        if (typeof tooltip?.returnValue === 'function') {
+          tooltip.returnValue([], e);
+        }
+
         this.tooltipClear();
       }
       this.listeners['mouse-leave']();


### PR DESCRIPTION
# 변경 사항 요약
- `returnValue` 메소드 추가 (뭔가 적절한 단어가 안떠올라서 좋은 단어 있으면 추천 부탁드립니다.)
  - returnValue 있을 경우 툴팁을 직접 그리지 않고 데이터만 받을 수 있게하여 외부 컴포넌트에 활용할 수 있도록 함.

# 기존 동작
- Canvas, html formatter 말곤 없음.

# 기대 동작
![after2](https://github.com/user-attachments/assets/9b20ad62-8c3f-43cf-a04e-3649a5d08c8f)
- 외부 컴포넌트를 사용할 수 있게됨.
- 가상 스크롤 및 각종 스크립트 커스텀 하기 용이해짐.