### PR TITLE
[#2058] Chart > Heatmap > stroke line 넓이가 item 사이즈보다 큰 경우 색상에 투명도가 반영됨

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.145",
+  "version": "3.4.146",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -546,10 +546,10 @@ class HeatMap {
     const ctx = context;
     const { stroke: strokeOpt, shadow: shadowOpt } = this.highlight;
 
-    let x = gdata.xp;
-    let y = gdata.yp;
-    let w = gdata.w;
-    let h = gdata.h;
+    const x = gdata.xp;
+    const y = gdata.yp;
+    const w = gdata.w;
+    const h = gdata.h;
     const cId = gdata.cId;
 
     let isShow;

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -546,10 +546,10 @@ class HeatMap {
     const ctx = context;
     const { stroke: strokeOpt, shadow: shadowOpt } = this.highlight;
 
-    const x = gdata.xp;
-    const y = gdata.yp;
-    const w = gdata.w;
-    const h = gdata.h;
+    let x = gdata.xp;
+    let y = gdata.yp;
+    let w = gdata.w;
+    let h = gdata.h;
     const cId = gdata.cId;
 
     let isShow;
@@ -586,33 +586,45 @@ class HeatMap {
       lineWidth: 1,
       opacity: 1,
       radius: 0,
-      show: true,
+      show: false,
     };
 
-    if (strokeOpt.use) {
+    if (strokeOpt.use && strokeOpt.width > 0) {
       const { color, width, radius } = strokeOpt;
-      borderOpt.show = true;
-      borderOpt.radius = radius;
 
-      ctx.lineWidth = width;
-      borderOpt.lineWidth = width;
+      const totalStrokeWidth = width * 2;
 
-      ctx.strokeStyle = color || dataColor;
-      borderOpt.color = color || dataColor;
-    } else {
-      borderOpt.show = false;
-      ctx.strokeStyle = dataColor;
-      borderOpt.color = dataColor;
+      const isBorderDrawable = totalStrokeWidth < w && totalStrokeWidth < h;
+
+      if (isBorderDrawable) {
+        borderOpt.show = true;
+        borderOpt.radius = radius;
+
+        ctx.lineWidth = width;
+        borderOpt.lineWidth = width;
+
+        ctx.strokeStyle = color || dataColor;
+        borderOpt.color = color || dataColor;
+
+        x += width;
+        y += width;
+        w -= totalStrokeWidth;
+        h -= totalStrokeWidth;
+      }
     }
 
-    const { lineWidth } = borderOpt;
+    if (!borderOpt.show) {
+      ctx.strokeStyle = dataColor;
+      ctx.lineWidth = 0;
+    }
 
     this.drawItem(
       ctx,
-      x - lineWidth,
-      y - lineWidth,
-      w + lineWidth * 2,
-      h + lineWidth * 2,
+      x - 0.5,
+      y - 0.5,
+      w + 1,
+      h + 1,
+      h,
       borderOpt,
     );
 

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -356,12 +356,14 @@ class HeatMap {
             };
           }
 
+          let isBorderDrawable = false;
+
           if (borderOpt.show && borderOpt.lineWidth > 0) {
             const { color, lineWidth, opacity: borderOpacity } = borderOpt;
 
             const totalStrokeWidth = lineWidth * 2;
 
-            const isBorderDrawable = totalStrokeWidth < w && totalStrokeWidth < h;
+            isBorderDrawable = totalStrokeWidth < w && totalStrokeWidth < h;
 
             ctx.strokeStyle = isBorderDrawable ? Util.colorStringToRgba(
               color,
@@ -387,7 +389,7 @@ class HeatMap {
           item.w = w;
           item.h = h;
 
-          this.drawItem(ctx, xp, yp, w, h, borderOpt);
+          this.drawItem(ctx, xp, yp, w, h, { ...borderOpt, show: isBorderDrawable });
           ctx.restore();
 
           if (this.showValue.use) {

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -586,47 +586,26 @@ class HeatMap {
       lineWidth: 1,
       opacity: 1,
       radius: 0,
-      show: false,
+      show: true,
     };
 
-    if (strokeOpt.use && strokeOpt.width > 0) {
+    if (strokeOpt.use) {
       const { color, width, radius } = strokeOpt;
+      borderOpt.show = true;
+      borderOpt.radius = radius;
 
-      const totalStrokeWidth = width * 2;
+      ctx.lineWidth = width;
+      borderOpt.lineWidth = width;
 
-      const isBorderDrawable = totalStrokeWidth < w && totalStrokeWidth < h;
-
-      if (isBorderDrawable) {
-        borderOpt.show = true;
-        borderOpt.radius = radius;
-
-        ctx.lineWidth = width;
-        borderOpt.lineWidth = width;
-
-        ctx.strokeStyle = color || dataColor;
-        borderOpt.color = color || dataColor;
-
-        x += width;
-        y += width;
-        w -= totalStrokeWidth;
-        h -= totalStrokeWidth;
-      }
-    }
-
-    if (!borderOpt.show) {
+      ctx.strokeStyle = color || dataColor;
+      borderOpt.color = color || dataColor;
+    } else {
+      borderOpt.show = false;
       ctx.strokeStyle = dataColor;
-      ctx.lineWidth = 0;
+      borderOpt.color = dataColor;
     }
 
-    this.drawItem(
-      ctx,
-      x - 0.5,
-      y - 0.5,
-      w + 1,
-      h + 1,
-      h,
-      borderOpt,
-    );
+    this.drawItem(ctx, x - 0.5, y - 0.5, w + 1, h + 1, borderOpt);
 
     ctx.restore();
 

--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -310,6 +310,7 @@ class HeatMap {
 
     this.data.forEach((item, index) => {
       const axisLineWidth = 1;
+
       let xp = this.calculateXY('x', item.x, xsp, minmaxX);
       let yp = this.calculateXY('y', item.y, ysp, minmaxY);
       let w = this.size.w;
@@ -355,20 +356,27 @@ class HeatMap {
             };
           }
 
-          if (borderOpt.show) {
+          if (borderOpt.show && borderOpt.lineWidth > 0) {
             const { color, lineWidth, opacity: borderOpacity } = borderOpt;
-            ctx.strokeStyle = Util.colorStringToRgba(
+
+            const totalStrokeWidth = lineWidth * 2;
+
+            const isBorderDrawable = totalStrokeWidth < w && totalStrokeWidth < h;
+
+            ctx.strokeStyle = isBorderDrawable ? Util.colorStringToRgba(
               color,
               itemOpacity === 1 ? borderOpacity : itemOpacity,
-            );
+            ) : undefined;
 
             // item 사이즈 보다 border 선 굵기가 큰 경우 lineWidth props 무시
-            if (lineWidth < w && lineWidth < h) {
+            if (isBorderDrawable) {
               ctx.lineWidth = lineWidth;
-              xp += (lineWidth * 0.5);
-              yp += (lineWidth * 0.5);
-              w -= (lineWidth);
-              h -= (lineWidth);
+              xp += lineWidth;
+              yp += lineWidth;
+              w -= totalStrokeWidth;
+              h -= totalStrokeWidth;
+            } else {
+              ctx.lineWidth = 0;
             }
           }
 
@@ -595,7 +603,16 @@ class HeatMap {
       borderOpt.color = dataColor;
     }
 
-    this.drawItem(ctx, x - 0.5, y - 0.5, w + 1, h + 1, borderOpt);
+    const { lineWidth } = borderOpt;
+
+    this.drawItem(
+      ctx,
+      x - lineWidth,
+      y - lineWidth,
+      w + lineWidth * 2,
+      h + lineWidth * 2,
+      borderOpt,
+    );
 
     ctx.restore();
 


### PR DESCRIPTION
[이슈]
stroke width가 큰 경우 stroke 색상으로 보여 실제 설정한 data color와 다르게 보이는 현상

<img width="1079" height="345" alt="image" src="https://github.com/user-attachments/assets/d0c2032e-b712-4248-bf5d-68b1be8ea585" />

[수정 내용]
stroke width * 2 (양쪽, 위아래 이기때문에 2를 곱해서 계산) item의 width 또는 height 보다 큰 경우 stroke이 반영되지 않도록 수정
lineWidth가 2인 경우 1로 반영되는 로직 수정

<img width="1030" height="196" alt="image" src="https://github.com/user-attachments/assets/431860f4-b8c5-46cc-be61-c33dff1b2a1a" />

