### PR TITLE
[#2056] Chart > Heatmap > 드래그한 범위 데이터가 실제 데이터와 맞지 않음

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.143",
+  "version": "3.4.144",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -469,6 +469,12 @@ class HeatMap {
 
   /**
    * 자바스크립트 부동 소수점 오차 때문에 범위를 조정
+   * @param {object} params - range information
+   * @param {number} params.xp - start x position
+   * @param {number} params.yp - start y position
+   * @param {number} params.width - width
+   * @param {number} params.height - height
+   * @returns {object} adjusted range
    */
   getAdjustedBounds({ xp, yp, width, height }) {
     const PRECISION = 100;
@@ -486,6 +492,12 @@ class HeatMap {
 
   /**
    *Returns items in range
+   * @param {object} params - range information
+   * @param {number} params.xsp - start x position
+   * @param {number} params.width - width
+   * @param {number} params.ysp - start y position
+   * @param {number} params.height - height
+   * @returns {array} items in range
    */
   findItems(params) {
     const gdata = this.data;
@@ -680,8 +692,6 @@ class HeatMap {
 
         if (findItem > -1) {
           point[key] = ['xsp', 'ysp'].includes(key) ? itemPoint : itemPoint + gap;
-        } else if (target < startPoint) {
-          point[key] = startPoint;
         }
       };
 

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -680,6 +680,8 @@ class HeatMap {
 
         if (findItem > -1) {
           point[key] = ['xsp', 'ysp'].includes(key) ? itemPoint : itemPoint + gap;
+        } else if (target < startPoint) {
+          point[key] = startPoint;
         }
       };
 

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -468,22 +468,47 @@ class HeatMap {
   }
 
   /**
-   *Returns items in range
-   * @param {object} params  range values
-   *
-   * @returns {array}
+   * 자바스크립트 부동 소수점 오차 때문에 범위를 조정
    */
-  findItems({ xsp, ysp, width, height }) {
-    const gdata = this.data;
-    const xep = xsp + width;
-    const yep = ysp + height;
-    return gdata.filter(({ xp, yp, w, h }) => {
-      const x1 = xp;
-      const x2 = xp + w;
-      const y1 = yp;
-      const y2 = yp + h;
+  getAdjustedBounds({ xp, yp, width, height }) {
+    const PRECISION = 100;
 
-      return ((x1 >= xsp && x2 <= xep) && (y1 >= ysp && y2 <= yep));
+    const adjustedWidth = Math.max(0, width);
+    const adjustedHeight = Math.max(0, height);
+
+    return {
+      xsp: Math.floor(xp * PRECISION) / PRECISION,
+      xep: Math.ceil((xp + adjustedWidth) * PRECISION) / PRECISION,
+      ysp: Math.floor(yp * PRECISION) / PRECISION,
+      yep: Math.ceil((yp + adjustedHeight) * PRECISION) / PRECISION,
+    };
+  }
+
+  /**
+   *Returns items in range
+   */
+  findItems(params) {
+    const gdata = this.data;
+
+    const { xsp, xep, ysp, yep } = this.getAdjustedBounds({
+      xp: params.xsp,
+      yp: params.ysp,
+      width: params.width,
+      height: params.height,
+    });
+
+    return gdata.filter(({ xp, yp, w, h }) => {
+      const { xsp: x1, xep: x2, ysp: y1, yep: y2 } = this.getAdjustedBounds({
+        xp,
+        yp,
+        width: w,
+        height: h,
+      });
+
+      return (
+        (x1 >= xsp && x2 <= xep)
+        && (y1 >= ysp && y2 <= yep)
+      );
     });
   }
 

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -692,6 +692,8 @@ class HeatMap {
 
         if (findItem > -1) {
           point[key] = ['xsp', 'ysp'].includes(key) ? itemPoint : itemPoint + gap;
+        } else if (target < startPoint) {
+          point[key] = startPoint;
         }
       };
 


### PR DESCRIPTION
[작업 배경]
드래그한 범위의 아이템 개수와 반환되는 데이터의 개수가 다름

차트 영역 좌측 밖으로 드래그했을 때 드래그가 시작점부터 되지 않음

[수정 내용]
시작점, 끝점에 100을 곱하고 소수점을 버림/올림으로 오차 보정
차트 영역 좌측 밖으로 드래그했을 경우 시작점부터 드래그 되도록 수정

[기존 동작]
![Dec-05-2025 10-22-41](https://github.com/user-attachments/assets/681440fa-d05b-4f85-ae4c-e7296003cc32)

![Dec-05-2025 11-21-14](https://github.com/user-attachments/assets/21124114-fec1-41db-890f-21510be167b1)


[기대 동작]
![Dec-05-2025 10-53-26](https://github.com/user-attachments/assets/3b19d27b-8557-4217-8500-8240287e4f10)
![Dec-05-2025 11-20-35](https://github.com/user-attachments/assets/5d05ea4f-b0bd-4ccb-af95-c1f46077e43b)



[테스트 환경]
http://10.20.141.23:9999/heatMap


