### PR TITLE
feat: 차트 범례를 외부에서 주입할 수 있도록 기능 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -41,7 +41,27 @@ const selectedLabel = ref({
 });
 ```
 
-### 3. data
+### 3. v-model:legend-data
+
+- option에서 [legend](#legend)의 `external`이 `true`일 때 유효한 바인딩
+- 차트 내부에 범례를 그리지 않고, 바인딩한 배열로 외부에서 범례를 렌더링할 때 사용
+- 차트가 갱신될 때마다 `{ sId, name, color, type, show }` 형태의 범례 아이템 배열로 갱신됨
+- 외부 범례에서 클릭/호버 시 ref로 노출되는 `toggleSeries(sId)`, `highlightSeries(sId)`, `unhighlightSeries()` 메서드 사용
+
+#### Example
+
+```
+const legendItems = ref([]);
+// legendItems[i]: { sId: string, name: string, color: string, type: string, show: boolean }
+<ev-chart
+  ref="chartRef"
+  v-model:legend-data="legendItems"
+  :options="{ legend: { show: true, external: true } }"
+  ...
+/>
+```
+
+### 4. data
 
 | 이름   | 타입   | 디폴트 | 설명                                              | 종류 |
 | ------ | ------ | ------ | ------------------------------------------------- | ---- |
@@ -107,7 +127,7 @@ const chartData = {
 }
 ```
 
-### 4. options
+### 5. options
 
 | 이름         | 타입                      | 디폴트                                    | 설명                                                                                                                                                                                   | 종류(예시)                      |
 | ------------ | ------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
