### PR TITLE
[#2005] 3.4 > Chart > interpolation: linear > Stack Line/Area > 처리 강화

### DIFF
--- a/docs/views/lineChart/example/Interpolation.vue
+++ b/docs/views/lineChart/example/Interpolation.vue
@@ -1,0 +1,257 @@
+<template>
+  <div class="case">
+    <ev-chart
+      :data="chartData"
+      :options="chartOptions"
+    />
+
+    <div class="description">
+      <div class="section">
+        <div class="section-body section-body--col">
+          <div class="section-item">
+            <span class="section-title">Chart Type</span>
+            <ev-select
+              v-model="chartType"
+              :items="chartTypeList"
+              @change="onChangeChartType"
+            />
+            <span class="section-title">Interpolation</span>
+            <ev-select
+              v-model="interpolation"
+              :items="interpolationList"
+              @change="onChangeInterpolation"
+            />
+          </div>
+        </div>
+
+        <div
+          v-for="series in chartSeries?.filter(s => chartData.series[s.key]?.show)?.reverse()"
+          :key="series.key"
+          class="section-body"
+        >
+          <h3 :class="`section-title--${series.key}`">
+            Chart Data - {{ series.key }}
+          </h3>
+          <div class="section-item">
+            <template
+              v-for="(data, jx) in series.data"
+              :key="`${series.key}-${jx}`"
+            >
+              <div class="column">
+                <label>{{ new Date(chartData.labels[jx]).getDate() }}</label>
+                <ev-input-number
+                  v-model="data.value"
+                  :disabled="data.isNull"
+                  :step="1"
+                  @change="changeValue"
+                />
+                <p>Null</p>
+                <ev-toggle v-model="data.isNull" />
+              </div>
+            </template>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { reactive, ref, watch } from 'vue';
+import dayjs from 'dayjs';
+import EvInputNumber from '../../../../src/components/inputNumber/InputNumber';
+
+export default {
+  components: { EvInputNumber },
+  setup() {
+    const chartSeries = ref([
+      {
+        key: 'series1',
+        data: [
+          { value: 17, isNull: true },
+          { value: 20, isNull: false },
+          { value: 5, isNull: false },
+          { value: 30, isNull: true },
+          { value: 10, isNull: false },
+          { value: 18, isNull: false },
+          { value: 10, isNull: true },
+        ],
+      },
+      {
+        key: 'series2',
+        data: [
+          { value: 4, isNull: true },
+          { value: 20, isNull: false },
+          { value: 10, isNull: false },
+          { value: 5, isNull: true },
+          { value: 10, isNull: false },
+          { value: 15, isNull: false },
+          { value: 10, isNull: true },
+        ],
+      },
+      {
+        key: 'series3',
+        data: [
+          { value: 4, isNull: true },
+          { value: 20, isNull: false },
+          { value: 10, isNull: false },
+          { value: 5, isNull: true },
+          { value: 10, isNull: false },
+          { value: 15, isNull: false },
+          { value: 10, isNull: true },
+        ],
+      },
+    ]);
+
+    const time = dayjs().format('YYYY-MM-DD HH:mm:ss');
+
+    const interpolation = ref('linear');
+    const interpolationList = [
+      { name: 'None', value: 'none' },
+      { name: 'Linear', value: 'linear' },
+      { name: 'Zero', value: 'zero' },
+    ];
+
+    const chartData = reactive({
+      series: {
+        series1: { name: 'series#1', interpolation: 'linear', fill: true, show: true },
+        series2: { name: 'series#2', interpolation: 'linear', fill: true, show: true },
+        series3: { name: 'series#3', interpolation: 'linear', fill: true, show: true },
+      },
+      labels: Array.from({ length: 7 }, (_, i) => dayjs(time).add(i, 'day')),
+      data: { series1: [], series2: [], series3: [] },
+      groups: [['series1', 'series2', 'series3']],
+    });
+
+    const chartType = ref('stackArea');
+    const chartTypeList = [
+      { name: 'Line', value: 'line' },
+      { name: 'Stack Line', value: 'stackLine' },
+      { name: 'Area', value: 'area' },
+      { name: 'Stack Area', value: 'stackArea' },
+    ];
+
+    const changeValue = () => {
+      Object.keys(chartData.data).forEach((key) => {
+        const series = chartSeries.value.find(s => s.key === key);
+        chartData.data[key] = series.data.map(item => (item.isNull ? null : item.value));
+      });
+    };
+
+    watch([chartSeries, chartType], changeValue, { deep: true });
+
+    const chartOptions = reactive({
+      type: 'line',
+      width: '100%',
+      height: '300px',
+      title: { text: 'Chart Title', show: true },
+      legend: { show: true },
+      axesX: [{ type: 'time', timeFormat: 'D', interval: 'day' }],
+      axesY: [{ type: 'linear', showGrid: true, startToZero: true, interval: 10 }],
+    });
+
+    const chartTypeConfig = {
+      line: {
+        series: {
+          series1: { show: true, fill: false },
+          series2: { show: false, fill: false },
+          series3: { show: false, fill: false },
+        },
+        groups: [],
+      },
+      stackLine: {
+        series: {
+          series1: { show: true, fill: false },
+          series2: { show: true, fill: false },
+          series3: { show: true, fill: false },
+        },
+        groups: [['series1', 'series2', 'series3']],
+      },
+      area: {
+        series: {
+          series1: { show: true, fill: true },
+          series2: { show: false, fill: false },
+          series3: { show: false, fill: false },
+        },
+        groups: [],
+      },
+      stackArea: {
+        series: {
+          series1: { show: true, fill: true },
+          series2: { show: true, fill: true },
+          series3: { show: true, fill: true },
+        },
+        groups: [['series1', 'series2', 'series3']],
+      },
+    };
+
+    const onChangeChartType = () => {
+      const config = chartTypeConfig[chartType.value];
+      if (!config) return;
+
+      Object.entries(config.series).forEach(([key, settings]) => {
+        Object.assign(chartData.series[key], settings);
+      });
+      chartData.groups = config.groups;
+    };
+
+    const onChangeInterpolation = () => {
+      Object.values(chartData.series).forEach((series) => {
+        series.interpolation = interpolation.value;
+      });
+    };
+
+    return {
+      chartData,
+      chartOptions,
+      chartType,
+      chartTypeList,
+      interpolation,
+      interpolationList,
+      chartSeries,
+      changeValue,
+      onChangeChartType,
+      onChangeInterpolation,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.section {
+  width: 100%;
+
+  &-title {
+    padding: 10px;
+
+    &--series1 {
+      background-color: #2B99F0;
+    }
+    &--series2 {
+      background-color: #8AC449;
+    }
+    &--series3 {
+      background-color: rgb(0, 196, 197);
+    }
+  }
+
+  &-body {
+    display: flex;
+    padding: 0 0 10px 10px;
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    .section-item {
+      display: flex;
+      width: 100%;
+      margin-top: 10px;
+
+      .ev-text-field,
+      .ev-input-number,
+      .ev-select {
+        width: auto;
+      }
+    }
+  }
+}
+</style>

--- a/docs/views/lineChart/example/PassingValue.vue
+++ b/docs/views/lineChart/example/PassingValue.vue
@@ -104,8 +104,8 @@ import EvInputNumber from '../../../../src/components/inputNumber/InputNumber';
 
       const chartData = reactive({
         series: {
-          series1: { name: 'series#1', interpolation: 'linear', passingValue: -1, fill: false },
-          series2: { name: 'series#1', interpolation: 'linear', passingValue: -1, show: false, fill: false },
+          series1: { name: 'series#1', interpolation: 'none', passingValue: -1, fill: false },
+          series2: { name: 'series#1', interpolation: 'none', passingValue: -1, show: false, fill: false },
         },
         labels: [
           dayjs(time),

--- a/docs/views/lineChart/props.js
+++ b/docs/views/lineChart/props.js
@@ -32,6 +32,8 @@ import LegendVirtualScroll from './example/LegendVirtualScroll';
 import LegendVirtualScrollRaw from '!!raw-loader!./example/LegendVirtualScroll';
 import Segments from './example/Segments';
 import SegmentsRaw from '!!raw-loader!./example/Segments';
+import Interpolation from './example/Interpolation';
+import InterpolationRaw from '!!raw-loader!./example/Interpolation';
 
 export default {
   mdText,
@@ -100,6 +102,11 @@ export default {
       description: 'passingValue를 설정하여 특정 시점에 line을 끊지 않고 자연스럽게 이을 수 있습니다.',
       component: PassingValue,
       parsedData: parseComponent(PassingValueRaw),
+    },
+    Interpolation: {
+      description: 'Interpolation 옵션을 설정하여 null Data를 보간하여 선을 그릴 수 있습니다.',
+      component: Interpolation,
+      parsedData: parseComponent(InterpolationRaw),
     },
     HoverWithGroup: {
       description: '',

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -146,12 +146,8 @@ class Line {
       curr.yp = y;
 
       if (isLinearInterpolation && curr.o === null) {
-        if (!this.isExistGrp) {
-          return;
-        }
-      }
-
-      if ((isNil(prevValid?.y) && !this.isExistGrp)
+        return;
+      } else if ((isNil(prevValid?.y) && !this.isExistGrp)
         || (!isLinearInterpolation && (isNil(prevValid?.y) || isNil(curr.o)))) {
         ctx.moveTo(x, y);
       } else {
@@ -235,7 +231,7 @@ class Line {
 
           if (ix === startIndex) {
             ctx.moveTo(currData.xp, currData.yp);
-          } else if (this.isExistGrp || currData.o !== null) {
+          } else if (currData.o !== null) {
             ctx.lineTo(currData.xp, currData.yp);
           }
 
@@ -243,7 +239,7 @@ class Line {
             for (let jx = endIndex; jx >= startIndex; jx--) {
               const nextData = this.data[jx];
               const xp = getXPos(nextData.x);
-              const bp = getYPos(nextData.b) ?? getYPos(0);
+              const bp = nextData.o === null ? getYPos(0) : getYPos(nextData.b) ?? getYPos(0);
               ctx.lineTo(xp, bp);
             }
 


### PR DESCRIPTION
### 이슈 내용 
- Stack Line/Area이고 Interpolation: linear 옵션을 사용할 때, null을 0으로 판단하고 그림 

### 변경 내용 
- Line은 데이터가 null일 경우, 다음 유효 지점으로 선을 자연스럽게 이어가도록 함
- Fill은 데이터가 null일 경우, 0을 기반으로 채움
- interpolation 전용 예제 코드 추가 
- passingValue 예제 코드에서 Interpolation 옵션을 기본값으로 설정 (none)


<img width="1372" height="768" alt="image" src="https://github.com/user-attachments/assets/314cb4d1-e8a2-47e5-bfed-e3fe336d574b" />

