### PR TITLE
fix: RealTimeScatter 메모리 누수 현상

### DIFF
--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -99,13 +99,13 @@ const modules = {
       const key = keys[x];
       const data = datas[key];
       const storeLength = data?.length;
-      let lastTime = 0;
 
-      if (!this.isInit || this.updateSeries) {
+      // 1) init / updateSeries 시 dataset shape 보장
+      if (!this.isInit || this.updateSeries || !this.dataSet[key]) {
         const defaultValues = {
           dataGroup: [],
           startIndex: 0,
-          endIndex: 0,
+          endIndex: null,
           length: 0,
           fromTime: 0,
           toTime: 0,
@@ -120,61 +120,85 @@ const modules = {
       const dataset = this.dataSet[key];
       const dataGroup = dataset.dataGroup;
 
-      dataset.length = this.options.realTimeScatter.range || 300;
+      // 2) range(length) 결정 + 변경 감지
+      const nextLength = this.options.realTimeScatter.range || 300;
+      const lengthChanged = dataset.length !== nextLength;
+      dataset.length = nextLength;
       const length = dataset.length;
 
+      // 3) 이번 배치의 lastTime(초 단위) 계산
+      let lastTime = 0;
       for (let i = 0; i < storeLength; i++) {
         const item = data[i];
-
-        if (lastTime < item.x) {
+        if (item && lastTime < item.x) {
           lastTime = item.x;
         }
       }
-
-      lastTime = Math.floor(lastTime / 1000) * 1000;
+      
+      lastTime = lastTime ? Math.floor(lastTime / 1000) * 1000 : 0;
 
       const dataGroupLastTime = dataGroup.at(-1)?.data?.at(-1)?.x || Date.now();
+      const fallbackTime = Math.floor(dataGroupLastTime / 1000) * 1000;
 
-      dataset.toTime =
-        lastTime || (dataGroupLastTime ? Math.floor(dataGroupLastTime / 1000) * 1000 : 0);
+      // 4) prevToTime은 덮기 전 값 (없으면 fallback)
+      const prevToTime = dataset.toTime || fallbackTime;
+
+      // 5) nextToTime 결정: 새 데이터가 있으면 lastTime, 없으면 이전 유지
+      const nextToTime = lastTime || prevToTime;
+
+      // 6) endIndex/startIndex 초기화 (최초 1회) + length 변경 시 재구성
+      if (dataset.endIndex == null || lengthChanged) {
+        dataset.startIndex = 0;
+        dataset.endIndex = length - 1;
+
+        // dataGroup 크기 맞추고 모두 reset
+        dataGroup.length = length;
+        for (let i = 0; i < length; i++) {
+          dataGroup[i] = dataGroup[i] || { data: [], max: 0, min: Infinity };
+          dataGroup[i].data.length = 0;
+          dataGroup[i].max = 0;
+          dataGroup[i].min = Infinity;
+        }
+
+        // toTime/fromTime도 새 기준으로 맞춤
+        dataset.toTime = nextToTime;
+        dataset.fromTime = dataset.toTime - length * 1000;
+      }
+
+      // 7) gapCount 계산 (반드시 정수) — prevToTime 기준
+      const rawGap = (nextToTime - prevToTime) / 1000;
+      const gapCount = Number.isFinite(rawGap) ? Math.max(0, Math.floor(rawGap)) : 0;
+
+      // 8) to/from 갱신
+      dataset.toTime = nextToTime;
       dataset.fromTime = dataset.toTime - length * 1000;
-      dataset.endIndex = length - 1;
 
-      if ((dataset.toTime - lastTime) / 1000 > length && key === '') {
+      // (원래 코드에 있던 early return 유지)
+      if (lastTime && (dataset.toTime - lastTime) / 1000 > length && key === '') {
         return;
       }
 
-      const gapCount = (lastTime - dataset.toTime) / 1000;
-      if (gapCount > 0) {
-        dataset.toTime = lastTime;
-        dataset.fromTime = lastTime - length * 1000;
-      }
-
       const resetDataGroup = (group) => {
-        if (group.data) {
-          group.data.length = 0;
-        } else {
-          group.data = [];
-        }
+        group.data.length = 0;
         group.max = 0;
         group.min = Infinity;
       };
 
+      // 9) dataGroup 슬롯 확보
       for (let i = 0; i < length; i++) {
         if (!dataGroup[i]) {
-          dataGroup[i] = {
-            data: [],
-            max: 0,
-            min: Infinity,
-          };
+          dataGroup[i] = { data: [], max: 0, min: Infinity };
+        } else if (!dataGroup[i].data) {
+          dataGroup[i].data = [];
+          dataGroup[i].max = 0;
+          dataGroup[i].min = Infinity;
         }
       }
 
+      // 10) gap만큼 링 전진 + 지나간 버킷 clear
       if (gapCount > 0) {
         if (gapCount >= length) {
-          for (let i = 0; i < length; i++) {
-            resetDataGroup(dataGroup[i]);
-          }
+          for (let i = 0; i < length; i++) resetDataGroup(dataGroup[i]);
           dataset.startIndex = 0;
           dataset.endIndex = length - 1;
         } else {
@@ -183,7 +207,6 @@ const modules = {
 
           for (let i = 0; i < gapCount; i++) {
             resetDataGroup(dataGroup[currentStart]);
-
             currentStart = (currentStart + 1) % length;
             currentEnd = (currentEnd + 1) % length;
           }
@@ -193,47 +216,43 @@ const modules = {
         }
       }
 
+      // 11) 데이터 push (윈도우 안에 들어오는 것만)
       for (let i = 0; i < storeLength; i++) {
         const item = data[i];
-        const xAxisTime = Math.floor(item.x / 1000) * 1000;
+        if (item) {
+          const xAxisTime = Math.floor(item.x / 1000) * 1000;
 
-        if (dataset.fromTime <= xAxisTime) {
-          let index = dataset.endIndex - (dataset.toTime - xAxisTime) / 1000;
-          if (index < 0) {
-            index = length + index;
+          if (dataset.fromTime <= xAxisTime) {
+            let index = dataset.endIndex - (dataset.toTime - xAxisTime) / 1000;
+            if (index < 0) index = length + index;
+
+            const group = dataGroup[index];
+            group.data.push({
+              x: item.x,
+              y: item.y,
+              o: item.value ?? item.y,
+              color: item.color,
+            });
+
+            group.max = Math.max(group.max, item.y);
+            group.min = Math.min(group.min, item.y);
           }
-
-          dataGroup[index].data.push({
-            x: item.x,
-            y: item.y,
-            o: item.value ?? item.y,
-            color: item.color,
-          });
-
-          dataGroup[index].max = Math.max(dataGroup[index].max, item.y);
-          dataGroup[index].min = Math.min(dataGroup[index].min, item.y);
         }
       }
 
-      const tempMinMax = {
-        maxY: 0,
-        minY: Infinity,
-      };
+      // 12) series min/max 계산
+      const tempMinMax = { maxY: 0, minY: Infinity };
 
-      for (let i = 0; i < this.dataSet[key].length; i++) {
-        if (this.dataSet[key].dataGroup[i].max > tempMinMax.maxY) {
-          tempMinMax.maxY = this.dataSet[key].dataGroup[i].max;
-        }
-
-        if (this.dataSet[key].dataGroup[i].min < tempMinMax.minY) {
-          tempMinMax.minY = this.dataSet[key].dataGroup[i].min;
-        }
+      for (let i = 0; i < length; i++) {
+        const g = dataGroup[i];
+        if (g.max > tempMinMax.maxY) tempMinMax.maxY = g.max;
+        if (g.min < tempMinMax.minY) tempMinMax.minY = g.min;
       }
 
       minMaxValues.maxY = Math.max(minMaxValues.maxY, tempMinMax.maxY);
       minMaxValues.minY = Math.min(minMaxValues.minY, tempMinMax.minY);
-      minMaxValues.fromTime = this.dataSet[key].fromTime;
-      minMaxValues.toTime = this.dataSet[key].toTime;
+      minMaxValues.fromTime = dataset.fromTime;
+      minMaxValues.toTime = dataset.toTime;
     }
 
     this.seriesInfo.charts.scatter.forEach((seriesID) => {


### PR DESCRIPTION
### 이슈 개요 
<img width="1594" height="467" alt="image" src="https://github.com/user-attachments/assets/ac915dfb-1c78-4025-bbb1-ce2974cdf8cb" />

-> **realTimeScatter를 장시간 틀어놓았을 때, 처음에 찍은 스냅샷 대비 `{x, y, o, color, xp, yp}` 객체 및 `{x, y, o, color}` 객체의 개수가 늘어나기만 하고 줄어드지 않는 현상 발생**

### 원인 
1.  `dataset.toTime = lastTime`으로 덮어씌우는 로직이 `gapCount(얼마나 이동했는지)` 계산 로직보다 앞에 있어 `gapCount`가 항상 0으로 계산되어 `resetDataGroup` 이 호출되지 않아 옛날 버킷이 계속 쌓임 

### 변경 내용
1. 새로운 데이터를 받아 앞으로 전진하기 전의 끝 시각 (prevToTime)을 잡아둠 
2. 이번 업데이트의 끝 시각(nextToTime)과 비교 
3. 이동한 칸 수 (gapCount)를 정확히 구하여 그만큼 앞 칸을 비움

### After
<img width="1574" height="449" alt="image" src="https://github.com/user-attachments/assets/f5b4698f-d7d7-462c-969e-4fb417f943d6" />

