### PR TITLE
[#2086] Chart > Tooltip > Bar/Line 차트 간 sync indicator 위치 불일치 수정

### DIFF
--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -976,9 +976,10 @@ const modules = {
     }
 
     const { horizontal } = this.options;
-    const { top, bottom, left, right } = this.chartDOM.getBoundingClientRect();
+    const rect = this.chartDOM.getBoundingClientRect();
+    const [mouseX, mouseY] = mousePosition;
     const isHoveredChart =
-      inRange(mousePosition[0], left, right) && inRange(mousePosition[1], bottom, top);
+      inRange(mouseX, rect.left, rect.right) && inRange(mouseY, rect.bottom, rect.top);
     if (isHoveredChart) {
       return;
     }
@@ -997,19 +998,39 @@ const modules = {
 
     if (horizontal) {
       const chartHeight = graphPos.y2 - graphPos.y1;
-      // CategoryMode인 경우 라벨들이 균등 간격으로 배치됨
       const isCategoryMode = this.options.axesY?.some((axis) => axis.categoryMode);
-      const positionY = isCategoryMode
-        ? graphPos.y1 + (chartHeight * (matchingLabelIndex + 0.5)) / labelsCount
-        : graphPos.y1 + (chartHeight * matchingLabelIndex) / (labelsCount - 1);
+      const isTimeAxis = this.options.axesY?.some((axis) => axis.type === 'time');
+
+      let positionY;
+      if (isCategoryMode) {
+        positionY = graphPos.y1 + (chartHeight * (matchingLabelIndex + 0.5)) / labelsCount;
+      } else if (isTimeAxis) {
+        // 틱 위치와 동일하게 graphMin/graphMax 사용
+        const axisStep = this.axesSteps?.y?.[0];
+        const graphMin = axisStep?.graphMin ?? +this.data.labels?.[0];
+        const graphMax = axisStep?.graphMax ?? +this.data.labels?.[this.data.labels.length - 1];
+        positionY = graphPos.y1 + (chartHeight * (+dataLabel - graphMin)) / (graphMax - graphMin);
+      } else {
+        positionY = graphPos.y1 + (chartHeight * matchingLabelIndex) / (labelsCount - 1);
+      }
       indicatorPosition = [graphPos.x2, positionY];
     } else {
       const chartWidth = graphPos.x2 - graphPos.x1;
-      // CategoryMode인 경우 라벨들이 균등 간격으로 배치됨
       const isCategoryMode = this.options.axesX?.some((axis) => axis.categoryMode);
-      const positionX = isCategoryMode
-        ? graphPos.x1 + (chartWidth * (matchingLabelIndex + 0.5)) / labelsCount
-        : graphPos.x1 + (chartWidth * matchingLabelIndex) / (labelsCount - 1);
+      const isTimeAxis = this.options.axesX?.some((axis) => axis.type === 'time');
+
+      let positionX;
+      if (isCategoryMode) {
+        positionX = graphPos.x1 + (chartWidth * (matchingLabelIndex + 0.5)) / labelsCount;
+      } else if (isTimeAxis) {
+        // 틱 위치와 동일하게 graphMin/graphMax 사용
+        const axisStep = this.axesSteps?.x?.[0];
+        const graphMin = axisStep?.graphMin ?? +this.data.labels?.[0];
+        const graphMax = axisStep?.graphMax ?? +this.data.labels?.[this.data.labels.length - 1];
+        positionX = graphPos.x1 + (chartWidth * (+dataLabel - graphMin)) / (graphMax - graphMin);
+      } else {
+        positionX = graphPos.x1 + (chartWidth * matchingLabelIndex) / (labelsCount - 1);
+      }
       indicatorPosition = [positionX, graphPos.y2];
     }
 


### PR DESCRIPTION
## Summary
- Time 축 사용 시 Bar 차트와 Line 차트 간 sync indicator 위치가 미세하게 불일치하는 문제 수정
- indicator 위치 계산에 axesSteps의 graphMin/graphMax 값을 사용하여 실제 틱 위치와 동일하게 계산되도록 개선

## Test plan
- [ ] Line 차트와 Bar 차트를 그룹으로 묶은 상태에서 hover 시 sync indicator 위치가 정확히 일치하는지 확인
- [ ] categoryMode와 일반 모드에서 모두 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)