### PR TITLE
test(pagination, message): 테스트 추가

### DIFF
--- a/src/components/message/Message.spec.js
+++ b/src/components/message/Message.spec.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvMessage from './Message.vue';
+
+describe('EvMessage Component', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const el = document.createElement('div');
+    el.id = 'ev-message-modal';
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    const el = document.getElementById('ev-message-modal');
+    if (el) {
+      document.body.removeChild(el);
+    }
+  });
+
+  const globalStubs = {
+    global: {
+      stubs: { teleport: true },
+    },
+  };
+
+  describe('렌더링', () => {
+    it('기본 메시지가 렌더링된다', () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '안녕하세요' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message').exists()).toBe(true);
+      expect(wrapper.find('.ev-message-content').text()).toBe('안녕하세요');
+    });
+
+    it('showClose가 true이면 닫기 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '메시지', showClose: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-close').exists()).toBe(true);
+      expect(wrapper.find('.ev-message').classes()).toContain('show-close');
+    });
+
+    it('showClose가 false이면 닫기 버튼이 없다', () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '메시지', showClose: false },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-close').exists()).toBe(false);
+    });
+
+    it('iconClass가 설정되면 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '메시지', iconClass: 'ev-icon-info' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-icon').exists()).toBe(true);
+      expect(wrapper.find('.ev-message').classes()).toContain('has-icon');
+    });
+  });
+
+  describe('Props', () => {
+    it('type prop에 따라 클래스가 적용된다', () => {
+      const types = ['info', 'success', 'warning', 'error'];
+
+      types.forEach((type) => {
+        const wrapper = mount(EvMessage, {
+          props: { message: '메시지', type },
+          ...globalStubs,
+        });
+        expect(wrapper.find('.ev-message').classes()).toContain(`type-${type}`);
+      });
+    });
+
+    it('useHTML이 true이면 HTML 렌더링된다', () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '<strong>굵은 메시지</strong>', useHTML: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-content strong').exists()).toBe(true);
+    });
+  });
+
+  describe('Events', () => {
+    it('닫기 버튼 클릭 시 메시지가 숨겨진다', async () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '메시지', showClose: true },
+        ...globalStubs,
+      });
+
+      await wrapper.find('.ev-message-close').trigger('click');
+
+      expect(wrapper.find('.ev-message').isVisible()).toBe(false);
+    });
+
+    it('닫기 시 onClose 콜백이 호출된다', async () => {
+      const onClose = vi.fn();
+      const wrapper = mount(EvMessage, {
+        props: { message: '메시지', showClose: true, onClose },
+        ...globalStubs,
+      });
+
+      await wrapper.find('.ev-message-close').trigger('click');
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('expose된 hide 메서드로 isShow 상태가 변경된다', () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '메시지', duration: 0 },
+        ...globalStubs,
+      });
+
+      expect(wrapper.vm.isShow).toBe(true);
+
+      wrapper.vm.hide();
+
+      expect(wrapper.vm.isShow).toBe(false);
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 type은 info이다', () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '메시지' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message').classes()).toContain('type-info');
+    });
+
+    it('기본 duration은 3000이다', () => {
+      expect(EvMessage.props.duration.default).toBe(3000);
+    });
+
+    it('컴포넌트 이름이 EvMessage이다', () => {
+      expect(EvMessage.name).toBe('EvMessage');
+    });
+  });
+});

--- a/src/components/pagination/Pagination.spec.js
+++ b/src/components/pagination/Pagination.spec.js
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvPagination from './Pagination.vue';
+
+describe('EvPagination Component', () => {
+  const defaultProps = {
+    total: 100,
+    perPage: 10,
+    modelValue: 1,
+  };
+
+  describe('렌더링', () => {
+    it('기본 페이지네이션이 렌더링된다', () => {
+      const wrapper = mount(EvPagination, {
+        props: defaultProps,
+      });
+
+      expect(wrapper.find('.pagination').exists()).toBe(true);
+      expect(wrapper.find('.pagination-list').exists()).toBe(true);
+    });
+
+    it('페이지 번호들이 렌더링된다', () => {
+      const wrapper = mount(EvPagination, {
+        props: defaultProps,
+      });
+
+      const pages = wrapper.findAll('.is-page');
+      expect(pages.length).toBeGreaterThan(0);
+    });
+
+    it('현재 페이지에 is-current 클래스가 적용된다', () => {
+      const wrapper = mount(EvPagination, {
+        props: defaultProps,
+      });
+
+      expect(wrapper.find('.is-current').exists()).toBe(true);
+    });
+
+    it('이전/다음 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvPagination, {
+        props: defaultProps,
+      });
+
+      expect(wrapper.find('.pagination-previous').exists()).toBe(true);
+      expect(wrapper.find('.pagination-next').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('첫 페이지에서 이전 버튼이 비활성화된다', () => {
+      const wrapper = mount(EvPagination, {
+        props: { ...defaultProps, modelValue: 1 },
+      });
+
+      const prevButton = wrapper.findAll('.step-button')[0];
+      expect(prevButton.classes()).toContain('is-disabled');
+    });
+
+    it('마지막 페이지에서 다음 버튼이 비활성화된다', () => {
+      const wrapper = mount(EvPagination, {
+        props: { ...defaultProps, modelValue: 10 },
+      });
+
+      const stepButtons = wrapper.findAll('.step-button');
+      const nextButton = stepButtons[stepButtons.length - 1];
+      expect(nextButton.classes()).toContain('is-disabled');
+    });
+
+    it('showPageInfo가 true이면 페이지 정보가 표시된다', () => {
+      const wrapper = mount(EvPagination, {
+        props: { ...defaultProps, showPageInfo: true },
+      });
+
+      expect(wrapper.find('.pagination-info').exists()).toBe(true);
+    });
+
+    it('showPageInfo가 false이면 페이지 정보가 숨겨진다', () => {
+      const wrapper = mount(EvPagination, {
+        props: { ...defaultProps, showPageInfo: false },
+      });
+
+      expect(wrapper.find('.pagination-info').exists()).toBe(false);
+    });
+  });
+
+  describe('Events', () => {
+    it('페이지 클릭 시 update:modelValue 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvPagination, {
+        props: defaultProps,
+      });
+
+      const pages = wrapper.findAll('.is-page');
+      const page2 = pages.find((p) => p.text().includes('2'));
+      if (page2) {
+        await page2.trigger('click');
+        expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+      }
+    });
+
+    it('페이지 클릭 시 change 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvPagination, {
+        props: defaultProps,
+      });
+
+      const pages = wrapper.findAll('.is-page');
+      const page2 = pages.find((p) => p.text().includes('2'));
+      if (page2) {
+        await page2.trigger('click');
+        expect(wrapper.emitted('change')).toBeTruthy();
+      }
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvPagination이다', () => {
+      expect(EvPagination.name).toBe('EvPagination');
+    });
+
+    it('기본 perPage는 20이다', () => {
+      expect(EvPagination.props.perPage.default).toBe(20);
+    });
+
+    it('기본 visiblePage는 8이다', () => {
+      expect(EvPagination.props.visiblePage.default).toBe(8);
+    });
+
+    it('기본 order는 left이다', () => {
+      expect(EvPagination.props.order.default).toBe('left');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Pagination, Message 컴포넌트 단위 테스트 추가
- Pagination: 페이지 네비게이션, is-disabled/is-current 클래스, showPageInfo (14 tests)
- Message: teleport 스텁, type 클래스, fake timers, vm.isShow 상태 직접 확인 (12 tests)

## Test plan
- [x] `npm run test:run` 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #2113