@@ -319,7 +339,8 @@ const chartData = {
 | table         | Object                      | ([상세](#legendtable))                   | Table 타입 Legend (값 표시 포함). bar, line, pie 전용 |                                  |
 | stopClickEvt  | Boolean                     | false                                    | Legend 표시 여부                                      | true /false                      |
 | virtualScroll | Boolean                     | false                                    | Legend에 가상 스크롤 적용 여부                        | true /false                      |
-| clickMode       | 'active' \| 'inactive'       | 'active'                                 | Legend 클릭 시 활성화 여부                             |                                  |
+| clickMode     | 'active' \| 'inactive'      | 'active'                                 | Legend 클릭 시 활성화 여부                            |                                  |
+| external      | Boolean                     | false                                    | 범례를 차트 외부에서 렌더링할지 여부. true이면 차트 내부에 범례를 그리지 않고, `v-model:legend-data`로 전달된 배열을 외부에서 렌더링할 수 있음. ref로 `toggleSeries(sId)`, `highlightSeries(sId)`, `unhighlightSeries()` 사용 | true / false                    |
 
 ##### legendTable
 

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -13,7 +13,27 @@
 
 > ## Props
 
-### 1. data
+### 1. v-model:legend-data
+
+- option에서 [legend](#legend)의 `external`이 `true`일 때 유효한 바인딩
+- 차트 내부에 범례를 그리지 않고, 바인딩한 배열로 외부에서 범례를 렌더링할 때 사용
+- 차트가 갱신될 때마다 `{ sId, name, color, type, show }` 형태의 범례 아이템 배열로 갱신됨
+- 외부 범례에서 클릭/호버 시 ref로 노출되는 `toggleSeries(sId)`, `highlightSeries(sId)`, `unhighlightSeries()` 메서드 사용
+
+#### Example
+
+```
+const legendItems = ref([]);
+// legendItems[i]: { sId: string, name: string, color: string, type: string, show: boolean }
+<ev-chart
+  ref="chartRef"
+  v-model:legend-data="legendItems"
+  :options="{ legend: { show: true, external: true } }"
+  ...
+/>
+```
+
+### 2. data
 
 | 이름   | 타입   | 디폴트 | 설명                           | 종류 |
 | ------ | ------ | ------ | ------------------------------ | ---- |
@@ -87,7 +107,7 @@ const chartData =
 };
 ```
 
-### 2. options
+### 3. options
 
 | 이름          | 타입            | 디폴트                                    | 설명                                                            | 종류(예시)                      |
 | ------------- | --------------- | ----------------------------------------- | --------------------------------------------------------------- | ------------------------------- |
@@ -209,7 +229,8 @@ const chartData =
 | allowResize   | Boolean                     | false                                    | Legend 영역 리사이즈 가능 여부                |                                  |
 | stopClickEvt  | Boolean                     | false                                    | Legend 표시 여부                              | true /false                      |
 | virtualScroll | Boolean                     | false                                    | Legend에 가상 스크롤 적용 여부                | true /false                      |
-| clickMode       | 'active' \| 'inactive'       | 'active'                                 | Legend 클릭 시 활성화 여부                             |                                  |
+| clickMode     | 'active' \| 'inactive'      | 'active'                                 | Legend 클릭 시 활성화 여부                    |                                  |
+| external      | Boolean                     | false                                    | 범례를 차트 외부에서 렌더링할지 여부. true이면 차트 내부에 범례를 그리지 않고, `v-model:legend-data`로 전달된 배열을 외부에서 렌더링할 수 있음. ref로 `toggleSeries(sId)`, `highlightSeries(sId)`, `unhighlightSeries()` 사용 | true / false                    |
 
 #### dragSelection
 

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -55,7 +55,28 @@ const selectedSeries = ref({
 });
 ```
 
-### 4. data
+### 4. v-model:legend-data
+
+- option에서 [legend](#legend)의 `external`이 `true`일 때 유효한 바인딩
+- 차트 내부에 범례를 그리지 않고, 바인딩한 배열로 외부에서 범례를 렌더링할 때 사용
+- 차트가 갱신될 때마다 `{ sId, name, color, type, show }` 형태의 범례 아이템 배열로 갱신됨
+- 외부 범례에서 클릭/호버 시 ref로 노출되는 `toggleSeries(sId)`, `highlightSeries(sId)`, `unhighlightSeries()` 메서드 사용
+
+#### Example
+
+```
+const legendItems = ref([]);
+
+// legendItems[i]: { sId: string, name: string, color: string, type: string, show: boolean }
+<ev-chart
+  ref="chartRef"
+  v-model:legend-data="legendItems"
+  :options="{ legend: { show: true, external: true } }"
+  ...
+/>
+```
+
+### 5. data
 
 | 이름   | 타입   | 디폴트 | 설명                                                        | 종류 |
 | ------ | ------ | ------ | ----------------------------------------------------------- | ---- |
@@ -107,7 +128,7 @@ const chartData =
 };
 ```
 
-### 5. options
+### 6. options
 
 | 이름       | 타입            | 디폴트                                    | 설명                                                                                                                                                                                   | 종류(예시)                      |
 | ---------- | --------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
@@ -260,6 +281,7 @@ const chartData =
 | stopClickEvt  | Boolean                     | false                                    | Legend 표시 여부                                      | true /false                      |
 | virtualScroll | Boolean                     | false                                    | Legend에 가상 스크롤 적용 여부                        | true /false                      |
 | clickMode     | 'active' \| 'inactive'      | 'active'                                 | Legend 클릭 시 활성화 여부                             |                                  |
+| external      | Boolean                     | false                                    | 범례를 차트 외부에서 렌더링할지 여부. true이면 차트 내부에 범례를 그리지 않고, `v-model:legend-data`로 전달된 배열을 외부에서 렌더링할 수 있음. ref로 `toggleSeries(sId)`, `highlightSeries(sId)`, `unhighlightSeries()` 사용 | true / false                    |
 
 ##### legendTable
 
@@ -460,13 +482,13 @@ const chartOptions = {
 | ----------- | ------- | --------- | -------------------------------------------------------------------- | -------------------- |
 | legendClick | String  | 'update'  | 범례 클릭 시 동작. 'update': 차트 즉시 갱신, 'emitOnly': click-legend만 emit(이중 렌더 방지) | 'update' \| 'emitOnly' |
 
-### 6. resize-timeout
+### 7. resize-timeout
 
 - Default : 0
 - debounce 사용. 연속으로 이벤트가 발생한 경우, 마지막 이벤트가 끝난 시점을 기준으로 `주어진 시간 (resize-timeout)` 이후 콜백 실행
 
 
-### 7. Event
+### 8. Event
 
 | 이름        | 파라미터     | 설명                                                                                                                                                                                                                                                                                                                                      |
 | ----------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/views/lineChart/example/ExternalLegend.vue
+++ b/docs/views/lineChart/example/ExternalLegend.vue
@@ -1,0 +1,203 @@
+<template>
+  <div class="case">
+    <div class="controls">
+      <span>범례 On/Off: </span>
+      <ev-toggle v-model="legendShow" />
+    </div>
+    <ev-chart
+      ref="chartRef"
+      :key="legendShow"
+      v-model:legend-data="legendItems"
+      :data="chartData"
+      :options="chartOptions"
+    />
+    <div v-if="legendShow && chartOptions.legend.external" class="external-legend">
+      <div
+        v-for="item in legendItems"
+        :key="item.sId"
+        class="legend-item"
+        :data-inactive="!item.show"
+        @click="onLegendClick(item.sId)"
+        @mouseenter="onLegendEnter(item.sId)"
+        @mouseleave="onLegendLeave"
+      >
+        <span
+          class="legend-color"
+          :style="{ backgroundColor: item.show ? item.color : '#aaa' }"
+        />
+        <span
+          class="legend-name"
+          :style="{ color: item.show ? '#353740' : '#aaa' }"
+        >
+          {{ item.name }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed } from 'vue';
+import dayjs from 'dayjs';
+
+export default {
+  setup() {
+    const chartRef = ref(null);
+    const legendItems = ref([]);
+    const legendShow = ref(true);
+    const time = dayjs().format('YYYY-MM-DD HH:mm:ss');
+
+    const chartData = {
+      series: {
+        series1: { name: 'Series 1', fill: true, point: true },
+        series2: { name: 'Series 2', fill: true, point: true },
+        series3: { name: 'Series 3', fill: true, point: true },
+      },
+      groups: [['series1', 'series2', 'series3']],
+      labels: Array(10)
+        .fill(0)
+        .map((_, index) => dayjs(time).add(index, 'day')),
+      data: {
+        series1: Array(10)
+          .fill(0)
+          .map(() => Math.floor(Math.random() * 100)),
+        series2: Array(10)
+          .fill(0)
+          .map(() => Math.floor(Math.random() * 100)),
+        series3: Array(10)
+          .fill(0)
+          .map(() => Math.floor(Math.random() * 100)),
+      },
+    };
+
+    const chartOptions = computed(() => ({
+      type: 'line',
+      width: '100%',
+      title: {
+        text: 'External Legend',
+        show: true,
+      },
+      legend: {
+        show: legendShow,
+        external: true,
+      },
+      axesX: [
+        {
+          type: 'time',
+          showGrid: false,
+          timeFormat: 'MM/DD',
+          interval: 'day',
+          labelStyle: {
+            color: '#A4A4A4',
+            fontSize: '11px',
+            fontFamily: 'Roboto',
+          },
+        },
+      ],
+      axesY: [
+        {
+          type: 'linear',
+          showGrid: true,
+          startToZero: true,
+          autoScaleRatio: 0.1,
+          labelStyle: {
+            color: '#A4A4A4',
+            fontSize: '11px',
+            fontFamily: 'Roboto',
+          },
+        },
+      ],
+    }));
+
+    const onLegendClick = (sId) => {
+      chartRef.value?.toggleSeries(sId);
+    };
+
+    const onLegendEnter = (sId) => {
+      chartRef.value?.highlightSeries(sId);
+    };
+
+    const onLegendLeave = () => {
+      chartRef.value?.unhighlightSeries();
+    };
+
+    return {
+      chartRef,
+      legendItems,
+      legendShow,
+      chartData,
+      chartOptions,
+      onLegendClick,
+      onLegendEnter,
+      onLegendLeave,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.case {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-height: 320px;
+  overflow: hidden;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px;
+  background: #f5f5f5;
+  border-radius: 4px;
+  margin-bottom: 8px;
+  font-size: 12px;
+}
+
+.ev-chart {
+  flex: 1;
+}
+
+:deep(.ev-chart-container) {
+  max-height: 100%;
+}
+
+.external-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 0;
+  justify-content: center;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  user-select: none;
+
+  &:hover {
+    background-color: #f5f5f5;
+  }
+
+  &[data-inactive='true'] {
+    opacity: 0.6;
+  }
+}
+
+.legend-color {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+}
+
+.legend-name {
+  font-size: 13px;
+  font-family: Roboto, sans-serif;
+}
+</style>

--- a/docs/views/lineChart/props.js
+++ b/docs/views/lineChart/props.js
@@ -30,6 +30,8 @@ import HoverWithGroup from './example/HoverWithGroup';
 import HoverWithGroupRaw from './example/HoverWithGroup?raw';
 import LegendVirtualScroll from './example/LegendVirtualScroll';
 import LegendVirtualScrollRaw from './example/LegendVirtualScroll?raw';
+import ExternalLegend from './example/ExternalLegend';
+import ExternalLegendRaw from './example/ExternalLegend?raw';
 import Segments from './example/Segments';
 import SegmentsRaw from './example/Segments?raw';
 import Interpolation from './example/Interpolation';
@@ -137,6 +139,12 @@ export default {
       description: 'Legend Virtual Scroll',
       component: LegendVirtualScroll,
       parsedData: parse(LegendVirtualScrollRaw).descriptor,
+    },
+    ExternalLegend: {
+      description:
+        'External Legend를 사용하여 차트 외부에서 범례를 커스터마이징할 수 있습니다.',
+      component: ExternalLegend,
+      parsedData: parse(ExternalLegendRaw).descriptor,
     },
     Segments: {
       description: 'Segments',

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -26,7 +26,27 @@ const selectedItem = ref({
 });
 ```
 
-### 2. data
+### 2. v-model:legend-data
+
+- option에서 [legend](#legend)의 `external`이 `true`일 때 유효한 바인딩
+- 차트 내부에 범례를 그리지 않고, 바인딩한 배열로 외부에서 범례를 렌더링할 때 사용
+- 차트가 갱신될 때마다 `{ sId, name, color, type, show }` 형태의 범례 아이템 배열로 갱신됨
+- 외부 범례에서 클릭/호버 시 ref로 노출되는 `toggleSeries(sId)`, `highlightSeries(sId)`, `unhighlightSeries()` 메서드 사용
+
+#### Example
+
+```
+const legendItems = ref([]);
+// legendItems[i]: { sId: string, name: string, color: string, type: string, show: boolean }
+<ev-chart
+  ref="chartRef"
+  v-model:legend-data="legendItems"
+  :options="{ legend: { show: true, external: true } }"
+  ...
+/>
+```
+
+### 3. data
 
 | 이름   | 타입   | 디폴트 | 설명                           | 종류 |
 | ------ | ------ | ------ | ------------------------------ | ---- |
@@ -67,7 +87,7 @@ const chartData =
 | fontSize  | Number                      | 12        | 글자 크기                                               |                                                               |
 | formatter | function                    | null      | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용 | ({value, percentage}) => percentage + '%' + '(' + value + ')' |
 
-### 3. options
+### 4. options
 
 | 이름             | 타입            | 디폴트                                         | 설명                                                            | 종류(예시)                      |
 | ---------------- | --------------- | ---------------------------------------------- | --------------------------------------------------------------- | ------------------------------- |
@@ -108,7 +128,8 @@ const chartData =
 | table         | Object                      | ([상세](#legendtable))                   | Table 타입 Legend (값 표시 포함). bar, line, pie 전용 |                                  |
 | stopClickEvt  | Boolean                     | false                                    | Legend 표시 여부                                      | true /false                      |
 | virtualScroll | Boolean                     | false                                    | Legend에 가상 스크롤 적용 여부                        | true /false                      |
-| clickMode       | 'active' \| 'inactive'       | 'active'                                 | Legend 클릭 시 활성화 여부                             |                                  |
+| clickMode     | 'active' \| 'inactive'      | 'active'                                 | Legend 클릭 시 활성화 여부                            |                                  |
+| external      | Boolean                     | false                                    | 범례를 차트 외부에서 렌더링할지 여부. true이면 차트 내부에 범례를 그리지 않고, `v-model:legend-data`로 전달된 배열을 외부에서 렌더링할 수 있음. ref로 `toggleSeries(sId)`, `highlightSeries(sId)`, `unhighlightSeries()` 사용 | true / false                    |
 
 ##### legendTable
 

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -27,7 +27,27 @@ const selectedItem = ref({
 });
 ```
 
-### 2. data
+### 2. v-model:legend-data
+
+- option에서 [legend](#legend)의 `external`이 `true`일 때 유효한 바인딩
+- 차트 내부에 범례를 그리지 않고, 바인딩한 배열로 외부에서 범례를 렌더링할 때 사용
+- 차트가 갱신될 때마다 `{ sId, name, color, type, show }` 형태의 범례 아이템 배열로 갱신됨
+- 외부 범례에서 클릭/호버 시 ref로 노출되는 `toggleSeries(sId)`, `highlightSeries(sId)`, `unhighlightSeries()` 메서드 사용
+
+#### Example
+
+```
+const legendItems = ref([]);
+// legendItems[i]: { sId: string, name: string, color: string, type: string, show: boolean }
+<ev-chart
+  ref="chartRef"
+  v-model:legend-data="legendItems"
+  :options="{ legend: { show: true, external: true } }"
+  ...
+/>
+```
+
+### 3. data
 
   | 이름 | 타입 | 디폴트 | 설명 | 종류 |
   |------------ |-----------|---------|-------------------------|---------------------------------------------------|
@@ -61,7 +81,7 @@ const chartData =
 };
 ```
 
-### 3. options
+### 4. options
 
   | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
   |------------ |-----------|---------|-------------------------|---------------------------------------------------|
@@ -215,9 +235,10 @@ const chartData =
 | height | Number | 24 | Legend의 높이 *('top', 'bottom'의 경우 조절)* | |
 | padding | Object | { top: 0, right: 0, left: 0, bottom: 0 } | Legend 내부 padding 값 | |
 | allowResize | Boolean | false | Legend 영역 리사이즈 가능 여부 | |
-| stopClickEvt| Boolean | false | Legend 표시 여부 | true /false |
-| virtualScroll | Boolean | false | Legend에 가상 스크롤 적용 여부  | true /false |
-| clickMode       | 'active' \| 'inactive'       | 'active'                                 | Legend 클릭 시 활성화 여부                             |                                  |
+| stopClickEvt  | Boolean | false | Legend 표시 여부 | true /false |
+| virtualScroll | Boolean | false | Legend에 가상 스크롤 적용 여부 | true /false |
+| clickMode     | 'active' \| 'inactive' | 'active' | Legend 클릭 시 활성화 여부 | |
+| external      | Boolean | false | 범례를 차트 외부에서 렌더링할지 여부. true이면 차트 내부에 범례를 그리지 않고, `v-model:legend-data`로 전달된 배열을 외부에서 렌더링할 수 있음. ref로 `toggleSeries(sId)`, `highlightSeries(sId)`, `unhighlightSeries()` 사용 | true / false |
 
 #### dragSelection
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.212",
+  "version": "3.4.213",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -173,6 +173,7 @@ export default {
       () => props.options,
       (chartOpt) => {
         const newOpt = getNormalizedOptions(chartOpt);
+        const prevLegendShow = evChart.options?.legend?.show ?? false;
         const isUpdateLegendType = !isEqual(newOpt.legend.table, evChart.options.legend.table);
         const isUpdateTooltip =
           newOpt.tooltip.use && !isEqual(newOpt.tooltip, evChart.options.tooltip);
@@ -185,6 +186,14 @@ export default {
           updateLegend: isUpdateLegendType,
           updateTooltip: isUpdateTooltip,
         });
+
+        if (
+          newOpt.legend.show &&
+          newOpt.legend.external &&
+          !prevLegendShow
+        ) {
+          evChart.emitLegendData();
+        }
 
         if (!injectIsChartGroup) {
           setOptionsForUseZoom(newOpt);

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -69,6 +69,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    legendData: {
+      type: Array,
+      default: () => [],
+    },
   },
   emits: [
     'click',
@@ -82,6 +86,7 @@ export default {
     'update:zoomEndIdx',
     'update:realTimeScatterReset',
     'click-legend',
+    'update:legendData',
   ],
   setup(props, { emit }) {
     let evChart = null;
@@ -156,6 +161,10 @@ export default {
 
         if (!injectIsChartGroup && normalizedOptions.zoom.toolbar.show) {
           createEvChartZoom();
+        }
+
+        if (normalizedOptions.legend.show && normalizedOptions.legend.external) {
+          evChart.emitLegendData();
         }
       }
     };
@@ -349,6 +358,18 @@ export default {
       }
     });
 
+    const toggleSeries = (sId) => {
+      evChart?.toggleSeries(sId);
+    };
+
+    const highlightSeries = (sId) => {
+      evChart?.highlightSeries(sId);
+    };
+
+    const unhighlightSeries = () => {
+      evChart?.unhighlightSeries();
+    };
+
     const redraw = () => {
       if (evChart && 'update' in evChart) {
         evChart.update({
@@ -375,6 +396,9 @@ export default {
       wrapperStyle,
       onResize,
       redraw,
+      toggleSeries,
+      highlightSeries,
+      unhighlightSeries,
 
       evChartToolbarRef,
       injectIsChartGroup,

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -1166,6 +1166,8 @@ class EvChart {
       color,
       type: series.type,
       show: series.show,
+      fill: series.fill,
+      fillColor: series.fillColor
     };
   }
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -138,6 +138,11 @@ class EvChart {
     this.isInit = true;
   }
 
+  _updateSeriesCount() {
+    this.seriesInfo.count = Object.values(this.seriesList)
+      .filter((s) => s.show).length;
+  }
+
   /**
    * Initialize chart rectangle
    *
@@ -153,12 +158,14 @@ class EvChart {
       this.showTitle();
     }
 
-    if (opt.legend.show) {
+    if (opt.legend.show && !opt.legend.external) {
       if (!this.isInitLegend) {
         this.initLegend();
       }
 
       this.setLegendPosition();
+    } else if (opt.legend.show && opt.legend.external) {
+      this._updateSeriesCount();
     }
 
     if (opt.axesX?.[0]?.scrollbar?.use || opt.axesY?.[0]?.scrollbar?.use) {
@@ -909,7 +916,7 @@ class EvChart {
 
       this.createSeriesSet(series, options.type, options.horizontal, groups);
 
-      if (this.legendDOM) {
+      if (this.legendDOM && !options.legend.external) {
         this.updateLegend();
       }
     }
@@ -953,7 +960,7 @@ class EvChart {
       }
 
       // legend Update
-      if (options.legend.show) {
+      if (options.legend.show && !options.legend.external) {
         const useTable =
           !!options.legend?.table?.use && options.type !== 'heatMap' && options.type !== 'scatter';
 
@@ -970,6 +977,11 @@ class EvChart {
         this.setLegendPosition();
         this.updateLegendContainerSize();
         this.showLegend();
+      } else if (options.legend.show && options.legend.external) {
+        if (updateSeries || updateData) {
+          this._updateSeriesCount();
+          this.emitLegendData();
+        }
       } else if (this.isInitLegend) {
         this.hideLegend();
       }
@@ -1123,6 +1135,183 @@ class EvChart {
   }
 
   /**
+   * Get legend series list respecting group order
+   *
+   * @returns {Array} array of [sId, series] pairs
+   */
+  _getLegendSeries() {
+    const groups = this.data.groups?.at(0);
+    if (groups) {
+      return groups
+        .filter((sId) => this.seriesList[sId]?.showLegend)
+        .map((sId) => [sId, this.seriesList[sId]]);
+    }
+    return Object.entries(this.seriesList)
+      .filter(([, series]) => series.showLegend);
+  }
+
+  /**
+   * Convert series object to plain legend item
+   *
+   * @param {object} series  series object
+   * @returns {object} legend item
+   */
+  _seriesToLegendItem(series) {
+    const color = typeof series.color !== 'string'
+      ? series.color[series.color.length - 1][1]
+      : series.color;
+    return {
+      sId: series.sId,
+      name: series.name,
+      color,
+      type: series.type,
+      show: series.show,
+    };
+  }
+
+  /**
+   * Build legend data array from current seriesList
+   *
+   * @returns {Array} legend items
+   */
+  buildLegendData() {
+    return this._getLegendSeries()
+      .map(([, series]) => this._seriesToLegendItem(series));
+  }
+
+  /**
+   * Emit legend data through listeners
+   *
+   * @returns {undefined}
+   */
+  emitLegendData() {
+    if (typeof this.listeners['update:legendData'] === 'function') {
+      this.listeners['update:legendData'](this.buildLegendData());
+    }
+  }
+
+  /**
+   * Toggle series visibility (for external legend)
+   *
+   * @param {string} sId  series ID to toggle
+   * @returns {undefined}
+   */
+  toggleSeries(sId) {
+    const series = this.seriesList[sId];
+    if (!series) {
+      return;
+    }
+
+    const opt = this.options.legend;
+    const legendSeries = this._getLegendSeries();
+
+    if (opt.clickMode === 'active') {
+      const isActiveAll = legendSeries.every(([, s]) => s.show);
+
+      if (isActiveAll) {
+        legendSeries.forEach(([, s]) => { s.show = false; });
+        series.show = true;
+        this.seriesInfo.count = 1;
+      } else if (series.show) {
+        series.show = false;
+        this.seriesInfo.count--;
+      } else {
+        series.show = true;
+        this.seriesInfo.count++;
+      }
+
+      const isInactiveAll = legendSeries.every(([, s]) => !s.show);
+      if (isInactiveAll) {
+        legendSeries.forEach(([, s]) => { s.show = true; });
+        this.seriesInfo.count = legendSeries.length;
+      }
+    } else {
+      if (series.show && this.seriesInfo.count === 1) {
+        return;
+      }
+
+      if (series.show) {
+        series.show = false;
+        this.seriesInfo.count--;
+      } else {
+        series.show = true;
+        this.seriesInfo.count++;
+      }
+    }
+
+    if (this.brushSeries) {
+      const { chartIdx } = this.data;
+      const seriesList = [...this.brushSeries.list];
+      seriesList[chartIdx] = this.seriesList;
+      this.brushSeries.list = seriesList;
+      this.brushSeries.chartIdx = chartIdx;
+    }
+
+    if (this.options.eventBehavior?.legendClick !== 'emitOnly') {
+      this.update({
+        updateSeries: false,
+        updateSelTip: { update: true, keepDomain: true },
+      });
+    }
+
+    const activeSeries = Object.values(this.seriesList).filter((s) => s.show);
+    const activeSeriesIds = activeSeries.map((s) => s.sId);
+    const isActiveAll = activeSeriesIds.length === Object.values(this.seriesList).length;
+    const args = {
+      data: {
+        seriesIds: isActiveAll ? [] : activeSeriesIds,
+        isActiveAll,
+      },
+    };
+
+    if (typeof this.listeners['click-legend'] === 'function') {
+      this.listeners['click-legend'](args);
+    }
+
+    if (this.options.legend.show && this.options.legend.external) {
+      this.emitLegendData();
+    }
+  }
+
+  /**
+   * Highlight a series (for external legend hover)
+   *
+   * @param {string} sId  series ID to highlight
+   * @returns {undefined}
+   */
+  highlightSeries(sId) {
+    const legendHitInfo = { sId, type: this.options.type };
+    this.legendHover = legendHitInfo;
+
+    this.update({
+      updateSeries: false,
+      updateSelTip: { update: false, keepDomain: false },
+      hitInfo: {
+        legend: legendHitInfo,
+      },
+      lightUpdate: true,
+    });
+  }
+
+  /**
+   * Remove series highlight (for external legend mouse leave)
+   *
+   * @returns {undefined}
+   */
+  unhighlightSeries() {
+    this.legendHover = null;
+
+    this.update({
+      updateSeries: false,
+      updateSelTip: { update: false, keepDomain: false },
+      hitInfo: {
+        legend: null,
+      },
+      lightUpdate: true,
+    });
+  }
+
+  /**
    * destroy chart component
    *
    * @returns {undefined}
@@ -1134,7 +1323,7 @@ class EvChart {
 
     const target = this.target;
 
-    if (this.options.legend.show) {
+    if (this.options.legend.show && !this.options.legend.external) {
       if (this.legendBoxDOM) {
         this.legendBoxDOM.removeEventListener('click', this.onLegendBoxClick);
         this.legendBoxDOM.removeEventListener('mouseover', this.onLegendBoxOver);

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -32,6 +32,7 @@ const DEFAULT_OPTIONS = {
     allowResize: false,
     virtualScroll: false,
     clickMode: 'active',
+    external: false,
     table: {
       use: false,
       columns: {
@@ -400,6 +401,10 @@ export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
     'click-legend': async (e) => {
       await nextTick();
       emit('click-legend', e);
+    },
+    'update:legendData': async (legendData) => {
+      await nextTick();
+      emit('update:legendData', legendData);
     },
   };
 


### PR DESCRIPTION
## 개요
- 현재 차트 내의 범례가 EVUI내에서 그려지고 있어서 커스텀이 어려움.
- 외부 html에서 주입할 수 있게 수정 필요

## 변경 사항
- 차트 범례를 차트 밖에서 렌더링·커스터마이징할 수 있는 External 기능을 추가.
  - legend 옵션에 external: true 추가 (기본값 false)
  - v-model:legend-data로 범례 아이템(sId, name, color, type, show) 동기화
  - 외부 범례용 API: toggleSeries(sId), highlightSeries(sId), unhighlightSeries()
  - chart.core에 buildLegendData, emitLegendData 및 범례 클릭/호버 처리 유지
  - 라인차트 문서에 External Legend 예제(ExternalLegend.vue) 추가

## 기대 동작
https://github.com/user-attachments/assets/35d085ef-010b-4370-8a25-c2c608e3f780

## 테스트 가이드
- http://localhost:9999/EVUI/lineChart > ExternalLegend로 만들어놨습니다.