### PR TITLE
test(calendar, datePicker): 테스트 추가

### DIFF
--- a/src/components/calendar/Calendar.spec.js
+++ b/src/components/calendar/Calendar.spec.js
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvCalendar from './Calendar.vue';
+
+describe('EvCalendar Component', () => {
+  describe('렌더링', () => {
+    it('기본 캘린더가 렌더링된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      expect(wrapper.find('.ev-calendar-wrapper').exists()).toBe(true);
+    });
+
+    it('헤더에 년/월이 렌더링된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      expect(wrapper.find('.ev-calendar-header').exists()).toBe(true);
+      expect(wrapper.find('.ev-calendar-year').exists()).toBe(true);
+      expect(wrapper.find('.ev-calendar-month').exists()).toBe(true);
+    });
+
+    it('요일 헤더가 렌더링된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      const headers = wrapper.findAll('.ev-calendar-table th');
+      expect(headers).toHaveLength(7);
+    });
+
+    it('날짜 테이블이 렌더링된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      expect(wrapper.find('.ev-calendar-table').exists()).toBe(true);
+      const dateCells = wrapper.findAll('.ev-calendar-date-td');
+      expect(dateCells.length).toBeGreaterThan(0);
+    });
+
+    it('이전/다음 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      const arrows = wrapper.findAll('.move-month-arrow');
+      expect(arrows).toHaveLength(2);
+    });
+  });
+
+  describe('Props', () => {
+    it('dateRange 모드에서 캘린더가 2개 렌더링된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: ['2024-01-15', '2024-02-15'], mode: 'dateRange' },
+      });
+
+      const dateAreas = wrapper.findAll('.ev-calendar-date-area');
+      expect(dateAreas).toHaveLength(2);
+    });
+
+    it('dateTime 모드에서 시간 영역이 렌더링된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15 10:30:00', mode: 'dateTime' },
+      });
+
+      expect(wrapper.find('.ev-calendar-time-area').exists()).toBe(true);
+    });
+
+    it('선택된 날짜에 selected 클래스가 적용된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      const selectedCells = wrapper.findAll('.ev-calendar-date-td.selected');
+      expect(selectedCells.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Events', () => {
+    it('년도 클릭 시 년도 선택기가 표시된다', async () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      await wrapper.find('.ev-calendar-year').trigger('click');
+
+      expect(wrapper.find('.ev-calendar-year-range').exists()).toBe(true);
+    });
+
+    it('월 클릭 시 월 선택기가 표시된다', async () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      await wrapper.find('.ev-calendar-month').trigger('click');
+
+      expect(wrapper.find('.ev-calendar-selector-table--month').exists()).toBe(true);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvCalendar이다', () => {
+      expect(EvCalendar.name).toBe('EvCalendar');
+    });
+
+    it('기본 mode는 date이다', () => {
+      expect(EvCalendar.props.mode.default).toBe('date');
+    });
+
+    it('기본 monthNotation은 fullName이다', () => {
+      expect(EvCalendar.props.monthNotation.default).toBe('fullName');
+    });
+
+    it('기본 dayOfTheWeekNotation은 abbrUpperName이다', () => {
+      expect(EvCalendar.props.dayOfTheWeekNotation.default).toBe('abbrUpperName');
+    });
+  });
+});

--- a/src/components/datePicker/DatePicker.spec.js
+++ b/src/components/datePicker/DatePicker.spec.js
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvDatePicker from './DatePicker.vue';
+
+describe('EvDatePicker Component', () => {
+  const globalConfig = {
+    global: {
+      directives: { clickoutside: {} },
+    },
+  };
+
+  describe('렌더링', () => {
+    it('기본 데이트피커가 렌더링된다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: { modelValue: '2024-01-15' },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-date-picker').exists()).toBe(true);
+    });
+
+    it('캘린더 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: { modelValue: '2024-01-15' },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-icon-calendar').exists()).toBe(true);
+    });
+
+    it('입력 필드가 렌더링된다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: { modelValue: '2024-01-15' },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-input').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled이면 disabled 클래스가 적용된다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: { modelValue: '2024-01-15', disabled: true },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-date-picker.disabled').exists()).toBe(true);
+    });
+
+    it('placeholder가 적용된다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: { modelValue: '', placeholder: '날짜 선택' },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-input').attributes('placeholder')).toBe('날짜 선택');
+    });
+
+    it('clearable이면 클리어 아이콘 영역이 존재한다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: { modelValue: '2024-01-15', clearable: true },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-input-suffix').exists()).toBe(true);
+    });
+
+    it('enableTextInput이 false이면 readonly 클래스가 적용된다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: { modelValue: '2024-01-15', enableTextInput: false },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-input.readonly').exists()).toBe(true);
+    });
+
+    it('dateMulti 모드에서 태그 래퍼가 렌더링된다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: {
+          modelValue: ['2024-01-15', '2024-01-16'],
+          mode: 'dateMulti',
+        },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-date-picker-tag-wrapper').exists()).toBe(true);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvDatePicker이다', () => {
+      expect(EvDatePicker.name).toBe('EvDatePicker');
+    });
+
+    it('기본 mode는 date이다', () => {
+      expect(EvDatePicker.props.mode.default).toBe('date');
+    });
+
+    it('기본 disabled는 false이다', () => {
+      expect(EvDatePicker.props.disabled.default).toBe(false);
+    });
+
+    it('기본 clearable은 false이다', () => {
+      expect(EvDatePicker.props.clearable.default).toBe(false);
+    });
+
+    it('기본 enableTextInput은 false이다', () => {
+      expect(EvDatePicker.props.enableTextInput.default).toBe(false);
+    });
+
+    it('기본 monthNotation은 fullName이다', () => {
+      expect(EvDatePicker.props.monthNotation.default).toBe('fullName');
+    });
+
+    it('기본 placeholder는 빈 문자열이다', () => {
+      expect(EvDatePicker.props.placeholder.default).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Calendar, DatePicker 컴포넌트 단위 테스트 추가
- Calendar: 헤더 년/월, 요일, 날짜 테이블, dateRange/dateTime 모드, 년/월 선택기 (14 tests)
- DatePicker: clickoutside 디렉티브 스텁, disabled, placeholder, clearable, dateMulti 모드 (15 tests)

## Test plan
- [x] `npm run test:run` 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #2113