### PR TITLE
test(slider, timePicker): 테스트 추가

### DIFF
--- a/src/components/slider/Slider.spec.js
+++ b/src/components/slider/Slider.spec.js
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvSlider from './Slider.vue';
+
+describe('EvSlider Component', () => {
+  describe('렌더링', () => {
+    it('기본 슬라이더가 렌더링된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50 },
+      });
+
+      expect(wrapper.find('.ev-slider').exists()).toBe(true);
+    });
+
+    it('슬라이더 라인이 렌더링된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50 },
+      });
+
+      expect(wrapper.find('.ev-slider-line').exists()).toBe(true);
+    });
+
+    it('핸들이 렌더링된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50 },
+      });
+
+      expect(wrapper.find('.ev-slider-handle').exists()).toBe(true);
+    });
+
+    it('range일 때 핸들이 2개 렌더링된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: [20, 80], range: true },
+      });
+
+      const handles = wrapper.findAll('.ev-slider-handle');
+      expect(handles).toHaveLength(2);
+    });
+
+    it('툴팁이 렌더링된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50 },
+      });
+
+      expect(wrapper.find('.ev-slider-tooltip').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled이면 disabled 클래스가 적용된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50, disabled: true },
+      });
+
+      expect(wrapper.find('.ev-slider.disabled').exists()).toBe(true);
+    });
+
+    it('readonly이면 readonly 클래스가 적용된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50, readonly: true },
+      });
+
+      expect(wrapper.find('.ev-slider.readonly').exists()).toBe(true);
+    });
+
+    it('showTooltip이 false이면 hide-tooltip 클래스가 적용된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50, showTooltip: false },
+      });
+
+      expect(wrapper.find('.ev-slider.hide-tooltip').exists()).toBe(true);
+    });
+
+    it('showStep이 true이고 step이 있으면 step이 렌더링된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50, showStep: true, step: 25 },
+      });
+
+      expect(wrapper.find('.ev-slider-step-wrapper').exists()).toBe(true);
+    });
+
+    it('mark가 설정되면 마크가 렌더링된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: {
+          modelValue: 50,
+          mark: { 0: '0', 50: '50', 100: '100' },
+        },
+      });
+
+      expect(wrapper.find('.ev-slider.show-mark').exists()).toBe(true);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvSlider이다', () => {
+      expect(EvSlider.name).toBe('EvSlider');
+    });
+
+    it('기본 min은 0이다', () => {
+      expect(EvSlider.props.min.default).toBe(0);
+    });
+
+    it('기본 max는 100이다', () => {
+      expect(EvSlider.props.max.default).toBe(100);
+    });
+
+    it('기본 step은 1이다', () => {
+      expect(EvSlider.props.step.default).toBe(1);
+    });
+
+    it('기본 disabled는 false이다', () => {
+      expect(EvSlider.props.disabled.default).toBe(false);
+    });
+
+    it('기본 readonly는 false이다', () => {
+      expect(EvSlider.props.readonly.default).toBe(false);
+    });
+
+    it('기본 range는 false이다', () => {
+      expect(EvSlider.props.range.default).toBe(false);
+    });
+
+    it('기본 showTooltip은 true이다', () => {
+      expect(EvSlider.props.showTooltip.default).toBe(true);
+    });
+
+    it('기본 showInput은 false이다', () => {
+      expect(EvSlider.props.showInput.default).toBe(false);
+    });
+
+    it('기본 showStep은 false이다', () => {
+      expect(EvSlider.props.showStep.default).toBe(false);
+    });
+  });
+});

--- a/src/components/timePicker/TimePicker.spec.js
+++ b/src/components/timePicker/TimePicker.spec.js
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvTimePicker from './TimePicker.vue';
+
+describe('EvTimePicker Component', () => {
+  describe('렌더링', () => {
+    it('기본 타임피커가 렌더링된다 (range 타입)', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: ['09:00', '18:00'] },
+      });
+
+      expect(wrapper.find('.ev-time-picker').exists()).toBe(true);
+      expect(wrapper.find('.ev-time-picker-range').exists()).toBe(true);
+    });
+
+    it('single 타입이면 single 레이아웃이 렌더링된다', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single' },
+      });
+
+      expect(wrapper.find('.ev-time-picker-single').exists()).toBe(true);
+    });
+
+    it('range 타입에서 물결표(~)가 렌더링된다', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: ['09:00', '18:00'] },
+      });
+
+      expect(wrapper.find('.tilde').exists()).toBe(true);
+      expect(wrapper.find('.tilde').text()).toBe('~');
+    });
+
+    it('range 타입에서 입력 필드가 2개 렌더링된다', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: ['09:00', '18:00'] },
+      });
+
+      const inputs = wrapper.findAll('.ev-input');
+      expect(inputs).toHaveLength(2);
+    });
+
+    it('single 타입에서 입력 필드가 1개 렌더링된다', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single' },
+      });
+
+      const inputs = wrapper.findAll('.ev-input');
+      expect(inputs).toHaveLength(1);
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled이면 disabled 클래스가 적용된다', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single', disabled: true },
+      });
+
+      expect(wrapper.find('.ev-time-picker-wrapper.disabled').exists()).toBe(true);
+    });
+
+    it('readonly이면 readonly 클래스가 적용된다', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single', readonly: true },
+      });
+
+      expect(wrapper.find('.ev-time-picker-wrapper.readonly').exists()).toBe(true);
+    });
+
+    it('clearable이면 클리어 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single', clearable: true },
+      });
+
+      expect(wrapper.find('.ev-input-suffix').exists()).toBe(true);
+    });
+
+    it('placeholder가 적용된다 (single)', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single', placeholder: '시간 입력' },
+      });
+
+      expect(wrapper.find('.ev-input').attributes('placeholder')).toBe('시간 입력');
+    });
+  });
+
+  describe('Events', () => {
+    it('single 타입에서 focus 시 focus 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single' },
+      });
+
+      await wrapper.find('.ev-input').trigger('focus');
+
+      expect(wrapper.emitted('focus')).toBeTruthy();
+    });
+
+    it('single 타입에서 blur 시 blur 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single' },
+      });
+
+      await wrapper.find('.ev-input').trigger('blur');
+
+      expect(wrapper.emitted('blur')).toBeTruthy();
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvTimePicker이다', () => {
+      expect(EvTimePicker.name).toBe('EvTimePicker');
+    });
+
+    it('기본 type은 range이다', () => {
+      expect(EvTimePicker.props.type.default).toBe('range');
+    });
+
+    it('기본 clearable은 false이다', () => {
+      expect(EvTimePicker.props.clearable.default).toBe(false);
+    });
+
+    it('기본 disabled는 false이다', () => {
+      expect(EvTimePicker.props.disabled.default).toBe(false);
+    });
+
+    it('기본 readonly는 false이다', () => {
+      expect(EvTimePicker.props.readonly.default).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Slider, TimePicker 컴포넌트 단위 테스트 추가
- Slider: disabled/readonly/hide-tooltip 클래스, range 핸들, step, mark 등 (20 tests)
- TimePicker: range/single 타입, disabled/readonly, clearable, focus/blur 이벤트 (16 tests)

## Test plan
- [x] `npm run test:run` 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #2113