### PR TITLE
test(scheduler,menu,contextMenu,window): 테스트 추가

### DIFF
--- a/src/components/contextMenu/ContextMenu.spec.js
+++ b/src/components/contextMenu/ContextMenu.spec.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import EvContextMenu from './ContextMenu.vue';
+
+describe('EvContextMenu Component', () => {
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvContextMenu이다', () => {
+      expect(EvContextMenu.name).toBe('EvContextMenu');
+    });
+
+    it('기본 customClass는 빈 문자열이다', () => {
+      expect(EvContextMenu.props.customClass.default).toBe('');
+    });
+
+    it('기본 isShowMenuOnClick는 false이다', () => {
+      expect(EvContextMenu.props.isShowMenuOnClick.default).toBe(false);
+    });
+
+    it('기본 items는 빈 배열이다', () => {
+      expect(EvContextMenu.props.items.default()).toEqual([]);
+    });
+  });
+});

--- a/src/components/menu/Menu.spec.js
+++ b/src/components/menu/Menu.spec.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvMenu from './Menu.vue';
+
+describe('EvMenu Component', () => {
+  const defaultItems = [
+    { text: '메뉴1', value: 'menu1' },
+    { text: '메뉴2', value: 'menu2' },
+    { text: '메뉴3', value: 'menu3' },
+  ];
+
+  describe('렌더링', () => {
+    it('기본 메뉴가 렌더링된다', () => {
+      const wrapper = mount(EvMenu, {
+        props: { items: defaultItems },
+      });
+
+      expect(wrapper.find('.ev-menu').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled prop이 전달된다', () => {
+      expect(EvMenu.props.disabled.default).toBe(false);
+    });
+
+    it('expandable prop이 전달된다', () => {
+      expect(EvMenu.props.expandable.default).toBe(true);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvMenu이다', () => {
+      expect(EvMenu.name).toBe('EvMenu');
+    });
+
+    it('기본 expandable은 true이다', () => {
+      expect(EvMenu.props.expandable.default).toBe(true);
+    });
+
+    it('기본 disabled는 false이다', () => {
+      expect(EvMenu.props.disabled.default).toBe(false);
+    });
+  });
+});

--- a/src/components/scheduler/Scheduler.spec.js
+++ b/src/components/scheduler/Scheduler.spec.js
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvScheduler from './Scheduler.vue';
+
+describe('EvScheduler Component', () => {
+  const createModelValue = (rows = 24, cols = 7) =>
+    Array.from({ length: rows }, () => Array(cols).fill(false));
+
+  describe('렌더링', () => {
+    it('기본 스케줄러가 렌더링된다', () => {
+      const wrapper = mount(EvScheduler, {
+        props: { modelValue: createModelValue() },
+      });
+
+      expect(wrapper.find('.ev-scheduler').exists()).toBe(true);
+    });
+
+    it('헤더 라벨이 렌더링된다', () => {
+      const wrapper = mount(EvScheduler, {
+        props: { modelValue: createModelValue() },
+      });
+
+      const headers = wrapper.findAll('.ev-scheduler-header-label');
+      expect(headers).toHaveLength(7);
+    });
+
+    it('바디 라벨이 렌더링된다', () => {
+      const wrapper = mount(EvScheduler, {
+        props: { modelValue: createModelValue() },
+      });
+
+      const bodyLabels = wrapper.findAll('.ev-scheduler-body-label');
+      expect(bodyLabels).toHaveLength(24);
+    });
+
+    it('셀 박스들이 렌더링된다', () => {
+      const wrapper = mount(EvScheduler, {
+        props: { modelValue: createModelValue() },
+      });
+
+      const boxes = wrapper.findAll('.ev-scheduler-body-box');
+      expect(boxes).toHaveLength(24 * 7);
+    });
+  });
+
+  describe('Props', () => {
+    it('커스텀 colLabels가 적용된다', () => {
+      const colLabels = ['월', '화', '수'];
+      const wrapper = mount(EvScheduler, {
+        props: { modelValue: createModelValue(24, 3), colLabels },
+      });
+
+      const headers = wrapper.findAll('.ev-scheduler-header-label');
+      expect(headers).toHaveLength(3);
+    });
+
+    it('커스텀 rowLabels가 적용된다', () => {
+      const rowLabels = ['오전', '오후'];
+      const wrapper = mount(EvScheduler, {
+        props: { modelValue: createModelValue(2), rowLabels },
+      });
+
+      const bodyLabels = wrapper.findAll('.ev-scheduler-body-label');
+      expect(bodyLabels).toHaveLength(2);
+    });
+
+    it('선택된 셀에 selected 클래스가 적용된다', () => {
+      const mv = createModelValue();
+      mv[0][0] = true;
+      const wrapper = mount(EvScheduler, {
+        props: { modelValue: mv },
+      });
+
+      const selectedBoxes = wrapper.findAll('.ev-scheduler-body-box.selected');
+      expect(selectedBoxes.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvScheduler이다', () => {
+      expect(EvScheduler.name).toBe('EvScheduler');
+    });
+  });
+});

--- a/src/components/window/Window.spec.js
+++ b/src/components/window/Window.spec.js
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvWindow from './Window.vue';
+
+describe('EvWindow Component', () => {
+  const globalStubs = {
+    global: {
+      stubs: { teleport: true },
+    },
+  };
+
+  describe('렌더링', () => {
+    it('visible이 true이면 창이 렌더링된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window').exists()).toBe(true);
+    });
+
+    it('visible이 false이면 창이 렌더링되지 않는다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: false },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window').exists()).toBe(false);
+    });
+
+    it('title이 있으면 제목이 렌더링된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true, title: '창 제목' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window-title').exists()).toBe(true);
+      expect(wrapper.find('.ev-window-title').text()).toBe('창 제목');
+    });
+
+    it('닫기 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window-close').exists()).toBe(true);
+    });
+
+    it('slot 내용이 content 영역에 렌더링된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true },
+        slots: { default: '<div class="test-content">내용</div>' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window-content .test-content').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('fullscreen이 true이면 fullscreen 클래스가 적용된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true, fullscreen: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window.fullscreen').exists()).toBe(true);
+    });
+
+    it('isModal이 true이면 dim 레이어가 렌더링된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true, isModal: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window-dim-layer').exists()).toBe(true);
+    });
+
+    it('isModal이 false이면 dim 레이어가 없다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true, isModal: false },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window-dim-layer').exists()).toBe(false);
+    });
+
+    it('iconClass가 설정되면 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true, iconClass: 'ev-icon-setting' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window-icon').exists()).toBe(true);
+    });
+
+    it('maximizable이 true이면 최대화 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true, maximizable: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window-maximizable').exists()).toBe(true);
+    });
+  });
+
+  describe('Events', () => {
+    it('닫기 버튼 클릭 시 update:visible 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true },
+        ...globalStubs,
+      });
+
+      await wrapper.find('.ev-window-close').trigger('click');
+
+      expect(wrapper.emitted('update:visible')).toBeTruthy();
+      expect(wrapper.emitted('update:visible')[0][0]).toBe(false);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvWindow이다', () => {
+      expect(EvWindow.name).toBe('EvWindow');
+    });
+
+    it('기본 isModal은 true이다', () => {
+      expect(EvWindow.props.isModal.default).toBe(true);
+    });
+
+    it('기본 draggable은 false이다', () => {
+      expect(EvWindow.props.draggable.default).toBe(false);
+    });
+
+    it('기본 resizable은 false이다', () => {
+      expect(EvWindow.props.resizable.default).toBe(false);
+    });
+
+    it('기본 fullscreen은 false이다', () => {
+      expect(EvWindow.props.fullscreen.default).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Scheduler, Menu, ContextMenu, Window 컴포넌트 단위 테스트 추가
- Scheduler: 2D 배열 modelValue, 헤더/바디 라벨, 셀 선택 (8 tests)
- Menu: 기본 렌더링, props 기본값 (6 tests)
- ContextMenu: props 기본값 확인 (4 tests)
- Window: teleport 스텁, visible, fullscreen, isModal, maximizable, close 이벤트 (16 tests)

## Test plan
- [x] `npm run test:run` 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #2113