### PR TITLE
fix(ci): add tagFormat and remove unused 3.0 branch from release config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
         default: '3.4'
         type: choice
         options:
-          - '3.0'
           - '3.4'
       dry-run:
         description: 'Dry-run 모드 (실제 배포 없이 테스트)'

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,6 @@
 {
-  "branches": ["3.0", "3.4"],
+  "tagFormat": "${version}",
+  "branches": ["3.4"],
   "plugins": [
     ["@semantic-release/commit-analyzer", {
       "releaseRules": [


### PR DESCRIPTION
## Summary
- Add `tagFormat: "${version}"` to `.releaserc.json` to match existing tag convention (`3.4.213`, no `v` prefix). Without this, semantic-release treats the project as fresh and starts from `1.0.0`.
- Remove unused `3.0` branch from `.releaserc.json` branches array and workflow dispatch options — only `3.4` is a release target.

## Test plan
- [ ] Run Release workflow with dry-run on branch `3.4`
- [ ] Verify logs show existing tag recognition (not "No git tag version found")
- [ ] Verify next version is calculated correctly from `3.4.213`

🤖 Generated with [Claude Code](https://claude.com/claude-code)