### PR TITLE
[#2058] Chart > Heatmap > stroke line 넓이가 item 사이즈보다 큰 경우 색상이 다르게 보임

### DIFF
--- a/src/components/chart/element/element.heatmap.js
+++ b/src/components/chart/element/element.heatmap.js
@@ -363,7 +363,7 @@ class HeatMap {
 
             const totalStrokeWidth = lineWidth * 2;
 
-            isBorderDrawable = totalStrokeWidth < w && totalStrokeWidth < h;
+            isBorderDrawable = totalStrokeWidth < Math.floor(w) && totalStrokeWidth < Math.floor(h);
 
             ctx.strokeStyle = isBorderDrawable ? Util.colorStringToRgba(
               color,


### PR DESCRIPTION
[이슈]
stroke width가 큰 경우 stroke 색상으로 보여 실제 설정한 data color와 다르게 보이는 현상

<img width="1000" height="472" alt="image" src="https://github.com/user-attachments/assets/efccb00d-e357-4435-81b6-34e793e0dfe2" />

[수정 내용]
stroke width 비교할때 Math.floor로 width, height 변경하여 비교하도록 수정

![Dec-08-2025 15-59-43](https://github.com/user-attachments/assets/be3309b5-1ef5-45f6-babf-ee4b71836337)
로 반영되는 로직 수정



