### PR TITLE
v-resize 직접구현하기

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,6 +23,7 @@ module.exports = {
         peerDependencies: true,
       },
     ],
+    "import/prefer-default-export": "off",
     // don't require .vue extension when importing
     'import/extensions': 'off',
     'import/no-unresolved': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evui",
-  "version": "3.4.207",
+  "version": "3.4.208",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "evui",
-      "version": "3.4.207",
+      "version": "3.4.208",
       "license": "MIT",
       "dependencies": {
         "@vitejs/plugin-vue": "^5.1.4",
@@ -16,7 +16,6 @@
         "sass": "^1.94.2",
         "vite": "^5.4.8",
         "vue": "^3.5.8",
-        "vue-resize-observer": "^2.0.15",
         "vue-router": "^4.6.3",
         "vue3-observe-visibility": "^1.0.1"
       },
@@ -38,7 +37,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "vue": "*"
+        "vue": "^3.5.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6607,12 +6606,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/vue-resize-observer": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/vue-resize-observer/-/vue-resize-observer-2.0.16.tgz",
-      "integrity": "sha512-E6LBZp0KSYAgA7KbqKv6GA4NRj6Q677Ldck5e+nTB2GCjhyPZQzdYJEzIeYoERDuwI6c6OcGF5Vd4a0+rjZECA==",
-      "license": "MIT"
     },
     "node_modules/vue-router": {
       "version": "4.6.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "sass": "^1.94.2",
     "vite": "^5.4.8",
     "vue": "^3.5.8",
-    "vue-resize-observer": "^2.0.15",
     "vue-router": "^4.6.3",
     "vue3-observe-visibility": "^1.0.1"
   },
@@ -61,6 +60,6 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "vue": "*"
+    "vue": "^3.5.8"
   }
 }

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -19,7 +19,7 @@ import {
   computed,
 } from 'vue';
 import { cloneDeep, isEqual, debounce } from 'lodash-es';
-import resize from 'vue-resize-observer';
+import { resize } from '@/directives/resize';
 import EvChart from './chart.core';
 import EvChartToolbar from './ChartToolbar';
 import { useModel, useWrapper, useZoomModel } from './uses';
@@ -348,14 +348,6 @@ export default {
       }
     });
 
-    const redraw = () => {
-      if (evChart && 'update' in evChart) {
-        evChart.update({
-          updateSeries: true,
-          updateSelTip: { update: true, keepDomain: false },
-        });
-      }
-    };
 
     const onResize = debounce(() => {
       if (evChart && 'resize' in evChart) {
@@ -373,7 +365,6 @@ export default {
       wrapper,
       wrapperStyle,
       onResize,
-      redraw,
 
       evChartToolbarRef,
       injectIsChartGroup,

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -1122,7 +1122,7 @@ class EvChart {
         }
         if (this.options.legend.virtualScroll && !this.useTable) {
           this.legendBoxDOM.removeEventListener('resize', this.updateVisibleRowCount);
-          this.legendBoxDOM.removeEventListener('scroll', this.renderVisibleLegends);
+          this.legendBoxDOM.removeEventListener('scroll', this.boundRenderVisibleLegends);
         }
       }
 
@@ -1164,6 +1164,9 @@ class EvChart {
     this.displayCanvas = null;
     this.bufferCanvas = null;
     this.overlayCanvas = null;
+    this.displayCtx = null;
+    this.bufferCtx = null;
+    this.overlayCtx = null;
 
     while (target.hasChildNodes()) {
       target.removeChild(target.firstChild);

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -616,7 +616,8 @@ const modules = {
 
     if (this.options.legend.virtualScroll && !this.useTable) {
       this.legendBoxDOM.addEventListener('resize', this.updateVisibleRowCount);
-      this.legendBoxDOM.addEventListener('scroll', this.renderVisibleLegends.bind(this));
+      this.boundRenderVisibleLegends = this.renderVisibleLegends.bind(this);
+      this.legendBoxDOM.addEventListener('scroll', this.boundRenderVisibleLegends);
     }
 
     this.initResizeEvent();

--- a/src/components/chartBrush/ChartBrush.vue
+++ b/src/components/chartBrush/ChartBrush.vue
@@ -21,7 +21,7 @@ import {
   onUpdated,
 } from 'vue';
 import { cloneDeep, debounce, isEqual } from 'lodash-es';
-import vResize from 'vue-resize-observer';
+import { resize } from '@/directives/resize';
 import EvChart from '../chart/chart.core';
 import { useModel, useWrapper } from '../chart/uses';
 import EvChartBrush from './chartBrush.core';
@@ -30,7 +30,7 @@ import { useBrushModel } from './uses';
 export default {
   name: 'EvChartBrush',
   directives: {
-    resize: vResize,
+    resize,
   },
   props: {
     options: {
@@ -308,9 +308,9 @@ export default {
      */
     const onResize = debounce(() => {
       if (evChart && 'resize' in evChart) {
-        const resize = new Promise((resolve) => evChart.resize(resolve));
+        const resizeResolver = new Promise((resolve) => evChart.resize(resolve));
 
-        resize.then((isResizeDone) => {
+        resizeResolver.then((isResizeDone) => {
           if (isResizeDone) {
             drawChartBrush(isResizeDone);
           }

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -585,7 +585,7 @@ import {
 } from 'vue';
 import { cloneDeep } from 'lodash-es';
 import { ObserveVisibility as vObserveVisibility } from 'vue3-observe-visibility';
-import resize from 'vue-resize-observer';
+import { resize } from '@/directives/resize';
 import { clickoutside } from '@/directives/clickoutside';
 import Toolbar from './GridToolbar';
 import GridPagination from './GridPagination';

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -65,7 +65,7 @@
 <script>
 import { ref, reactive, computed, provide, triggerRef, onBeforeUpdate, nextTick } from 'vue';
 import { ObserveVisibility as vObserveVisibility } from 'vue3-observe-visibility';
-import resize from 'vue-resize-observer';
+import { resize } from '@/directives/resize';
 
 export default {
   name: 'EvTabs',

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -274,7 +274,7 @@ import {
 } from 'vue';
 import { cloneDeep } from 'lodash-es';
 import { ObserveVisibility as vObserveVisibility } from 'vue3-observe-visibility';
-import resize from 'vue-resize-observer';
+import { resize } from '@/directives/resize';
 import TreeGridNode from './TreeGridNode';
 import Toolbar from './TreeGridToolbar';
 import GridPagination from '../grid/GridPagination';

--- a/src/directives/resize.js
+++ b/src/directives/resize.js
@@ -1,0 +1,18 @@
+export const resize = {
+  mounted(el, binding) {
+    const handler = binding.value;
+
+    const observer = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      handler({ width, height });
+    });
+
+    observer.observe(el);
+    el.__resizeObserver__ = observer;
+  },
+
+  unmounted(el) {
+    el.__resizeObserver__?.disconnect();
+    el.__resizeObserver__ = null;
+  },
+};


### PR DESCRIPTION
### 변경사항
- v-resize를 직접 구현했습니다.
- vue-resize-observer 의존성을 제거했습니다.
- 이벤트 핸들러가 해제되지 않을 수 있는 곳을 수정했습니다.

fix #2074 