### PR TITLE
[#2020] [3.4.204] chart > axis > linear > 소수점 옵션 : auto 추가

### DIFF
--- a/docs/views/lineChart/example/Default.vue
+++ b/docs/views/lineChart/example/Default.vue
@@ -21,11 +21,11 @@
     setup() {
       const chartData = reactive({
         series: {
-          series1: { name: 'series#1', point: false },
-          series2: { name: 'series#2', point: false },
-          series3: { name: 'series#3', point: false },
-          series4: { name: 'series#4', point: false },
-          series5: { name: 'series#5', point: false },
+          series1: { name: '정수', point: false },
+          series2: { name: '소수점 2자리', point: false },
+          series3: { name: '소수점 3자리', point: false },
+          series4: { name: '소수점 4자리', point: false },
+          series5: { name: '소수점 5자리', point: false },
         },
         labels: [],
         data: {
@@ -77,6 +77,7 @@
           type: 'linear',
           showGrid: true,
           startToZero: true,
+          decimalPoint: 'auto',
           autoScaleRatio: 0.1,
         }],
       });
@@ -93,12 +94,22 @@
         timeValue = dayjs(timeValue).add(1, 'hour');
         chartData.labels.push(dayjs(timeValue));
 
-        Object.values(chartData.data).forEach((seriesData) => {
+        Object.values(chartData.data).forEach((seriesData, sIndex) => {
           if (isLive.value) {
             seriesData.shift();
           }
 
-          seriesData.push(Math.floor(Math.random() * ((999999 - 5) + 1)) + 5);
+          if (sIndex === 0) {
+            seriesData.push(Math.random() * 10000);
+          } else if (sIndex === 1) {
+            seriesData.push(Math.random() * 0.1);
+          } else if (sIndex === 2) {
+            seriesData.push(Math.random() * 0.01);
+          } else if (sIndex === 3) {
+            seriesData.push(Math.random() * 0.001);
+          } else {
+            seriesData.push(Math.random() * 0.0001);
+          }
         });
       };
 
@@ -131,11 +142,11 @@
 </script>
 
 <style lang="scss" scoped>
-  .case {
-    height: 100%;
-  }
-  .toggle-label {
-    vertical-align: top;
-    margin-right: 7px;
-  }
+.case {
+  height: 100%;
+}
+.toggle-label {
+  vertical-align: top;
+  margin-right: 7px;
+}
 </style>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.205",
+  "version": "3.4.206",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/helpers/helpers.constant.js
+++ b/src/components/chart/helpers/helpers.constant.js
@@ -96,7 +96,7 @@ export const AXIS_OPTION = {
   timeFormat: 'mm:ss',
   range: null,
   interval: null,
-  decimalPoint: null,
+  decimalPoint: 'auto',
   labelStyle: {
     show: true,
     fontSize: 12,

--- a/src/components/chart/scale/scale.linear.js
+++ b/src/components/chart/scale/scale.linear.js
@@ -30,6 +30,8 @@ class LinearScale extends Scale {
   getInterval(range) {
     if (this.interval) return this.interval;
 
+    let _interval = 0;
+
     const max = range.maxValue;
     const min = range.minValue;
     const steps = range.maxSteps;
@@ -59,15 +61,53 @@ class LinearScale extends Scale {
         }
       }
 
-      return Math.ceil(
-        Math.max(
+      _interval = Math.max(
           Math.abs(min) / (negativeSteps || 1),
           Math.abs(max) / (positiveSteps || 1),
-        ),
-      );
+        );
+    } else {
+      _interval = (max - min) / steps;
     }
-    return Math.ceil((max - min) / steps);
+
+    return this.decimalPoint ? _interval : Math.ceil(_interval);
   }
+
+      /**
+   * Get decimal point from range
+   * @param {object} {
+   *  graphRange: number,
+   *  numberOfSteps: number,
+   *  interval: number,
+   * }
+   * @returns {number} decimal point
+   */
+    getDecimalPointFromRange({
+      graphRange,
+      numberOfSteps,
+    }) {
+      if (numberOfSteps <= 0 || graphRange === 0) {
+        return 0;
+      }
+
+      const interval = graphRange / numberOfSteps;
+      if (interval === 0) {
+        return 0;
+      }
+
+      let decimals = 0;
+      let temp = interval;
+
+      while (temp < 1) {
+        temp *= 10;
+        decimals++;
+
+        if (decimals > 10) {
+          break;
+        }
+      }
+
+      return decimals;
+    }
 
     /**
    * With range information, calculate how many labels in axis
@@ -129,6 +169,13 @@ class LinearScale extends Scale {
       interval = Math.ceil(graphRange / numberOfSteps);
     }
 
+    if (this.decimalPoint === 'auto') {
+      this.decimalPoint = this?.getDecimalPointFromRange?.({
+        graphRange,
+        numberOfSteps,
+      });
+    }
+
     return {
       steps: numberOfSteps,
       interval,
@@ -169,7 +216,8 @@ class LinearScale extends Scale {
       if (this.autoScaleRatio) {
         const temp = maxValue;
         // 양수 방향에만 autoScaleRatio 적용
-        maxValue = Math.ceil(maxValue * (this.autoScaleRatio + 1));
+        const _maxValue = maxValue * (this.autoScaleRatio + 1);
+        maxValue = this.decimalPoint ? _maxValue : Math.ceil(_maxValue);
 
         if (maxValue > 0 && minValue < 0) {
           // 양수/음수 혼합 케이스 -- 음수 방향에도 maxValue 증가분만큼 더하기
@@ -177,7 +225,8 @@ class LinearScale extends Scale {
           minValue += diff;
         } else if (maxValue < 0 && minValue < 0) {
           // 전부 음수 케이스 -- 음수 방향에도 autoScaleRatio 적용
-          minValue = Math.ceil(minValue * (this.autoScaleRatio + 1));
+          const _minValue = minValue * (this.autoScaleRatio + 1);
+          minValue = this.decimalPoint ? _minValue : Math.ceil(_minValue);
         }
       }
 


### PR DESCRIPTION
### 상세 내용 (3.4.120 버전을 기준으로 만든 PR 참고)
https://github.com/ex-em/EVUI/pull/2021#issue-3475996097

### 작업 내용 
위의 변경사항을 음수값 적용한 버전에서 재작업 
- 3.4.120에서는 축의 interval 및 step 계산하는 로직이 scale.js에 있었음
- 3.4.200부터는 scale.linear.js 로 옮겨짐에 따라 재작업함

### 음수 적용 예시 
- 모든값이 양수일 때
   - ![auto decimal positive values](https://github.com/user-attachments/assets/3dfb2fb2-5ff2-4f10-a19d-7faa9d7ebef9)
- 모든값이 음수일 때
   - ![auto decimal negative values](https://github.com/user-attachments/assets/d9ab86c4-dd10-45a4-bef7-38030cb0fc6a)
