### PR TITLE
[#2022] 3.4 > Chart > Axis > showAxisTick 옵션 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -153,7 +153,8 @@ const chartData = {
 | plotBands      | Array                                       | ([상세](#plotband))       | plot band(임계영역 표시 용도) 설정                                                                 |                                                                                          |
 | formatter      | function                                    | null                      | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용                                            | (value, { prev, isDefaultMaxSameAsMin }) => value + '%'                                  |
 | title          | Object                                      | ([상세](#title))          | 라벨의 폰트 스타일을 설정                                                                          |                                                                                          |
-| scrollbar      | Object                                      | ([상세](#axes-scrollbar)) | 차트 축 스크롤 설정(range 옵션 설정되어 있어야 정상 동작합니다.)                                   |                           
+| scrollbar      | Object                                      | ([상세](#axes-scrollbar)) | 차트 축 스크롤 설정(range 옵션 설정되어 있어야 정상 동작합니다.)                                   |                                                                                          |
+| showAxisTick   | Boolean   | false    | 보조 눈금 표시 여부                                     |                                                         |
 
 ##### axesX
 

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -154,7 +154,7 @@ const chartData = {
 | formatter      | function                                    | null                      | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용                                            | (value, { prev, isDefaultMaxSameAsMin }) => value + '%'                                  |
 | title          | Object                                      | ([상세](#title))          | 라벨의 폰트 스타일을 설정                                                                          |                                                                                          |
 | scrollbar      | Object                                      | ([상세](#axes-scrollbar)) | 차트 축 스크롤 설정(range 옵션 설정되어 있어야 정상 동작합니다.)                                   |                                                                                          |
-| showAxisTick   | Boolean   | false    | 보조 눈금 표시 여부                                     |                                                         |
+| showAxisTick   | Boolean   | true    | 보조 눈금 표시 여부                                     |                                                         |
 
 ##### axesX
 

--- a/docs/views/barChart/example/Default.vue
+++ b/docs/views/barChart/example/Default.vue
@@ -24,12 +24,16 @@
         thickness: 1,
         axesX: [{
           type: 'step',
+          showAxisTick: true,
+          axisLineColor: '#25262E',
         }],
         axesY: [{
           showAxis: true,
           type: 'linear',
           startToZero: true,
           autoScaleRatio: 0.1,
+          showAxisTick: true,
+          axisLineColor: '#25262E',
         }],
       };
 

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -125,6 +125,7 @@ const chartData =
 | formatter      | function      | null                      | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용                                        | (value, { prev, isDefaultMaxSameAsMin }) => value + '%' |
 | title          | Object        | ([상세](#axes-title))     | 라벨의 폰트 스타일을 설정                                                                      |                                                         |
 | scrollbar      | Object        | ([상세](#axes-scrollbar)) | 차트 축 스크롤 설정(range 옵션 설정되어 있어야 정상 동작합니다.)                               |                                                         |
+| showAxisTick   | Boolean   | false    | 보조 눈금 표시 여부                                     |                                                         |
 
 ##### linear type
 

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -125,7 +125,7 @@ const chartData =
 | formatter      | function      | null                      | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용                                        | (value, { prev, isDefaultMaxSameAsMin }) => value + '%' |
 | title          | Object        | ([상세](#axes-title))     | 라벨의 폰트 스타일을 설정                                                                      |                                                         |
 | scrollbar      | Object        | ([상세](#axes-scrollbar)) | 차트 축 스크롤 설정(range 옵션 설정되어 있어야 정상 동작합니다.)                               |                                                         |
-| showAxisTick   | Boolean   | false    | 보조 눈금 표시 여부                                     |                                                         |
+| showAxisTick   | Boolean   | true    | 보조 눈금 표시 여부                                     |                                                         |
 
 ##### linear type
 

--- a/docs/views/heatMap/example/StepAxis.vue
+++ b/docs/views/heatMap/example/StepAxis.vue
@@ -53,6 +53,8 @@ import { reactive, ref, watch } from 'vue';
           labelStyle: {
             alignToGridLine: true,
           },
+          showAxisTick: true,
+          axisLineColor: '#25262E',
         }],
         axesY: [{
           type: 'step',
@@ -60,6 +62,8 @@ import { reactive, ref, watch } from 'vue';
           labelStyle: {
             alignToGridLine: true,
           },
+          showAxisTick: true,
+          axisLineColor: '#25262E',
         }],
         heatMapColor: {
           min: '#CAF0F8',

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -145,7 +145,7 @@ const chartData =
 | plotBands      | Array    | ([상세](#plotband))   | plot band(임계영역 표시 용도) 설정                            |                                                         |
 | formatter      | function | null                  | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용       | (value, { prev, isDefaultMaxSameAsMin }) => value + '%' |
 | title          | Object   | ([상세](#title))      | 라벨의 폰트 스타일을 설정                                     |                                                         |
-| showAxisTick   | Boolean   | false    | 보조 눈금 표시 여부                                     |                                                         |
+| showAxisTick   | Boolean   | true    | 보조 눈금 표시 여부                                     |                                                         |
 
 ##### axesX
 

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -145,6 +145,7 @@ const chartData =
 | plotBands      | Array    | ([상세](#plotband))   | plot band(임계영역 표시 용도) 설정                            |                                                         |
 | formatter      | function | null                  | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용       | (value, { prev, isDefaultMaxSameAsMin }) => value + '%' |
 | title          | Object   | ([상세](#title))      | 라벨의 폰트 스타일을 설정                                     |                                                         |
+| showAxisTick   | Boolean   | false    | 보조 눈금 표시 여부                                     |                                                         |
 
 ##### axesX
 

--- a/docs/views/lineChart/example/Default.vue
+++ b/docs/views/lineChart/example/Default.vue
@@ -72,12 +72,16 @@
             return dayjs(value)
                 .format('DD HH:mm');
           },
+          showAxisTick: true,
+          axisLineColor: '#25262E',
         }],
         axesY: [{
           type: 'linear',
           showGrid: true,
           startToZero: true,
           autoScaleRatio: 0.1,
+          showAxisTick: true,
+          axisLineColor: '#25262E',
         }],
       });
 

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -100,7 +100,8 @@ const chartData =
   | plotLines | Array | ([상세](#plotline)) | plot line(임계선 표시 용도) 설정 | |
   | plotBands | Array | ([상세](#plotband)) | plot band(임계영역 표시 용도) 설정 | |
   | formatter      | function | null                | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용                   | (value, { prev, isDefaultMaxSameAsMin }) => value + '%' |
-  | title | Object | ([상세](#title)) | 라벨의 폰트 스타일을 설정 | |
+  | title | Object | ([상세](#title)) | 라벨의 폰트 스타일을 설정 | |  
+  | showAxisTick   | Boolean   | false    | 보조 눈금 표시 여부                                     |                                                         |
 
 ##### axesX
 

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -101,7 +101,7 @@ const chartData =
   | plotBands | Array | ([상세](#plotband)) | plot band(임계영역 표시 용도) 설정 | |
   | formatter      | function | null                | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용                   | (value, { prev, isDefaultMaxSameAsMin }) => value + '%' |
   | title | Object | ([상세](#title)) | 라벨의 폰트 스타일을 설정 | |  
-  | showAxisTick   | Boolean   | false    | 보조 눈금 표시 여부                                     |                                                         |
+  | showAxisTick   | Boolean   | true    | 보조 눈금 표시 여부                                     |                                                         |
 
 ##### axesX
 

--- a/docs/views/scatterChart/example/Default.vue
+++ b/docs/views/scatterChart/example/Default.vue
@@ -147,6 +147,7 @@ export default {
         plotLines: [],
         plotBands: [],
         formatter: null,
+        showAxisTick: true,
       }],
       title: {
         text: '',

--- a/src/components/chart/helpers/helpers.constant.js
+++ b/src/components/chart/helpers/helpers.constant.js
@@ -92,6 +92,7 @@ export const AXIS_OPTION = {
   axisLineWidth: 1,
   showGrid: true,
   gridLineColor: '#C9CFDC',
+  showAxisTick: true,
   showIndicator: false,
   timeFormat: 'mm:ss',
   range: null,

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -282,6 +282,8 @@ class Scale {
     const offsetPoint = aPos[this.units.rectOffset(this.position)];
     const offsetCounterPoint = aPos[this.units.rectOffsetCounter(this.position)];
 
+    const AXIS_TICK_LENGTH = 5;
+
     let aliasPixel;
 
     this.drawAxisTitle(chartRect, labelOffset);
@@ -309,8 +311,8 @@ class Scale {
         ctx.moveTo(startPoint, offsetPoint + aliasPixel);
         ctx.lineTo(endPoint, offsetPoint + aliasPixel);
       } else {
-        ctx.moveTo(offsetPoint + aliasPixel + 1, startPoint);
-        ctx.lineTo(offsetPoint + aliasPixel + 1, endPoint);
+        ctx.moveTo(offsetPoint + aliasPixel, startPoint);
+        ctx.lineTo(offsetPoint + aliasPixel, endPoint);
       }
       ctx.stroke();
       ctx.closePath();
@@ -404,9 +406,23 @@ class Scale {
                 });
               }
             }
+
+            if (this.showAxisTick) {
+              ctx.beginPath();
+              ctx.strokeStyle = this.axisLineColor;
+              ctx.moveTo(linePosition, offsetPoint);
+              ctx.lineTo(linePosition, offsetPoint + AXIS_TICK_LENGTH);
+              ctx.stroke();
+              ctx.closePath();
+            }
+
             if ((ix !== 0 || options?.axesX[0].flow) && this.showGrid) {
+              ctx.beginPath();
+              ctx.strokeStyle = this.gridLineColor;
               ctx.moveTo(linePosition, offsetPoint);
               ctx.lineTo(linePosition, offsetCounterPoint);
+              ctx.stroke();
+              ctx.closePath();
             }
           } else {
             labelPoint = this.position === 'left' ? offsetPoint - 10 : offsetPoint + 10;
@@ -418,14 +434,24 @@ class Scale {
               linePosition -= 1;
             }
 
+            if (this.showAxisTick) {
+              ctx.beginPath();
+              ctx.strokeStyle = this.axisLineColor;
+              ctx.moveTo(offsetPoint + (this.axisLineWidth ?? 1), linePosition);
+              ctx.lineTo(offsetPoint - AXIS_TICK_LENGTH, linePosition);
+              ctx.stroke();
+              ctx.closePath();
+            }
+
             if (ix !== 0 && this.showGrid) {
+              ctx.beginPath();
+              ctx.strokeStyle = this.gridLineColor;
               ctx.moveTo(offsetPoint, linePosition);
               ctx.lineTo(offsetCounterPoint, linePosition);
+              ctx.stroke();
+              ctx.closePath();
             }
           }
-
-          ctx.stroke();
-          ctx.closePath();
         }
       }
     }

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -137,6 +137,8 @@ class StepScale extends Scale {
     const offsetCounterPoint = aPos[this.units.rectOffsetCounter(this.position)];
     const maxWidth = this.labelStyle?.maxWidth ?? chartRect.chartWidth / (steps + 2);
 
+    const AXIS_TICK_LENGTH = 5;
+
     this.drawAxisTitle(chartRect, labelOffset);
 
     if (this.labelStyle?.show) {
@@ -245,9 +247,22 @@ class StepScale extends Scale {
             }
           }
 
+          if (this.showAxisTick) {
+            ctx.beginPath();
+            ctx.strokeStyle = this.axisLineColor;
+            ctx.moveTo(linePosition, offsetPoint);
+            ctx.lineTo(linePosition, offsetPoint + AXIS_TICK_LENGTH);
+            ctx.stroke();
+            ctx.closePath();
+          }
+
           if (index > 0 && this.showGrid) {
+            ctx.beginPath();
+            ctx.strokeStyle = this.gridLineColor;
             ctx.moveTo(linePosition, offsetPoint);
             ctx.lineTo(linePosition, offsetCounterPoint);
+            ctx.stroke();
+            ctx.closePath();
           }
         } else {
           labelPoint = this.position === 'left' ? offsetPoint - 10 : offsetPoint + 10;
@@ -255,9 +270,22 @@ class StepScale extends Scale {
           ctx.fillText(labelText, labelPoint, yPoint);
           drawnLabels.push(labelText);
 
+          if (this.showAxisTick) {
+            ctx.beginPath();
+            ctx.strokeStyle = this.axisLineColor;
+            ctx.moveTo(offsetPoint + (this.axisLineWidth ?? 1), linePosition);
+            ctx.lineTo(offsetPoint - AXIS_TICK_LENGTH, linePosition);
+            ctx.stroke();
+            ctx.closePath();
+          }
+
           if (index > 0 && this.showGrid) {
-            ctx.moveTo(offsetPoint, linePosition);
-            ctx.lineTo(offsetCounterPoint, linePosition);
+              ctx.beginPath();
+              ctx.strokeStyle = this.gridLineColor;
+              ctx.moveTo(offsetPoint, linePosition);
+              ctx.lineTo(offsetCounterPoint, linePosition);
+              ctx.stroke();
+              ctx.closePath();
           }
         }
         ctx.stroke();

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -250,8 +250,8 @@ class StepScale extends Scale {
           if (this.showAxisTick) {
             ctx.beginPath();
             ctx.strokeStyle = this.axisLineColor;
-            ctx.moveTo(linePosition, offsetPoint);
-            ctx.lineTo(linePosition, offsetPoint + AXIS_TICK_LENGTH);
+            ctx.moveTo(labelCenter + (labelGap / 2), offsetPoint);
+            ctx.lineTo(labelCenter + (labelGap / 2), offsetPoint + AXIS_TICK_LENGTH);
             ctx.stroke();
             ctx.closePath();
           }
@@ -273,8 +273,8 @@ class StepScale extends Scale {
           if (this.showAxisTick) {
             ctx.beginPath();
             ctx.strokeStyle = this.axisLineColor;
-            ctx.moveTo(offsetPoint + (this.axisLineWidth ?? 1), linePosition);
-            ctx.lineTo(offsetPoint - AXIS_TICK_LENGTH, linePosition);
+            ctx.moveTo(offsetPoint + (this.axisLineWidth ?? 1), yPoint);
+            ctx.lineTo(offsetPoint - AXIS_TICK_LENGTH, yPoint);
             ctx.stroke();
             ctx.closePath();
           }

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -132,6 +132,8 @@ class TimeCategoryScale extends Scale {
     const offsetPoint = aPos[this.units.rectOffset(this.position)];
     const offsetCounterPoint = aPos[this.units.rectOffsetCounter(this.position)];
 
+    const AXIS_TICK_LENGTH = 5;
+
     this.drawAxisTitle(chartRect, labelOffset);
 
     // label font 설정
@@ -253,24 +255,51 @@ class TimeCategoryScale extends Scale {
             });
           }
         }
+
+        if (this.showAxisTick) {
+          ctx.beginPath();
+          ctx.strokeStyle = this.axisLineColor;
+          ctx.moveTo(linePosition, offsetPoint);
+          ctx.lineTo(linePosition, offsetPoint + AXIS_TICK_LENGTH);
+          ctx.stroke();
+          ctx.closePath();
+        }
+
         if (
           ix < oriSteps && this.showGrid && (
             isStartPointRightOfRectStart || (!isStartPointRightOfRectStart && ix !== 0)
           )
         ) {
-          ctx.moveTo(linePosition, offsetPoint);
-          ctx.lineTo(linePosition, offsetCounterPoint);
+            ctx.beginPath();
+            ctx.strokeStyle = this.gridLineColor;
+            ctx.moveTo(linePosition, offsetPoint);
+            ctx.lineTo(linePosition, offsetCounterPoint);
+            ctx.stroke();
+            ctx.closePath();
         }
       } else {
         labelPoint = this.position === 'left' ? offsetPoint - 10 : offsetPoint + 10;
         ctx.fillText(labelText, labelPoint, labelCenter);
 
+        if (this.showAxisTick) {
+          ctx.beginPath();
+          ctx.strokeStyle = this.axisLineColor;
+          ctx.moveTo(offsetPoint + (this.axisLineWidth ?? 1), linePosition);
+          ctx.lineTo(offsetPoint - AXIS_TICK_LENGTH, linePosition);
+          ctx.stroke();
+          ctx.closePath();
+        }
+
         if (
           ix < oriSteps && this.showGrid && (
             isStartPointRightOfRectStart || (!isStartPointRightOfRectStart && ix !== 0)
           )) {
-          ctx.moveTo(offsetPoint, linePosition);
-          ctx.lineTo(offsetCounterPoint, linePosition);
+              ctx.beginPath();
+              ctx.strokeStyle = this.gridLineColor;
+              ctx.moveTo(offsetPoint, linePosition);
+              ctx.lineTo(offsetCounterPoint, linePosition);
+              ctx.stroke();
+              ctx.closePath();
         }
       }
 


### PR DESCRIPTION
### 요구사항 
- 축 > 보조눈금 필요

### 변경내용 
- Axis > `showAxisTick` 옵션 추가 
- 색상은 기존 axisLineColor를 따름
- 설명 추가

### Example
1. y: linear / x: time
   - <img width="574" height="198" alt="image" src="https://github.com/user-attachments/assets/e2c0e457-957f-4737-993b-8c4a84fd8feb" />
2. y: step / x: time
   - <img width="574" height="228" alt="image" src="https://github.com/user-attachments/assets/9ba150d5-2795-4445-94b2-379f240372cc" />
3. y: linear / x: step
   - <img width="533" height="280" alt="image" src="https://github.com/user-attachments/assets/053a42a2-61cf-4c7e-bb2b-f1acd027f40a" />
4. x: real time 
   - <img width="612" height="130" alt="image" src="https://github.com/user-attachments/assets/0e9770c4-3e58-4241-83ab-8c936d3ebe46" />


### TODO
- 임시 테스트 코드 삭제