### PR TITLE
[#2063] axis type step이고 fitWidth true인 경우 label 잘리는 문제 해결

### DIFF
--- a/docs/views/barChart/example/Scrollbar.vue
+++ b/docs/views/barChart/example/Scrollbar.vue
@@ -148,16 +148,16 @@ export default {
         series20: { name: 'series#20' },
       },
       labels: [
-        'value1',
-        'value2',
-        'value3',
-        'value4',
-        'value5',
-        'value6',
-        'value7',
-        'value8',
-        'value9',
-        'value10',
+        'Short 1',
+        'Very Long Label Name That Will Be Truncated 2',
+        'Short 3',
+        'Very Long Label Name That Will Be Truncated 4',
+        'Short 5',
+        'Very Long Label Name That Will Be Truncated 6',
+        'Short 7',
+        'Very Long Label Name That Will Be Truncated 8',
+        'Short 9',
+        'Very Long Label Name That Will Be Truncated 10',
       ],
       groups: [
         [
@@ -231,16 +231,16 @@ export default {
         series20: { name: 'series#20' },
       },
       labels: [
-        'value1',
-        'value2',
-        'value3',
-        'value4',
-        'value5',
-        'value6',
-        'value7',
-        'value8',
-        'value9',
-        'value10',
+        'Short 1',
+        'Very Long Label Name That Will Be Truncated 2',
+        'Short 3',
+        'Very Long Label Name That Will Be Truncated 4',
+        'Short 5',
+        'Very Long Label Name That Will Be Truncated 6',
+        'Short 7',
+        'Very Long Label Name That Will Be Truncated 8',
+        'Short 9',
+        'Very Long Label Name That Will Be Truncated 10',
       ],
       groups: [
         [
@@ -310,7 +310,8 @@ export default {
           showGrid: false,
           labelStyle: {
             fitWidth: true,
-            fitDir: 'left',
+            fitDir: 'right',
+            maxWidth: 80,
           },
           range: RANGE,
           scrollbar: {
@@ -372,7 +373,8 @@ export default {
           showGrid: false,
           labelStyle: {
             fitWidth: true,
-            fitDir: 'left',
+            fitDir: 'right',
+            maxWidth: 80, // ellipsis 테스트: 긴 label만 "..."으로 표시
           },
           range: RANGE,
           scrollbar: {
@@ -428,7 +430,11 @@ export default {
         ...chartData1.value,
         labels: Array(10)
           .fill(0)
-          .map((_, i) => `value${i + 1}`),
+          .map((_, i) =>
+            i % 2 === 0
+              ? `Short ${i + 1}`
+              : `Very Long Label Name That Will Be Truncated ${i + 1}`
+          ),
         data: {
           series1: getRandArr(10),
           series2: getRandArr(10),
@@ -440,7 +446,11 @@ export default {
         ...chartData2.value,
         labels: Array(10)
           .fill(0)
-          .map((_, i) => `value${i + 1}`),
+          .map((_, i) =>
+            i % 2 === 0
+              ? `Short ${i + 1}`
+              : `Very Long Label Name That Will Be Truncated ${i + 1}`
+          ),
         data: {
           series1: getRandArr(10),
           series2: getRandArr(10),
@@ -455,7 +465,11 @@ export default {
       const len = getRandLength();
       const labels = Array(len)
         .fill(0)
-        .map((_, i) => `value${i + 1}`);
+        .map((_, i) =>
+          i % 2 === 0
+            ? `Short ${i + 1}`
+            : `Very Long Label Name That Will Be Truncated ${i + 1}`
+        );
       const series1 = getRandArr(len);
       const series2 = getRandArr(len);
 
@@ -484,7 +498,11 @@ export default {
         ...chartData1.value,
         labels: Array(10)
           .fill(0)
-          .map((_, i) => `value${i + 1}`),
+          .map((_, i) =>
+            i % 2 === 0
+              ? `Short ${i + 1}`
+              : `Very Long Label Name That Will Be Truncated ${i + 1}`
+          ),
         data: {
           series1: getRandArr(10),
           series2: getRandArr(10),
@@ -495,7 +513,11 @@ export default {
         ...chartData2.value,
         labels: Array(10)
           .fill(0)
-          .map((_, i) => `value${i + 1}`),
+          .map((_, i) =>
+            i % 2 === 0
+              ? `Short ${i + 1}`
+              : `Very Long Label Name That Will Be Truncated ${i + 1}`
+          ),
         data: {
           series1: getRandArr(10),
           series2: getRandArr(10),
@@ -509,7 +531,11 @@ export default {
         ...chartData1.value,
         labels: Array(7)
           .fill(0)
-          .map((_, i) => `value${i + 1}`),
+          .map((_, i) =>
+            i % 2 === 0
+              ? `Short ${i + 1}`
+              : `Very Long Label Name That Will Be Truncated ${i + 1}`
+          ),
         data: {
           series1: getRandArr(7),
           series2: getRandArr(7),
@@ -520,7 +546,11 @@ export default {
         ...chartData2.value,
         labels: Array(7)
           .fill(0)
-          .map((_, i) => `value${i + 1}`),
+          .map((_, i) =>
+            i % 2 === 0
+              ? `Short ${i + 1}`
+              : `Very Long Label Name That Will Be Truncated ${i + 1}`
+          ),
         data: {
           series1: getRandArr(7),
           series2: getRandArr(7),

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -174,54 +174,76 @@ class EvChart {
   }
 
   adjustXAndYAxisWidth() {
-    // fitWidth(maxWidth에 넘을 시 말줄임표 들어가는 기능)을 사용중인 step Axis인 경우에는 적용 제외
-    const isStepXAxisUseFitWidth = this.options.axesX?.some(axisX => axisX.type === 'step' && axisX.labelStyle?.fitWidth);
-    const isStepYAxisUseFitWidth = this.options.axesY?.some(axisY => axisY.type === 'step' && axisY.labelStyle?.fitWidth);
-
-    const getNotFormattedLabels = (axesSteps) => {
-      const { interval, graphMin, graphMax, steps = 0 } = axesSteps ?? {};
+    const getNotFormattedLabels = (axesSteps, axisType, axis) => {
+      const {
+        interval,
+        graphMin,
+        graphMax,
+        steps = 0,
+        minIndex,
+        maxIndex,
+        indexInterval,
+      } = axesSteps ?? {};
       let result = [];
 
-      if (interval) {
+      // StepScale의 경우 실제로 표시될 모든 라벨들을 포함
+      if (axis?.type === 'step' && minIndex !== undefined && maxIndex !== undefined && indexInterval !== undefined) {
+        const { labels } = this.data;
+        const axisLabels = axisType === 'x' ? (labels?.x ?? labels ?? []) : (labels?.y ?? labels ?? []);
+        result = [];
+        for (let i = minIndex; i <= maxIndex; i += indexInterval) {
+          if (axisLabels[i] !== undefined) {
+            result.push(axisLabels[i]);
+          }
+        }
+      } else if (interval) {
         result = Array.from({ length: steps }, (_, i) => graphMin + i * interval);
         result.push(graphMax);
       } else {
         const { labels } = this.data;
-        result = labels?.y ?? labels ?? [];
+        result = axisType === 'x' ? (labels?.x ?? labels ?? []) : (labels?.y ?? labels ?? []);
       }
 
       return result;
     };
 
-    const notFormattedXLabels = getNotFormattedLabels(this.axesSteps?.x[0]);
-    const notFormattedYLabels = getNotFormattedLabels(this.axesSteps?.y[0]);
-
-    const yFixWidth = truthyNumber(this.axesY[0]?.labelStyle?.fixWidth)
-      ? this.axesY[0]?.labelStyle?.fixWidth
-      : 0;
-    const xFixWidth = truthyNumber(this.axesX[0]?.labelStyle?.fixWidth)
-      ? this.axesX[0]?.labelStyle?.fixWidth
-      : 0;
-
-    const xMaxWidth = this.axesX[0]?.getLabelWidthHasMaxLength(notFormattedXLabels);
-    const yMaxWidth = this.axesY[0]?.getLabelWidthHasMaxLength(notFormattedYLabels);
-
-
     const adjustedRange = {
-      x: !isStepXAxisUseFitWidth ? this.axesRange?.x?.map(value => ({
-        ...value,
-        size: {
-          width: xFixWidth || Math.max(xMaxWidth, value.size.width),
-          height: value.size.height,
-        },
-      })) : this.axesRange?.x,
-      y: !isStepYAxisUseFitWidth ? this.axesRange?.y?.map(value => ({
-        ...value,
-        size: {
-          width: yFixWidth || Math.max(yMaxWidth, value.size.width),
-          height: value.size.height,
-        },
-      })) : this.axesRange?.y,
+      x: this.axesRange?.x?.map((value, index) => {
+        const axis = this.axesX[index];
+        const axesSteps = this.axesSteps?.x[index];
+        const notFormattedLabels = getNotFormattedLabels(axesSteps, 'x', axis);
+
+        const fixWidth = truthyNumber(axis?.labelStyle?.fixWidth)
+          ? axis.labelStyle.fixWidth
+          : 0;
+        const maxWidth = axis?.getLabelWidthHasMaxLength?.(notFormattedLabels, this.chartRect) ?? 0;
+
+        return {
+          ...value,
+          size: {
+            width: fixWidth || Math.max(maxWidth, value.size.width),
+            height: value.size.height,
+          },
+        };
+      }),
+      y: this.axesRange?.y?.map((value, index) => {
+        const axis = this.axesY[index];
+        const axesSteps = this.axesSteps?.y[index];
+        const notFormattedLabels = getNotFormattedLabels(axesSteps, 'y', axis);
+
+        const fixWidth = truthyNumber(axis?.labelStyle?.fixWidth)
+          ? axis.labelStyle.fixWidth
+          : 0;
+        const maxWidth = axis?.getLabelWidthHasMaxLength?.(notFormattedLabels, this.chartRect) ?? 0;
+
+        return {
+          ...value,
+          size: {
+            width: fixWidth || Math.max(maxWidth, value.size.width),
+            height: value.size.height,
+          },
+        };
+      }),
     };
 
     this.axesRange = adjustedRange;

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -127,9 +127,11 @@ class Scale {
   /**
    * return width what has max length
    * @param {string[]} notFormattedLabels
+   * @param {object} chartRect - unused in base class, used in StepScale override
    * @reutrn number maxWidth
    */
-  getLabelWidthHasMaxLength(notFormattedLabels) {
+  // eslint-disable-next-line no-unused-vars
+  getLabelWidthHasMaxLength(notFormattedLabels, chartRect) {
     return (notFormattedLabels ?? []).reduce((max, label) => {
       const formattedLabel = this.getLabelFormat(label);
       const width = Util.calcTextSizeCanvas(

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -443,7 +443,7 @@ class StepScale extends Scale {
     return (notFormattedLabels ?? []).reduce((max, label) => {
       // ellipsis가 적용된 label의 width를 계산
       const formattedLabel = this.getLabelFormat(label, maxWidth);
-      const width = Util.calcTextSize(
+      const width = Util.calcTextSizeCanvas(
         formattedLabel,
         labelStyle,
       )?.width ?? 0;

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -426,6 +426,31 @@ class StepScale extends Scale {
 
     return Util.truncateLabelWithEllipsis(value, maxWidth, ctx, dir);
   }
+
+  /**
+   * return width what has max length
+   * ellipsis가 적용된 label의 width를 계산 (fontSize 적용)
+   * @param {string[]} notFormattedLabels
+   * @param {object} chartRect
+   * @returns {number} maxWidth
+   */
+  getLabelWidthHasMaxLength(notFormattedLabels, chartRect) {
+    // fontSize를 포함한 labelStyle 가져오기
+    const labelStyle = Util.getLabelStyle(this.labelStyle);
+    const labelCount = notFormattedLabels?.length ?? 0;
+    const maxWidth = this.labelStyle?.maxWidth ?? chartRect?.chartWidth / (labelCount + 2);
+
+    return (notFormattedLabels ?? []).reduce((max, label) => {
+      // ellipsis가 적용된 label의 width를 계산
+      const formattedLabel = this.getLabelFormat(label, maxWidth);
+      const width = Util.calcTextSize(
+        formattedLabel,
+        labelStyle,
+      )?.width ?? 0;
+
+      return Math.max(max, width);
+    }, 0);
+  }
 }
 
 export default StepScale;


### PR DESCRIPTION
## 해결 내용
axis type이 step이고 fitWidth가 true인 경우 긴 label이 잘리는 문제를 해결했습니다.

## 테스트 방법
http://localhost:9999/barChart#scrollbar 에서 스크롤했을 때 축 label이 잘리지 않고 잘 보여지는지 확인해주세요.

수정 전)
![y축label잘림](https://github.com/user-attachments/assets/7db2ad88-ef21-40ea-b59c-419fd7d84f4b)

수정 후)
![y축label 잘림 해결](https://github.com/user-attachments/assets/04a5a7b9-38ed-4ece-8398-016ff63fe0a7)

close #2063 