### PR TITLE
[#2031] Grid 컬럼 순서 변경 후 컬럼 숨김 처리간 순서 초기화 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.135",
+  "version": "3.4.136",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -78,20 +78,17 @@ export const commonFunctions = () => {
 };
 
 export const getUpdatedColumns = (stores) => {
-  if (stores.movedColumns?.length) {
-    const orderedColumnsIndexes = stores.orderedColumns?.map(column => column.index);
-    const extraColumns = stores.originColumns?.filter(
-      column => !orderedColumnsIndexes.includes(column.index),
-    );
-    const copyOrderedColumns = stores.orderedColumns;
-    return [...copyOrderedColumns, ...extraColumns];
-  }
-  const { originColumns, filteredColumns } = stores;
-  return originColumns.map((col) => {
-    const changedCol = filteredColumns.find(fcol => fcol.index === col.index) ?? {};
+  const baseColumns = (
+    stores.movedColumns?.length ? stores.movedColumns : stores.originColumns
+  ) ?? [];
+  const filteredColumnsMap = new Map(
+    (stores.filteredColumns ?? []).map(filtered => [filtered.index, filtered]),
+  );
+  return baseColumns.map((column) => {
+    const filteredColumn = filteredColumnsMap.get(column.index) ?? {};
     return {
-      ...col,
-      ...changedCol,
+      ...column,
+      ...filteredColumn,
     };
   });
 };
@@ -1475,6 +1472,28 @@ export const columnSettingEvent = (params) => {
     columnSettingInfo.visibleColumnIdx = [];
     columnSettingInfo.hiddenColumn = '';
   };
+  const getBaseColumns = () => {
+    if (Array.isArray(stores.movedColumns) && stores.movedColumns.length) {
+      return stores.movedColumns;
+    }
+    return stores.originColumns || [];
+  };
+  const syncHiddenState = (column, hidden) => {
+    if (!column) {
+      return;
+    }
+    column.hiddenDisplay = hidden;
+    const originColumn = stores.originColumns?.find(col => col.index === column.index);
+    if (originColumn && originColumn !== column) {
+      originColumn.hiddenDisplay = hidden;
+    }
+    if (Array.isArray(stores.movedColumns)) {
+      const movedColumn = stores.movedColumns.find(col => col.index === column.index);
+      if (movedColumn && movedColumn !== column) {
+        movedColumn.hiddenDisplay = hidden;
+      }
+    }
+  };
   const setFilteringColumn = () => {
     columnSettingInfo.visibleColumnIdx = stores.filteredColumns.map(col => col.index);
 
@@ -1499,18 +1518,13 @@ export const columnSettingEvent = (params) => {
       return;
     }
 
-    stores.filteredColumns = stores.originColumns
-      .filter((col) => {
-        if (columnNames.includes(col.field) || !col.caption) {
-          // 보여줄 컬럼들은 hiddenDisplay 속성을 false로 전부 적용
-          col.hiddenDisplay = false;
-          return true;
-        }
-
-        // 보여주지 않을 컬럼들은 hiddenDisplay 속성을 전부 ture로 적용
-        col.hiddenDisplay = true;
-        return false;
-      });
+    const baseColumns = getBaseColumns();
+    const columnNameSet = new Set(columnNames);
+    stores.filteredColumns = baseColumns.filter((col) => {
+      const shouldShow = columnNameSet.has(col.field) || !col.caption;
+      syncHiddenState(col, !shouldShow);
+      return shouldShow;
+    });
     columnSettingInfo.hiddenColumn = '';
     setFilteringColumn();
     emit('change-column-status', {
@@ -1530,13 +1544,16 @@ export const columnSettingEvent = (params) => {
     }
     stores.filteredColumns = columns
       .filter((col) => {
-        if (col.field !== val) {
-          col.hiddenDisplay = false;
-          return true;
-        }
-        col.hiddenDisplay = true;
-        return false;
+        const shouldHide = col.field === val;
+        syncHiddenState(col, shouldHide);
+        return !shouldHide;
       });
+    const baseColumns = getBaseColumns();
+    baseColumns.forEach((col) => {
+      if (col.field === val) {
+        syncHiddenState(col, true);
+      }
+    });
     columnSettingInfo.hiddenColumn = val;
     setFilteringColumn();
   };

--- a/src/components/grid/uses.js
+++ b/src/components/grid/uses.js
@@ -1568,6 +1568,19 @@ export const columnSettingEvent = (params) => {
 
 export const dragEvent = ({ stores }) => {
   const { emit } = getCurrentInstance();
+  const buildMovedColumns = (visibleColumns) => {
+    const baseColumns = (stores.movedColumns?.length
+      ? [...stores.movedColumns]
+      : [...stores.originColumns]);
+    const queue = [...visibleColumns];
+    const visibleIndexSet = new Set(queue.map(column => column.index));
+    stores.movedColumns = baseColumns.map((column) => {
+      if (visibleIndexSet.has(column.index)) {
+        return queue.shift();
+      }
+      return column;
+    });
+  };
   const setColumnMoving = (currentIndex, droppedIndex) => {
     const oldIndex = parseInt(currentIndex, 10);
     const newPositionIndex = parseInt(droppedIndex, 10);
@@ -1584,9 +1597,8 @@ export const dragEvent = ({ stores }) => {
 
     if (stores.filteredColumns.length) {
       stores.filteredColumns = columns;
-    } else {
-      stores.movedColumns = columns;
     }
+    buildMovedColumns(columns);
   };
   const onDragStart = (e) => {
     e.dataTransfer.setData('text/plain', e.currentTarget.dataset.index);

--- a/src/components/treeGrid/TreeGridNode.vue
+++ b/src/components/treeGrid/TreeGridNode.vue
@@ -235,8 +235,14 @@ export default {
     const isDataIcon = computed(() => ((parentIconMV.value !== 'none' || childIconMV.value !== 'none')));
 
     const expandColumnIdx = computed(() => {
-      const expandColumnIndex = props.orderedColumns.findIndex(v => v.expandColumn);
-      return expandColumnIndex > 0 ? expandColumnIndex : 0;
+      const columns = props.orderedColumns || [];
+      const visibleExpandIdx = columns.findIndex(column =>
+        column.expandColumn && !column.hide && !column.hiddenDisplay);
+      if (visibleExpandIdx !== -1) {
+        return visibleExpandIdx;
+      }
+      const firstVisibleIdx = columns.findIndex(column => !column.hide && !column.hiddenDisplay);
+      return firstVisibleIdx !== -1 ? firstVisibleIdx : 0;
     });
     const getRowClass = nodeInfo => ({
       row: true,


### PR DESCRIPTION
[이슈]
Grid 에서 컬럼 순서 변경 후 컬럼 숨김 처리 변경간 변경했던 순서가 초기화 됨

[변경 내용]
- getUpdatedColumns가 이동된 순서를 기준으로 hidden 상태를 병합하도록 재작성했습니다. 컬럼 설정 시 숨김 토글을 해도 컬럼 순서가 초기화되지 않도록 getBaseColumns, syncHiddenState 헬퍼를 추가해 originColumns, movedColumns, filteredColumns의 hidden 상태를 동기화
- TreeGrid 확장 아이콘을 표시할 컬럼을 “첫 번째로 보이는 컬럼” 기준으로 재계산해, 지정된 확장 컬럼이 숨겨져도 아이콘이 사라지지 않게 수정.

[기존 동작]
-  Grid 컬럼 순서 변경 후 컬럼 숨긴 처리 변경간 컬럼 순서 초기화.
- TreeGrid 컬럼 숨김 처리간 컬럼 숨김 설정창에 순서 컬럼 순서와 다름

[새 동작]
- Grid 컬럼 순서 변경 후 컬럼 숨긴 처리 변경간 컬럼 순서 유지.
- TreeGrid 컬럼 숨김 처리간 컬럼 숨김 설정창에 순서 컬럼 순서와 유지

[테스트 가이드]
Grid
1. grid 컬럼 순서 변경
2. grid 컬럼 숨김 수정 저장
3. 컬럼 순서 유지 되는 지 확인
4. 컬럼 숨김 설정창에 순서 동기화 되는지 확인

TreeGrid 
1. 첫번째 컬럼 숨김 처리후 저장
2. 첫번째 보이는 컬럼에 expand 아이콘 잘 표현되는지 확인
3. 컬럼 숨김 설정창에 순서 동기화 되는 지 확인