### PR TITLE
test(progress, loading): 테스트 추가

### DIFF
--- a/src/components/loading/Loading.spec.js
+++ b/src/components/loading/Loading.spec.js
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvLoading from './Loading.vue';
+
+describe('EvLoading Component', () => {
+  const globalStubs = {
+    global: {
+      stubs: { teleport: true },
+    },
+  };
+
+  describe('렌더링', () => {
+    it('modelValue가 true이면 로딩이 렌더링된다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-loading').exists()).toBe(true);
+    });
+
+    it('modelValue가 false이면 로딩이 렌더링되지 않는다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: false },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-loading').exists()).toBe(false);
+    });
+
+    it('spinner가 렌더링된다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-loading-spinner').exists()).toBe(true);
+    });
+
+    it('기본 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-loading-icon').exists()).toBe(true);
+      expect(wrapper.find('.ev-icon-refresh2').exists()).toBe(true);
+    });
+
+    it('slot 내용이 렌더링되면 기본 아이콘은 표시되지 않는다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true },
+        slots: { default: '<span class="custom-spinner">로딩중</span>' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.custom-spinner').exists()).toBe(true);
+      expect(wrapper.find('.ev-loading-icon').exists()).toBe(false);
+    });
+  });
+
+  describe('Props', () => {
+    it('fullscreen이 true이면 full-screen 클래스가 적용된다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true, fullscreen: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-loading.full-screen').exists()).toBe(true);
+    });
+
+    it('iconClass prop이 적용된다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true, iconClass: 'ev-icon-spinner' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-icon-spinner').exists()).toBe(true);
+    });
+
+    it('iconStyle prop이 아이콘에 적용된다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true, iconStyle: { fontSize: '40px' } },
+        ...globalStubs,
+      });
+
+      const icon = wrapper.find('.ev-loading-icon');
+      expect(icon.element.style.fontSize).toBe('40px');
+    });
+  });
+
+  describe('Events', () => {
+    it('clickOutside가 true일 때 클릭하면 update:modelValue가 발생한다', async () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true, clickOutside: true },
+        ...globalStubs,
+      });
+
+      await wrapper.find('.ev-loading').trigger('click');
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+      expect(wrapper.emitted('update:modelValue')[0][0]).toBe(false);
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 modelValue는 false이다', () => {
+      const wrapper = mount(EvLoading, {
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-loading').exists()).toBe(false);
+    });
+
+    it('컴포넌트 이름이 EvLoading이다', () => {
+      expect(EvLoading.name).toBe('EvLoading');
+    });
+  });
+});

--- a/src/components/progress/Progress.spec.js
+++ b/src/components/progress/Progress.spec.js
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvProgress from './Progress.vue';
+
+describe('EvProgress Component', () => {
+  describe('렌더링', () => {
+    it('기본 프로그레스가 렌더링된다', () => {
+      const wrapper = mount(EvProgress);
+
+      expect(wrapper.find('.ev-progress').exists()).toBe(true);
+      expect(wrapper.find('.ev-progress-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ev-progress-inner').exists()).toBe(true);
+    });
+
+    it('slot 내용이 label로 렌더링된다', () => {
+      const wrapper = mount(EvProgress, {
+        slots: {
+          default: '50%',
+        },
+      });
+
+      expect(wrapper.find('.ev-progress-label').exists()).toBe(true);
+      expect(wrapper.text()).toContain('50%');
+    });
+
+    it('slot이 없으면 label이 렌더링되지 않는다', () => {
+      const wrapper = mount(EvProgress);
+
+      expect(wrapper.find('.ev-progress-label').exists()).toBe(false);
+    });
+  });
+
+  describe('Props', () => {
+    it('modelValue에 따라 inner 너비가 설정된다', () => {
+      const wrapper = mount(EvProgress, {
+        props: { modelValue: 50 },
+      });
+
+      const inner = wrapper.find('.ev-progress-inner');
+      expect(inner.element.style.width).toBe('50%');
+    });
+
+    it('color prop이 배경색으로 적용된다', () => {
+      const wrapper = mount(EvProgress, {
+        props: { modelValue: 50, color: '#FF0000' },
+      });
+
+      const inner = wrapper.find('.ev-progress-inner');
+      expect(inner.element.style.backgroundColor).toBe('rgb(255, 0, 0)');
+    });
+
+    it('strokeWidth prop이 wrapper 높이에 적용된다', () => {
+      const wrapper = mount(EvProgress, {
+        props: { strokeWidth: 10 },
+      });
+
+      const wrapperEl = wrapper.find('.ev-progress-wrapper');
+      expect(wrapperEl.element.style.height).toBe('10px');
+    });
+
+    it('innerText prop이 렌더링된다', () => {
+      const wrapper = mount(EvProgress, {
+        props: { modelValue: 50, innerText: '50%' },
+      });
+
+      expect(wrapper.find('.ev-progress-inner-text').exists()).toBe(true);
+      expect(wrapper.find('.ev-progress-inner-text').text()).toBe('50%');
+    });
+
+    it('innerText가 빈 문자열이면 inner-text가 렌더링되지 않는다', () => {
+      const wrapper = mount(EvProgress, {
+        props: { modelValue: 50 },
+      });
+
+      expect(wrapper.find('.ev-progress-inner-text').exists()).toBe(false);
+    });
+
+    it('color가 배열이면 값에 따라 색상이 결정된다', () => {
+      const colorList = [
+        { value: 30, color: '#FF0000' },
+        { value: 70, color: '#FFFF00' },
+        { value: 100, color: '#00FF00' },
+      ];
+      const wrapper = mount(EvProgress, {
+        props: { modelValue: 50, color: colorList },
+      });
+
+      const inner = wrapper.find('.ev-progress-inner');
+      expect(inner.element.style.backgroundColor).toBe('rgb(255, 255, 0)');
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 modelValue는 0이다', () => {
+      const wrapper = mount(EvProgress);
+
+      const inner = wrapper.find('.ev-progress-inner');
+      expect(inner.element.style.width).toBe('0%');
+    });
+
+    it('기본 strokeWidth는 6이다', () => {
+      const wrapper = mount(EvProgress);
+
+      const wrapperEl = wrapper.find('.ev-progress-wrapper');
+      expect(wrapperEl.element.style.height).toBe('6px');
+    });
+
+    it('기본 color는 #409EFF이다', () => {
+      const wrapper = mount(EvProgress, {
+        props: { modelValue: 50 },
+      });
+
+      const inner = wrapper.find('.ev-progress-inner');
+      expect(inner.element.style.backgroundColor).toBe('rgb(64, 158, 255)');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Progress, Loading 컴포넌트 단위 테스트 추가
- Progress: width/backgroundColor 스타일, color 배열, strokeWidth 등 (12 tests)
- Loading: teleport 스텁, fullscreen, clickOutside 이벤트, slot 등 (11 tests)

## Test plan
- [x] `npm run test:run` 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #2113