### PR TITLE
fix: use isNil instead of null check for hitItemId in chart interaction

### DIFF
--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1,4 +1,4 @@
-import { cloneDeep, defaultsDeep, inRange, isEqual } from 'lodash-es';
+import { cloneDeep, defaultsDeep, inRange, isEqual, isNil } from 'lodash-es';
 import dayjs from 'dayjs';
 import { numberWithComma } from '@/common/utils';
 import throttle from '@/common/utils.throttle';
@@ -347,7 +347,7 @@ const modules = {
         const hitItemId = hitInfo.hitId || Object.keys(hitInfo.items)[0];
         const hitItem = hitInfo.items[hitItemId];
 
-        if (hitItemId !== null) {
+        if (!isNil(hitItemId)) {
           const allSelectedList = this.updateSelectedSeriesInfo(hitItemId, false);
           this.defaultSelectInfo.seriesId = allSelectedList.seriesId;
 


### PR DESCRIPTION
## Summary
- `hitItemId`가 `Object.keys(hitInfo.items)[0]`에서 `undefined`를 반환할 수 있는데, 기존 `!== null` 체크로는 이를 감지하지 못하는 문제를 수정
- `lodash-es`의 `isNil`을 사용하여 `null`과 `undefined` 모두 처리하도록 변경

## Test plan
- [ ] 차트에서 빈 데이터로 클릭 인터랙션 시 에러가 발생하지 않는지 확인
- [ ] 정상적인 데이터가 있는 경우 기존 클릭 선택 기능이 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)