### PR TITLE
[#2089][3.4] Chart > clickLegend emit 이벤트 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -499,5 +499,6 @@ const chartOptions = {
 | click      | selectedItem | 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                           |
 | dbl-click  | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                      |
 | mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환 |
+| click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -318,6 +318,7 @@ const chartData = {
 | stopClickEvt  | Boolean                     | false                                    | Legend 표시 여부                                      | true /false                      |
 | virtualScroll | Boolean                     | false                                    | Legend에 가상 스크롤 적용 여부                        | true /false                      |
 | clickMode       | 'active' \| 'inactive'       | 'active'                                 | Legend 클릭 시 활성화 여부                             |                                  |
+| clickEmitOnly | Boolean                     | false                                    | true이면 클릭 시 차트 갱신 없이 click-legend만 emit (이중 렌더 방지) | true/false | 
 
 ##### legendTable
 

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -129,6 +129,7 @@ const chartData = {
 | selectLabel  | Object                    | ([상세](#selectlabel))                    | 차트 라벨 선택 기능 활성화 여부 및 속성                                                                                                                                                |                                 |
 | padding      | Object                    | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값                                                                                                                                                                   |                                 |
 | syncHover    | boolean                   | true                                      | options.syncHover가 true인 EvChartGroup으로 감싼경우, 해당 차트에서는 그룹으로 묶긴 차트들 사이의 syncHover선을 그리고싶지 않을 때 사용하는 속성 (time관련된 축을 가질때만 적용됩니다) |                                 |
+| eventBehavior | Object                    | ([상세](#eventbehavior))                  | 이벤트별 동작 설정                                                                 |                                 |
 
 #### axesX axesY
 
@@ -318,7 +319,6 @@ const chartData = {
 | stopClickEvt  | Boolean                     | false                                    | Legend 표시 여부                                      | true /false                      |
 | virtualScroll | Boolean                     | false                                    | Legend에 가상 스크롤 적용 여부                        | true /false                      |
 | clickMode       | 'active' \| 'inactive'       | 'active'                                 | Legend 클릭 시 활성화 여부                             |                                  |
-| clickEmitOnly | Boolean                     | false                                    | true이면 클릭 시 차트 갱신 없이 click-legend만 emit (이중 렌더 방지) | true/false | 
 
 ##### legendTable
 
@@ -487,6 +487,14 @@ const chartOptions = {
 | fixedPosTop         | Boolean                     | false     | tip의 위치를 최대값으로 고정                                               |            |
 | useApproximateValue | Boolean                     | false     | 가까운 label을 선택                                                        |            |
 | tipBackground       | Hex, RGB, RGBA Code(String) | '#000000' | tip 배경색상                                                               |            |
+
+#### eventBehavior
+
+이벤트별 동작을 설정하는 옵션 객체.
+
+| 이름         | 타입   | 디폴트   | 설명                                                                 | 종류(예시)           |
+| ----------- | ------ | -------- | -------------------------------------------------------------------- | -------------------- |
+| legendClick | String | 'update' | 범례 클릭 시 동작. 'update': 차트 즉시 갱신, 'emitOnly': click-legend만 emit(이중 렌더 방지) | 'update' \| 'emitOnly' |
 
 ### 5. resize-timeout
 

--- a/docs/views/barChart/example/LegendClickMode.vue
+++ b/docs/views/barChart/example/LegendClickMode.vue
@@ -18,6 +18,10 @@
       </p>
     </div>
     <ev-chart :data="chartData" :options="chartOptions" />
+    <div class="result">
+      <div class="badge yellow">클릭된 시리즈 ID</div>
+      {{ clickedSeriesIds }}
+    </div>
   </div>
 </template>
 
@@ -78,10 +82,18 @@ export default {
       ],
     }));
 
+    const clickedSeriesIds = ref([]);
+
+    const handleClickLegend = (e) => {
+      clickedSeriesIds.value = e.data.seriesIds;
+    };
+
     return {
       legendClickMode,
       chartData,
       chartOptions,
+      clickedSeriesIds,
+      handleClickLegend,
     };
   },
 };

--- a/docs/views/barChart/example/LegendClickMode.vue
+++ b/docs/views/barChart/example/LegendClickMode.vue
@@ -17,7 +17,7 @@
         inactive, 처음 클릭시 해당 시리즈만 감춤, 마지막 남은 범례 클릭시 무시
       </p>
     </div>
-    <ev-chart :data="chartData" :options="chartOptions" />
+    <ev-chart :data="chartData" :options="chartOptions" @click-legend="handleClickLegend" />
     <div class="result">
       <div class="badge yellow">클릭된 시리즈 ID</div>
       {{ clickedSeriesIds }}

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -463,5 +463,6 @@ const chartOptions = {
 | dbl-click   | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                                                                                                                                                                                     |
 | mouse-move  |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                                                |
 | drag-select | data, range  | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
+| click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -257,7 +257,8 @@ const chartData =
 | table         | Object                      | ([상세](#legendtable))                   | Table 타입 Legend (값 표시 포함). bar, line, pie 전용 |                                  |
 | stopClickEvt  | Boolean                     | false                                    | Legend 표시 여부                                      | true /false                      |
 | virtualScroll | Boolean                     | false                                    | Legend에 가상 스크롤 적용 여부                        | true /false                      |
-| clickMode       | 'active' \| 'inactive'       | 'active'                                 | Legend 클릭 시 활성화 여부                             |                                  |
+| clickMode     | 'active' \| 'inactive'      | 'active'                                 | Legend 클릭 시 활성화 여부                             |                                  |
+| clickEmitOnly | Boolean                     | false                                    | true이면 클릭 시 차트 갱신 없이 click-legend만 emit (이중 렌더 방지) | true/false | 
 
 ##### legendTable
 

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -124,6 +124,7 @@ const chartData =
 | selectItem | Object          | ([상세](#selectitem))                     | 차트 아이템 선택 기능 활성화 여부 및 속성                                                                                                                                              |                                 |
 | padding    | Object          | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값                                                                                                                                                                   |
 | syncHover  | boolean         | true                                      | options.syncHover가 true인 EvChartGroup으로 감싼경우, 해당 차트에서는 그룹으로 묶긴 차트들 사이의 syncHover선을 그리고싶지 않을 때 사용하는 속성 (time관련된 축을 가질때만 적용됩니다) |
+| eventBehavior | Object      | ([상세](#eventbehavior))                  | 이벤트별 동작 설정 | | 
 
 #### axesX axesY
 
@@ -258,7 +259,6 @@ const chartData =
 | stopClickEvt  | Boolean                     | false                                    | Legend 표시 여부                                      | true /false                      |
 | virtualScroll | Boolean                     | false                                    | Legend에 가상 스크롤 적용 여부                        | true /false                      |
 | clickMode     | 'active' \| 'inactive'      | 'active'                                 | Legend 클릭 시 활성화 여부                             |                                  |
-| clickEmitOnly | Boolean                     | false                                    | true이면 클릭 시 차트 갱신 없이 click-legend만 emit (이중 렌더 방지) | true/false | 
 
 ##### legendTable
 
@@ -451,10 +451,19 @@ const chartOptions = {
 | fillColor   | Hex, RGB, RGBA Code(String) | '#38ACEC' | 선택 영역 색상               |              |
 | opacity     | Number                      | 0.65      | 선택 영역 불투명도           | 0 ~ 1        |
 
+#### eventBehavior
+
+이벤트별 동작을 설정하는 옵션 객체.
+
+| 이름         | 타입    | 디폴트    | 설명                                                                 | 종류(예시)           |
+| ----------- | ------- | --------- | -------------------------------------------------------------------- | -------------------- |
+| legendClick | String  | 'update'  | 범례 클릭 시 동작. 'update': 차트 즉시 갱신, 'emitOnly': click-legend만 emit(이중 렌더 방지) | 'update' \| 'emitOnly' |
+
 ### 6. resize-timeout
 
 - Default : 0
 - debounce 사용. 연속으로 이벤트가 발생한 경우, 마지막 이벤트가 끝난 시점을 기준으로 `주어진 시간 (resize-timeout)` 이후 콜백 실행
+
 
 ### 7. Event
 
@@ -467,3 +476,5 @@ const chartOptions = {
 | click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환
+
+

--- a/docs/views/lineChart/example/LegendClickMode.vue
+++ b/docs/views/lineChart/example/LegendClickMode.vue
@@ -17,7 +17,11 @@
         inactive, 처음 클릭시 해당 시리즈만 감춤, 마지막 남은 범례 클릭시 무시
       </p>
     </div>
-    <ev-chart :data="chartData" :options="chartOptions" />
+    <ev-chart :data="chartData" :options="chartOptions" @click-legend="handleClickLegend" />
+    <div class="result">
+      <div class="badge yellow">클릭된 시리즈 ID</div>
+      {{ clickedSeriesIds }}
+    </div>
   </div>
 </template>
 
@@ -101,10 +105,18 @@ export default {
       ],
     }));
 
+    const clickedSeriesIds = ref([]);
+
+    const handleClickLegend = (e) => {
+      clickedSeriesIds.value = e.data.seriesIds;
+    };
+
     return {
       legendClickMode,
       chartData,
       chartOptions,
+      clickedSeriesIds,
+      handleClickLegend,
     };
   },
 };

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -79,6 +79,7 @@ const chartData =
 | doughnutHoleSize | number          | 0                                              | 내부 hole 사이즈                                                | 0 ~ 1                           |
 | pieStroke        | Object          | { show: true, color: '#FFFFFF', lineWidth: 2 } | 차트의 테두리선 표시 여부 및 색상, 두께를 설정하는 옵션         |                                 |
 | tooltip          | Object          | ([상세](#tooltip))                             | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성                |                                 |
+| eventBehavior    | Object          | ([상세](#eventbehavior))                       | 이벤트별 동작 설정                                             |                                 |
 
 #### title
 
@@ -108,7 +109,6 @@ const chartData =
 | stopClickEvt  | Boolean                     | false                                    | Legend 표시 여부                                      | true /false                      |
 | virtualScroll | Boolean                     | false                                    | Legend에 가상 스크롤 적용 여부                        | true /false                      |
 | clickMode       | 'active' \| 'inactive'       | 'active'                                 | Legend 클릭 시 활성화 여부                             |                                  |
-| clickEmitOnly | Boolean                     | false                                    | true이면 클릭 시 차트 갱신 없이 click-legend만 emit (이중 렌더 방지) | true/false | 
 
 ##### legendTable
 
@@ -205,6 +205,14 @@ const chartOptions = {
 | 이름 | 타입    | 디폴트 | 설명                  | 종류(예시) |
 | ---- | ------- | ------ | --------------------- | ---------- |
 | use  | Boolean | false  | 차트 아이템 선택 기능 |            |
+
+#### eventBehavior
+
+이벤트별 동작을 설정하는 옵션 객체.
+
+| 이름         | 타입   | 디폴트   | 설명                                                                 | 종류(예시)           |
+| ----------- | ------ | -------- | -------------------------------------------------------------------- | -------------------- |
+| legendClick | String | 'update' | 범례 클릭 시 동작. 'update': 차트 즉시 갱신, 'emitOnly': click-legend만 emit(이중 렌더 방지) | 'update' \| 'emitOnly' |
 
 ### 4. resize-timeout
 

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -108,6 +108,7 @@ const chartData =
 | stopClickEvt  | Boolean                     | false                                    | Legend 표시 여부                                      | true /false                      |
 | virtualScroll | Boolean                     | false                                    | Legend에 가상 스크롤 적용 여부                        | true /false                      |
 | clickMode       | 'active' \| 'inactive'       | 'active'                                 | Legend 클릭 시 활성화 여부                             |                                  |
+| clickEmitOnly | Boolean                     | false                                    | true이면 클릭 시 차트 갱신 없이 click-legend만 emit (이중 렌더 방지) | true/false | 
 
 ##### legendTable
 

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -216,5 +216,6 @@ const chartOptions = {
 | --------- | ------------ | ---------------------------------------------- |
 | click     | selectedItem | 클릭된 series의 value, seriesID 값을 반환      |
 | dbl-click | selectedItem | 더블 클릭된 series의 value, seriesID 값을 반환 |
+| click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -217,6 +217,7 @@ const chartData =
 | stopClickEvt| Boolean | false | Legend 표시 여부 | true /false |
 | virtualScroll | Boolean | false | Legend에 가상 스크롤 적용 여부  | true /false |
 | clickMode       | 'active' \| 'inactive'       | 'active'                                 | Legend 클릭 시 활성화 여부                             |                                  |
+| clickEmitOnly | Boolean                     | false                                    | true이면 클릭 시 차트 갱신 없이 click-legend만 emit (이중 렌더 방지) | true/false | 
 
 #### dragSelection
 

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -80,6 +80,7 @@ const chartData =
   | realTimeScatter | Object | ([상세](#realtimescatter)) | 실시간으로 데이터를 처리하는 real time scatter로 변경 여부 및 속성 | |
   | seriesReverse | Boolean | false | 시리즈 순서 반대로 표시 여부 | |
   | coordinateDedupe | Boolean | true | 좌표 중복 제거 여부 | |
+  | eventBehavior | Object | ([상세](#eventbehavior)) | 이벤트별 동작 설정 | |
 
 #### axesX axesY
 
@@ -217,7 +218,6 @@ const chartData =
 | stopClickEvt| Boolean | false | Legend 표시 여부 | true /false |
 | virtualScroll | Boolean | false | Legend에 가상 스크롤 적용 여부  | true /false |
 | clickMode       | 'active' \| 'inactive'       | 'active'                                 | Legend 클릭 시 활성화 여부                             |                                  |
-| clickEmitOnly | Boolean                     | false                                    | true이면 클릭 시 차트 갱신 없이 click-legend만 emit (이중 렌더 방지) | true/false | 
 
 #### dragSelection
 
@@ -230,6 +230,14 @@ const chartData =
 | opacity | Number | 0.65 | 선택 영역 불투명도 | 0 ~ 1 |
 
 - PC버전에서는 drag, Mobile에서는 touch로 선택 영역을 지정할 수 있습니다.
+
+#### eventBehavior
+
+이벤트별 동작을 설정하는 옵션 객체.
+
+| 이름         | 타입   | 디폴트   | 설명                                                                 | 종류(예시)           |
+| ----------- | ------ | -------- | -------------------------------------------------------------------- | -------------------- |
+| legendClick | String | 'update' | 범례 클릭 시 동작. 'update': 차트 즉시 갱신, 'emitOnly': click-legend만 emit(이중 렌더 방지) | 'update' \| 'emitOnly' |
 
 #### tooltip
 

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -359,6 +359,7 @@ const chartOptions = {
  |------|----------|------|
  | mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                 |
  | drag-select | data, range | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
+| click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
 
 - drag-select는  `dragSelection` 옵션의 `use`값이 `true` 일 때 이벤트를 발생 시킬 수 있다.
  그리고 선택영역은 그래프에 표시된 데이터의 중앙이 포함 되어야 선택영역 내 데이터로 인식 한다.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evui",
-  "version": "3.4.207",
+  "version": "3.4.211",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "evui",
-      "version": "3.4.207",
+      "version": "3.4.211",
       "license": "MIT",
       "dependencies": {
         "@vitejs/plugin-vue": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.210",
+  "version": "3.4.211",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -81,6 +81,7 @@ export default {
     'update:zoomStartIdx',
     'update:zoomEndIdx',
     'update:realTimeScatterReset',
+    'click-legend',
   ],
   setup(props, { emit }) {
     let evChart = null;
@@ -159,26 +160,34 @@ export default {
       }
     };
 
+    const updateChartOptions = debounce((chartOpt) => {
+      if (!evChart) {
+        return;
+      }
+
+      const newOpt = getNormalizedOptions(chartOpt);
+      const isUpdateLegendType = !isEqual(newOpt.legend.table, evChart.options.legend.table);
+      const isUpdateTooltip =
+        newOpt.tooltip.use && !isEqual(newOpt.tooltip, evChart.options.tooltip);
+
+      evChart.options = cloneDeep(newOpt);
+
+      evChart.update({
+        updateSeries: false,
+        updateSelTip: { update: false, keepDomain: false },
+        updateLegend: isUpdateLegendType,
+        updateTooltip: isUpdateTooltip,
+      });
+
+      if (!injectIsChartGroup) {
+        setOptionsForUseZoom(newOpt);
+      }
+    }, props.resizeTimeout || 100);
+
     watch(
       () => props.options,
       (chartOpt) => {
-        const newOpt = getNormalizedOptions(chartOpt);
-        const isUpdateLegendType = !isEqual(newOpt.legend.table, evChart.options.legend.table);
-        const isUpdateTooltip =
-          newOpt.tooltip.use && !isEqual(newOpt.tooltip, evChart.options.tooltip);
-
-        evChart.options = cloneDeep(newOpt);
-
-        evChart.update({
-          updateSeries: false,
-          updateSelTip: { update: false, keepDomain: false },
-          updateLegend: isUpdateLegendType,
-          updateTooltip: isUpdateTooltip,
-        });
-
-        if (!injectIsChartGroup) {
-          setOptionsForUseZoom(newOpt);
-        }
+        updateChartOptions(chartOpt);
       },
       { deep: true, flush: 'post' },
     );
@@ -331,6 +340,8 @@ export default {
     });
 
     onBeforeUnmount(() => {
+      updateChartOptions.cancel();
+
       if (evChart && 'destroy' in evChart) {
         evChart.destroy();
       }

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -160,43 +160,26 @@ export default {
       }
     };
 
-    const applyOptionsToChart = (newOpt) => {
-      const isUpdateLegendType = !isEqual(newOpt.legend.table, evChart.options.legend.table);
-      const isUpdateTooltip =
-        newOpt.tooltip.use && !isEqual(newOpt.tooltip, evChart.options.tooltip);
-
-      evChart.options = cloneDeep(newOpt);
-
-      
-
-      return { isUpdateLegendType, isUpdateTooltip };
-    };
-
-    const updateChartOptions = debounce((chartOpt) => {
-      if (!evChart) {
-        return;
-      }
-
-      const newOpt = getNormalizedOptions(chartOpt);
-      const { isUpdateLegendType, isUpdateTooltip } = applyOptionsToChart(newOpt);
-
-      evChart.update({
-        updateSeries: false,
-        updateSelTip: { update: false, keepDomain: false },
-        updateLegend: isUpdateLegendType,
-        updateTooltip: isUpdateTooltip,
-      });
-
-      if (!injectIsChartGroup) {
-        setOptionsForUseZoom(newOpt);
-      }
-
-    }, props.resizeTimeout || 100);
-
     watch(
       () => props.options,
       (chartOpt) => {
-        updateChartOptions(chartOpt);
+        const newOpt = getNormalizedOptions(chartOpt);
+        const isUpdateLegendType = !isEqual(newOpt.legend.table, evChart.options.legend.table);
+        const isUpdateTooltip =
+          newOpt.tooltip.use && !isEqual(newOpt.tooltip, evChart.options.tooltip);
+
+        evChart.options = cloneDeep(newOpt);
+
+        evChart.update({
+          updateSeries: false,
+          updateSelTip: { update: false, keepDomain: false },
+          updateLegend: isUpdateLegendType,
+          updateTooltip: isUpdateTooltip,
+        });
+
+        if (!injectIsChartGroup) {
+          setOptionsForUseZoom(newOpt);
+        }
       },
       { deep: true, flush: 'post' },
     );
@@ -204,10 +187,6 @@ export default {
     watch(
       () => props.data,
       (chartData) => {
-        if (!evChart) {
-          return;
-        }
-
         const newData = props.options.realTimeScatter?.use
           ? { ...chartData, groups: [], labels: [] }
           : getNormalizedData(chartData);
@@ -220,18 +199,10 @@ export default {
 
         evChart.data = props.options.realTimeScatter?.use ? newData : cloneDeep(newData);
 
-        // data와 options가 동시에 바뀐 경우 한 번에 반영 (options debounce로 인한 이중 렌더 방지)
-        const newOpt = getNormalizedOptions(props.options);
-        const { isUpdateLegendType, isUpdateTooltip } = applyOptionsToChart(newOpt);
-
-        updateChartOptions.cancel();
-
         evChart.update({
           updateSeries: isUpdateSeries,
           updateSelTip: { update: true, keepDomain: false },
           updateData: isUpdateData,
-          updateLegend: isUpdateLegendType,
-          updateTooltip: isUpdateTooltip,
         });
 
         if (!injectIsChartGroup && isUpdateData) {
@@ -318,7 +289,7 @@ export default {
         }
       },
     );
-
+ 
     watch(
       () => props.options.realTimeScatter?.use,
       (use) => {
@@ -361,8 +332,6 @@ export default {
     });
 
     onBeforeUnmount(() => {
-      updateChartOptions.cancel();
-
       if (evChart && 'destroy' in evChart) {
         evChart.destroy();
       }

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -160,17 +160,25 @@ export default {
       }
     };
 
+    const applyOptionsToChart = (newOpt) => {
+      const isUpdateLegendType = !isEqual(newOpt.legend.table, evChart.options.legend.table);
+      const isUpdateTooltip =
+        newOpt.tooltip.use && !isEqual(newOpt.tooltip, evChart.options.tooltip);
+
+      evChart.options = cloneDeep(newOpt);
+
+      
+
+      return { isUpdateLegendType, isUpdateTooltip };
+    };
+
     const updateChartOptions = debounce((chartOpt) => {
       if (!evChart) {
         return;
       }
 
       const newOpt = getNormalizedOptions(chartOpt);
-      const isUpdateLegendType = !isEqual(newOpt.legend.table, evChart.options.legend.table);
-      const isUpdateTooltip =
-        newOpt.tooltip.use && !isEqual(newOpt.tooltip, evChart.options.tooltip);
-
-      evChart.options = cloneDeep(newOpt);
+      const { isUpdateLegendType, isUpdateTooltip } = applyOptionsToChart(newOpt);
 
       evChart.update({
         updateSeries: false,
@@ -182,6 +190,7 @@ export default {
       if (!injectIsChartGroup) {
         setOptionsForUseZoom(newOpt);
       }
+
     }, props.resizeTimeout || 100);
 
     watch(
@@ -195,6 +204,10 @@ export default {
     watch(
       () => props.data,
       (chartData) => {
+        if (!evChart) {
+          return;
+        }
+
         const newData = props.options.realTimeScatter?.use
           ? { ...chartData, groups: [], labels: [] }
           : getNormalizedData(chartData);
@@ -207,10 +220,18 @@ export default {
 
         evChart.data = props.options.realTimeScatter?.use ? newData : cloneDeep(newData);
 
+        // data와 options가 동시에 바뀐 경우 한 번에 반영 (options debounce로 인한 이중 렌더 방지)
+        const newOpt = getNormalizedOptions(props.options);
+        const { isUpdateLegendType, isUpdateTooltip } = applyOptionsToChart(newOpt);
+
+        updateChartOptions.cancel();
+
         evChart.update({
           updateSeries: isUpdateSeries,
           updateSelTip: { update: true, keepDomain: false },
           updateData: isUpdateData,
+          updateLegend: isUpdateLegendType,
+          updateTooltip: isUpdateTooltip,
         });
 
         if (!injectIsChartGroup && isUpdateData) {

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -561,10 +561,12 @@ const modules = {
         this.brushSeries.chartIdx = chartIdx;
       }
 
-      this.update({
-        updateSeries: false,
-        updateSelTip: { update: true, keepDomain: true },
-      });
+      if (!opt.clickEmitOnly) {
+        this.update({
+          updateSeries: false,
+          updateSelTip: { update: true, keepDomain: true },
+        });
+      }
 
       // click-legend event 발생
       const activeSeries = Object.values(this.seriesList).filter((series) => series.show);
@@ -785,10 +787,10 @@ const modules = {
         }
       }
 
-      this.update({
-        updateSeries: false,
-        updateSelTip: { update: true, keepDomain: true },
-      });
+        this.update({
+          updateSeries: false,
+          updateSelTip: { update: true, keepDomain: true },
+        });
     };
 
     /**

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -565,6 +565,22 @@ const modules = {
         updateSeries: false,
         updateSelTip: { update: true, keepDomain: true },
       });
+
+      // click-legend event 발생
+      const activeSeries = Object.values(this.seriesList).filter((series) => series.show);
+      const activeSeriesIds = activeSeries.map((series) => series.sId);
+      const isActiveAll = activeSeriesIds.length === Object.values(this.seriesList).length;
+      const args = {
+        e,
+        data: {
+          seriesIds: isActiveAll ? [] : activeSeriesIds,
+          isActiveAll,
+        },
+      };
+
+      if (typeof this.listeners['click-legend'] === 'function') {
+        this.listeners['click-legend'](args);
+      }
     };
 
     /**

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -561,7 +561,7 @@ const modules = {
         this.brushSeries.chartIdx = chartIdx;
       }
 
-      if (!opt.clickEmitOnly) {
+      if (this.options.eventBehavior?.legendClick !== 'emitOnly') {
         this.update({
           updateSeries: false,
           updateSelTip: { update: true, keepDomain: true },

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -32,7 +32,6 @@ const DEFAULT_OPTIONS = {
     allowResize: false,
     virtualScroll: false,
     clickMode: 'active',
-    clickEmitOnly: false,
     table: {
       use: false,
       columns: {
@@ -241,6 +240,9 @@ const DEFAULT_OPTIONS = {
   },
   seriesReverse: false,
   coordinateDedupe: true,
+  eventBehavior: {
+    legendClick: 'update',
+  },
 };
 
 const DEFAULT_DATA = {

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -393,6 +393,10 @@ export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
         injectGroupHoveredLabel.value.label = null;
       }
     },
+    'click-legend': async (e) => {
+      await nextTick();
+      emit('click-legend', e);
+    },
   };
 
   return {

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -32,6 +32,7 @@ const DEFAULT_OPTIONS = {
     allowResize: false,
     virtualScroll: false,
     clickMode: 'active',
+    clickEmitOnly: false,
     table: {
       use: false,
       columns: {


### PR DESCRIPTION
[이슈]
범례 클릭했을 때 차트 내부에서 컨트롤 하기 때문에 emit 이벤트가 따로 없음
차트 외부에서도 현재 활성화된 범례를 알 수 있도록 하기 위해 emit 이벤트 추가 필요

[변경 사항]
- click-legend 이벤트 추가
  - 반환값
     1. seriesIds: 활성화된 시리즈 ID
     2. isActiveAll: 모두 활성 여부 
  - 단, 모두 활성화됐을 때 seriesIds를 빈배열로 보냄
  
  
![Jan-28-2026 16-09-29](https://github.com/user-attachments/assets/36d1c02b-8ce9-4efe-aca6-7b33bc83512c)

- ~~options 변경시 debounce 추가~~
- ~~clickEmitOnly 옵션 추가~~
  - legend 클릭시 차트 업데이트 반영 여부
  - true일 경우 차트 업데이트 하지 않고 emit만 올림
  - 이중 랜더링 방지
- eventBehavior 옵션 추가
   - 이벤트별 동작 설정
   - legendClick: 'update' | 'emitOnly' 
      - 'update' : 범례 클릭시 차트 즉시 갱신
      - 'emitOnly': 범례 클릭시 emit만 올림, 차트 갱신 x  

[테스트 방법]
[l](http://localhost:9999/EVUI/barChart) > LegendClickMode 에서 범례를 클릭했을 때 활성화된 시리즈 id가 반환되는지 확인해주세요.