### PR TITLE
test(inputNumber, select): 테스트 추가

### DIFF
--- a/src/components/inputNumber/InputNumber.spec.js
+++ b/src/components/inputNumber/InputNumber.spec.js
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvInputNumber from './InputNumber.vue';
+
+describe('EvInputNumber Component', () => {
+  describe('렌더링', () => {
+    it('기본 숫자 입력이 렌더링된다', () => {
+      const wrapper = mount(EvInputNumber);
+
+      expect(wrapper.find('.ev-input-number').exists()).toBe(true);
+      expect(wrapper.find('.ev-input').exists()).toBe(true);
+    });
+
+    it('step up/down 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvInputNumber);
+
+      expect(wrapper.find('.step-up').exists()).toBe(true);
+      expect(wrapper.find('.step-down').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled prop이 적용된다', () => {
+      const wrapper = mount(EvInputNumber, {
+        props: { disabled: true },
+      });
+
+      expect(wrapper.classes()).toContain('disabled');
+      expect(wrapper.find('.ev-input').element.disabled).toBe(true);
+    });
+
+    it('readonly prop이 적용된다', () => {
+      const wrapper = mount(EvInputNumber, {
+        props: { readonly: true },
+      });
+
+      expect(wrapper.classes()).toContain('readonly');
+      expect(wrapper.find('.ev-input').element.readOnly).toBe(true);
+    });
+
+    it('placeholder prop이 적용된다', () => {
+      const wrapper = mount(EvInputNumber, {
+        props: { placeholder: '숫자를 입력하세요' },
+      });
+
+      expect(wrapper.find('.ev-input').attributes('placeholder')).toBe('숫자를 입력하세요');
+    });
+  });
+
+  describe('Events', () => {
+    it('focus 시 focus 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvInputNumber);
+
+      await wrapper.find('.ev-input').trigger('focus');
+
+      expect(wrapper.emitted('focus')).toBeTruthy();
+    });
+
+    it('blur 시 blur 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvInputNumber);
+
+      await wrapper.find('.ev-input').trigger('blur');
+
+      expect(wrapper.emitted('blur')).toBeTruthy();
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvInputNumber이다', () => {
+      expect(EvInputNumber.name).toBe('EvInputNumber');
+    });
+
+    it('기본 step은 1이다', () => {
+      expect(EvInputNumber.props.step.default).toBe(1);
+    });
+
+    it('기본 precision은 0이다', () => {
+      expect(EvInputNumber.props.precision.default).toBe(0);
+    });
+  });
+});

--- a/src/components/select/Select.spec.js
+++ b/src/components/select/Select.spec.js
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvSelect from './Select.vue';
+
+describe('EvSelect Component', () => {
+  const defaultProps = {
+    items: [
+      { name: '옵션1', value: 'opt1' },
+      { name: '옵션2', value: 'opt2' },
+      { name: '옵션3', value: 'opt3' },
+    ],
+  };
+
+  const globalConfig = {
+    global: {
+      directives: {
+        clickoutside: {},
+      },
+    },
+  };
+
+  describe('렌더링', () => {
+    it('기본 셀렉트가 렌더링된다', () => {
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-select').exists()).toBe(true);
+      expect(wrapper.find('.ev-input').exists()).toBe(true);
+    });
+
+    it('화살표 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-input-suffix-arrow').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled prop이 적용된다', () => {
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, disabled: true },
+        ...globalConfig,
+      });
+
+      expect(wrapper.classes()).toContain('disabled');
+      expect(wrapper.find('.ev-input').element.disabled).toBe(true);
+    });
+
+    it('placeholder prop이 적용된다', () => {
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, placeholder: '선택하세요' },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-input').attributes('placeholder')).toBe('선택하세요');
+    });
+
+    it('multiple prop이 적용되면 다중 선택 UI가 렌더링된다', () => {
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, multiple: true, modelValue: [] },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-select-tag-wrapper').exists()).toBe(true);
+    });
+  });
+
+  describe('Events', () => {
+    it('클릭 시 드롭박스가 열린다', async () => {
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+
+      expect(wrapper.find('.ev-select-dropbox').exists()).toBe(true);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvSelect이다', () => {
+      expect(EvSelect.name).toBe('EvSelect');
+    });
+
+    it('기본 multiple은 false이다', () => {
+      expect(EvSelect.props.multiple.default).toBe(false);
+    });
+
+    it('기본 clearable은 false이다', () => {
+      expect(EvSelect.props.clearable.default).toBe(false);
+    });
+
+    it('기본 filterable은 false이다', () => {
+      expect(EvSelect.props.filterable.default).toBe(false);
+    });
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -20,5 +20,6 @@ export default defineConfig({
     alias: {
       '@': resolve(__dirname, 'src'),
     },
+    extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'],
   },
 });


### PR DESCRIPTION
## Summary
- InputNumber, Select 컴포넌트 단위 테스트 추가
- InputNumber: step up/down 버튼, focus/blur 이벤트, props 기본값 (10 tests)
- Select: clickoutside 디렉티브 스텁, 드롭다운, multiple 모드, disabled (10 tests)
- vitest.config.js: resolve.extensions에 .vue 추가 (extensionless import 지원)

## Test plan
- [x] `npm run test:run` 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #2113