### PR TITLE
[#2001] Chart > x축 time, categoryMode 일 때 label이 2개일 때 label text가 그려지지 않음

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.124",
+  "version": "3.4.125",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -182,10 +182,15 @@ class TimeCategoryScale extends Scale {
     let labelPoint;
     let ix;
 
-    const gap = Math.round(oriSteps / steps);
-    const count = gap === oriSteps ? 1 : gap;
+    // 2개 이하일 경우, 첫번째와 마지막 라벨만 표시
+    let count = steps <= 2 ? oriSteps : Math.round(oriSteps / steps);
 
-    const maxIndex = gap === oriSteps ? oriSteps : oriSteps - 1;
+    // 첫번째 라벨이 축 시작점보다 오른쪽에 있을 경우, count를 1로 설정
+    if (this.type === 'x' && startPoint > Math.ceil(aPos[this.units.rectStart]) && count === oriSteps) {
+      count = 1;
+    }
+
+    const maxIndex = count === oriSteps ? oriSteps : oriSteps - 1;
 
     for (ix = 0; ix <= maxIndex; ix += count) {
       ticks[ix] = dayjs(axisMin).valueOf() + (ix * stepValue);

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -185,8 +185,10 @@ class TimeCategoryScale extends Scale {
     // 2개 이하일 경우, 첫번째와 마지막 라벨만 표시
     let count = steps <= 2 ? oriSteps : Math.round(oriSteps / steps);
 
+    const isStartPointRightOfRectStart = startPoint > Math.ceil(aPos[this.units.rectStart]);
+
     // 첫번째 라벨이 축 시작점보다 오른쪽에 있을 경우, count를 1로 설정
-    if (this.type === 'x' && startPoint > Math.ceil(aPos[this.units.rectStart]) && count === oriSteps) {
+    if (this.type === 'x' && isStartPointRightOfRectStart && count === oriSteps) {
       count = 1;
     }
 
@@ -251,7 +253,11 @@ class TimeCategoryScale extends Scale {
             });
           }
         }
-        if ((ix < oriSteps && this.showGrid)) {
+        if (
+          ix < oriSteps && this.showGrid && (
+            isStartPointRightOfRectStart || (!isStartPointRightOfRectStart && ix !== 0)
+          )
+        ) {
           ctx.moveTo(linePosition, offsetPoint);
           ctx.lineTo(linePosition, offsetCounterPoint);
         }
@@ -259,7 +265,10 @@ class TimeCategoryScale extends Scale {
         labelPoint = this.position === 'left' ? offsetPoint - 10 : offsetPoint + 10;
         ctx.fillText(labelText, labelPoint, labelCenter);
 
-        if ((ix < oriSteps && this.showGrid)) {
+        if (
+          ix < oriSteps && this.showGrid && (
+            isStartPointRightOfRectStart || (!isStartPointRightOfRectStart && ix !== 0)
+          )) {
           ctx.moveTo(offsetPoint, linePosition);
           ctx.lineTo(offsetCounterPoint, linePosition);
         }

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -127,9 +127,6 @@ class TimeCategoryScale extends Scale {
     const stepValue = stepInfo.rawInterval;
     const oriSteps = stepInfo.oriSteps;
 
-    // 2개 이하일 경우, 첫번째와 마지막 라벨만 표시
-    const count = steps <= 2 ? oriSteps : Math.round(oriSteps / steps);
-
     let startPoint = aPos[this.units.rectStart];
     const endPoint = aPos[this.units.rectEnd];
     const offsetPoint = aPos[this.units.rectOffset(this.position)];
@@ -184,7 +181,12 @@ class TimeCategoryScale extends Scale {
     let labelText;
     let labelPoint;
     let ix;
-    const maxIndex = oriSteps === count ? oriSteps : oriSteps - 1;
+
+    const gap = Math.round(oriSteps / steps);
+    const count = gap === oriSteps ? 1 : gap;
+
+    const maxIndex = gap === oriSteps ? oriSteps : oriSteps - 1;
+
     for (ix = 0; ix <= maxIndex; ix += count) {
       ticks[ix] = dayjs(axisMin).valueOf() + (ix * stepValue);
 
@@ -244,7 +246,7 @@ class TimeCategoryScale extends Scale {
             });
           }
         }
-        if ((ix !== 0 && ix < oriSteps && this.showGrid)) {
+        if ((ix < oriSteps && this.showGrid)) {
           ctx.moveTo(linePosition, offsetPoint);
           ctx.lineTo(linePosition, offsetCounterPoint);
         }
@@ -252,7 +254,7 @@ class TimeCategoryScale extends Scale {
         labelPoint = this.position === 'left' ? offsetPoint - 10 : offsetPoint + 10;
         ctx.fillText(labelText, labelPoint, labelCenter);
 
-        if ((ix !== 0 && ix < oriSteps && this.showGrid)) {
+        if ((ix < oriSteps && this.showGrid)) {
           ctx.moveTo(offsetPoint, linePosition);
           ctx.lineTo(offsetCounterPoint, linePosition);
         }

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -185,9 +185,9 @@ class TimeCategoryScale extends Scale {
     // 2개 이하일 경우, 첫번째와 마지막 라벨만 표시
     let count = steps <= 2 ? oriSteps : Math.round(oriSteps / steps);
 
-    const isStartPointRightOfRectStart = startPoint > Math.ceil(aPos[this.units.rectStart]);
-
     // 첫번째 라벨이 축 시작점보다 오른쪽에 있을 경우, count를 1로 설정
+    // 추후 개선 필요: 근본적 문제는 라벨이 2개인 경우 oriSteps가 1로 와야하는데 2로 옴. horizontal일 때 예외처리 필요.
+    const isStartPointRightOfRectStart = startPoint > Math.ceil(aPos[this.units.rectStart]);
     if (this.type === 'x' && isStartPointRightOfRectStart && count === oriSteps) {
       count = 1;
     }


### PR DESCRIPTION
### 이슈

x축 type: time, categoryMode: true일때 label이 2개인 경우 두번째 label text가 그려지지 않음

<img width="1082" height="410" alt="image" src="https://github.com/user-attachments/assets/043c305d-378e-440c-b58f-4067a1e76dfb" />


### 수정 내용

- 기존에 값에서 x축의 첫번째 label의 x축 좌측 선보다 이후에 있고 oristep과 count가 같을 경우 count를 1로 변경

<img width="1066" height="421" alt="image" src="https://github.com/user-attachments/assets/30445827-744d-4e78-958f-f5fd05f4d96a" />

<img width="1048" height="364" alt="image" src="https://github.com/user-attachments/assets/30520ad4-d1f0-468e-9ee7-4980bafa5554" />


### 테스트 방법

1. combo > linebar 예제에서 onMounted 안에 for문 조건식 값 변경 1~100 으로 변경하여 모든 label이 나오는지 확인
` onMounted(() => {
        for (let ix = 0; ix < 2; ix++) {
          addRandomChartData();
        }
      });`


2. bar chart > time 예제에서 넓이를 최대한 줄였을 때 첫번째와 마지막 label만 나오는지 확인
(https://github.com/ex-em/EVUI/pull/1918)

![Sep-08-2025 12-59-16](https://github.com/user-attachments/assets/2dcc5855-665d-48a1-a3cb-6a9386c6715f)

