### PR TITLE
유효한 데이터 틱을 찾을때 최대 1틱의 간격까지 확인합니다.(2/2)

### DIFF
--- a/docs/views/lineChart/example/Event.vue
+++ b/docs/views/lineChart/example/Event.vue
@@ -48,7 +48,7 @@
           dayjs(time).add(6, 'day'),
         ],
         data: {
-          series1: [100, 25, null, null, 0, null, null],
+          series1: [null, null, null, null, null, null, null],
           series2: [80, 36, null, null, 15, null, null],
         },
       });
@@ -87,6 +87,8 @@
           fixedPosTop: true,
           showIndicator: true,
           useDeselectOverflow: true,
+          useLabelOpacity: false,
+          useSeriesOpacity: false,
           limit: 1,
         },
         maxTip: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.133",
+  "version": "3.4.134",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -358,7 +358,9 @@ class Line {
         });
 
         if (validData.length === 0) {
-          return item;
+          gdata.forEach((point, idx) => {
+            validData.push({ ...point, originalIndex: idx });
+          });
         }
 
         // 이진 탐색으로 가장 가까운 포인트 찾기

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1034,8 +1034,7 @@ const modules = {
       }
     }
 
-    let closestDistance = this.seriesList?.[referenceSeries]?.useLinearInterpolation?.()
-      ? Infinity : avgInterval;
+    let closestDistance = Infinity;
     let closestIndex = -1;
 
     // 각 라벨에서 가장 가까운 것 찾기
@@ -1066,6 +1065,23 @@ const modules = {
           }
         }
       }
+    }
+
+    if (closestDistance >= avgInterval) {
+      const useLinearInterpolation = sIds.some((sId) => {
+        const series = this.seriesList[sId];
+
+        if (series?.show) {
+          const passingValue = series.passingValue;
+          const interpolation = series.interpolation;
+          const hasPassingValueInData = series.hasPassingValueInData;
+
+          return interpolation === 'linear' || (interpolation === 'none' && !!passingValue && hasPassingValueInData);
+        }
+
+        return false;
+      });
+      return useLinearInterpolation ? closestIndex : -1;
     }
 
     return closestIndex;


### PR DESCRIPTION
bug fix
1. 유효한 데이터가 하나도 없을 경우 라벨 선택이 안되는 버그
2. 시리즈가 여러개일 경우에, referenc series는 interpolation이 아니고 다른 시리즈는 interpolation인 경우