### PR TITLE
[fix] Scatter > realTimeScatter에서 autoScale 시 y축 범위가 제대로 업데이트되지 않는 문제 수정

### DIFF
--- a/docs/views/scatterChart/example/RealTimeScatter.vue
+++ b/docs/views/scatterChart/example/RealTimeScatter.vue
@@ -145,10 +145,13 @@ export default {
         let randomY = 0;
         if (!isInit) {
           randomX = floor(Date.now() + getRandomInt(-3000, 0)); // -3초 ~ 현재
-          randomY = floor(getRandomInt(3000, 95000));
+          randomY = floor(getRandomInt(3000, 95000)); // 업데이트 시에는 작은 값만
         } else {
           randomX = floor(Date.now() + getRandomInt(-300000, 0)); // -5분 ~ 현재
-          randomY = floor(getRandomInt(3000, 57000));
+          // 처음 5개만 큰 값
+          randomY = i < 5
+            ? floor(getRandomInt(150000, 200000))
+            : floor(getRandomInt(3000, 57000));
         }
         const randomType = getRandomInt(0, 1);
 

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -233,19 +233,36 @@ const modules = {
         }
       }
 
+      // 실제 차트에 그려지는 데이터(fromTime ~ toTime 범위)에서만 min/max 계산
       const tempMinMax = {
-        maxY: 0,
+        maxY: -Infinity,
         minY: Infinity,
       };
 
-      for (let i = 0; i < this.dataSet[key].length; i++) {
-        if (this.dataSet[key].dataGroup[i].max > tempMinMax.maxY) {
-          tempMinMax.maxY = this.dataSet[key].dataGroup[i].max;
-        }
+      const { fromTime, toTime } = this.dataSet[key];
 
-        if (this.dataSet[key].dataGroup[i].min < tempMinMax.minY) {
-          tempMinMax.minY = this.dataSet[key].dataGroup[i].min;
+      for (let i = 0; i < this.dataSet[key].length; i++) {
+        const groupData = this.dataSet[key].dataGroup[i].data;
+        for (let j = 0; j < groupData.length; j++) {
+          const item = groupData[j];
+          // 현재 시간 범위 내의 데이터만 minMax 계산에 포함
+          if (item.x >= fromTime && item.x <= toTime) {
+            if (item.y > tempMinMax.maxY) {
+              tempMinMax.maxY = item.y;
+            }
+            if (item.y < tempMinMax.minY) {
+              tempMinMax.minY = item.y;
+            }
+          }
         }
+      }
+
+      // 유효한 데이터가 없는 경우 기본값 설정
+      if (!Number.isFinite(tempMinMax.maxY)) {
+        tempMinMax.maxY = 0;
+      }
+      if (!Number.isFinite(tempMinMax.minY)) {
+        tempMinMax.minY = 0;
       }
 
       minMaxValues.maxY = Math.max(minMaxValues.maxY, tempMinMax.maxY);


### PR DESCRIPTION
## Summary
- realTimeScatter + autoScale 조합 시 y축 범위가 현재 보이는 데이터 기준으로 업데이트되지 않는 문제 수정
- 시간 범위(fromTime ~ toTime) 내의 데이터만 min/max 계산에 포함하도록 변경

![y scale 수정 후](https://github.com/user-attachments/assets/57e4564a-30aa-4160-b06f-6d91c86b63c8)

 ## Test
  - [x] realTimeScatter 예시에서 초기 큰 값이 시간 범위 밖으로 밀려나면 y축 범위가 줄어드는지 확인

close #2077 