### PR TITLE
[#2028] Layout > Context Menu > Slot 추가

### DIFF
--- a/docs/views/contextMenu/api/contextMenu.md
+++ b/docs/views/contextMenu/api/contextMenu.md
@@ -12,16 +12,28 @@
       isShowMenu: true, // Boolean - 항목 클릭시에도 메뉴 유지
       click: () => { ... }, // 클릭 시 발생하는 메소드
     },
-    { ... },
+    {
+      text: '기본 텍스트',
+      slotKey: 'customItem', // slot key 지정
+      click: () => { ... },
+    },
     { ... },
   ]"
-/>
+>
+  <!-- slotKey로 지정된 slot -->
+  <template #customItem="{ item }">
+    <span style="color: red;">{{ item.text }} - 커스텀</span>
+  </template>
+</ev-context-menu>
 ```
 - <컨텍스트메뉴>는 특정 영역에 우클릭이벤트(@contextmenu="REF명.show")에서 실행 가능
 - 메뉴 값에 바인딩되는 items는 nested 구조
 - 텍스트명, 아이콘, 항목 사용여부, 클릭 이벤트 바인딩 가능
 - 클릭 시 item.click이 실행되며 <컨텍스트메뉴>전체가 hide
 - nested 구조의 항목에서 같은 레벨의 항목에 mouseenter를 하였을 때, 해당 레벨의 자식 컴포넌트가 숨김처리됨
+- slotKey를 사용하여 메뉴 항목의 텍스트를 커스터마이징할 수 있음
+- slotKey가 지정된 항목은 기본 text 대신 해당 slot의 내용이 렌더링됨
+- slot에는 item 객체가 전달되어 메뉴 항목의 모든 정보에 접근 가능
 
 
 ### Binding
@@ -43,5 +55,6 @@
 | | | disabled | <컨텍스트메뉴> 항목 사용 여부 | false, true |
 | | | isShowMenu | 클릭한 항목 선택 후에도 <컨텍스트 메뉴> 유지 | false, true |
 | | | click | <컨텍스트메뉴> 항목 클릭 시 발생하는 메소드 |  |
+| | | slotKey | <컨텍스트메뉴> 항목에 slot key. slotKey가 지정된 경우 해당 slot을 사용하여 커스텀 텍스트 렌더링 가능 |  |
 | customClass | String | '' | <컨텍스트메뉴>에 지정할 클래스명 | |
 | isShowMenuOnClick | Boolean | false | <컨텍스트 메뉴> 항목 및 영역 외 클릭 시에도 메뉴 유지 | |

--- a/docs/views/contextMenu/example/Default.vue
+++ b/docs/views/contextMenu/example/Default.vue
@@ -52,6 +52,21 @@
         <template #customText="{ item }">
           <span>{{ item.text }} - CUSTOM TEXT</span>
         </template>
+        <template #customText1="{ item }">
+          <span>{{ item.text }} - CUSTOM TEXT1</span>
+        </template>
+        <template #customText2="{ item }">
+          <span>{{ item.text }} - CUSTOM TEXT2</span>
+        </template>
+        <template #customText2-1="{ item }">
+          <span>{{ item.text }} - CUSTOM TEXT2-1</span>
+        </template>
+        <template #customText2-2="{ item }">
+          <span>{{ item.text }} - CUSTOM TEXT2-2</span>
+        </template>
+        <template #customText3="{ item }">
+          <span>{{ item.text }} - CUSTOM TEXT3</span>
+        </template>
       </ev-context-menu>
       컨텍스트 메뉴 우클릭 영역
     </div>
@@ -169,8 +184,34 @@ export default {
     const menuItems3 = ref([
       {
         text: 'TEXT1',
+        slotKey: 'customText1',
         iconClass: 'ev-icon-s-panel-out',
-        slotKey: 'customText',
+        disabled: true,
+        click: () => console.log('CLICK text1'),
+      },
+      {
+        text: 'TEXT2',
+        iconClass: 'ev-icon-s-pause',
+        slotKey: 'customText2',
+        children: [
+          {
+            text: 'TEXT2-1',
+            slotKey: 'customText2-1',
+            iconClass: 'ev-icon-server2',
+            click: () => console.log('CLICK text2-1'),
+          },
+          {
+            text: 'TEXT2-2',
+            slotKey: 'customText2-2',
+            disabled: true,
+            iconClass: 'ev-icon-server',
+          },
+        ],
+      },
+      {
+        text: 'TEXT3',
+        disabled: true,
+        slotKey: 'customText3',
       },
     ]);
 

--- a/docs/views/contextMenu/example/Default.vue
+++ b/docs/views/contextMenu/example/Default.vue
@@ -39,6 +39,23 @@
       </span>
     </div>
   </div>
+  <div class="case">
+    <p class="case-title">Custom Text</p>
+    <div
+      class="sample-context"
+      @contextmenu.prevent="menu3.show"
+    >
+      <ev-context-menu
+        ref="menu3"
+        :items="menuItems3"
+      >
+        <template #customText="{ item }">
+          <span>{{ item.text }} - CUSTOM TEXT</span>
+        </template>
+      </ev-context-menu>
+      컨텍스트 메뉴 우클릭 영역
+    </div>
+  </div>
 </template>
 
 <script>
@@ -148,6 +165,15 @@ export default {
       });
     };
 
+    const menu3 = ref(null);
+    const menuItems3 = ref([
+      {
+        text: 'TEXT1',
+        iconClass: 'ev-icon-s-panel-out',
+        slotKey: 'customText',
+      },
+    ]);
+
     return {
       menu,
       menuItems,
@@ -155,6 +181,8 @@ export default {
       menu2,
       menuItems2,
       addChild,
+      menu3,
+      menuItems3,
     };
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.134",
+  "version": "3.4.135",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/contextMenu/ContextMenu.vue
+++ b/src/components/contextMenu/ContextMenu.vue
@@ -9,7 +9,18 @@
         :items="items"
         :style="menuStyle"
         :comp="comp"
-      />
+      >
+        <template
+          v-for="(_, slotName) in $slots"
+          :key="slotName"
+          #[slotName]="slotProps"
+        >
+          <slot
+            :name="slotName"
+            v-bind="slotProps"
+          />
+        </template>
+      </menu-list>
     </teleport>
   </template>
 </template>

--- a/src/components/contextMenu/MenuList.vue
+++ b/src/components/contextMenu/MenuList.vue
@@ -15,7 +15,18 @@
           class="ev-menu-li-prefix"
           :class="item.iconClass"
         />
-        {{ item.text }}
+        <span class="ev-menu-li-text">
+          <slot
+            v-if="item.slotKey"
+            :name="item.slotKey"
+            :item="item"
+          >
+            {{ item.text }}
+          </slot>
+          <template v-else>
+            {{ item.text }}
+          </template>
+        </span>
         <i
           v-if="item.children || item.isShowMenu"
           class="ev-menu-li-suffix ev-icon-arrow-right2"
@@ -31,7 +42,18 @@
         :comp="comp"
         :items="childrenItems"
         :style="menuStyle"
-      />
+      >
+        <template
+          v-for="(_, slotName) in $slots"
+          :key="slotName"
+          #[slotName]="slotProps"
+        >
+          <slot
+            :name="slotName"
+            v-bind="slotProps"
+          />
+        </template>
+      </component>
     </template>
   </div>
 </template>
@@ -151,5 +173,10 @@ export default {
 .ev-menu-li-prefix {
   position: absolute;
   left: 3px;
+}
+
+.ev-menu-li-text {
+  display: inline-block;
+  padding-left: 20px;
 }
 </style>

--- a/src/components/menu/Menu.vue
+++ b/src/components/menu/Menu.vue
@@ -9,7 +9,18 @@
       :disabled="disabled"
       :comp="component"
       @click="clickMenu"
-    />
+    >
+      <template
+        v-for="(_, slotName) in $slots"
+        :key="slotName"
+        #[slotName]="slotProps"
+      >
+        <slot
+          :name="slotName"
+          v-bind="slotProps"
+        />
+      </template>
+    </menu-item>
   </ul>
 </template>
 

--- a/src/components/menu/MenuItem.vue
+++ b/src/components/menu/MenuItem.vue
@@ -21,7 +21,18 @@
         :class="['front-icon', item.iconClass]"
       />
       <span class="text">
-        {{ item.text || item.value }}
+        <slot
+          v-if="item.slotKey"
+          :name="item.slotKey"
+          :item="item"
+          :depth="depth"
+          :selected-item="selectedItem"
+        >
+          {{ item.text || item.value }}
+        </slot>
+        <template v-else>
+          {{ item.text || item.value }}
+        </template>
       </span>
       <span
         v-if="expandable && hasChild"
@@ -83,6 +94,9 @@ export default {
           return false;
         } else if (obj.disabled !== undefined && typeof obj.disabled !== 'boolean') {
           console.warn('[EVUI][Menu] disabled attribute must be \'Boolean\' type.');
+          return false;
+        } else if (obj.slotKey !== undefined && typeof obj.slotKey !== 'string') {
+          console.warn('[EVUI][Menu] slotKey attribute must be \'String\' type.');
           return false;
         }
         return true;


### PR DESCRIPTION
[이슈]
- context menu 에서 텍스트를 변경할 때 class를 사용하여 css로 변경하는 어려움이 있음

[수정 내용]
- context menu item에 slotKey를 추가하여 item의 slotKey가 있으면 slot 추가하도록 수정

[기대 동작]
<img width="548" height="494" alt="image" src="https://github.com/user-attachments/assets/fce1583b-5c6a-40cc-b4eb-118179e69cd4" />
