### PR TITLE
feat(build): tree-shaking 지원 및 auto-import resolver 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,15 @@
   "files": [
     "dist"
   ],
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
+  "main": "dist/main.js",
+  "module": "dist/main.js",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "import": "./dist/main.js"
     },
     "./style": {
       "import": "./dist/style.css",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     ".": {
       "import": "./dist/main.js"
     },
+    "./resolver": {
+      "import": "./dist/resolver.js"
+    },
     "./style": {
       "import": "./dist/style.css",
       "require": "./dist/style.css"

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -1,0 +1,20 @@
+export default function EvuiResolver(options = {}) {
+  const { importStyle = true, exclude } = options;
+
+  return {
+    type: 'component',
+    resolve: (name) => {
+      if (!name.match(/^Ev[A-Z]/)) {
+        return undefined;
+      }
+      if (exclude && name.match(exclude)) {
+        return undefined;
+      }
+      return {
+        name,
+        from: 'evui',
+        sideEffects: importStyle ? 'evui/style' : undefined,
+      };
+    },
+  };
+}

--- a/src/resolver.spec.js
+++ b/src/resolver.spec.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import EvuiResolver from './resolver';
+
+describe('EvuiResolver', () => {
+  describe('기본 동작', () => {
+    it('type이 component인 resolver를 반환해야 한다', () => {
+      const resolver = EvuiResolver();
+      expect(resolver.type).toBe('component');
+      expect(typeof resolver.resolve).toBe('function');
+    });
+  });
+
+  describe('컴포넌트 매칭', () => {
+    it('Ev로 시작하는 PascalCase 컴포넌트를 resolve해야 한다', () => {
+      const { resolve } = EvuiResolver();
+
+      expect(resolve('EvButton')).toEqual({
+        name: 'EvButton',
+        from: 'evui',
+        sideEffects: 'evui/style',
+      });
+      expect(resolve('EvGrid')).toEqual({
+        name: 'EvGrid',
+        from: 'evui',
+        sideEffects: 'evui/style',
+      });
+      expect(resolve('EvChart')).toEqual({
+        name: 'EvChart',
+        from: 'evui',
+        sideEffects: 'evui/style',
+      });
+    });
+
+    it('Ev로 시작하지 않는 컴포넌트는 undefined를 반환해야 한다', () => {
+      const { resolve } = EvuiResolver();
+
+      expect(resolve('VButton')).toBeUndefined();
+      expect(resolve('ElInput')).toBeUndefined();
+      expect(resolve('MyComponent')).toBeUndefined();
+    });
+
+    it('Ev 뒤에 소문자가 오는 이름은 매칭하지 않아야 한다 (오탐 방지)', () => {
+      const { resolve } = EvuiResolver();
+
+      expect(resolve('Event')).toBeUndefined();
+      expect(resolve('Every')).toBeUndefined();
+      expect(resolve('Evaluate')).toBeUndefined();
+    });
+  });
+
+  describe('importStyle 옵션', () => {
+    it('기본값(true)이면 sideEffects에 evui/style을 포함해야 한다', () => {
+      const { resolve } = EvuiResolver();
+
+      expect(resolve('EvButton').sideEffects).toBe('evui/style');
+    });
+
+    it('true이면 sideEffects에 evui/style을 포함해야 한다', () => {
+      const { resolve } = EvuiResolver({ importStyle: true });
+
+      expect(resolve('EvButton').sideEffects).toBe('evui/style');
+    });
+
+    it('false이면 sideEffects가 undefined여야 한다', () => {
+      const { resolve } = EvuiResolver({ importStyle: false });
+
+      expect(resolve('EvButton').sideEffects).toBeUndefined();
+    });
+  });
+
+  describe('exclude 옵션', () => {
+    it('exclude 패턴에 매칭되는 컴포넌트는 undefined를 반환해야 한다', () => {
+      const { resolve } = EvuiResolver({ exclude: /EvChart/ });
+
+      expect(resolve('EvChart')).toBeUndefined();
+      expect(resolve('EvChartGroup')).toBeUndefined();
+      expect(resolve('EvButton')).toBeDefined();
+    });
+
+    it('exclude 없으면 모든 Ev 컴포넌트를 resolve해야 한다', () => {
+      const { resolve } = EvuiResolver();
+
+      expect(resolve('EvChart')).toBeDefined();
+      expect(resolve('EvChartGroup')).toBeDefined();
+      expect(resolve('EvButton')).toBeDefined();
+    });
+  });
+});

--- a/vite.config.lib.js
+++ b/vite.config.lib.js
@@ -6,7 +6,10 @@ import path from 'path';
 export default defineConfig({
   build: {
     lib: {
-      entry: path.resolve(__dirname, 'src/main.js'),
+      entry: {
+        main: path.resolve(__dirname, 'src/main.js'),
+        resolver: path.resolve(__dirname, 'src/resolver.js'),
+      },
       formats: ['es'],
     },
     rollupOptions: {

--- a/vite.config.lib.js
+++ b/vite.config.lib.js
@@ -7,15 +7,22 @@ export default defineConfig({
   build: {
     lib: {
       entry: path.resolve(__dirname, 'src/main.js'),
-      name: 'evui',
-      fileName: 'index',
+      formats: ['es'],
     },
     rollupOptions: {
-      external: ['vue'],
+      external: [
+        'vue',
+        'lodash-es',
+        'dayjs',
+        'bignumber.js',
+        'korean-regexp',
+        'vue-resize-observer',
+        'vue3-observe-visibility',
+      ],
       output: {
-        globals: {
-          vue: 'Vue',
-        },
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+        entryFileNames: '[name].js',
       },
     },
   },


### PR DESCRIPTION
## Summary

- `preserveModules`를 적용하여 개별 컴포넌트 단위 tree-shaking 지원
- `unplugin-vue-components`용 `EvuiResolver` 제공으로 auto-import 지원

## 왜 필요한가?

현재 EVUI는 단일 번들(`dist/index.js`)로 빌드되어, 소비자가 `EvButton` 하나만 import해도 전체 라이브러리 코드가 포함됩니다.

ESM 번들이라 번들러가 tree-shaking을 시도하긴 하지만, `main.js`에서 각 컴포넌트의 `index.js`를 bare import(`import './components/tabs/index.js'`)하고 있어 실질적으로 동작하지 않습니다. 단일 번들에서는 이 side effect import들이 전부 하나의 파일에 인라인되고, `sideEffects` 필드는 파일 단위로 동작하므로 개별 컴포넌트만 선택적으로 제거할 수 없습니다.

**preserveModules**를 적용하면 각 컴포넌트의 `index.js`가 별도 파일로 유지되어, import하지 않은 컴포넌트 파일은 아예 포함되지 않습니다.

여기에 **EvuiResolver**를 추가하면, `app.use(EVUI)` 전역 등록 대신 `unplugin-vue-components`가 템플릿에서 사용된 컴포넌트만 자동으로 개별 import를 삽입하여 tree-shaking이 동작합니다.

### 사용법

```js
// vite.config.js
import Components from 'unplugin-vue-components/vite';
import EvuiResolver from 'evui/resolver';

export default {
  plugins: [
    Components({
      resolvers: [EvuiResolver()],
    }),
  ],
};
```

### EvuiResolver 옵션

| 옵션 | 기본값 | 설명 |
|------|--------|------|
| `importStyle` | `true` | `evui/style` CSS 자동 import |
| `exclude` | - | 특정 컴포넌트 제외 (RegExp) |

## 변경 파일

| 파일 | 변경 |
|------|------|
| `vite.config.lib.js` | `preserveModules: true`, ESM 전용, entry에 resolver 추가, 모든 의존성 external 처리 |
| `package.json` | `sideEffects` 추가, exports에 `./resolver` 추가 |
| `src/resolver.js` | 신규 — EvuiResolver 함수 (빌드 타임 전용, 런타임 의존성 없음, 0.34KB) |
| `src/resolver.spec.js` | 신규 — EvuiResolver 테스트 (9 tests) |

## Test plan

- [x] `npm run build:lib` 빌드 성공 (169개 모듈)
- [x] `dist/resolver.js` 생성 확인 (0.34 KB, 외부 import 없는 순수 함수)
- [x] 출력 파일에 `@/` alias 누출 없음
- [x] resolver 테스트 9개 통과
- [ ] 소비자 프로젝트에서 `EvuiResolver` 적용 후 번들 크기 감소 확인
- [ ] `import EVUI from 'evui'` 전체 import 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)