### PR TITLE
fix(ci): replace semantic-release/git with create-pull-request action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,16 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release ${{ inputs.dry-run && '--dry-run' || '' }}
+
+      - name: Create version bump PR
+        if: ${{ !inputs.dry-run }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: 'chore(release): update package.json and CHANGELOG.md'
+          title: 'chore(release): version bump'
+          branch: release/version-bump
+          delete-branch: true
+          base: '3.4'
+          add-paths: |
+            package.json
+            CHANGELOG.md

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,10 +15,6 @@
       "changelogFile": "CHANGELOG.md"
     }],
     "@semantic-release/npm",
-    ["@semantic-release/git", {
-      "assets": ["package.json", "CHANGELOG.md"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-    }],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
- `@semantic-release/git` 플러그인을 제거하고 `peter-evans/create-pull-request` 액션으로 대체
- 릴리즈 시 `package.json`과 `CHANGELOG.md` 변경사항을 직접 커밋하는 대신 PR을 생성하도록 변경

## Test plan
- [ ] dry-run 모드에서 create-pull-request 스텝이 스킵되는지 확인
- [ ] 실제 릴리즈 시 version bump PR이 정상 생성되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)