### PR TITLE
[#2061] Chart > 성능개선 1차

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.146",
+  "version": "3.4.147",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -223,14 +223,17 @@ export default {
    */
   calcTextSizeCanvas(text, fontStyle) {
     textMeasureCtx.font = fontStyle;
-
     const metrics = textMeasureCtx.measureText(text);
+
+    const fontSizeMatch = fontStyle.match(/(\d+(?:\.\d+)?)px/);
+    const fontSize = fontSizeMatch ? Number(fontSizeMatch[1]) : 14;
+
+    // DOM 기본 line-height 보정 (대략 1.2 ~ 1.3)
+    const lineHeight = fontSize * 1.2;
 
     return {
       width: Math.ceil(metrics.width),
-      height: Math.ceil(
-        metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent,
-      ),
+      height: Math.ceil(lineHeight),
     };
   },
 

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -7,6 +7,10 @@ import {
 } from '@/common/utils';
 import { isNil } from 'lodash-es';
 
+// Text Size 측정용 singleton canvas
+const textMeasureCanvas = document.createElement('canvas');
+const textMeasureCtx = textMeasureCanvas.getContext('2d');
+
 export default {
   /**
    * Transforming hex to rgb code
@@ -209,6 +213,25 @@ export default {
     calc.remove();
 
     return { width, height };
+  },
+
+  /**
+   * Calculate text size with Canvas
+   * @param {string} text         text is needed to check size
+   * @param {string} fontStyle    text font style
+   * @returns {object} text size information
+   */
+  calcTextSizeCanvas(text, fontStyle) {
+    textMeasureCtx.font = fontStyle;
+
+    const metrics = textMeasureCtx.measureText(text);
+
+    return {
+      width: Math.ceil(metrics.width),
+      height: Math.ceil(
+        metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent,
+      ),
+    };
   },
 
   /**

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -222,6 +222,10 @@ export default {
    * @returns {object} text size information
    */
   calcTextSizeCanvas(text, fontStyle) {
+    if (!text) {
+      return { width: 2, height: 2 };
+    }
+
     textMeasureCtx.font = fontStyle;
     const metrics = textMeasureCtx.measureText(text);
 
@@ -265,7 +269,7 @@ export default {
   /**
    * Truncate the long string to short string with ellipsis until fitting maxWidth
    * @param {string} str         target string
-   * @param {number} maxWidth    maximum string width on canvas
+   * @param {number} maxWidth    maximum string width on canva
    * @param {Object} ctx         canvas context
    * @param {string} direction   left or right  (default: right)
    */

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -219,7 +219,7 @@ export default {
    * Calculate text size with Canvas
    * @param {string} text         text is needed to check size
    * @param {string} fontStyle    text font style
-   * @returns {object} text size information
+   * @returns {{width: number; height: number;}} text size information
    */
   calcTextSizeCanvas(text, fontStyle) {
     textMeasureCtx.font = fontStyle;

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -232,8 +232,8 @@ export default {
     const lineHeight = fontSize * 1.2;
 
     return {
-      width: Math.ceil(metrics.width),
-      height: Math.ceil(lineHeight),
+      width: Math.max(Math.ceil(metrics.width), 2),
+      height: Math.max(Math.ceil(lineHeight), 2),
     };
   },
 

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -405,30 +405,42 @@ const modules = {
    * @returns {ChartSeriesDataPoint[]} data for each series
    */
   addSeriesStackDS(data, label, bsIds, sIdx = 0) {
+    const seriesList = this.seriesList;
     const isHorizontal = this.options.horizontal;
     const sdata = [];
+    const basePositionCache = new Map();
 
     const getBaseDataPosition = (baseIndex, dataIndex) => {
-      const nextBaseSeriesIndex = baseIndex - 1;
-      const baseSeries = this.seriesList[bsIds[baseIndex]];
-      const baseDataList = baseSeries.data;
-      const baseData = baseDataList[dataIndex];
-      const position = isHorizontal ? baseData?.x : baseData?.y;
-      const isPassingValue = baseSeries.passingValue === baseData?.o;
-
-      if (isPassingValue || position == null || !baseSeries.show) {
-        if (nextBaseSeriesIndex > -1) {
-          return getBaseDataPosition(nextBaseSeriesIndex, dataIndex);
-        }
-
-        return 0;
+      const key = `${baseIndex}-${dataIndex}`;
+      if (basePositionCache.has(key)) {
+        return basePositionCache.get(key);
       }
 
-      return position;
+      let result = 0;
+      let idx = baseIndex;
+
+      while (idx >= 0) {
+        const baseSeries = seriesList[bsIds[idx]];
+        if (baseSeries.show) {
+          const baseData = baseSeries.data[dataIndex];
+          const position = isHorizontal ? baseData?.x : baseData?.y;
+          if (
+            position != null && baseSeries.passingValue !== baseData?.o
+          ) {
+            result = position;
+            break;
+          }
+        }
+        idx--;
+      }
+
+      basePositionCache.set(key, result);
+      return result;
     };
 
+    const lastBaseIndex = bsIds.length - 1;
     data.forEach((curr, index) => {
-      const baseIndex = bsIds.length - 1 < 0 ? 0 : bsIds.length - 1;
+      const baseIndex = lastBaseIndex < 0 ? 0 : lastBaseIndex;
       let bdata = getBaseDataPosition(baseIndex, index); // base(previous) series data
       let odata = curr; // current series original data
       let ldata = label[index]; // label data

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -411,7 +411,7 @@ const modules = {
     const basePositionCache = new Map();
 
     const getBaseDataPosition = (baseIndex, dataIndex) => {
-      const key = `${baseIndex}-${dataIndex}`;
+      const key = (baseIndex << 20) | dataIndex;
       if (basePositionCache.has(key)) {
         return basePositionCache.get(key);
       }
@@ -421,11 +421,17 @@ const modules = {
 
       while (idx >= 0) {
         const baseSeries = seriesList[bsIds[idx]];
-        if (baseSeries.show) {
+        if (baseSeries?.show && Array.isArray(baseSeries?.data)) {
           const baseData = baseSeries.data[dataIndex];
-          const position = isHorizontal ? baseData?.x : baseData?.y;
+          const { x = null, y = null, o = null } = baseData ?? {};
+
+          const position = isHorizontal ? x : y;
+
+          const isPassingValue = Util.isNullOrUndefined(baseSeries.passingValue) === false
+          && baseSeries?.passingValue === o;
+
           if (
-            position != null && baseSeries.passingValue !== baseData?.o
+            position != null && !isPassingValue
           ) {
             result = position;
             break;
@@ -440,14 +446,14 @@ const modules = {
 
     const lastBaseIndex = bsIds.length - 1;
     data.forEach((curr, index) => {
-      const baseIndex = lastBaseIndex < 0 ? 0 : lastBaseIndex;
+      const baseIndex = Math.max(0, lastBaseIndex);
       let bdata = getBaseDataPosition(baseIndex, index); // base(previous) series data
       let odata = curr; // current series original data
       let ldata = label[index]; // label data
       let gdata = curr; // current series data which added previous series's value
 
-      if (bdata != null && ldata != null) {
-        if (gdata && typeof gdata === 'object' && (curr.x || curr.y)) {
+      if (ldata != null) {
+        if (gdata && typeof gdata === 'object' && ('x' in gdata || 'y' in gdata)) {
           odata = isHorizontal ? curr.x : curr.y;
           ldata = isHorizontal ? curr.y : curr.x;
         }

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -116,7 +116,7 @@ class Scale {
       max: maxValue,
       minLabel,
       maxLabel,
-      size: Util.calcTextSize(
+      size: Util.calcTextSizeCanvas(
         maxLabel,
         Util.getLabelStyle(this.labelStyle),
         this.labelStyle?.padding,
@@ -132,7 +132,7 @@ class Scale {
   getLabelWidthHasMaxLength(notFormattedLabels) {
     return (notFormattedLabels ?? []).reduce((max, label) => {
       const formattedLabel = this.getLabelFormat(label);
-      const width = Util.calcTextSize(
+      const width = Util.calcTextSizeCanvas(
           formattedLabel,
           Util.getLabelStyle(this.labelStyle),
       )?.width ?? 0;

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -57,7 +57,7 @@ class StepScale extends Scale {
       maxIndex,
       minLabel: this.getLabelFormat(minValue, maxWidth),
       maxLabel: this.getLabelFormat(maxValue, maxWidth),
-      size: Util.calcTextSize(
+      size: Util.calcTextSizeCanvas(
         this.getLabelFormat(maxValue, maxWidth),
         Util.getLabelStyle(this.labelStyle),
       ),


### PR DESCRIPTION
## 변경사항
### getBaseDataPosition
- Stack 데이터를 생성하는 로직에서 data.length * base Series Ids 만큼 재귀호출하는 형태 
   - 재귀호출 -> 반복문으로 변경 
   - 동일한 계산 -> 캐싱 
   - this 접근 -> 전역 캐싱


### calcTextSize
- 글자의 실제 크기(px)를 구하기 위해 body element에 임시 element를 추가했다가 삭제하는 형태 
   - calcTextSizeCanvas로 변경 
   - canvas는 1회만 생성함
   - canvas의 measureText를 사용하도록 함
   
   
## Before (5.15ms)
- <img width="679" height="607" alt="image" src="https://github.com/user-attachments/assets/7140951c-dffa-426e-9490-973f7839a340" />


## After (0.79ms) 약 84.7% 개선
- <img width="808" height="574" alt="image" src="https://github.com/user-attachments/assets/42deaff7-aa12-41e8-9c8b-a5a7f842d0b3" />

## 테스트 가이드 
- 기존과 동일하게 동작하는지 확인해주세요 
http://localhost:9999/barChart#scrollbar
https://ex-em.github.io/EVUI/barChart#scrollbar
