### PR TITLE
[#2020] [3.4.120] chart > axis > linear > 소수점 옵션 : auto 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -153,7 +153,7 @@ const chartData = {
 | plotBands      | Array                                       | ([상세](#plotband))       | plot band(임계영역 표시 용도) 설정                                                                 |                                                                                          |
 | formatter      | function                                    | null                      | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용                                            | (value, { prev, isDefaultMaxSameAsMin }) => value + '%'                                  |
 | title          | Object                                      | ([상세](#title))          | 라벨의 폰트 스타일을 설정                                                                          |                                                                                          |
-| scrollbar      | Object                                      | ([상세](#axes-scrollbar)) | 차트 축 스크롤 설정(range 옵션 설정되어 있어야 정상 동작합니다.)                                   |                                                                                          |
+| scrollbar      | Object                                      | ([상세](#axes-scrollbar)) | 차트 축 스크롤 설정(range 옵션 설정되어 있어야 정상 동작합니다.)                                   |                           
 
 ##### axesX
 
@@ -168,7 +168,9 @@ const chartData = {
 - Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌
   - 예를 들어, Label에 필요한 값이 1,500일 경우 '1.5K'로 표기
 - decimalPoint
+  - Number / 'auto'
   - 소수점 자릿수 표시 (default: 0)
+  - 'auto' 일 경우, 축의 min~max 값을 보고 적절한 자릿수 산출
 - range
   - 축의 min 값, max 값을 array로 넘겨줌 ([0, 100])
 
@@ -186,7 +188,7 @@ const chartData = {
   - 시간에 따라 x축 label이 움직일지의 여부
   - categoryMode일 때는 작동하지 않음.
 
-##### Logarithmic type
+##### Logarithmic type (Deprecated)
 
 - logarithmic Type Axis는 Axis의 min max를 로그로 계산하여 자동으로 추가 buffer값을 제공
 - Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -167,7 +167,7 @@ const chartData = {
   - 미지정 시 Chart 내부에서 해당 Axis 데이터의 max/min value를 기반으로 interval을 구함
 - Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌
   - 예를 들어, Label에 필요한 값이 1,500일 경우 '1.5K'로 표기
-- decimalPoint
+- decimalPoint (default: 'auto')
   - Number / 'auto'
   - 소수점 자릿수 표시 (default: 0)
   - 'auto' 일 경우, 축의 min~max 값을 보고 적절한 자릿수 산출
@@ -193,8 +193,6 @@ const chartData = {
 - logarithmic Type Axis는 Axis의 min max를 로그로 계산하여 자동으로 추가 buffer값을 제공
 - Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌
   - 예를 들어, Label에 필요한 값이 1,500일 경우 '1.5K'로 표
-- decimalPoint
-  - 소수점 자릿수 표시 (default: 0)
 - range
 
   - 축의 min 값, max 값을 array로 넘겨줌 ([0, 100])

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -126,6 +126,19 @@ const chartData =
 | title          | Object        | ([상세](#axes-title))     | 라벨의 폰트 스타일을 설정                                                                      |                                                         |
 | scrollbar      | Object        | ([상세](#axes-scrollbar)) | 차트 축 스크롤 설정(range 옵션 설정되어 있어야 정상 동작합니다.)                               |                                                         |
 
+##### linear type
+
+- interval (Axis Label 표기를 위한 interval)
+  - 미지정 시 Chart 내부에서 해당 Axis 데이터의 max/min value를 기반으로 interval을 구함
+- Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌
+  - 예를 들어, Label에 필요한 값이 1,500일 경우 '1.5K'로 표기
+- decimalPoint
+  - Number / 'auto'
+  - 소수점 자릿수 표시 (default: 0)
+  - 'auto' 일 경우, 축의 min~max 값을 보고 적절한 자릿수 산출
+- range
+  - 축의 min 값, max 값을 array로 넘겨줌 ([0, 100])
+
 ##### time type
 
 - interval (Axis Label 표기를 위한 interval)

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -132,7 +132,7 @@ const chartData =
   - 미지정 시 Chart 내부에서 해당 Axis 데이터의 max/min value를 기반으로 interval을 구함
 - Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌
   - 예를 들어, Label에 필요한 값이 1,500일 경우 '1.5K'로 표기
-- decimalPoint
+- decimalPoint (default: 'auto')
   - Number / 'auto'
   - 소수점 자릿수 표시 (default: 0)
   - 'auto' 일 경우, 축의 min~max 값을 보고 적절한 자릿수 산출

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -152,6 +152,19 @@ const chartData =
 | ---- | ------- | ------ | ------------------------------------------------------------------------------------------------------------- | ---------- |
 | flow | boolean | false  | 시간에 따라 x축 label이 움직일지의 여부, time type에서만 사용하길 권장.<br>categoryMode일 때는 작동하지 않음. |            |
 
+##### linear type
+
+- interval (Axis Label 표기를 위한 interval)
+  - 미지정 시 Chart 내부에서 해당 Axis 데이터의 max/min value를 기반으로 interval을 구함
+- Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌
+  - 예를 들어, Label에 필요한 값이 1,500일 경우 '1.5K'로 표기
+- decimalPoint
+  - Number / 'auto'
+  - 소수점 자릿수 표시 (default: 0)
+  - 'auto' 일 경우, 축의 min~max 값을 보고 적절한 자릿수 산출
+- range
+  - 축의 min 값, max 값을 array로 넘겨줌 ([0, 100])
+
 ##### time type
 
 - interval (Axis Label 표기를 위한 interval)
@@ -163,6 +176,26 @@ const chartData =
 - flow
   - 시간에 따라 x축 label이 움직일지의 여부
   - categoryMode일 때는 작동하지 않음.
+
+##### Logarithmic type (Deprecated)
+
+- logarithmic Type Axis는 Axis의 min max를 로그로 계산하여 자동으로 추가 buffer값을 제공
+- Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌
+  - 예를 들어, Label에 필요한 값이 1,500일 경우 '1.5K'로 표
+- decimalPoint
+  - 소수점 자릿수 표시 (default: 0)
+- range
+  - 축의 min 값, max 값을 array로 넘겨줌 ([0, 100])
+
+##### step type
+
+- timeMode
+  - Step Axis를 Time 기반으로 변경, default: false
+- timeFormat
+  - dayjs의 timeFormat 이용 [참고URL](https://day.js.org/docs/en/parse/string-format/)
+- range
+  - 축의 label의 minIndex, maxIndex 값을 array로 넘겨줌 ([0, 5])
+
 
 ##### labelStyle
 

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -158,7 +158,7 @@ const chartData =
   - 미지정 시 Chart 내부에서 해당 Axis 데이터의 max/min value를 기반으로 interval을 구함
 - Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌
   - 예를 들어, Label에 필요한 값이 1,500일 경우 '1.5K'로 표기
-- decimalPoint
+- decimalPoint (default: 'auto')
   - Number / 'auto'
   - 소수점 자릿수 표시 (default: 0)
   - 'auto' 일 경우, 축의 min~max 값을 보고 적절한 자릿수 산출
@@ -182,8 +182,6 @@ const chartData =
 - logarithmic Type Axis는 Axis의 min max를 로그로 계산하여 자동으로 추가 buffer값을 제공
 - Linear Type의 Axis Label은 각 숫자 단위에 맞춰 'K', 'M', 'G'로 숫자를 변환하여 보여줌
   - 예를 들어, Label에 필요한 값이 1,500일 경우 '1.5K'로 표
-- decimalPoint
-  - 소수점 자릿수 표시 (default: 0)
 - range
   - 축의 min 값, max 값을 array로 넘겨줌 ([0, 100])
 

--- a/docs/views/lineChart/example/Default.vue
+++ b/docs/views/lineChart/example/Default.vue
@@ -21,11 +21,11 @@
     setup() {
       const chartData = reactive({
         series: {
-          series1: { name: 'series#1', point: false },
-          series2: { name: 'series#2', point: false },
-          series3: { name: 'series#3', point: false },
-          series4: { name: 'series#4', point: false },
-          series5: { name: 'series#5', point: false },
+          series1: { name: '정수', point: false },
+          series2: { name: '소수점 2자리', point: false },
+          series3: { name: '소수점 3자리', point: false },
+          series4: { name: '소수점 4자리', point: false },
+          series5: { name: '소수점 5자리', point: false },
         },
         labels: [],
         data: {
@@ -77,6 +77,7 @@
           type: 'linear',
           showGrid: true,
           startToZero: true,
+          decimalPoint: 'auto',
           autoScaleRatio: 0.1,
         }],
       });
@@ -93,12 +94,22 @@
         timeValue = dayjs(timeValue).add(1, 'hour');
         chartData.labels.push(dayjs(timeValue));
 
-        Object.values(chartData.data).forEach((seriesData) => {
+        Object.values(chartData.data).forEach((seriesData, sIndex) => {
           if (isLive.value) {
             seriesData.shift();
           }
 
-          seriesData.push(Math.floor(Math.random() * ((999999 - 5) + 1)) + 5);
+          if (sIndex === 0) {
+            seriesData.push(Math.random() * 10000);
+          } else if (sIndex === 1) {
+            seriesData.push(Math.random() * 0.1);
+          } else if (sIndex === 2) {
+            seriesData.push(Math.random() * 0.01);
+          } else if (sIndex === 3) {
+            seriesData.push(Math.random() * 0.001);
+          } else {
+            seriesData.push(Math.random() * 0.0001);
+          }
         });
       };
 

--- a/docs/views/lineChart/example/Default.vue
+++ b/docs/views/lineChart/example/Default.vue
@@ -97,6 +97,8 @@
           if (isLive.value) {
             seriesData.shift();
           }
+
+          seriesData.push(Math.floor(Math.random() * ((999999 - 5) + 1)) + 5);
         });
       };
 

--- a/docs/views/lineChart/example/Default.vue
+++ b/docs/views/lineChart/example/Default.vue
@@ -21,11 +21,11 @@
     setup() {
       const chartData = reactive({
         series: {
-          series1: { name: '정수', point: false },
-          series2: { name: '소수점 2자리', point: false },
-          series3: { name: '소수점 3자리', point: false },
-          series4: { name: '소수점 4자리', point: false },
-          series5: { name: '소수점 5자리', point: false },
+          series1: { name: 'series#1', point: false },
+          series2: { name: 'series#2', point: false },
+          series3: { name: 'series#3', point: false },
+          series4: { name: 'series#4', point: false },
+          series5: { name: 'series#5', point: false },
         },
         labels: [],
         data: {
@@ -93,21 +93,9 @@
         timeValue = dayjs(timeValue).add(1, 'hour');
         chartData.labels.push(dayjs(timeValue));
 
-        Object.values(chartData.data).forEach((seriesData, sIndex) => {
+        Object.values(chartData.data).forEach((seriesData) => {
           if (isLive.value) {
             seriesData.shift();
-          }
-
-          if (sIndex === 0) {
-            seriesData.push(Math.random() * 10000);
-          } else if (sIndex === 1) {
-            seriesData.push(Math.random() * 0.1);
-          } else if (sIndex === 2) {
-            seriesData.push(Math.random() * 0.01);
-          } else if (sIndex === 3) {
-            seriesData.push(Math.random() * 0.001);
-          } else {
-            seriesData.push(Math.random() * 0.0001);
           }
         });
       };

--- a/docs/views/lineChart/example/Default.vue
+++ b/docs/views/lineChart/example/Default.vue
@@ -77,7 +77,6 @@
           type: 'linear',
           showGrid: true,
           startToZero: true,
-          decimalPoint: 'auto',
           autoScaleRatio: 0.1,
         }],
       });

--- a/src/components/chart/helpers/helpers.constant.js
+++ b/src/components/chart/helpers/helpers.constant.js
@@ -96,7 +96,7 @@ export const AXIS_OPTION = {
   timeFormat: 'mm:ss',
   range: null,
   interval: null,
-  decimalPoint: null,
+  decimalPoint: 'auto',
   labelStyle: {
     show: true,
     fontSize: 12,

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -89,7 +89,11 @@ class Scale {
     }
 
     if (this.autoScaleRatio) {
-      maxValue = Math.ceil(maxValue * (this.autoScaleRatio + 1));
+      if (this.decimalPoint) {
+        maxValue *= (this.autoScaleRatio + 1);
+      } else {
+        maxValue = Math.ceil(maxValue * (this.autoScaleRatio + 1));
+      }
     }
 
     if (this.startToZero) {
@@ -184,6 +188,13 @@ class Scale {
 
     if (graphMax - graphMin > (numberOfSteps * interval)) {
       interval = Math.ceil((graphMax - graphMin) / numberOfSteps);
+    }
+
+    if (this.decimalPoint === 'auto') {
+      this.decimalPoint = this?.getDecimalPointFromRange?.({
+        graphRange,
+        numberOfSteps,
+      });
     }
 
     return {

--- a/src/components/chart/scale/scale.linear.js
+++ b/src/components/chart/scale/scale.linear.js
@@ -32,7 +32,52 @@ class LinearScale extends Scale {
     const min = range.minValue;
     const step = range.maxSteps;
 
-    return this.interval ? this.interval : Math.ceil((max - min) / step);
+    if (this.interval) {
+      return this.interval;
+    }
+
+    if (this.decimalPoint) {
+      return (max - min) / step;
+    }
+
+    return Math.ceil((max - min) / step);
+  }
+
+    /**
+   * Get decimal point from range
+   * @param {object} {
+   *  graphRange: number,
+   *  numberOfSteps: number,
+   *  interval: number,
+   * }
+   * @returns {number} decimal point
+   */
+  getDecimalPointFromRange({
+    graphRange,
+    numberOfSteps,
+  }) {
+    if (numberOfSteps <= 0 || graphRange === 0) {
+      return 0;
+    }
+
+    const interval = graphRange / numberOfSteps;
+    if (interval === 0) {
+      return 0;
+    }
+
+    let decimals = 0;
+    let temp = interval;
+
+    while (temp < 1) {
+      temp *= 10;
+      decimals++;
+
+      if (decimals > 10) {
+        break;
+      }
+    }
+
+    return decimals;
   }
 }
 


### PR DESCRIPTION
### 문제상황 및 개선방향
- 'linear' 타입의 축에서 'decimalPoint' 옵션을 부여하지 않을 때 정수로만 축이 구성됨 
    - <img width="568" height="323" alt="image" src="https://github.com/user-attachments/assets/d5236788-070f-46f2-83c8-290cae0a71c4" />

- 데이터에 따라 동적으로 변경되는 'auto' 기능 필요 

### 변경내용
1. scale.linear.js
   - 데이터 범위에서 적절한 소수점 자릿수를 산출하는 함수 추가 
   - interval 계산로직에서 decimalPoint값이 있을 경우 Math.ceil 을 호출하지 않도록 함
2. scale.js
   - autoScaleRatio 옵션을 사용할 때, decimalPoint값이 있다면 Math.ceil을 호출하지 않도록 함 
3. docs 업데이트 


![auto decimal](https://github.com/user-attachments/assets/8aa0907a-f357-4fea-9235-715a7a47cb77)


### TODO
- 예제 코드 원복
- 3.4 대응으로는 별도의 PR 오픈 예정