### PR TITLE
[#2038][3.4.120] linear 타입의 축 사용 할 때, 숫자가 아닌값을 받을 경우 에러로그 발생

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.139",
+  "version": "3.4.140",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/scale/scale.linear.js
+++ b/src/components/chart/scale/scale.linear.js
@@ -10,14 +10,16 @@ class LinearScale extends Scale {
    *
    * @returns {string} formatted label
    */
+  getTruthyValue(value) {
+    return truthyNumber(value) ? Number(value.toFixed(this.decimalPoint)) : value;
+  }
+
   getLabelFormat(value, data = {}) {
     if (this.formatter) {
-      const formattedLabel = this.formatter(Number(value.toFixed(this.decimalPoint)), {
+      const formattedLabel = this.formatter(this.getTruthyValue(value), {
         ...data,
         prevOriginalValue: data?.prev,
-        prevDecimalPointValue: truthyNumber(data?.prev)
-        ? Number(data?.prev.toFixed(this.decimalPoint))
-        : null,
+        prevDecimalPointValue: this.getTruthyValue(data?.prev),
         currentOriginalValue: value,
         currentDecimalPointValue: Number(value.toFixed(this.decimalPoint)),
       });


### PR DESCRIPTION
### 문제상황 
- 데이터에 숫자가 아닌값이 섞여있을 경우, toFixed 함수 호출 예외 에러 발생 

### 수정내용
- 숫자 타입인지 체크하는 로직 추가

### Before
<img width="494" height="202" alt="image" src="https://github.com/user-attachments/assets/80a4e730-5ce5-441e-b333-50844a3fb26f" />
<img width="278" height="92" alt="image" src="https://github.com/user-attachments/assets/de43c7be-5c3e-4762-b289-db5339a70b6d" />
<img width="214" height="151" alt="image" src="https://github.com/user-attachments/assets/730197e7-ec2c-4951-9a17-c30ad9e7347d" />

### After
<img width="227" height="131" alt="image" src="https://github.com/user-attachments/assets/e1859cc6-48cf-4ff6-b7a6-59bb132b3fba" />
<img width="227" height="100" alt="image" src="https://github.com/user-attachments/assets/d6c09044-5b5a-474d-ad3e-4c269b1fd493" />
