### PR TITLE
fix: 파이 차트 레전드 호버 시 전체 투명화 방지

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -867,7 +867,11 @@ class EvChart {
       this.updateScrollbar?.(updateData);
     }
 
+    const preservedPieDataSet = lightUpdate ? this.pieDataSet : null;
     this.resetProps();
+    if (lightUpdate && preservedPieDataSet) {
+      this.pieDataSet = preservedPieDataSet;
+    }
 
     this.updateSeries = updateSeries;
     if (updateSeries) {
@@ -903,7 +907,7 @@ class EvChart {
         this.lastHitInfo = null;
       }
     }
-    
+
     if (!lightUpdate) {
       // group update
       if (groups.length) {
@@ -919,7 +923,7 @@ class EvChart {
       } else {
         this.createDataSet(data, labels);
       }
-      
+
       // title update
       if (options.title.show) {
         if (!this.isInitTitle) {
@@ -927,12 +931,12 @@ class EvChart {
         } else {
           this.updateTitle();
         }
-  
+
         this.showTitle();
       } else if (this.isInitTitle) {
         this.hideTitle();
       }
-      
+
       // legend Update
       if (options.legend.show) {
         const useTable =

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -867,11 +867,7 @@ class EvChart {
       this.updateScrollbar?.(updateData);
     }
 
-    const preservedPieDataSet = lightUpdate ? this.pieDataSet : null;
     this.resetProps();
-    if (lightUpdate && preservedPieDataSet) {
-      this.pieDataSet = preservedPieDataSet;
-    }
 
     this.updateSeries = updateSeries;
     if (updateSeries) {
@@ -1008,7 +1004,6 @@ class EvChart {
     this.axesRange = null;
     this.labelOffset = null;
     this.chartRect = null;
-    this.pieDataSet = [];
   }
 
   /**


### PR DESCRIPTION
### Summary

https://github.com/user-attachments/assets/a383417f-2953-4019-b390-397b0f8d6562

 -  레전드 영역의 빈 공간을 호버하면 legendHitInfo가 sId 없이 전달되면서 파이 시리즈 전체가 downplay 처리되고, lightUpdate 경로에서 pieDataSet까지 초기화돼 투명 상태가 유지되는 문제가 있었습니다.
-  해결책으로 legendHitInfo.sId가 있을 때만 downplay를 적용하도록 가드하고, lightUpdate 시에는 기존 pieDataSet을 보존해 레전드 hover/leave로도 파이 데이터가 사라지지 않도록 했습니다.


### Test
- 파이차트 레전드영역 호버간 차트 사라지는지 확인