### PR TITLE
test(notification, messageBox): 테스트 추가

### DIFF
--- a/src/components/messageBox/MessageBox.spec.js
+++ b/src/components/messageBox/MessageBox.spec.js
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvMessageBox from './MessageBox.vue';
+
+describe('EvMessageBox Component', () => {
+  const globalStubs = {
+    global: {
+      stubs: { teleport: true },
+    },
+  };
+
+  describe('렌더링', () => {
+    it('기본 메시지 박스가 렌더링된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인하시겠습니까?' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box').exists()).toBe(true);
+      expect(wrapper.find('.ev-message-box-message').text()).toBe('확인하시겠습니까?');
+    });
+
+    it('title이 있으면 제목이 렌더링된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { title: '확인', message: '내용' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-title').exists()).toBe(true);
+      expect(wrapper.find('.ev-message-box-title').text()).toBe('확인');
+    });
+
+    it('확인 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-confirm').exists()).toBe(true);
+    });
+
+    it('취소 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-cancel').exists()).toBe(true);
+    });
+
+    it('닫기 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', showClose: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-close').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('showConfirmBtn이 false이면 확인 버튼이 없다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', showConfirmBtn: false },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-confirm').exists()).toBe(false);
+    });
+
+    it('showCancelBtn이 false이면 취소 버튼이 없다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', showCancelBtn: false },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-cancel').exists()).toBe(false);
+    });
+
+    it('confirmBtnText prop이 적용된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', confirmBtnText: '예' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-confirm').text()).toBe('예');
+    });
+
+    it('cancelBtnText prop이 적용된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', cancelBtnText: '아니오' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-cancel').text()).toBe('아니오');
+    });
+
+    it('useHTML이 true이면 HTML 렌더링된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '<strong>중요</strong>', useHTML: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-message strong').exists()).toBe(true);
+    });
+
+    it('type prop에 따라 클래스가 적용된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', type: 'warning' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box').classes()).toContain('type-warning');
+    });
+  });
+
+  describe('Events', () => {
+    it('확인 버튼 클릭 시 onClose가 ok로 호출된다', async () => {
+      const onClose = vi.fn();
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', onClose },
+        ...globalStubs,
+      });
+
+      await wrapper.find('.ev-message-box-confirm').trigger('click');
+
+      expect(onClose).toHaveBeenCalledWith('ok');
+    });
+
+    it('취소 버튼 클릭 시 onClose가 cancel로 호출된다', async () => {
+      const onClose = vi.fn();
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', onClose },
+        ...globalStubs,
+      });
+
+      await wrapper.find('.ev-message-box-cancel').trigger('click');
+
+      expect(onClose).toHaveBeenCalledWith('cancel');
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 showClose는 true이다', () => {
+      expect(EvMessageBox.props.showClose.default).toBe(true);
+    });
+
+    it('기본 showConfirmBtn은 true이다', () => {
+      expect(EvMessageBox.props.showConfirmBtn.default).toBe(true);
+    });
+
+    it('기본 showCancelBtn은 true이다', () => {
+      expect(EvMessageBox.props.showCancelBtn.default).toBe(true);
+    });
+
+    it('기본 confirmBtnText는 OK이다', () => {
+      expect(EvMessageBox.props.confirmBtnText.default).toBe('OK');
+    });
+
+    it('기본 cancelBtnText는 Cancel이다', () => {
+      expect(EvMessageBox.props.cancelBtnText.default).toBe('Cancel');
+    });
+
+    it('컴포넌트 이름이 EvMessageBox이다', () => {
+      expect(EvMessageBox.name).toBe('EvMessageBox');
+    });
+  });
+});

