### PR TITLE
test(radio, radioGroup): 테스트 추가

### DIFF
--- a/src/components/radio/Radio.spec.js
+++ b/src/components/radio/Radio.spec.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvRadio from './Radio.vue';
+
+describe('EvRadio Component', () => {
+  describe('렌더링', () => {
+    it('기본 라디오가 렌더링된다', () => {
+      const wrapper = mount(EvRadio);
+
+      expect(wrapper.find('.ev-radio').exists()).toBe(true);
+      expect(wrapper.find('.ev-radio-input').exists()).toBe(true);
+      expect(wrapper.find('.ev-radio-label').exists()).toBe(true);
+    });
+
+    it('label prop이 텍스트로 표시된다', () => {
+      const wrapper = mount(EvRadio, {
+        props: { label: '옵션1' },
+      });
+
+      expect(wrapper.find('.ev-radio-label').text()).toBe('옵션1');
+    });
+
+    it('slot 내용이 label 대신 렌더링된다', () => {
+      const wrapper = mount(EvRadio, {
+        props: { label: '옵션1' },
+        slots: { default: '커스텀 라벨' },
+      });
+
+      expect(wrapper.find('.ev-radio-label').text()).toBe('커스텀 라벨');
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled prop이 적용된다', () => {
+      const wrapper = mount(EvRadio, {
+        props: { disabled: true },
+      });
+
+      expect(wrapper.classes()).toContain('disabled');
+      expect(wrapper.find('input').element.disabled).toBe(true);
+    });
+
+    it('size prop이 클래스로 적용된다', () => {
+      const wrapper = mount(EvRadio, {
+        props: { size: 'small' },
+      });
+
+      expect(wrapper.classes()).toContain('small');
+    });
+
+    it('modelValue와 label이 같으면 checked 클래스가 적용된다', () => {
+      const wrapper = mount(EvRadio, {
+        props: { modelValue: 'a', label: 'a' },
+      });
+
+      expect(wrapper.classes()).toContain('checked');
+    });
+
+    it('modelValue와 label이 다르면 checked 클래스가 없다', () => {
+      const wrapper = mount(EvRadio, {
+        props: { modelValue: 'a', label: 'b' },
+      });
+
+      expect(wrapper.classes()).not.toContain('checked');
+    });
+  });
+
+  describe('Events', () => {
+    it('변경 시 update:modelValue 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvRadio, {
+        props: { modelValue: 'a', label: 'b' },
+      });
+
+      const input = wrapper.find('input');
+      await input.setValue('b');
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 disabled는 false이다', () => {
+      const wrapper = mount(EvRadio);
+
+      expect(wrapper.classes()).not.toContain('disabled');
+    });
+
+    it('컴포넌트 이름이 EvRadio이다', () => {
+      expect(EvRadio.name).toBe('EvRadio');
+    });
+  });
+});

--- a/src/components/radioGroup/RadioGroup.integration.spec.js
+++ b/src/components/radioGroup/RadioGroup.integration.spec.js
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvRadioGroup from './RadioGroup.vue';
+import EvRadio from '../radio/Radio.vue';
+
+describe('EvRadioGroup Integration', () => {
+  describe('렌더링', () => {
+    it('라디오 그룹이 렌더링된다', () => {
+      const wrapper = mount(EvRadioGroup);
+
+      expect(wrapper.find('.ev-radio-group').exists()).toBe(true);
+      expect(wrapper.attributes('role')).toBe('group');
+    });
+
+    it('자식 라디오들이 렌더링된다', () => {
+      const wrapper = mount(EvRadioGroup, {
+        props: { modelValue: 'a' },
+        slots: {
+          default: [
+            '<ev-radio label="a">옵션A</ev-radio>',
+            '<ev-radio label="b">옵션B</ev-radio>',
+          ].join(''),
+        },
+        global: {
+          components: { EvRadio },
+        },
+      });
+
+      expect(wrapper.findAllComponents(EvRadio)).toHaveLength(2);
+    });
+  });
+
+  describe('Props', () => {
+    it('type이 button이면 type-button 클래스가 적용된다', () => {
+      const wrapper = mount(EvRadioGroup, {
+        props: { type: 'button' },
+      });
+
+      expect(wrapper.classes()).toContain('type-button');
+    });
+
+    it('type이 radio이면 type-button 클래스가 없다', () => {
+      const wrapper = mount(EvRadioGroup, {
+        props: { type: 'radio' },
+      });
+
+      expect(wrapper.classes()).not.toContain('type-button');
+    });
+  });
+
+  describe('provide/inject 통합', () => {
+    it('그룹의 modelValue가 자식 라디오에 전달된다', () => {
+      const wrapper = mount(EvRadioGroup, {
+        props: { modelValue: 'a' },
+        slots: {
+          default: [
+            '<ev-radio label="a">옵션A</ev-radio>',
+            '<ev-radio label="b">옵션B</ev-radio>',
+          ].join(''),
+        },
+        global: {
+          components: { EvRadio },
+        },
+      });
+
+      const radios = wrapper.findAllComponents(EvRadio);
+      expect(radios[0].classes()).toContain('checked');
+      expect(radios[1].classes()).not.toContain('checked');
+    });
+  });
+
+  describe('Events', () => {
+    it('자식 라디오 선택 시 update:modelValue가 발생한다', async () => {
+      const wrapper = mount(EvRadioGroup, {
+        props: { modelValue: 'a' },
+        slots: {
+          default: [
+            '<ev-radio label="a">옵션A</ev-radio>',
+            '<ev-radio label="b">옵션B</ev-radio>',
+          ].join(''),
+        },
+        global: {
+          components: { EvRadio },
+        },
+      });
+
+      const radios = wrapper.findAllComponents(EvRadio);
+      const input = radios[1].find('input');
+      await input.setValue('b');
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 type은 radio이다', () => {
+      const wrapper = mount(EvRadioGroup);
+
+      expect(wrapper.classes()).not.toContain('type-button');
+    });
+
+    it('컴포넌트 이름이 EvRadioGroup이다', () => {
+      expect(EvRadioGroup.name).toBe('EvRadioGroup');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Radio, RadioGroup 컴포넌트 단위 테스트 추가
- Radio: inject 패턴, checked computed, disabled 등 (10 tests)
- RadioGroup: provide/inject 통합 테스트, 라디오 선택 동작 (8 tests)

## Test plan
- [x] `npm run test:run` 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #2113