### PR TITLE
test(tabPanel, tabs): 테스트 추가

### DIFF
--- a/src/components/tabPanel/TabPanel.spec.js
+++ b/src/components/tabPanel/TabPanel.spec.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import EvTabPanel from './TabPanel.vue';
+
+describe('EvTabPanel Component', () => {
+  const mountWithTabs = (props = {}, selectedValue = 'tab1') => mount(EvTabPanel, {
+    props: { value: 'tab1', text: '탭1', ...props },
+    slots: { default: '<div class="panel-content">패널 내용</div>' },
+    global: {
+      provide: {
+        evTabs: ref(selectedValue),
+      },
+    },
+  });
+
+  describe('렌더링', () => {
+    it('선택된 탭 패널이 렌더링된다', () => {
+      const wrapper = mountWithTabs({ value: 'tab1' }, 'tab1');
+
+      expect(wrapper.find('.ev-tab-panel').exists()).toBe(true);
+      expect(wrapper.find('.ev-tab-panel').isVisible()).toBe(true);
+    });
+
+    it('선택되지 않은 탭 패널은 숨겨진다', () => {
+      const wrapper = mountWithTabs({ value: 'tab1' }, 'tab2');
+
+      expect(wrapper.find('.ev-tab-panel').exists()).toBe(true);
+      expect(wrapper.find('.ev-tab-panel').isVisible()).toBe(false);
+    });
+
+    it('slot 내용이 렌더링된다', () => {
+      const wrapper = mountWithTabs();
+
+      expect(wrapper.find('.panel-content').exists()).toBe(true);
+      expect(wrapper.text()).toContain('패널 내용');
+    });
+  });
+
+  describe('Props', () => {
+    it('value prop이 선택 상태를 결정한다', () => {
+      const wrapper = mountWithTabs({ value: 'tab2' }, 'tab2');
+
+      expect(wrapper.find('.ev-tab-panel').isVisible()).toBe(true);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvTabPanel이다', () => {
+      expect(EvTabPanel.name).toBe('EvTabPanel');
+    });
+
+    it('기본 disabled는 false이다', () => {
+      expect(EvTabPanel.props.disabled.default).toBe(false);
+    });
+  });
+});

--- a/src/components/tabs/Tabs.spec.js
+++ b/src/components/tabs/Tabs.spec.js
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvTabs from './Tabs.vue';
+
+describe('EvTabs Component', () => {
+  const defaultPanels = [
+    { text: '탭1', value: 'tab1' },
+    { text: '탭2', value: 'tab2' },
+    { text: '탭3', value: 'tab3' },
+  ];
+
+  const globalConfig = {
+    global: {
+      directives: {
+        resize: {},
+        observeVisibility: {},
+      },
+    },
+  };
+
+  describe('렌더링', () => {
+    it('기본 탭이 렌더링된다', () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: defaultPanels },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-tabs').exists()).toBe(true);
+      expect(wrapper.find('.ev-tabs-header').exists()).toBe(true);
+      expect(wrapper.find('.ev-tabs-body').exists()).toBe(true);
+    });
+
+    it('탭 목록이 렌더링된다', () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: defaultPanels },
+        ...globalConfig,
+      });
+
+      const tabs = wrapper.findAll('.ev-tabs-title');
+      expect(tabs).toHaveLength(3);
+      expect(tabs[0].text()).toContain('탭1');
+      expect(tabs[1].text()).toContain('탭2');
+    });
+
+    it('선택된 탭에 active 클래스가 적용된다', () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab2', panels: defaultPanels },
+        ...globalConfig,
+      });
+
+      const tabs = wrapper.findAll('.ev-tabs-title');
+      expect(tabs[0].classes()).not.toContain('active');
+      expect(tabs[1].classes()).toContain('active');
+    });
+  });
+
+  describe('Props', () => {
+    it('closable prop이 적용된다', () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: defaultPanels, closable: true },
+        ...globalConfig,
+      });
+
+      expect(wrapper.classes()).toContain('closable');
+      expect(wrapper.findAll('.close-icon').length).toBeGreaterThan(0);
+    });
+
+    it('stretch prop이 적용된다', () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: defaultPanels, stretch: true },
+        ...globalConfig,
+      });
+
+      expect(wrapper.classes()).toContain('stretch');
+    });
+  });
+
+  describe('Events', () => {
+    it('탭 클릭 시 update:modelValue 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: defaultPanels },
+        ...globalConfig,
+      });
+
+      const tabs = wrapper.findAll('.ev-tabs-title');
+      await tabs[1].trigger('click');
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+      expect(wrapper.emitted('update:modelValue')[0][0]).toBe('tab2');
+    });
+
+    it('탭 클릭 시 change 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: defaultPanels },
+        ...globalConfig,
+      });
+
+      const tabs = wrapper.findAll('.ev-tabs-title');
+      await tabs[1].trigger('click');
+
+      expect(wrapper.emitted('change')).toBeTruthy();
+      expect(wrapper.emitted('change')[0][0]).toBe('tab2');
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvTabs이다', () => {
+      expect(EvTabs.name).toBe('EvTabs');
+    });
+
+    it('기본 closable은 false이다', () => {
+      expect(EvTabs.props.closable.default).toBe(false);
+    });
+
+    it('기본 stretch는 false이다', () => {
+      expect(EvTabs.props.stretch.default).toBe(false);
+    });
+
+    it('기본 draggable은 false이다', () => {
+      expect(EvTabs.props.draggable.default).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- TabPanel, Tabs 컴포넌트 단위 테스트 추가
- TabPanel: provide evTabs wrapper, v-show 가시성 테스트 (6 tests)
- Tabs: v-resize/v-observe-visibility 디렉티브 스텁, 탭 클릭 이벤트 (11 tests)

## Test plan
- [x] `npm run test:run` 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #2113