### PR TITLE
refactor: remove redundant getChartRect() call in chart resize()

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -1097,7 +1097,6 @@ class EvChart {
 
     this.initRect();
     this.initScale();
-    this.chartRect = this.getChartRect();
     this.drawChart();
     if (this.dragInfoBackup) {
       this.drawSelectionArea?.(this.dragInfoBackup);


### PR DESCRIPTION
## Summary
- `resize()` 메서드에서 `this.chartRect = this.getChartRect()` 중복 호출 제거
- `initRect()` 내부에서 이미 `this.chartRect = this.getChartRect()`를 설정하며, 그 사이의 `initScale()`은 `pixelRatio` 계산과 canvas context scale만 수행하여 `chartRect`에 영향 없음
- 불필요한 DOM 측정(`getBoundingClientRect`)과 reflow 제거 효과

Closes #2118

## Test plan
- [x] `npm run lint` 통과 확인
- [x] `npx vitest run` 전체 197 테스트 통과 확인
- [ ] 차트 리사이즈 시 정상 동작 확인 (수동 테스트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)