### PR TITLE
test(tree,grid,treeGrid,chartGroup): 테스트 추가

### DIFF
--- a/src/components/chartGroup/ChartGroup.spec.js
+++ b/src/components/chartGroup/ChartGroup.spec.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import EvChartGroup from './ChartGroup.vue';
+
+describe('EvChartGroup Component', () => {
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvChartGroup이다', () => {
+      expect(EvChartGroup.name).toBe('EvChartGroup');
+    });
+
+    it('기본 options는 빈 객체이다', () => {
+      expect(EvChartGroup.props.options.default()).toEqual({});
+    });
+
+    it('기본 zoomStartIdx는 0이다', () => {
+      expect(EvChartGroup.props.zoomStartIdx.default).toBe(0);
+    });
+
+    it('기본 zoomEndIdx는 0이다', () => {
+      expect(EvChartGroup.props.zoomEndIdx.default).toBe(0);
+    });
+
+    it('기본 groupSelectedLabel은 null이다', () => {
+      expect(EvChartGroup.props.groupSelectedLabel.default).toBeNull();
+    });
+  });
+});

--- a/src/components/grid/Grid.spec.js
+++ b/src/components/grid/Grid.spec.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import EvGrid from './Grid.vue';
+
+describe('EvGrid Component', () => {
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvGrid이다', () => {
+      expect(EvGrid.name).toBe('EvGrid');
+    });
+
+    it('기본 columns는 빈 배열이다', () => {
+      expect(EvGrid.props.columns.default()).toEqual([]);
+    });
+
+    it('기본 rows는 빈 배열이다', () => {
+      expect(EvGrid.props.rows.default()).toEqual([]);
+    });
+
+    it('기본 width는 100%이다', () => {
+      expect(EvGrid.props.width.default).toBe('100%');
+    });
+
+    it('기본 height는 100%이다', () => {
+      expect(EvGrid.props.height.default).toBe('100%');
+    });
+
+    it('기본 selected는 빈 배열이다', () => {
+      expect(EvGrid.props.selected.default()).toEqual([]);
+    });
+
+    it('기본 checked는 빈 배열이다', () => {
+      expect(EvGrid.props.checked.default()).toEqual([]);
+    });
+
+    it('기본 option은 빈 객체이다', () => {
+      expect(EvGrid.props.option.default()).toEqual({});
+    });
+
+    it('기본 expanded는 빈 배열이다', () => {
+      expect(EvGrid.props.expanded.default()).toEqual([]);
+    });
+
+    it('기본 disabledRows는 빈 배열이다', () => {
+      expect(EvGrid.props.disabledRows.default()).toEqual([]);
+    });
+
+    it('기본 uncheckable은 빈 배열이다', () => {
+      expect(EvGrid.props.uncheckable.default()).toEqual([]);
+    });
+  });
+});

--- a/src/components/tree/Tree.spec.js
+++ b/src/components/tree/Tree.spec.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvTree from './Tree.vue';
+
+describe('EvTree Component', () => {
+  const sampleData = [
+    {
+      title: '루트',
+      children: [
+        { title: '자식1' },
+        { title: '자식2' },
+      ],
+    },
+  ];
+
+  describe('렌더링', () => {
+    it('기본 트리가 렌더링된다', () => {
+      const wrapper = mount(EvTree, {
+        props: { data: sampleData },
+      });
+
+      expect(wrapper.find('.ev-tree-view').exists()).toBe(true);
+    });
+
+    it('데이터가 없으면 빈 텍스트가 표시된다', () => {
+      const wrapper = mount(EvTree, {
+        props: { data: [] },
+      });
+
+      expect(wrapper.text()).toContain('No Data');
+    });
+
+    it('커스텀 emptyText가 표시된다', () => {
+      const wrapper = mount(EvTree, {
+        props: { data: [], emptyText: '데이터 없음' },
+      });
+
+      expect(wrapper.text()).toContain('데이터 없음');
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvTree이다', () => {
+      expect(EvTree.name).toBe('EvTree');
+    });
+
+    it('기본 data는 빈 배열이다', () => {
+      expect(EvTree.props.data.default()).toEqual([]);
+    });
+
+    it('기본 useCheckbox는 false이다', () => {
+      expect(EvTree.props.useCheckbox.default).toBe(false);
+    });
+
+    it('기본 emptyText는 No Data이다', () => {
+      expect(EvTree.props.emptyText.default).toBe('No Data');
+    });
+
+    it('기본 searchWord는 빈 문자열이다', () => {
+      expect(EvTree.props.searchWord.default).toBe('');
+    });
+
+    it('기본 searchIncludeChildren은 false이다', () => {
+      expect(EvTree.props.searchIncludeChildren.default).toBe(false);
+    });
+
+    it('기본 contextMenuItems는 빈 배열이다', () => {
+      expect(EvTree.props.contextMenuItems.default()).toEqual([]);
+    });
+  });
+});

--- a/src/components/treeGrid/TreeGrid.spec.js
+++ b/src/components/treeGrid/TreeGrid.spec.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import EvTreeGrid from './TreeGrid.vue';
+
+describe('EvTreeGrid Component', () => {
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvTreeGrid이다', () => {
+      expect(EvTreeGrid.name).toBe('EvTreeGrid');
+    });
+
+    it('기본 columns는 빈 배열이다', () => {
+      expect(EvTreeGrid.props.columns.default()).toEqual([]);
+    });
+
+    it('기본 rows는 null이다', () => {
+      expect(EvTreeGrid.props.rows.default()).toBeNull();
+    });
+
+    it('기본 width는 100%이다', () => {
+      expect(EvTreeGrid.props.width.default).toBe('100%');
+    });
+
+    it('기본 height는 100%이다', () => {
+      expect(EvTreeGrid.props.height.default).toBe('100%');
+    });
+
+    it('기본 selected는 빈 배열이다', () => {
+      expect(EvTreeGrid.props.selected.default()).toEqual([]);
+    });
+
+    it('기본 checked는 빈 배열이다', () => {
+      expect(EvTreeGrid.props.checked.default()).toEqual([]);
+    });
+
+    it('기본 option은 빈 객체이다', () => {
+      expect(EvTreeGrid.props.option.default()).toEqual({});
+    });
+
+    it('기본 expandIcon은 빈 문자열이다', () => {
+      expect(EvTreeGrid.props.expandIcon.default).toBe('');
+    });
+
+    it('기본 collapseIcon은 빈 문자열이다', () => {
+      expect(EvTreeGrid.props.collapseIcon.default).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Tree, Grid, TreeGrid, ChartGroup 컴포넌트 단위 테스트 추가
- Tree: 렌더링, 빈 텍스트, props 기본값 (10 tests)
- Grid: props 기본값 확인 (11 tests)
- TreeGrid: props 기본값 확인 (10 tests)
- ChartGroup: props 기본값 확인 (5 tests)

## Test plan
- [x] `npm run test:run` 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #2113