### PR TITLE
[#2091] 3.4 > Stack line 에서 interpolation: linear를 사용중일 때, 어색하게 그려지는 현상 발생

### DIFF
--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -251,8 +251,11 @@ class Line {
             for (let jx = endIndex; jx >= startIndex; jx--) {
               const nextData = this.data[jx];
               const xp = getXPos(nextData.x);
-              const bp = nextData.o === null ? getYPos(0) : (getYPos(nextData.b) ?? getYPos(0));
-              ctx.lineTo(xp, bp);
+
+              if(nextData.o !== null) {
+                const bp = getYPos(nextData.b) ?? getYPos(0);
+                ctx.lineTo(xp, bp);
+              }
             }
 
             ctx.closePath();


### PR DESCRIPTION
## 이슈 개요
1. chart > Interpolation 옵션 중 linear 를 사용하고 있고, 누적 area 형태를 보고있을 때, baseSeries (그리고 있는 series의 발판이 되는 series) 값이 null 이라면 0으로 치환되어 어색하게 표현됨 

## 처리 방향 
- baseSeries의 값이 null이라면 무조건 0으로 치환하지 않고 linear이기 때문에 lineTo를 스킵하고 다음 Point로 넘거가서 자연스럽게 이어지도록 함

## Before
<img width="732" height="803" alt="image" src="https://github.com/user-attachments/assets/927140f7-8fec-4469-80cc-5bc7d6279c5b" />

## After
<img width="710" height="767" alt="image" src="https://github.com/user-attachments/assets/5dd07b20-170d-4095-901c-d92e238445c1" />


## 테스트 방법 
- http://localhost:9999/EVUI/lineChart#interpolation
- interpolation 방식 및, 차트 데이터 값, null 여부 등을 조작하여 테스트 부탁드립니다.