### PR TITLE
[#2016] 3.4 > Chart > Y축이 음수이고 PlotBand의 from값이 0일때 이슈

### DIFF
--- a/docs/views/lineChart/example/PlotLine.vue
+++ b/docs/views/lineChart/example/PlotLine.vue
@@ -26,7 +26,7 @@ export default {
         dayjs(time).add(6, 'day'),
       ],
       data: {
-        series1: [100, 25, 36, 47, 0, 50, 80],
+        series1: [-50, 25, 36, 47, 0, 50, 80],
         series2: [80, 36, 25, 47, 15, 100, 0],
       },
     };
@@ -79,7 +79,7 @@ export default {
         autoScaleRatio: 0.1,
         plotLines: [{
           color: '#FF0000',
-          value: 50,
+          value: -50,
           segments: [6, 2],
           lineWidth: 1,
           label: {
@@ -89,7 +89,7 @@ export default {
         }],
         plotBands: [{
           color: 'rgba(250, 222, 76, 0.8)',
-          from: 20,
+          from: 0,
           to: 40,
           label: {
             show: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.201",
+  "version": "3.4.202",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -444,8 +444,12 @@ class Scale {
 
         const mergedPlotBandOpt = defaultsDeep({}, plotBand, PLOT_BAND_OPTION);
         const { from: userDefinedFrom, to: userDefinedTo, label: labelOpt } = mergedPlotBandOpt;
-        const from = userDefinedFrom ? Math.max(userDefinedFrom, axisMin) : axisMin;
-        const to = userDefinedTo ? Math.min(userDefinedTo, axisMax) : axisMax;
+        const from = !Util.isNullOrUndefined(userDefinedFrom)
+         ? Math.max(userDefinedFrom, axisMin)
+         : axisMin;
+        const to = !Util.isNullOrUndefined(userDefinedTo)
+          ? Math.min(userDefinedTo, axisMax)
+          : axisMax;
 
         this.setPlotBandStyle(mergedPlotBandOpt);
 


### PR DESCRIPTION
### 이슈 내용 
- Axis > PlotBand 옵션에서 from 을 0으로 지정할 경우, 0부터 그려지지 않고 차트 가장 하단부터 그려짐  (음수 축일때)
- <img width="1141" height="304" alt="image" src="https://github.com/user-attachments/assets/06e8ed5e-25d6-4384-b1f3-486478ccfced" />

### 처리 내용 
- 0을 falsy 로 판단하여 생긴 문제 
- null or undefined 검사로 변경 
- <img width="1168" height="353" alt="image" src="https://github.com/user-attachments/assets/065b6323-8e63-4c39-9528-5aeb01a1190f" />

### 기타 
- EVUI 버전 변경
- 예제 코드 일부 수정
