### PR TITLE
[#2035] Chart > Scatter > 툴팁 나오지 않음

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.206",
+  "version": "3.4.207",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -97,7 +97,7 @@ const modules = {
       }
 
       // tooltip 기반 indicator가 아직 설정되지 않은 경우에만 일반 indicator 처리
-      if (!args.hoveredLabel && type !== 'pie' && type !== 'scatter' && type !== 'heatMap') {
+      if (!args.hoveredLabel && this.isNotUseIndicator()) {
         // line 차트가 아니고 line series가 없거나, tooltip이 없을 때는 일반 indicator 표시
         const hasLineSeries = Object.values(this.seriesList || {}).some(series => series.type === 'line');
         if ((type !== 'line' && !hasLineSeries) || !tooltip.use || !Object.keys(hitInfo.items).length) {
@@ -906,7 +906,7 @@ const modules = {
     // 1. 먼저 공통으로 사용할 데이터 인덱스 결정
     const targetDataIndex = this.findClosestDataIndex(offset, sIds);
 
-    if (targetDataIndex === -1 && this.options.type !== 'pie') {
+    if (targetDataIndex === -1 && this.isNotUseIndicator()) {
       return { items, hitId, maxTip: [maxs, maxv], maxHighlight: null };
     }
 
@@ -1635,6 +1635,10 @@ const modules = {
     }
 
     return 'canvas';
+  },
+
+  isNotUseIndicator() {
+    return this.options.type !== 'pie' && this.options.type !== 'scatter' && this.options.type !== 'heatMap';
   },
 
   /**

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -97,7 +97,7 @@ const modules = {
       }
 
       // tooltip 기반 indicator가 아직 설정되지 않은 경우에만 일반 indicator 처리
-      if (!args.hoveredLabel && this.isNotUseIndicator()) {
+      if (!args.hoveredLabel && !this.isNotUseIndicator()) {
         // line 차트가 아니고 line series가 없거나, tooltip이 없을 때는 일반 indicator 표시
         const hasLineSeries = Object.values(this.seriesList || {}).some(series => series.type === 'line');
         if ((type !== 'line' && !hasLineSeries) || !tooltip.use || !Object.keys(hitInfo.items).length) {
@@ -906,7 +906,7 @@ const modules = {
     // 1. 먼저 공통으로 사용할 데이터 인덱스 결정
     const targetDataIndex = this.findClosestDataIndex(offset, sIds);
 
-    if (targetDataIndex === -1 && this.isNotUseIndicator()) {
+    if (targetDataIndex === -1 && !this.isNotUseIndicator()) {
       return { items, hitId, maxTip: [maxs, maxv], maxHighlight: null };
     }
 
@@ -1638,7 +1638,7 @@ const modules = {
   },
 
   isNotUseIndicator() {
-    return this.options.type !== 'pie' && this.options.type !== 'scatter' && this.options.type !== 'heatMap';
+    return this.options.type === 'pie' || this.options.type === 'scatter' || this.options.type === 'heatMap';
   },
 
   /**


### PR DESCRIPTION
[작업 배경]
- scatter 차트에서 툴팁이 나오지 않는 시리즈 확인됨
- line 또는 bar 차트에서 indicator와 툴팁 표현시 끊어짐이 없게 하기 위해 가까운 시리즈를 찾아 반환해주는데 scatter 나 heatmap, pie의 경우는 indicator를 사용하지 않아 불필요

![Nov-04-2025 14-37-49](https://github.com/user-attachments/assets/beb07e71-cb3f-44dd-ae73-e265e5996cee)


[수정 내용]
scatter, heatmap, pie 인 경우는 가까운 시리즈를 찾는 findClosestDataIndex 의 dataIndex를 무시하도록 수정

[테스트 방법]
scatter > event 예제에서 모든 툴팁이 나오는지 확인해주세요.