### PR TITLE
fix(ci): use PAT for release workflow to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -46,7 +47,7 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release ${{ inputs.dry-run && '--dry-run' || '' }}


### PR DESCRIPTION
## Summary
- Release 워크플로우에서 `GITHUB_TOKEN` 대신 `RELEASE_TOKEN` (PAT) 사용하도록 변경
- `actions/checkout`에 `token` 추가하여 git push 시 PAT 인증 적용
- `@semantic-release/git`이 보호된 `3.4` 브랜치에 릴리스 커밋(CHANGELOG.md, package.json)을 push할 수 있도록 함

## 사전 작업 (머지 전 필요)
- [ ] Fine-grained PAT 생성 (Contents: Read/Write, Metadata: Read)
- [ ] `RELEASE_TOKEN` 시크릿 등록 (repo Settings > Secrets > Actions)
- [ ] `3.4` 브랜치 보호 규칙에서 PAT 소유자를 bypass 목록에 추가

## Test plan
- [ ] dry-run 모드로 워크플로우 실행하여 정상 동작 확인
- [ ] 실제 릴리스 후 CHANGELOG.md, package.json 커밋이 3.4에 push되는지 확인
- [ ] npm 배포 및 GitHub Release 정상 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)