--- a/src/components/notification/Notification.spec.js
+++ b/src/components/notification/Notification.spec.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvNotification from './Notification.vue';
+
+describe('EvNotification Component', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('렌더링', () => {
+    it('기본 알림이 렌더링된다', () => {
+      const wrapper = mount(EvNotification, {
+        props: { message: '알림 메시지' },
+      });
+
+      expect(wrapper.find('.ev-notification').exists()).toBe(true);
+      expect(wrapper.find('.message').text()).toBe('알림 메시지');
+    });
+
+    it('title이 있으면 제목이 렌더링된다', () => {
+      const wrapper = mount(EvNotification, {
+        props: { title: '알림 제목', message: '내용' },
+      });
+
+      expect(wrapper.find('.title').exists()).toBe(true);
+      expect(wrapper.find('.title').text()).toBe('알림 제목');
+    });
+
+    it('showClose가 true이면 닫기 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvNotification, {
+        props: { message: '알림', showClose: true },
+      });
+
+      expect(wrapper.find('.ev-notification-close').exists()).toBe(true);
+      expect(wrapper.find('.ev-notification').classes()).toContain('show-close');
+    });
+
+    it('iconClass가 설정되면 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvNotification, {
+        props: { message: '알림', iconClass: 'ev-icon-info' },
+      });
+
+      expect(wrapper.find('.ev-notification-icon').exists()).toBe(true);
+      expect(wrapper.find('.ev-notification').classes()).toContain('has-icon');
+    });
+  });
+
+  describe('Props', () => {
+    it('type prop에 따라 클래스가 적용된다', () => {
+      const types = ['info', 'success', 'warning', 'error'];
+
+      types.forEach((type) => {
+        const wrapper = mount(EvNotification, {
+          props: { message: '알림', type },
+        });
+        expect(wrapper.find('.ev-notification').classes()).toContain(`type-${type}`);
+      });
+    });
+
+    it('useHTML이 true이면 HTML 렌더링된다', () => {
+      const wrapper = mount(EvNotification, {
+        props: { message: '<strong>굵은 알림</strong>', useHTML: true },
+      });
+
+      expect(wrapper.find('.message strong').exists()).toBe(true);
+    });
+
+    it('onClick이 있으면 has-click 클래스가 적용된다', () => {
+      const wrapper = mount(EvNotification, {
+        props: { message: '알림', onClick: vi.fn() },
+      });
+
+      expect(wrapper.find('.ev-notification').classes()).toContain('has-click');
+    });
+  });
+
+  describe('Events', () => {
+    it('닫기 버튼 클릭 시 isShow가 false가 된다', async () => {
+      const wrapper = mount(EvNotification, {
+        props: { message: '알림', showClose: true },
+      });
+
+      expect(wrapper.vm.isShow).toBe(true);
+
+      await wrapper.find('.ev-notification-close').trigger('click');
+
+      expect(wrapper.vm.isShow).toBe(false);
+    });
+
+    it('닫기 시 onClose 콜백이 호출된다', async () => {
+      const onClose = vi.fn();
+      const wrapper = mount(EvNotification, {
+        props: { message: '알림', showClose: true, onClose },
+      });
+
+      await wrapper.find('.ev-notification-close').trigger('click');
+
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 type은 info이다', () => {
+      const wrapper = mount(EvNotification, {
+        props: { message: '알림' },
+      });
+
+      expect(wrapper.find('.ev-notification').classes()).toContain('type-info');
+    });
+
+    it('기본 showClose는 true이다', () => {
+      expect(EvNotification.props.showClose.default).toBe(true);
+    });
+
+    it('기본 position은 top-right이다', () => {
+      expect(EvNotification.props.position.default).toBe('top-right');
+    });
+
+    it('컴포넌트 이름이 EvNotification이다', () => {
+      expect(EvNotification.name).toBe('EvNotification');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Notification, MessageBox 컴포넌트 단위 테스트 추가
- Notification: type 클래스, onClick/has-click, showClose 등 (13 tests)
- MessageBox: teleport 스텁, confirm/cancel 버튼, onClose 콜백, useHTML (19 tests)

## Test plan
- [x] `npm run test:run` 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #2113