### PR TITLE
[#2129][3.4.120] Y축 라벨이 잘려보이는 현상 발생

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.149",
+  "version": "3.4.150",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -207,8 +207,8 @@ class EvChart {
       return result;
     };
 
-    const adjustedRange = {
-      x: this.axesRange?.x?.map((value, index) => {
+    const remeasureRange = currentRange => ({
+      x: currentRange?.x?.map((value, index) => {
         const axis = this.axesX[index];
         const axesSteps = this.axesSteps?.x[index];
         const notFormattedLabels = getNotFormattedLabels(axesSteps, 'x', axis);
@@ -226,7 +226,7 @@ class EvChart {
           },
         };
       }),
-      y: this.axesRange?.y?.map((value, index) => {
+      y: currentRange?.y?.map((value, index) => {
         const axis = this.axesY[index];
         const axesSteps = this.axesSteps?.y[index];
         const notFormattedLabels = getNotFormattedLabels(axesSteps, 'y', axis);
@@ -244,12 +244,17 @@ class EvChart {
           },
         };
       }),
-    };
+    });
 
-    this.axesRange = adjustedRange;
-    this.labelOffset = this.getLabelOffset(adjustedRange);
+    this.axesRange = remeasureRange(this.axesRange);
+    this.labelOffset = this.getLabelOffset(this.axesRange);
     this.labelRange = this.getAxesLabelRange();
     this.axesSteps = this.calculateSteps();
+
+    // 새로운 step 기준으로 라벨 너비를 다시 측정하여 잘림 방지
+    // TODO: 추후 개선 (3.4.200 이후 버전)
+    this.axesRange = remeasureRange(this.axesRange);
+    this.labelOffset = this.getLabelOffset(this.axesRange);
   }
 
   /**


### PR DESCRIPTION
### 이슈 개요 
- <img width="492" height="486" alt="image" src="https://github.com/user-attachments/assets/5683e151-97ba-4813-8df2-4027b8cda25d" />
- formatter를 사용하는 Y축 라벨이 잘려보이는 현상 발생 

### 이슈 원인
예를 들어, Y축 최대값이 363으로 계산되어 해당 너비만큼 Y축 영역을 확보했으나, 이후 차트 영역 변동에 의해(미세한 리사이즈) 최대값이 363.006으로 변경되면서 실제 그려지는 라벨이 확보된 너비를 초과해 잘리게 됨
<img width="757" height="226" alt="image" src="https://github.com/user-attachments/assets/aa408f23-4b5c-4ee9-9308-461cab3c4cbf" />

### 수정 내용
adjustXAndYAxisWidth() 내부의 라벨 너비 측정 로직을 remeasureRange() 함수로 추출하고, 
calculateSteps() 재계산 이후 라벨 너비를 한 번 더 측정하여 axesRange와 labelOffset을 갱신하도록 수정했습니다.
-> 임시처리로, 축 계산 로직을 1회만 실행할 수 있도록 3.4.2xx 대의 버전에서 대규모 수정 예정입니다.