### PR TITLE
test: 전체 컴포넌트 및 유틸리티 테스트 추가 (628개 테스트)

### DIFF
--- a/src/common/utils.table.spec.js
+++ b/src/common/utils.table.spec.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import tableUtils from './utils.table';
+
+describe('utils.table', () => {
+  describe('quantity', () => {
+    it('숫자 문자열을 파싱한다', () => {
+      expect(tableUtils.quantity('100')).toEqual({ value: 100, unit: undefined });
+    });
+
+    it('px 단위를 파싱한다', () => {
+      expect(tableUtils.quantity('100px')).toEqual({ value: 100, unit: 'px' });
+    });
+
+    it('% 단위를 파싱한다', () => {
+      expect(tableUtils.quantity('50%')).toEqual({ value: 50, unit: '%' });
+    });
+
+    it('소수점을 파싱한다', () => {
+      expect(tableUtils.quantity('10.5px')).toEqual({ value: 10.5, unit: 'px' });
+    });
+
+    it('숫자 타입을 파싱한다', () => {
+      expect(tableUtils.quantity(100)).toEqual({ value: 100, unit: undefined });
+    });
+
+    it('유효하지 않은 문자열은 undefined를 반환한다', () => {
+      expect(tableUtils.quantity('abc')).toBeUndefined();
+    });
+
+    it('객체는 undefined를 반환한다', () => {
+      expect(tableUtils.quantity({})).toBeUndefined();
+    });
+
+    it('null은 undefined를 반환한다', () => {
+      expect(tableUtils.quantity(null)).toBeUndefined();
+    });
+  });
+
+  describe('numberToPixel', () => {
+    it('숫자 문자열을 px로 변환한다', () => {
+      expect(tableUtils.numberToPixel('100')).toBe('100px');
+    });
+
+    it('px 단위는 그대로 반환한다', () => {
+      expect(tableUtils.numberToPixel('100px')).toBe('100px');
+    });
+
+    it('% 단위는 그대로 반환한다', () => {
+      expect(tableUtils.numberToPixel('50%')).toBe('50%');
+    });
+
+    it('숫자 타입을 px로 변환한다', () => {
+      expect(tableUtils.numberToPixel(200)).toBe('200px');
+    });
+
+    it('유효하지 않은 값은 undefined를 반환한다', () => {
+      expect(tableUtils.numberToPixel('abc')).toBeUndefined();
+    });
+
+    it('객체는 undefined를 반환한다', () => {
+      expect(tableUtils.numberToPixel({})).toBeUndefined();
+    });
+  });
+
+  describe('isPercentValue', () => {
+    it('% 포함 문자열은 true를 반환한다', () => {
+      expect(tableUtils.isPercentValue('50%')).toBe(true);
+    });
+
+    it('% 없는 문자열은 false를 반환한다', () => {
+      expect(tableUtils.isPercentValue('50px')).toBe(false);
+    });
+
+    it('숫자 타입은 false를 반환한다', () => {
+      expect(tableUtils.isPercentValue(50)).toBe(false);
+    });
+
+    it('빈 문자열은 true를 반환한다 (edge case)', () => {
+      // indexOf('%') === -1, length - 1 === -1 이므로 true 반환
+      expect(tableUtils.isPercentValue('')).toBe(true);
+    });
+  });
+
+  describe('checkColSize', () => {
+    it('min보다 작으면 min을 반환한다', () => {
+      expect(tableUtils.checkColSize(10, 50, 200)).toBe(50);
+    });
+
+    it('max보다 크면 max를 반환한다', () => {
+      expect(tableUtils.checkColSize(300, 50, 200)).toBe(200);
+    });
+
+    it('범위 안이면 그대로 반환한다', () => {
+      expect(tableUtils.checkColSize(100, 50, 200)).toBe(100);
+    });
+
+    it('min이 없으면 min 체크를 건너뛴다', () => {
+      expect(tableUtils.checkColSize(10, null, 200)).toBe(10);
+    });
+
+    it('max가 없으면 max 체크를 건너뛴다', () => {
+      expect(tableUtils.checkColSize(300, 50, null)).toBe(300);
+    });
+  });
+});

--- a/src/components/calendar/Calendar.spec.js
+++ b/src/components/calendar/Calendar.spec.js
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvCalendar from './Calendar.vue';
+
+describe('EvCalendar Component', () => {
+  describe('렌더링', () => {
+    it('기본 캘린더가 렌더링된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      expect(wrapper.find('.ev-calendar-wrapper').exists()).toBe(true);
+    });
+
+    it('헤더에 년/월이 렌더링된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      expect(wrapper.find('.ev-calendar-header').exists()).toBe(true);
+      expect(wrapper.find('.ev-calendar-year').exists()).toBe(true);
+      expect(wrapper.find('.ev-calendar-month').exists()).toBe(true);
+    });
+
+    it('요일 헤더가 렌더링된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      const headers = wrapper.findAll('.ev-calendar-table th');
+      expect(headers).toHaveLength(7);
+    });
+
+    it('날짜 테이블이 렌더링된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      expect(wrapper.find('.ev-calendar-table').exists()).toBe(true);
+      const dateCells = wrapper.findAll('.ev-calendar-date-td');
+      expect(dateCells.length).toBeGreaterThan(0);
+    });
+
+    it('이전/다음 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      const arrows = wrapper.findAll('.move-month-arrow');
+      expect(arrows).toHaveLength(2);
+    });
+  });
+
+  describe('Props', () => {
+    it('dateRange 모드에서 캘린더가 2개 렌더링된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: ['2024-01-15', '2024-02-15'], mode: 'dateRange' },
+      });
+
+      const dateAreas = wrapper.findAll('.ev-calendar-date-area');
+      expect(dateAreas).toHaveLength(2);
+    });
+
+    it('dateTime 모드에서 시간 영역이 렌더링된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15 10:30:00', mode: 'dateTime' },
+      });
+
+      expect(wrapper.find('.ev-calendar-time-area').exists()).toBe(true);
+    });
+
+    it('선택된 날짜에 selected 클래스가 적용된다', () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      const selectedCells = wrapper.findAll('.ev-calendar-date-td.selected');
+      expect(selectedCells.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Events', () => {
+    it('년도 클릭 시 년도 선택기가 표시된다', async () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      await wrapper.find('.ev-calendar-year').trigger('click');
+
+      expect(wrapper.find('.ev-calendar-year-range').exists()).toBe(true);
+    });
+
+    it('월 클릭 시 월 선택기가 표시된다', async () => {
+      const wrapper = mount(EvCalendar, {
+        props: { modelValue: '2024-01-15' },
+      });
+
+      await wrapper.find('.ev-calendar-month').trigger('click');
+
+      expect(wrapper.find('.ev-calendar-selector-table--month').exists()).toBe(true);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvCalendar이다', () => {
+      expect(EvCalendar.name).toBe('EvCalendar');
+    });
+
+    it('기본 mode는 date이다', () => {
+      expect(EvCalendar.props.mode.default).toBe('date');
+    });
+
+    it('기본 monthNotation은 fullName이다', () => {
+      expect(EvCalendar.props.monthNotation.default).toBe('fullName');
+    });
+
+    it('기본 dayOfTheWeekNotation은 abbrUpperName이다', () => {
+      expect(EvCalendar.props.dayOfTheWeekNotation.default).toBe('abbrUpperName');
+    });
+  });
+});

--- a/src/components/calendar/uses.spec.js
+++ b/src/components/calendar/uses.spec.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { lpadToTwoDigits } from './uses';
+
+describe('lpadToTwoDigits', () => {
+  it('한 자리 숫자를 두 자리로 패딩한다', () => {
+    expect(lpadToTwoDigits(1)).toBe('01');
+    expect(lpadToTwoDigits(9)).toBe('09');
+    expect(lpadToTwoDigits(0)).toBe('00');
+  });
+
+  it('두 자리 이상 숫자는 그대로 반환한다', () => {
+    expect(lpadToTwoDigits(10)).toBe(10);
+    expect(lpadToTwoDigits(31)).toBe(31);
+    expect(lpadToTwoDigits(12)).toBe(12);
+  });
+
+  it('문자열 숫자도 처리한다', () => {
+    expect(lpadToTwoDigits('5')).toBe('05');
+    expect(lpadToTwoDigits('12')).toBe('12');
+  });
+
+  it('null이면 00을 반환한다', () => {
+    expect(lpadToTwoDigits(null)).toBe('00');
+  });
+});

--- a/src/components/chart/element/element.bar.spec.js
+++ b/src/components/chart/element/element.bar.spec.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import Bar from './element.bar';
+
+const createBar = (overrides = {}) => {
+  const bar = Object.create(Bar.prototype);
+  Object.assign(bar, overrides);
+  return bar;
+};
+
+describe('Bar Element', () => {
+  describe('calculateBarSize', () => {
+    it('px 문자열을 파싱하여 크기를 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize('30px', 50)).toBe(30);
+    });
+
+    it('px 값이 bArea보다 크면 bArea를 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize('100px', 50)).toBe(50);
+    });
+
+    it('0~1 사이 숫자는 비율로 계산한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize(0.5, 100)).toBe(50);
+    });
+
+    it('비율 0은 0을 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize(0, 100)).toBe(0);
+    });
+
+    it('비율 1은 전체 영역을 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize(1, 100)).toBe(100);
+    });
+
+    it('유효하지 않은 값은 bArea를 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize('auto', 80)).toBe(80);
+      expect(bar.calculateBarSize(null, 80)).toBe(80);
+      expect(bar.calculateBarSize(2, 80)).toBe(80);
+    });
+  });
+
+  describe('isPointInBar', () => {
+    it('바 영역 내 점은 true를 반환한다', () => {
+      const bar = createBar();
+      const barData = { xp: 10, yp: 50, w: 20, h: -30 };
+      // bar: x 10~30, y 20~50
+      expect(bar.isPointInBar([15, 40], barData)).toBe(true);
+    });
+
+    it('바 영역 밖 점은 false를 반환한다', () => {
+      const bar = createBar();
+      const barData = { xp: 10, yp: 50, w: 20, h: -30 };
+      expect(bar.isPointInBar([5, 40], barData)).toBe(false);
+      expect(bar.isPointInBar([35, 40], barData)).toBe(false);
+    });
+  });
+});

--- a/src/components/chart/element/element.heatmap.spec.js
+++ b/src/components/chart/element/element.heatmap.spec.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import HeatMap from './element.heatmap';
+
+const createHeatMap = (overrides = {}) => {
+  const hm = Object.create(HeatMap.prototype);
+  Object.assign(hm, overrides);
+  return hm;
+};
+
+describe('HeatMap Element', () => {
+  describe('getAdjustedBounds', () => {
+    it('기본 범위를 조정한다', () => {
+      const hm = createHeatMap();
+      const result = hm.getAdjustedBounds({
+        xp: 10,
+        yp: 20,
+        width: 30,
+        height: 40,
+      });
+      expect(result.xsp).toBe(10);
+      expect(result.xep).toBe(40);
+      expect(result.ysp).toBe(20);
+      expect(result.yep).toBe(60);
+    });
+
+    it('음수 width/height는 0으로 조정된다', () => {
+      const hm = createHeatMap();
+      const result = hm.getAdjustedBounds({
+        xp: 10,
+        yp: 20,
+        width: -5,
+        height: -10,
+      });
+      expect(result.xep).toBeGreaterThanOrEqual(result.xsp);
+      expect(result.yep).toBeGreaterThanOrEqual(result.ysp);
+    });
+
+    it('소수점 값의 부동소수점 오차를 보정한다', () => {
+      const hm = createHeatMap();
+      const result = hm.getAdjustedBounds({
+        xp: 10.123,
+        yp: 20.456,
+        width: 5.789,
+        height: 3.012,
+      });
+      // xsp는 floor, xep는 ceil 처리
+      expect(result.xsp).toBeLessThanOrEqual(10.123);
+      expect(result.xep).toBeGreaterThanOrEqual(10.123 + 5.789);
+    });
+  });
+
+  describe('getFilteredLabel', () => {
+    it('count가 일치하면 labels을 그대로 반환한다', () => {
+      const hm = createHeatMap();
+      const labels = [1, 2, 3, 4, 5];
+      expect(hm.getFilteredLabel(labels, 5, 1, 5)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('count가 다르면 min/max 범위로 필터링한다', () => {
+      const hm = createHeatMap();
+      const labels = [1, 2, 3, 4, 5];
+      expect(hm.getFilteredLabel(labels, 10, 2, 4)).toEqual([2, 3, 4]);
+    });
+
+    it('범위에 맞는 레이블이 없으면 빈 배열을 반환한다', () => {
+      const hm = createHeatMap();
+      const labels = [1, 2, 3];
+      expect(hm.getFilteredLabel(labels, 10, 10, 20)).toEqual([]);
+    });
+  });
+});

--- a/src/components/chart/model/model.series.spec.js
+++ b/src/components/chart/model/model.series.spec.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import modules from './model.series';
+
+describe('model.series', () => {
+  describe('getOverlappingSeriesKeys', () => {
+    it('bar 시리즈를 groups 역순으로 정렬한다', () => {
+      const series = {
+        s1: { type: 'bar' },
+        s2: { type: 'bar' },
+        s3: { type: 'bar' },
+      };
+      const groups = [['s1', 's2', 's3']];
+      const result = modules.getOverlappingSeriesKeys(series, 'bar', groups);
+      expect(result).toEqual(['s3', 's2', 's1']);
+    });
+
+    it('non-bar 시리즈는 bar 뒤에 위치한다', () => {
+      const series = {
+        line1: { type: 'line' },
+        bar1: { type: 'bar' },
+        bar2: { type: 'bar' },
+      };
+      const groups = [['bar1', 'bar2']];
+      const result = modules.getOverlappingSeriesKeys(series, 'bar', groups);
+      expect(result[result.length - 1]).toBe('line1');
+    });
+
+    it('groups가 비어있으면 모든 시리즈가 other로 분류된다', () => {
+      const series = {
+        s1: { type: 'bar' },
+        s2: { type: 'bar' },
+      };
+      const result = modules.getOverlappingSeriesKeys(series, 'bar', []);
+      expect(result).toHaveLength(2);
+    });
+
+    it('defaultType으로 타입이 결정된다', () => {
+      const series = {
+        s1: {},
+        s2: { type: 'line' },
+      };
+      const groups = [['s1']];
+      const result = modules.getOverlappingSeriesKeys(series, 'bar', groups);
+      // s1은 default type이 bar이므로 bar로 분류
+      expect(result[0]).toBe('s1');
+      expect(result[1]).toBe('s2');
+    });
+  });
+});

--- a/src/components/chart/scale/scale.linear.spec.js
+++ b/src/components/chart/scale/scale.linear.spec.js
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import LinearScale from './scale.linear';
+
+// LinearScale의 순수 계산 메서드를 테스트하기 위해 최소 mock 생성
+const createScale = (overrides = {}) => {
+  const scale = Object.create(LinearScale.prototype);
+  scale.interval = null;
+  scale.decimalPoint = null;
+  scale.startToZero = false;
+  scale.fixedSteps = false;
+  scale.niceScale = false;
+  scale.formatter = null;
+  Object.assign(scale, overrides);
+  return scale;
+};
+
+describe('LinearScale', () => {
+  describe('getInterval', () => {
+    it('기본 interval을 계산한다', () => {
+      const scale = createScale();
+      const result = scale.getInterval({ maxValue: 100, minValue: 0, maxSteps: 5 });
+      expect(result).toBe(20);
+    });
+
+    it('사용자 지정 interval이 있으면 그대로 반환한다', () => {
+      const scale = createScale({ interval: 25 });
+      const result = scale.getInterval({ maxValue: 100, minValue: 0, maxSteps: 5 });
+      expect(result).toBe(25);
+    });
+
+    it('steps가 0이면 0을 반환한다', () => {
+      const scale = createScale();
+      const result = scale.getInterval({ maxValue: 100, minValue: 0, maxSteps: 0 });
+      expect(result).toBe(0);
+    });
+
+    it('소수점이 없으면 ceil 처리한다', () => {
+      const scale = createScale();
+      const result = scale.getInterval({ maxValue: 100, minValue: 0, maxSteps: 3 });
+      // 100/3 = 33.33... → ceil → 34
+      expect(result).toBe(34);
+    });
+
+    it('소수점이 있으면 그대로 반환한다', () => {
+      const scale = createScale({ decimalPoint: 2 });
+      const result = scale.getInterval({ maxValue: 1, minValue: 0, maxSteps: 3 });
+      expect(result).toBeCloseTo(0.333, 2);
+    });
+
+    it('startToZero이고 음수 포함 시 올바르게 계산한다', () => {
+      const scale = createScale({ startToZero: true });
+      const result = scale.getInterval({ maxValue: 80, minValue: -20, maxSteps: 5 });
+      expect(result).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getDecimalPointFromRange', () => {
+    it('정수 범위는 0을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getDecimalPointFromRange({ graphRange: 100, numberOfSteps: 5 })).toBe(0);
+    });
+
+    it('소수점 범위의 자릿수를 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getDecimalPointFromRange({ graphRange: 1, numberOfSteps: 10 })).toBe(1);
+    });
+
+    it('매우 작은 범위의 자릿수를 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getDecimalPointFromRange({ graphRange: 0.01, numberOfSteps: 10 })).toBe(3);
+    });
+
+    it('numberOfSteps가 0이면 0을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getDecimalPointFromRange({ graphRange: 100, numberOfSteps: 0 })).toBe(0);
+    });
+
+    it('graphRange가 0이면 0을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getDecimalPointFromRange({ graphRange: 0, numberOfSteps: 5 })).toBe(0);
+    });
+  });
+
+  describe('getNiceInterval', () => {
+    it('양수 값에 대해 nice interval을 반환한다', () => {
+      const scale = createScale();
+      const result = scale.getNiceInterval(33);
+      // 33 → exponent=1, normalized=3.3 → fraction=5 → 50
+      expect(result).toBe(50);
+    });
+
+    it('작은 양수에 대해 동작한다', () => {
+      const scale = createScale();
+      const result = scale.getNiceInterval(0.7);
+      expect(result).toBe(1);
+    });
+
+    it('음수 값에 대해 음수 nice interval을 반환한다', () => {
+      const scale = createScale();
+      const result = scale.getNiceInterval(-33);
+      expect(result).toBe(-50);
+    });
+
+    it('0은 0을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getNiceInterval(0)).toBe(0);
+    });
+
+    it('Infinity는 0을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getNiceInterval(Infinity)).toBe(0);
+    });
+
+    it('NaN은 0을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getNiceInterval(NaN)).toBe(0);
+    });
+
+    it('1에 대해 1을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getNiceInterval(1)).toBe(1);
+    });
+
+    it('10에 대해 10을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getNiceInterval(10)).toBe(10);
+    });
+
+    it('15에 대해 20을 반환한다', () => {
+      const scale = createScale();
+      // 15 → exponent=1, normalized=1.5 → fraction=2 → 20
+      expect(scale.getNiceInterval(15)).toBe(20);
+    });
+  });
+});

--- a/src/components/chart/scale/scale.logarithmic.spec.js
+++ b/src/components/chart/scale/scale.logarithmic.spec.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import LogarithmicScale from './scale.logarithmic';
+
+const createScale = (overrides = {}) => {
+  const scale = Object.create(LogarithmicScale.prototype);
+  scale.interval = null;
+  scale.decimalPoint = null;
+  scale.startToZero = false;
+  scale.range = null;
+  scale.formatter = null;
+  Object.assign(scale, overrides);
+  return scale;
+};
+
+describe('LogarithmicScale', () => {
+  describe('getInterval', () => {
+    it('범위에 따라 로그 스케일 인터벌을 계산한다', () => {
+      const scale = createScale();
+      const result = scale.getInterval({ maxValue: 1000, minValue: 0 });
+      // 10^calculateMagnitude(1000) = 10^3 = 1000 or similar
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it('작은 범위에 대해 작은 인터벌을 반환한다', () => {
+      const scale = createScale();
+      const small = scale.getInterval({ maxValue: 10, minValue: 0 });
+      const large = scale.getInterval({ maxValue: 1000, minValue: 0 });
+      expect(small).toBeLessThan(large);
+    });
+
+    it('같은 min/max는 0을 반환한다', () => {
+      const scale = createScale();
+      const result = scale.getInterval({ maxValue: 50, minValue: 50 });
+      // calculateMagnitude(0) = -Infinity → 10^(-Infinity) = 0
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('getLabelFormat', () => {
+    it('formatter가 없으면 기본 포맷을 사용한다', () => {
+      const scale = createScale();
+      const result = scale.getLabelFormat(1000);
+      expect(typeof result).toBe('string');
+    });
+
+    it('formatter가 있으면 formatter를 사용한다', () => {
+      const scale = createScale({
+        formatter: (v) => `${v}K`,
+      });
+      expect(scale.getLabelFormat(100)).toBe('100K');
+    });
+
+    it('formatter가 문자열을 반환하지 않으면 기본 포맷을 사용한다', () => {
+      const scale = createScale({
+        formatter: () => 123,
+      });
+      const result = scale.getLabelFormat(100);
+      expect(typeof result).toBe('string');
+    });
+  });
+});

--- a/src/components/chart/scale/scale.step.spec.js
+++ b/src/components/chart/scale/scale.step.spec.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import StepScale from './scale.step';
+
+const createScale = (overrides = {}) => {
+  const scale = Object.create(StepScale.prototype);
+  scale.labels = [];
+  scale.interval = null;
+  Object.assign(scale, overrides);
+  return scale;
+};
+
+describe('StepScale', () => {
+  describe('getIndexInterval', () => {
+    it('labels 수를 step으로 나눈 인터벌을 반환한다', () => {
+      const scale = createScale({
+        labels: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
+      });
+      const result = scale.getIndexInterval({ maxSteps: 5 });
+      expect(result).toBe(2);
+    });
+
+    it('사용자 지정 interval이 있으면 그대로 반환한다', () => {
+      const scale = createScale({
+        labels: ['a', 'b', 'c', 'd', 'e'],
+        interval: 3,
+      });
+      expect(scale.getIndexInterval({ maxSteps: 5 })).toBe(3);
+    });
+
+    it('labels가 step보다 적으면 1을 반환한다', () => {
+      const scale = createScale({
+        labels: ['a', 'b'],
+      });
+      expect(scale.getIndexInterval({ maxSteps: 5 })).toBe(1);
+    });
+
+    it('labels가 비어있으면 0을 반환한다', () => {
+      const scale = createScale({ labels: [] });
+      expect(scale.getIndexInterval({ maxSteps: 5 })).toBe(0);
+    });
+  });
+});

--- a/src/components/chart/scale/scale.time.category.spec.js
+++ b/src/components/chart/scale/scale.time.category.spec.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import TimeCategoryScale from './scale.time.category';
+
+const createScale = (overrides = {}) => {
+  const scale = Object.create(TimeCategoryScale.prototype);
+  scale.interval = null;
+  scale.labels = [];
+  Object.assign(scale, overrides);
+  return scale;
+};
+
+describe('TimeCategoryScale', () => {
+  describe('getInterval', () => {
+    it('사용자 지정 interval이 숫자이면 그대로 반환한다', () => {
+      const scale = createScale({ interval: 3600000 });
+      const result = scale.getInterval({ maxValue: 100000, minValue: 0, maxSteps: 5 });
+      expect(result).toBe(3600000);
+    });
+
+    it('사용자 지정 interval이 문자열이면 TIME_INTERVALS에서 조회한다', () => {
+      const scale = createScale({ interval: 'second' });
+      const result = scale.getInterval({ maxValue: 10000, minValue: 0, maxSteps: 5 });
+      expect(result).toBe(1000);
+    });
+
+    it('사용자 지정 interval이 객체이면 time * unit size로 계산한다', () => {
+      const scale = createScale({ interval: { time: 5, unit: 'minute' } });
+      const result = scale.getInterval({ maxValue: 600000, minValue: 0, maxSteps: 5 });
+      expect(result).toBe(5 * 60000);
+    });
+
+    it('interval이 없으면 범위/step으로 계산한다', () => {
+      const scale = createScale();
+      const result = scale.getInterval({ maxValue: 100, minValue: 0, maxSteps: 5 });
+      expect(result).toBe(20);
+    });
+
+    it('나누어 떨어지지 않으면 ceil 처리한다', () => {
+      const scale = createScale();
+      const result = scale.getInterval({ maxValue: 100, minValue: 0, maxSteps: 3 });
+      expect(result).toBe(34);
+    });
+  });
+});

--- a/src/components/chartBrush/uses.spec.js
+++ b/src/components/chartBrush/uses.spec.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { useBrushModel } from './uses';
+
+describe('chartBrush uses', () => {
+  describe('getNormalizedBrushOptions', () => {
+    const { getNormalizedBrushOptions } = useBrushModel();
+
+    it('빈 옵션에 기본값을 적용한다', () => {
+      const result = getNormalizedBrushOptions({});
+      expect(result.show).toBe(true);
+      expect(result.useDebounce).toBe(true);
+      expect(result.chartIdx).toBe(0);
+      expect(result.height).toBe(100);
+      expect(result.showLabel).toBe(false);
+      expect(result.useWheelMove).toBe(true);
+    });
+
+    it('사용자 옵션이 기본값을 덮어쓴다', () => {
+      const result = getNormalizedBrushOptions({
+        show: false,
+        height: 200,
+        chartIdx: 2,
+      });
+      expect(result.show).toBe(false);
+      expect(result.height).toBe(200);
+      expect(result.chartIdx).toBe(2);
+    });
+
+    it('selection 기본값이 적용된다', () => {
+      const result = getNormalizedBrushOptions({});
+      expect(result.selection.fillColor).toBe('#38ACEC');
+      expect(result.selection.opacity).toBe(0.65);
+    });
+
+    it('selection 부분 덮어쓰기가 동작한다', () => {
+      const result = getNormalizedBrushOptions({
+        selection: { opacity: 0.8 },
+      });
+      expect(result.selection.fillColor).toBe('#38ACEC');
+      expect(result.selection.opacity).toBe(0.8);
+    });
+  });
+});

--- a/src/components/chartGroup/ChartGroup.spec.js
+++ b/src/components/chartGroup/ChartGroup.spec.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import EvChartGroup from './ChartGroup.vue';
+
+describe('EvChartGroup Component', () => {
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvChartGroup이다', () => {
+      expect(EvChartGroup.name).toBe('EvChartGroup');
+    });
+
+    it('기본 options는 빈 객체이다', () => {
+      expect(EvChartGroup.props.options.default()).toEqual({});
+    });
+
+    it('기본 zoomStartIdx는 0이다', () => {
+      expect(EvChartGroup.props.zoomStartIdx.default).toBe(0);
+    });
+
+    it('기본 zoomEndIdx는 0이다', () => {
+      expect(EvChartGroup.props.zoomEndIdx.default).toBe(0);
+    });
+
+    it('기본 groupSelectedLabel은 null이다', () => {
+      expect(EvChartGroup.props.groupSelectedLabel.default).toBeNull();
+    });
+  });
+});

--- a/src/components/chartGroup/uses.spec.js
+++ b/src/components/chartGroup/uses.spec.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { useGroupModel } from './uses';
+
+describe('chartGroup uses', () => {
+  describe('getNormalizedOptions', () => {
+    const { getNormalizedOptions } = useGroupModel();
+
+    it('빈 옵션에 기본값을 적용한다', () => {
+      const result = getNormalizedOptions({});
+      expect(result.zoom).toBeDefined();
+      expect(result.zoom.bufferMemoryCnt).toBe(100);
+      expect(result.zoom.keepZoomStatus).toBe(false);
+      expect(result.zoom.useAnimation).toBe(true);
+      expect(result.zoom.useWheelMove).toBe(true);
+    });
+
+    it('사용자 옵션이 기본값을 덮어쓴다', () => {
+      const result = getNormalizedOptions({
+        zoom: { bufferMemoryCnt: 50, keepZoomStatus: true },
+      });
+      expect(result.zoom.bufferMemoryCnt).toBe(50);
+      expect(result.zoom.keepZoomStatus).toBe(true);
+      expect(result.zoom.useAnimation).toBe(true);
+    });
+
+    it('toolbar 기본값이 적용된다', () => {
+      const result = getNormalizedOptions({});
+      expect(result.zoom.toolbar.show).toBe(false);
+      expect(result.zoom.toolbar.items.reset).toBeDefined();
+      expect(result.zoom.toolbar.items.reset.icon).toBe('ev-icon-redo');
+    });
+
+    it('toolbar 부분 덮어쓰기가 동작한다', () => {
+      const result = getNormalizedOptions({
+        zoom: { toolbar: { show: true } },
+      });
+      expect(result.zoom.toolbar.show).toBe(true);
+      expect(result.zoom.toolbar.items.reset.icon).toBe('ev-icon-redo');
+    });
+  });
+});

--- a/src/components/checkbox/Checkbox.spec.js
+++ b/src/components/checkbox/Checkbox.spec.js
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvCheckbox from './Checkbox.vue';
+
+describe('EvCheckbox Component', () => {
+  describe('렌더링', () => {
+    it('기본 체크박스가 렌더링된다', () => {
+      const wrapper = mount(EvCheckbox);
+
+      expect(wrapper.find('.ev-checkbox').exists()).toBe(true);
+      expect(wrapper.find('.ev-checkbox-input').exists()).toBe(true);
+      expect(wrapper.find('.ev-checkbox-label').exists()).toBe(true);
+    });
+
+    it('label prop이 텍스트로 표시된다', () => {
+      const wrapper = mount(EvCheckbox, {
+        props: { label: '동의합니다' },
+      });
+
+      expect(wrapper.find('.ev-checkbox-label').text()).toBe('동의합니다');
+    });
+
+    it('slot 내용이 label 대신 렌더링된다', () => {
+      const wrapper = mount(EvCheckbox, {
+        props: { label: '원래라벨' },
+        slots: { default: '커스텀 라벨' },
+      });
+
+      expect(wrapper.find('.ev-checkbox-label').text()).toBe('커스텀 라벨');
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled prop이 적용된다', () => {
+      const wrapper = mount(EvCheckbox, {
+        props: { disabled: true },
+      });
+
+      expect(wrapper.classes()).toContain('disabled');
+      expect(wrapper.find('input').element.disabled).toBe(true);
+    });
+
+    it('modelValue가 true이면 checked 클래스가 적용된다', () => {
+      const wrapper = mount(EvCheckbox, {
+        props: { modelValue: true },
+      });
+
+      expect(wrapper.classes()).toContain('checked');
+    });
+
+    it('modelValue가 false이면 checked 클래스가 없다', () => {
+      const wrapper = mount(EvCheckbox, {
+        props: { modelValue: false },
+      });
+
+      expect(wrapper.classes()).not.toContain('checked');
+    });
+
+    it('readonly prop이 input에 적용된다', () => {
+      const wrapper = mount(EvCheckbox, {
+        props: { readonly: true },
+      });
+
+      expect(wrapper.find('input').element.readOnly).toBe(true);
+    });
+  });
+
+  describe('Events', () => {
+    it('변경 시 update:modelValue 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvCheckbox, {
+        props: { modelValue: false },
+      });
+
+      const input = wrapper.find('input');
+      await input.setValue(true);
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    });
+
+    it('변경 시 change 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvCheckbox, {
+        props: { modelValue: false },
+      });
+
+      const input = wrapper.find('input');
+      await input.trigger('change');
+
+      expect(wrapper.emitted('change')).toBeTruthy();
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 disabled는 false이다', () => {
+      const wrapper = mount(EvCheckbox);
+
+      expect(wrapper.classes()).not.toContain('disabled');
+    });
+
+    it('기본 readonly는 false이다', () => {
+      const wrapper = mount(EvCheckbox);
+
+      expect(wrapper.find('input').element.readOnly).toBe(false);
+    });
+
+    it('컴포넌트 이름이 EvCheckbox이다', () => {
+      expect(EvCheckbox.name).toBe('EvCheckbox');
+    });
+  });
+});

--- a/src/components/contextMenu/ContextMenu.spec.js
+++ b/src/components/contextMenu/ContextMenu.spec.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import EvContextMenu from './ContextMenu.vue';
+
+describe('EvContextMenu Component', () => {
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvContextMenu이다', () => {
+      expect(EvContextMenu.name).toBe('EvContextMenu');
+    });
+
+    it('기본 customClass는 빈 문자열이다', () => {
+      expect(EvContextMenu.props.customClass.default).toBe('');
+    });
+
+    it('기본 isShowMenuOnClick는 false이다', () => {
+      expect(EvContextMenu.props.isShowMenuOnClick.default).toBe(false);
+    });
+
+    it('기본 items는 빈 배열이다', () => {
+      expect(EvContextMenu.props.items.default()).toEqual([]);
+    });
+  });
+});

--- a/src/components/datePicker/DatePicker.spec.js
+++ b/src/components/datePicker/DatePicker.spec.js
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvDatePicker from './DatePicker.vue';
+
+describe('EvDatePicker Component', () => {
+  const globalConfig = {
+    global: {
+      directives: { clickoutside: {} },
+    },
+  };
+
+  describe('렌더링', () => {
+    it('기본 데이트피커가 렌더링된다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: { modelValue: '2024-01-15' },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-date-picker').exists()).toBe(true);
+    });
+
+    it('캘린더 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: { modelValue: '2024-01-15' },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-icon-calendar').exists()).toBe(true);
+    });
+
+    it('입력 필드가 렌더링된다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: { modelValue: '2024-01-15' },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-input').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled이면 disabled 클래스가 적용된다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: { modelValue: '2024-01-15', disabled: true },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-date-picker.disabled').exists()).toBe(true);
+    });
+
+    it('placeholder가 적용된다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: { modelValue: '', placeholder: '날짜 선택' },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-input').attributes('placeholder')).toBe('날짜 선택');
+    });
+
+    it('clearable이면 클리어 아이콘 영역이 존재한다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: { modelValue: '2024-01-15', clearable: true },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-input-suffix').exists()).toBe(true);
+    });
+
+    it('enableTextInput이 false이면 readonly 클래스가 적용된다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: { modelValue: '2024-01-15', enableTextInput: false },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-input.readonly').exists()).toBe(true);
+    });
+
+    it('dateMulti 모드에서 태그 래퍼가 렌더링된다', () => {
+      const wrapper = mount(EvDatePicker, {
+        props: {
+          modelValue: ['2024-01-15', '2024-01-16'],
+          mode: 'dateMulti',
+        },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-date-picker-tag-wrapper').exists()).toBe(true);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvDatePicker이다', () => {
+      expect(EvDatePicker.name).toBe('EvDatePicker');
+    });
+
+    it('기본 mode는 date이다', () => {
+      expect(EvDatePicker.props.mode.default).toBe('date');
+    });
+
+    it('기본 disabled는 false이다', () => {
+      expect(EvDatePicker.props.disabled.default).toBe(false);
+    });
+
+    it('기본 clearable은 false이다', () => {
+      expect(EvDatePicker.props.clearable.default).toBe(false);
+    });
+
+    it('기본 enableTextInput은 false이다', () => {
+      expect(EvDatePicker.props.enableTextInput.default).toBe(false);
+    });
+
+    it('기본 monthNotation은 fullName이다', () => {
+      expect(EvDatePicker.props.monthNotation.default).toBe('fullName');
+    });
+
+    it('기본 placeholder는 빈 문자열이다', () => {
+      expect(EvDatePicker.props.placeholder.default).toBe('');
+    });
+  });
+});

--- a/src/components/grid/Grid.spec.js
+++ b/src/components/grid/Grid.spec.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import EvGrid from './Grid.vue';
+
+describe('EvGrid Component', () => {
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvGrid이다', () => {
+      expect(EvGrid.name).toBe('EvGrid');
+    });
+
+    it('기본 columns는 빈 배열이다', () => {
+      expect(EvGrid.props.columns.default()).toEqual([]);
+    });
+
+    it('기본 rows는 빈 배열이다', () => {
+      expect(EvGrid.props.rows.default()).toEqual([]);
+    });
+
+    it('기본 width는 100%이다', () => {
+      expect(EvGrid.props.width.default).toBe('100%');
+    });
+
+    it('기본 height는 100%이다', () => {
+      expect(EvGrid.props.height.default).toBe('100%');
+    });
+
+    it('기본 selected는 빈 배열이다', () => {
+      expect(EvGrid.props.selected.default()).toEqual([]);
+    });
+
+    it('기본 checked는 빈 배열이다', () => {
+      expect(EvGrid.props.checked.default()).toEqual([]);
+    });
+
+    it('기본 option은 빈 객체이다', () => {
+      expect(EvGrid.props.option.default()).toEqual({});
+    });
+
+    it('기본 expanded는 빈 배열이다', () => {
+      expect(EvGrid.props.expanded.default()).toEqual([]);
+    });
+
+    it('기본 disabledRows는 빈 배열이다', () => {
+      expect(EvGrid.props.disabledRows.default()).toEqual([]);
+    });
+
+    it('기본 uncheckable은 빈 배열이다', () => {
+      expect(EvGrid.props.uncheckable.default()).toEqual([]);
+    });
+  });
+});

--- a/src/components/grid/uses.spec.js
+++ b/src/components/grid/uses.spec.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { getUpdatedColumns } from './uses';
+
+describe('getUpdatedColumns', () => {
+  it('originColumns만 있으면 그대로 반환한다', () => {
+    const stores = {
+      originColumns: [
+        { index: 0, field: 'name', width: 100 },
+        { index: 1, field: 'age', width: 80 },
+      ],
+      filteredColumns: [],
+    };
+    const result = getUpdatedColumns(stores);
+    expect(result).toEqual([
+      { index: 0, field: 'name', width: 100 },
+      { index: 1, field: 'age', width: 80 },
+    ]);
+  });
+
+  it('filteredColumns 정보가 병합된다', () => {
+    const stores = {
+      originColumns: [
+        { index: 0, field: 'name', width: 100 },
+        { index: 1, field: 'age', width: 80 },
+      ],
+      filteredColumns: [
+        { index: 1, width: 120, hidden: true },
+      ],
+    };
+    const result = getUpdatedColumns(stores);
+    expect(result[0]).toEqual({ index: 0, field: 'name', width: 100 });
+    expect(result[1]).toEqual({ index: 1, field: 'age', width: 120, hidden: true });
+  });
+
+  it('movedColumns가 있으면 originColumns 대신 사용한다', () => {
+    const stores = {
+      originColumns: [
+        { index: 0, field: 'name' },
+        { index: 1, field: 'age' },
+      ],
+      movedColumns: [
+        { index: 1, field: 'age' },
+        { index: 0, field: 'name' },
+      ],
+      filteredColumns: [],
+    };
+    const result = getUpdatedColumns(stores);
+    expect(result[0].field).toBe('age');
+    expect(result[1].field).toBe('name');
+  });
+
+  it('빈 stores를 처리한다', () => {
+    const stores = {
+      originColumns: [],
+      filteredColumns: [],
+    };
+    expect(getUpdatedColumns(stores)).toEqual([]);
+  });
+});

--- a/src/components/inputNumber/InputNumber.spec.js
+++ b/src/components/inputNumber/InputNumber.spec.js
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvInputNumber from './InputNumber.vue';
+
+describe('EvInputNumber Component', () => {
+  describe('렌더링', () => {
+    it('기본 숫자 입력이 렌더링된다', () => {
+      const wrapper = mount(EvInputNumber);
+
+      expect(wrapper.find('.ev-input-number').exists()).toBe(true);
+      expect(wrapper.find('.ev-input').exists()).toBe(true);
+    });
+
+    it('step up/down 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvInputNumber);
+
+      expect(wrapper.find('.step-up').exists()).toBe(true);
+      expect(wrapper.find('.step-down').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled prop이 적용된다', () => {
+      const wrapper = mount(EvInputNumber, {
+        props: { disabled: true },
+      });
+
+      expect(wrapper.classes()).toContain('disabled');
+      expect(wrapper.find('.ev-input').element.disabled).toBe(true);
+    });
+
+    it('readonly prop이 적용된다', () => {
+      const wrapper = mount(EvInputNumber, {
+        props: { readonly: true },
+      });
+
+      expect(wrapper.classes()).toContain('readonly');
+      expect(wrapper.find('.ev-input').element.readOnly).toBe(true);
+    });
+
+    it('placeholder prop이 적용된다', () => {
+      const wrapper = mount(EvInputNumber, {
+        props: { placeholder: '숫자를 입력하세요' },
+      });
+
+      expect(wrapper.find('.ev-input').attributes('placeholder')).toBe('숫자를 입력하세요');
+    });
+  });
+
+  describe('Events', () => {
+    it('focus 시 focus 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvInputNumber);
+
+      await wrapper.find('.ev-input').trigger('focus');
+
+      expect(wrapper.emitted('focus')).toBeTruthy();
+    });
+
+    it('blur 시 blur 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvInputNumber);
+
+      await wrapper.find('.ev-input').trigger('blur');
+
+      expect(wrapper.emitted('blur')).toBeTruthy();
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvInputNumber이다', () => {
+      expect(EvInputNumber.name).toBe('EvInputNumber');
+    });
+
+    it('기본 step은 1이다', () => {
+      expect(EvInputNumber.props.step.default).toBe(1);
+    });
+
+    it('기본 precision은 0이다', () => {
+      expect(EvInputNumber.props.precision.default).toBe(0);
+    });
+  });
+});

--- a/src/components/inputNumber/uses.spec.js
+++ b/src/components/inputNumber/uses.spec.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { getValueCloseToStep } from './uses';
+
+describe('getValueCloseToStep', () => {
+  describe('정수 step', () => {
+    it('정확한 step 값은 그대로 반환한다', () => {
+      expect(getValueCloseToStep(50, { min: 0, max: 100, step: 10 })).toBe(50);
+    });
+
+    it('step 절반보다 큰 나머지는 다음 step으로 올린다', () => {
+      expect(getValueCloseToStep(56, { min: 0, max: 100, step: 10 })).toBe(60);
+    });
+
+    it('step 절반보다 작은 나머지는 이전 step으로 내린다', () => {
+      expect(getValueCloseToStep(54, { min: 0, max: 100, step: 10 })).toBe(50);
+    });
+
+    it('min보다 작으면 min을 반환한다', () => {
+      expect(getValueCloseToStep(-5, { min: 0, max: 100, step: 10 })).toBe(0);
+    });
+
+    it('max보다 크면 max에 가장 가까운 step 값을 반환한다', () => {
+      expect(getValueCloseToStep(105, { min: 0, max: 100, step: 10 })).toBe(100);
+    });
+
+    it('min이 0이 아닌 경우에도 올바르게 계산한다', () => {
+      expect(getValueCloseToStep(15, { min: 10, max: 50, step: 10 })).toBe(10);
+      expect(getValueCloseToStep(26, { min: 10, max: 50, step: 10 })).toBe(30);
+    });
+
+    it('step이 1인 경우 값을 그대로 반환한다', () => {
+      expect(getValueCloseToStep(7, { min: 0, max: 100, step: 1 })).toBe(7);
+    });
+  });
+
+  describe('소수 step', () => {
+    it('소수점 step을 올바르게 계산한다', () => {
+      expect(getValueCloseToStep(0.3, { min: 0, max: 1, step: 0.1 })).toBe(0.3);
+    });
+
+    it('소수점에서 반올림이 올바르게 동작한다', () => {
+      const result = getValueCloseToStep(0.15, { min: 0, max: 1, step: 0.1 });
+      expect(result).toBe(0.1);
+    });
+
+    it('소수점 min과 함께 동작한다', () => {
+      expect(getValueCloseToStep(0.5, { min: 0.1, max: 1, step: 0.2 })).toBe(0.5);
+    });
+  });
+});

--- a/src/components/loading/Loading.spec.js
+++ b/src/components/loading/Loading.spec.js
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvLoading from './Loading.vue';
+
+describe('EvLoading Component', () => {
+  const globalStubs = {
+    global: {
+      stubs: { teleport: true },
+    },
+  };
+
+  describe('렌더링', () => {
+    it('modelValue가 true이면 로딩이 렌더링된다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-loading').exists()).toBe(true);
+    });
+
+    it('modelValue가 false이면 로딩이 렌더링되지 않는다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: false },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-loading').exists()).toBe(false);
+    });
+
+    it('spinner가 렌더링된다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-loading-spinner').exists()).toBe(true);
+    });
+
+    it('기본 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-loading-icon').exists()).toBe(true);
+      expect(wrapper.find('.ev-icon-refresh2').exists()).toBe(true);
+    });
+
+    it('slot 내용이 렌더링되면 기본 아이콘은 표시되지 않는다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true },
+        slots: { default: '<span class="custom-spinner">로딩중</span>' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.custom-spinner').exists()).toBe(true);
+      expect(wrapper.find('.ev-loading-icon').exists()).toBe(false);
+    });
+  });
+
+  describe('Props', () => {
+    it('fullscreen이 true이면 full-screen 클래스가 적용된다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true, fullscreen: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-loading.full-screen').exists()).toBe(true);
+    });
+
+    it('iconClass prop이 적용된다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true, iconClass: 'ev-icon-spinner' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-icon-spinner').exists()).toBe(true);
+    });
+
+    it('iconStyle prop이 아이콘에 적용된다', () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true, iconStyle: { fontSize: '40px' } },
+        ...globalStubs,
+      });
+
+      const icon = wrapper.find('.ev-loading-icon');
+      expect(icon.element.style.fontSize).toBe('40px');
+    });
+  });
+
+  describe('Events', () => {
+    it('clickOutside가 true일 때 클릭하면 update:modelValue가 발생한다', async () => {
+      const wrapper = mount(EvLoading, {
+        props: { modelValue: true, clickOutside: true },
+        ...globalStubs,
+      });
+
+      await wrapper.find('.ev-loading').trigger('click');
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+      expect(wrapper.emitted('update:modelValue')[0][0]).toBe(false);
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 modelValue는 false이다', () => {
+      const wrapper = mount(EvLoading, {
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-loading').exists()).toBe(false);
+    });
+
+    it('컴포넌트 이름이 EvLoading이다', () => {
+      expect(EvLoading.name).toBe('EvLoading');
+    });
+  });
+});

--- a/src/components/menu/Menu.spec.js
+++ b/src/components/menu/Menu.spec.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvMenu from './Menu.vue';
+
+describe('EvMenu Component', () => {
+  const defaultItems = [
+    { text: '메뉴1', value: 'menu1' },
+    { text: '메뉴2', value: 'menu2' },
+    { text: '메뉴3', value: 'menu3' },
+  ];
+
+  describe('렌더링', () => {
+    it('기본 메뉴가 렌더링된다', () => {
+      const wrapper = mount(EvMenu, {
+        props: { items: defaultItems },
+      });
+
+      expect(wrapper.find('.ev-menu').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled prop이 전달된다', () => {
+      expect(EvMenu.props.disabled.default).toBe(false);
+    });
+
+    it('expandable prop이 전달된다', () => {
+      expect(EvMenu.props.expandable.default).toBe(true);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvMenu이다', () => {
+      expect(EvMenu.name).toBe('EvMenu');
+    });
+
+    it('기본 expandable은 true이다', () => {
+      expect(EvMenu.props.expandable.default).toBe(true);
+    });
+
+    it('기본 disabled는 false이다', () => {
+      expect(EvMenu.props.disabled.default).toBe(false);
+    });
+  });
+});

--- a/src/components/message/Message.spec.js
+++ b/src/components/message/Message.spec.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvMessage from './Message.vue';
+
+describe('EvMessage Component', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const el = document.createElement('div');
+    el.id = 'ev-message-modal';
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    const el = document.getElementById('ev-message-modal');
+    if (el) {
+      document.body.removeChild(el);
+    }
+  });
+
+  const globalStubs = {
+    global: {
+      stubs: { teleport: true },
+    },
+  };
+
+  describe('렌더링', () => {
+    it('기본 메시지가 렌더링된다', () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '안녕하세요' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message').exists()).toBe(true);
+      expect(wrapper.find('.ev-message-content').text()).toBe('안녕하세요');
+    });
+
+    it('showClose가 true이면 닫기 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '메시지', showClose: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-close').exists()).toBe(true);
+      expect(wrapper.find('.ev-message').classes()).toContain('show-close');
+    });
+
+    it('showClose가 false이면 닫기 버튼이 없다', () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '메시지', showClose: false },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-close').exists()).toBe(false);
+    });
+
+    it('iconClass가 설정되면 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '메시지', iconClass: 'ev-icon-info' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-icon').exists()).toBe(true);
+      expect(wrapper.find('.ev-message').classes()).toContain('has-icon');
+    });
+  });
+
+  describe('Props', () => {
+    it('type prop에 따라 클래스가 적용된다', () => {
+      const types = ['info', 'success', 'warning', 'error'];
+
+      types.forEach((type) => {
+        const wrapper = mount(EvMessage, {
+          props: { message: '메시지', type },
+          ...globalStubs,
+        });
+        expect(wrapper.find('.ev-message').classes()).toContain(`type-${type}`);
+      });
+    });
+
+    it('useHTML이 true이면 HTML 렌더링된다', () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '<strong>굵은 메시지</strong>', useHTML: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-content strong').exists()).toBe(true);
+    });
+  });
+
+  describe('Events', () => {
+    it('닫기 버튼 클릭 시 메시지가 숨겨진다', async () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '메시지', showClose: true },
+        ...globalStubs,
+      });
+
+      await wrapper.find('.ev-message-close').trigger('click');
+
+      expect(wrapper.find('.ev-message').isVisible()).toBe(false);
+    });
+
+    it('닫기 시 onClose 콜백이 호출된다', async () => {
+      const onClose = vi.fn();
+      const wrapper = mount(EvMessage, {
+        props: { message: '메시지', showClose: true, onClose },
+        ...globalStubs,
+      });
+
+      await wrapper.find('.ev-message-close').trigger('click');
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('expose된 hide 메서드로 isShow 상태가 변경된다', () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '메시지', duration: 0 },
+        ...globalStubs,
+      });
+
+      expect(wrapper.vm.isShow).toBe(true);
+
+      wrapper.vm.hide();
+
+      expect(wrapper.vm.isShow).toBe(false);
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 type은 info이다', () => {
+      const wrapper = mount(EvMessage, {
+        props: { message: '메시지' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message').classes()).toContain('type-info');
+    });
+
+    it('기본 duration은 3000이다', () => {
+      expect(EvMessage.props.duration.default).toBe(3000);
+    });
+
+    it('컴포넌트 이름이 EvMessage이다', () => {
+      expect(EvMessage.name).toBe('EvMessage');
+    });
+  });
+});

--- a/src/components/messageBox/MessageBox.spec.js
+++ b/src/components/messageBox/MessageBox.spec.js
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvMessageBox from './MessageBox.vue';
+
+describe('EvMessageBox Component', () => {
+  const globalStubs = {
+    global: {
+      stubs: { teleport: true },
+    },
+  };
+
+  describe('렌더링', () => {
+    it('기본 메시지 박스가 렌더링된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인하시겠습니까?' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box').exists()).toBe(true);
+      expect(wrapper.find('.ev-message-box-message').text()).toBe('확인하시겠습니까?');
+    });
+
+    it('title이 있으면 제목이 렌더링된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { title: '확인', message: '내용' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-title').exists()).toBe(true);
+      expect(wrapper.find('.ev-message-box-title').text()).toBe('확인');
+    });
+
+    it('확인 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-confirm').exists()).toBe(true);
+    });
+
+    it('취소 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-cancel').exists()).toBe(true);
+    });
+
+    it('닫기 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', showClose: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-close').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('showConfirmBtn이 false이면 확인 버튼이 없다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', showConfirmBtn: false },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-confirm').exists()).toBe(false);
+    });
+
+    it('showCancelBtn이 false이면 취소 버튼이 없다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', showCancelBtn: false },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-cancel').exists()).toBe(false);
+    });
+
+    it('confirmBtnText prop이 적용된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', confirmBtnText: '예' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-confirm').text()).toBe('예');
+    });
+
+    it('cancelBtnText prop이 적용된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', cancelBtnText: '아니오' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-cancel').text()).toBe('아니오');
+    });
+
+    it('useHTML이 true이면 HTML 렌더링된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '<strong>중요</strong>', useHTML: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box-message strong').exists()).toBe(true);
+    });
+
+    it('type prop에 따라 클래스가 적용된다', () => {
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', type: 'warning' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-message-box').classes()).toContain('type-warning');
+    });
+  });
+
+  describe('Events', () => {
+    it('확인 버튼 클릭 시 onClose가 ok로 호출된다', async () => {
+      const onClose = vi.fn();
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', onClose },
+        ...globalStubs,
+      });
+
+      await wrapper.find('.ev-message-box-confirm').trigger('click');
+
+      expect(onClose).toHaveBeenCalledWith('ok');
+    });
+
+    it('취소 버튼 클릭 시 onClose가 cancel로 호출된다', async () => {
+      const onClose = vi.fn();
+      const wrapper = mount(EvMessageBox, {
+        props: { message: '확인', onClose },
+        ...globalStubs,
+      });
+
+      await wrapper.find('.ev-message-box-cancel').trigger('click');
+
+      expect(onClose).toHaveBeenCalledWith('cancel');
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 showClose는 true이다', () => {
+      expect(EvMessageBox.props.showClose.default).toBe(true);
+    });
+
+    it('기본 showConfirmBtn은 true이다', () => {
+      expect(EvMessageBox.props.showConfirmBtn.default).toBe(true);
+    });
+
+    it('기본 showCancelBtn은 true이다', () => {
+      expect(EvMessageBox.props.showCancelBtn.default).toBe(true);
+    });
+
+    it('기본 confirmBtnText는 OK이다', () => {
+      expect(EvMessageBox.props.confirmBtnText.default).toBe('OK');
+    });
+
+    it('기본 cancelBtnText는 Cancel이다', () => {
+      expect(EvMessageBox.props.cancelBtnText.default).toBe('Cancel');
+    });
+
+    it('컴포넌트 이름이 EvMessageBox이다', () => {
+      expect(EvMessageBox.name).toBe('EvMessageBox');
+    });
+  });
+});

--- a/src/components/notification/Notification.spec.js
+++ b/src/components/notification/Notification.spec.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvNotification from './Notification.vue';
+
+describe('EvNotification Component', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('렌더링', () => {
+    it('기본 알림이 렌더링된다', () => {
+      const wrapper = mount(EvNotification, {
+        props: { message: '알림 메시지' },
+      });
+
+      expect(wrapper.find('.ev-notification').exists()).toBe(true);
+      expect(wrapper.find('.message').text()).toBe('알림 메시지');
+    });
+
+    it('title이 있으면 제목이 렌더링된다', () => {
+      const wrapper = mount(EvNotification, {
+        props: { title: '알림 제목', message: '내용' },
+      });
+
+      expect(wrapper.find('.title').exists()).toBe(true);
+      expect(wrapper.find('.title').text()).toBe('알림 제목');
+    });
+
+    it('showClose가 true이면 닫기 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvNotification, {
+        props: { message: '알림', showClose: true },
+      });
+
+      expect(wrapper.find('.ev-notification-close').exists()).toBe(true);
+      expect(wrapper.find('.ev-notification').classes()).toContain('show-close');
+    });
+
+    it('iconClass가 설정되면 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvNotification, {
+        props: { message: '알림', iconClass: 'ev-icon-info' },
+      });
+
+      expect(wrapper.find('.ev-notification-icon').exists()).toBe(true);
+      expect(wrapper.find('.ev-notification').classes()).toContain('has-icon');
+    });
+  });
+
+  describe('Props', () => {
+    it('type prop에 따라 클래스가 적용된다', () => {
+      const types = ['info', 'success', 'warning', 'error'];
+
+      types.forEach((type) => {
+        const wrapper = mount(EvNotification, {
+          props: { message: '알림', type },
+        });
+        expect(wrapper.find('.ev-notification').classes()).toContain(`type-${type}`);
+      });
+    });
+
+    it('useHTML이 true이면 HTML 렌더링된다', () => {
+      const wrapper = mount(EvNotification, {
+        props: { message: '<strong>굵은 알림</strong>', useHTML: true },
+      });
+
+      expect(wrapper.find('.message strong').exists()).toBe(true);
+    });
+
+    it('onClick이 있으면 has-click 클래스가 적용된다', () => {
+      const wrapper = mount(EvNotification, {
+        props: { message: '알림', onClick: vi.fn() },
+      });
+
+      expect(wrapper.find('.ev-notification').classes()).toContain('has-click');
+    });
+  });
+
+  describe('Events', () => {
+    it('닫기 버튼 클릭 시 isShow가 false가 된다', async () => {
+      const wrapper = mount(EvNotification, {
+        props: { message: '알림', showClose: true },
+      });
+
+      expect(wrapper.vm.isShow).toBe(true);
+
+      await wrapper.find('.ev-notification-close').trigger('click');
+
+      expect(wrapper.vm.isShow).toBe(false);
+    });
+
+    it('닫기 시 onClose 콜백이 호출된다', async () => {
+      const onClose = vi.fn();
+      const wrapper = mount(EvNotification, {
+        props: { message: '알림', showClose: true, onClose },
+      });
+
+      await wrapper.find('.ev-notification-close').trigger('click');
+
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 type은 info이다', () => {
+      const wrapper = mount(EvNotification, {
+        props: { message: '알림' },
+      });
+
+      expect(wrapper.find('.ev-notification').classes()).toContain('type-info');
+    });
+
+    it('기본 showClose는 true이다', () => {
+      expect(EvNotification.props.showClose.default).toBe(true);
+    });
+
+    it('기본 position은 top-right이다', () => {
+      expect(EvNotification.props.position.default).toBe('top-right');
+    });
+
+    it('컴포넌트 이름이 EvNotification이다', () => {
+      expect(EvNotification.name).toBe('EvNotification');
+    });
+  });
+});

--- a/src/components/pagination/Pagination.spec.js
+++ b/src/components/pagination/Pagination.spec.js
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvPagination from './Pagination.vue';
+
+describe('EvPagination Component', () => {
+  const defaultProps = {
+    total: 100,
+    perPage: 10,
+    modelValue: 1,
+  };
+
+  describe('렌더링', () => {
+    it('기본 페이지네이션이 렌더링된다', () => {
+      const wrapper = mount(EvPagination, {
+        props: defaultProps,
+      });
+
+      expect(wrapper.find('.pagination').exists()).toBe(true);
+      expect(wrapper.find('.pagination-list').exists()).toBe(true);
+    });
+
+    it('페이지 번호들이 렌더링된다', () => {
+      const wrapper = mount(EvPagination, {
+        props: defaultProps,
+      });
+
+      const pages = wrapper.findAll('.is-page');
+      expect(pages.length).toBeGreaterThan(0);
+    });
+
+    it('현재 페이지에 is-current 클래스가 적용된다', () => {
+      const wrapper = mount(EvPagination, {
+        props: defaultProps,
+      });
+
+      expect(wrapper.find('.is-current').exists()).toBe(true);
+    });
+
+    it('이전/다음 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvPagination, {
+        props: defaultProps,
+      });
+
+      expect(wrapper.find('.pagination-previous').exists()).toBe(true);
+      expect(wrapper.find('.pagination-next').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('첫 페이지에서 이전 버튼이 비활성화된다', () => {
+      const wrapper = mount(EvPagination, {
+        props: { ...defaultProps, modelValue: 1 },
+      });
+
+      const prevButton = wrapper.findAll('.step-button')[0];
+      expect(prevButton.classes()).toContain('is-disabled');
+    });
+
+    it('마지막 페이지에서 다음 버튼이 비활성화된다', () => {
+      const wrapper = mount(EvPagination, {
+        props: { ...defaultProps, modelValue: 10 },
+      });
+
+      const stepButtons = wrapper.findAll('.step-button');
+      const nextButton = stepButtons[stepButtons.length - 1];
+      expect(nextButton.classes()).toContain('is-disabled');
+    });
+
+    it('showPageInfo가 true이면 페이지 정보가 표시된다', () => {
+      const wrapper = mount(EvPagination, {
+        props: { ...defaultProps, showPageInfo: true },
+      });
+
+      expect(wrapper.find('.pagination-info').exists()).toBe(true);
+    });
+
+    it('showPageInfo가 false이면 페이지 정보가 숨겨진다', () => {
+      const wrapper = mount(EvPagination, {
+        props: { ...defaultProps, showPageInfo: false },
+      });
+
+      expect(wrapper.find('.pagination-info').exists()).toBe(false);
+    });
+  });
+
+  describe('Events', () => {
+    it('페이지 클릭 시 update:modelValue 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvPagination, {
+        props: defaultProps,
+      });
+
+      const pages = wrapper.findAll('.is-page');
+      const page2 = pages.find((p) => p.text().includes('2'));
+      if (page2) {
+        await page2.trigger('click');
+        expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+      }
+    });
+
+    it('페이지 클릭 시 change 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvPagination, {
+        props: defaultProps,
+      });
+
+      const pages = wrapper.findAll('.is-page');
+      const page2 = pages.find((p) => p.text().includes('2'));
+      if (page2) {
+        await page2.trigger('click');
+        expect(wrapper.emitted('change')).toBeTruthy();
+      }
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvPagination이다', () => {
+      expect(EvPagination.name).toBe('EvPagination');
+    });
+
+    it('기본 perPage는 20이다', () => {
+      expect(EvPagination.props.perPage.default).toBe(20);
+    });
+
+    it('기본 visiblePage는 8이다', () => {
+      expect(EvPagination.props.visiblePage.default).toBe(8);
+    });
+
+    it('기본 order는 left이다', () => {
+      expect(EvPagination.props.order.default).toBe('left');
+    });
+  });
+});

--- a/src/components/progress/Progress.spec.js
+++ b/src/components/progress/Progress.spec.js
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvProgress from './Progress.vue';
+
+describe('EvProgress Component', () => {
+  describe('렌더링', () => {
+    it('기본 프로그레스가 렌더링된다', () => {
+      const wrapper = mount(EvProgress);
+
+      expect(wrapper.find('.ev-progress').exists()).toBe(true);
+      expect(wrapper.find('.ev-progress-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ev-progress-inner').exists()).toBe(true);
+    });
+
+    it('slot 내용이 label로 렌더링된다', () => {
+      const wrapper = mount(EvProgress, {
+        slots: {
+          default: '50%',
+        },
+      });
+
+      expect(wrapper.find('.ev-progress-label').exists()).toBe(true);
+      expect(wrapper.text()).toContain('50%');
+    });
+
+    it('slot이 없으면 label이 렌더링되지 않는다', () => {
+      const wrapper = mount(EvProgress);
+
+      expect(wrapper.find('.ev-progress-label').exists()).toBe(false);
+    });
+  });
+
+  describe('Props', () => {
+    it('modelValue에 따라 inner 너비가 설정된다', () => {
+      const wrapper = mount(EvProgress, {
+        props: { modelValue: 50 },
+      });
+
+      const inner = wrapper.find('.ev-progress-inner');
+      expect(inner.element.style.width).toBe('50%');
+    });
+
+    it('color prop이 배경색으로 적용된다', () => {
+      const wrapper = mount(EvProgress, {
+        props: { modelValue: 50, color: '#FF0000' },
+      });
+
+      const inner = wrapper.find('.ev-progress-inner');
+      expect(inner.element.style.backgroundColor).toBe('rgb(255, 0, 0)');
+    });
+
+    it('strokeWidth prop이 wrapper 높이에 적용된다', () => {
+      const wrapper = mount(EvProgress, {
+        props: { strokeWidth: 10 },
+      });
+
+      const wrapperEl = wrapper.find('.ev-progress-wrapper');
+      expect(wrapperEl.element.style.height).toBe('10px');
+    });
+
+    it('innerText prop이 렌더링된다', () => {
+      const wrapper = mount(EvProgress, {
+        props: { modelValue: 50, innerText: '50%' },
+      });
+
+      expect(wrapper.find('.ev-progress-inner-text').exists()).toBe(true);
+      expect(wrapper.find('.ev-progress-inner-text').text()).toBe('50%');
+    });
+
+    it('innerText가 빈 문자열이면 inner-text가 렌더링되지 않는다', () => {
+      const wrapper = mount(EvProgress, {
+        props: { modelValue: 50 },
+      });
+
+      expect(wrapper.find('.ev-progress-inner-text').exists()).toBe(false);
+    });
+
+    it('color가 배열이면 값에 따라 색상이 결정된다', () => {
+      const colorList = [
+        { value: 30, color: '#FF0000' },
+        { value: 70, color: '#FFFF00' },
+        { value: 100, color: '#00FF00' },
+      ];
+      const wrapper = mount(EvProgress, {
+        props: { modelValue: 50, color: colorList },
+      });
+
+      const inner = wrapper.find('.ev-progress-inner');
+      expect(inner.element.style.backgroundColor).toBe('rgb(255, 255, 0)');
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 modelValue는 0이다', () => {
+      const wrapper = mount(EvProgress);
+
+      const inner = wrapper.find('.ev-progress-inner');
+      expect(inner.element.style.width).toBe('0%');
+    });
+
+    it('기본 strokeWidth는 6이다', () => {
+      const wrapper = mount(EvProgress);
+
+      const wrapperEl = wrapper.find('.ev-progress-wrapper');
+      expect(wrapperEl.element.style.height).toBe('6px');
+    });
+
+    it('기본 color는 #409EFF이다', () => {
+      const wrapper = mount(EvProgress, {
+        props: { modelValue: 50 },
+      });
+
+      const inner = wrapper.find('.ev-progress-inner');
+      expect(inner.element.style.backgroundColor).toBe('rgb(64, 158, 255)');
+    });
+  });
+});

--- a/src/components/radio/Radio.spec.js
+++ b/src/components/radio/Radio.spec.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvRadio from './Radio.vue';
+
+describe('EvRadio Component', () => {
+  describe('렌더링', () => {
+    it('기본 라디오가 렌더링된다', () => {
+      const wrapper = mount(EvRadio);
+
+      expect(wrapper.find('.ev-radio').exists()).toBe(true);
+      expect(wrapper.find('.ev-radio-input').exists()).toBe(true);
+      expect(wrapper.find('.ev-radio-label').exists()).toBe(true);
+    });
+
+    it('label prop이 텍스트로 표시된다', () => {
+      const wrapper = mount(EvRadio, {
+        props: { label: '옵션1' },
+      });
+
+      expect(wrapper.find('.ev-radio-label').text()).toBe('옵션1');
+    });
+
+    it('slot 내용이 label 대신 렌더링된다', () => {
+      const wrapper = mount(EvRadio, {
+        props: { label: '옵션1' },
+        slots: { default: '커스텀 라벨' },
+      });
+
+      expect(wrapper.find('.ev-radio-label').text()).toBe('커스텀 라벨');
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled prop이 적용된다', () => {
+      const wrapper = mount(EvRadio, {
+        props: { disabled: true },
+      });
+
+      expect(wrapper.classes()).toContain('disabled');
+      expect(wrapper.find('input').element.disabled).toBe(true);
+    });
+
+    it('size prop이 클래스로 적용된다', () => {
+      const wrapper = mount(EvRadio, {
+        props: { size: 'small' },
+      });
+
+      expect(wrapper.classes()).toContain('small');
+    });
+
+    it('modelValue와 label이 같으면 checked 클래스가 적용된다', () => {
+      const wrapper = mount(EvRadio, {
+        props: { modelValue: 'a', label: 'a' },
+      });
+
+      expect(wrapper.classes()).toContain('checked');
+    });
+
+    it('modelValue와 label이 다르면 checked 클래스가 없다', () => {
+      const wrapper = mount(EvRadio, {
+        props: { modelValue: 'a', label: 'b' },
+      });
+
+      expect(wrapper.classes()).not.toContain('checked');
+    });
+  });
+
+  describe('Events', () => {
+    it('변경 시 update:modelValue 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvRadio, {
+        props: { modelValue: 'a', label: 'b' },
+      });
+
+      const input = wrapper.find('input');
+      await input.setValue('b');
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 disabled는 false이다', () => {
+      const wrapper = mount(EvRadio);
+
+      expect(wrapper.classes()).not.toContain('disabled');
+    });
+
+    it('컴포넌트 이름이 EvRadio이다', () => {
+      expect(EvRadio.name).toBe('EvRadio');
+    });
+  });
+});

--- a/src/components/radioGroup/RadioGroup.integration.spec.js
+++ b/src/components/radioGroup/RadioGroup.integration.spec.js
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvRadioGroup from './RadioGroup.vue';
+import EvRadio from '../radio/Radio.vue';
+
+describe('EvRadioGroup Integration', () => {
+  describe('렌더링', () => {
+    it('라디오 그룹이 렌더링된다', () => {
+      const wrapper = mount(EvRadioGroup);
+
+      expect(wrapper.find('.ev-radio-group').exists()).toBe(true);
+      expect(wrapper.attributes('role')).toBe('group');
+    });
+
+    it('자식 라디오들이 렌더링된다', () => {
+      const wrapper = mount(EvRadioGroup, {
+        props: { modelValue: 'a' },
+        slots: {
+          default: [
+            '<ev-radio label="a">옵션A</ev-radio>',
+            '<ev-radio label="b">옵션B</ev-radio>',
+          ].join(''),
+        },
+        global: {
+          components: { EvRadio },
+        },
+      });
+
+      expect(wrapper.findAllComponents(EvRadio)).toHaveLength(2);
+    });
+  });
+
+  describe('Props', () => {
+    it('type이 button이면 type-button 클래스가 적용된다', () => {
+      const wrapper = mount(EvRadioGroup, {
+        props: { type: 'button' },
+      });
+
+      expect(wrapper.classes()).toContain('type-button');
+    });
+
+    it('type이 radio이면 type-button 클래스가 없다', () => {
+      const wrapper = mount(EvRadioGroup, {
+        props: { type: 'radio' },
+      });
+
+      expect(wrapper.classes()).not.toContain('type-button');
+    });
+  });
+
+  describe('provide/inject 통합', () => {
+    it('그룹의 modelValue가 자식 라디오에 전달된다', () => {
+      const wrapper = mount(EvRadioGroup, {
+        props: { modelValue: 'a' },
+        slots: {
+          default: [
+            '<ev-radio label="a">옵션A</ev-radio>',
+            '<ev-radio label="b">옵션B</ev-radio>',
+          ].join(''),
+        },
+        global: {
+          components: { EvRadio },
+        },
+      });
+
+      const radios = wrapper.findAllComponents(EvRadio);
+      expect(radios[0].classes()).toContain('checked');
+      expect(radios[1].classes()).not.toContain('checked');
+    });
+  });
+
+  describe('Events', () => {
+    it('자식 라디오 선택 시 update:modelValue가 발생한다', async () => {
+      const wrapper = mount(EvRadioGroup, {
+        props: { modelValue: 'a' },
+        slots: {
+          default: [
+            '<ev-radio label="a">옵션A</ev-radio>',
+            '<ev-radio label="b">옵션B</ev-radio>',
+          ].join(''),
+        },
+        global: {
+          components: { EvRadio },
+        },
+      });
+
+      const radios = wrapper.findAllComponents(EvRadio);
+      const input = radios[1].find('input');
+      await input.setValue('b');
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 type은 radio이다', () => {
+      const wrapper = mount(EvRadioGroup);
+
+      expect(wrapper.classes()).not.toContain('type-button');
+    });
+
+    it('컴포넌트 이름이 EvRadioGroup이다', () => {
+      expect(EvRadioGroup.name).toBe('EvRadioGroup');
+    });
+  });
+});

--- a/src/components/scheduler/Scheduler.spec.js
+++ b/src/components/scheduler/Scheduler.spec.js
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvScheduler from './Scheduler.vue';
+
+describe('EvScheduler Component', () => {
+  const createModelValue = (rows = 24, cols = 7) =>
+    Array.from({ length: rows }, () => Array(cols).fill(false));
+
+  describe('렌더링', () => {
+    it('기본 스케줄러가 렌더링된다', () => {
+      const wrapper = mount(EvScheduler, {
+        props: { modelValue: createModelValue() },
+      });
+
+      expect(wrapper.find('.ev-scheduler').exists()).toBe(true);
+    });
+
+    it('헤더 라벨이 렌더링된다', () => {
+      const wrapper = mount(EvScheduler, {
+        props: { modelValue: createModelValue() },
+      });
+
+      const headers = wrapper.findAll('.ev-scheduler-header-label');
+      expect(headers).toHaveLength(7);
+    });
+
+    it('바디 라벨이 렌더링된다', () => {
+      const wrapper = mount(EvScheduler, {
+        props: { modelValue: createModelValue() },
+      });
+
+      const bodyLabels = wrapper.findAll('.ev-scheduler-body-label');
+      expect(bodyLabels).toHaveLength(24);
+    });
+
+    it('셀 박스들이 렌더링된다', () => {
+      const wrapper = mount(EvScheduler, {
+        props: { modelValue: createModelValue() },
+      });
+
+      const boxes = wrapper.findAll('.ev-scheduler-body-box');
+      expect(boxes).toHaveLength(24 * 7);
+    });
+  });
+
+  describe('Props', () => {
+    it('커스텀 colLabels가 적용된다', () => {
+      const colLabels = ['월', '화', '수'];
+      const wrapper = mount(EvScheduler, {
+        props: { modelValue: createModelValue(24, 3), colLabels },
+      });
+
+      const headers = wrapper.findAll('.ev-scheduler-header-label');
+      expect(headers).toHaveLength(3);
+    });
+
+    it('커스텀 rowLabels가 적용된다', () => {
+      const rowLabels = ['오전', '오후'];
+      const wrapper = mount(EvScheduler, {
+        props: { modelValue: createModelValue(2), rowLabels },
+      });
+
+      const bodyLabels = wrapper.findAll('.ev-scheduler-body-label');
+      expect(bodyLabels).toHaveLength(2);
+    });
+
+    it('선택된 셀에 selected 클래스가 적용된다', () => {
+      const mv = createModelValue();
+      mv[0][0] = true;
+      const wrapper = mount(EvScheduler, {
+        props: { modelValue: mv },
+      });
+
+      const selectedBoxes = wrapper.findAll('.ev-scheduler-body-box.selected');
+      expect(selectedBoxes.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvScheduler이다', () => {
+      expect(EvScheduler.name).toBe('EvScheduler');
+    });
+  });
+});

--- a/src/components/select/Select.spec.js
+++ b/src/components/select/Select.spec.js
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvSelect from './Select.vue';
+
+describe('EvSelect Component', () => {
+  const defaultProps = {
+    items: [
+      { name: '옵션1', value: 'opt1' },
+      { name: '옵션2', value: 'opt2' },
+      { name: '옵션3', value: 'opt3' },
+    ],
+  };
+
+  const globalConfig = {
+    global: {
+      directives: {
+        clickoutside: {},
+      },
+    },
+  };
+
+  describe('렌더링', () => {
+    it('기본 셀렉트가 렌더링된다', () => {
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-select').exists()).toBe(true);
+      expect(wrapper.find('.ev-input').exists()).toBe(true);
+    });
+
+    it('화살표 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-input-suffix-arrow').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled prop이 적용된다', () => {
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, disabled: true },
+        ...globalConfig,
+      });
+
+      expect(wrapper.classes()).toContain('disabled');
+      expect(wrapper.find('.ev-input').element.disabled).toBe(true);
+    });
+
+    it('placeholder prop이 적용된다', () => {
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, placeholder: '선택하세요' },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-input').attributes('placeholder')).toBe('선택하세요');
+    });
+
+    it('multiple prop이 적용되면 다중 선택 UI가 렌더링된다', () => {
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, multiple: true, modelValue: [] },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-select-tag-wrapper').exists()).toBe(true);
+    });
+  });
+
+  describe('Events', () => {
+    it('클릭 시 드롭박스가 열린다', async () => {
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+
+      expect(wrapper.find('.ev-select-dropbox').exists()).toBe(true);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvSelect이다', () => {
+      expect(EvSelect.name).toBe('EvSelect');
+    });
+
+    it('기본 multiple은 false이다', () => {
+      expect(EvSelect.props.multiple.default).toBe(false);
+    });
+
+    it('기본 clearable은 false이다', () => {
+      expect(EvSelect.props.clearable.default).toBe(false);
+    });
+
+    it('기본 filterable은 false이다', () => {
+      expect(EvSelect.props.filterable.default).toBe(false);
+    });
+  });
+});

--- a/src/components/slider/Slider.spec.js
+++ b/src/components/slider/Slider.spec.js
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvSlider from './Slider.vue';
+
+describe('EvSlider Component', () => {
+  describe('렌더링', () => {
+    it('기본 슬라이더가 렌더링된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50 },
+      });
+
+      expect(wrapper.find('.ev-slider').exists()).toBe(true);
+    });
+
+    it('슬라이더 라인이 렌더링된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50 },
+      });
+
+      expect(wrapper.find('.ev-slider-line').exists()).toBe(true);
+    });
+
+    it('핸들이 렌더링된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50 },
+      });
+
+      expect(wrapper.find('.ev-slider-handle').exists()).toBe(true);
+    });
+
+    it('range일 때 핸들이 2개 렌더링된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: [20, 80], range: true },
+      });
+
+      const handles = wrapper.findAll('.ev-slider-handle');
+      expect(handles).toHaveLength(2);
+    });
+
+    it('툴팁이 렌더링된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50 },
+      });
+
+      expect(wrapper.find('.ev-slider-tooltip').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled이면 disabled 클래스가 적용된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50, disabled: true },
+      });
+
+      expect(wrapper.find('.ev-slider.disabled').exists()).toBe(true);
+    });
+
+    it('readonly이면 readonly 클래스가 적용된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50, readonly: true },
+      });
+
+      expect(wrapper.find('.ev-slider.readonly').exists()).toBe(true);
+    });
+
+    it('showTooltip이 false이면 hide-tooltip 클래스가 적용된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50, showTooltip: false },
+      });
+
+      expect(wrapper.find('.ev-slider.hide-tooltip').exists()).toBe(true);
+    });
+
+    it('showStep이 true이고 step이 있으면 step이 렌더링된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: { modelValue: 50, showStep: true, step: 25 },
+      });
+
+      expect(wrapper.find('.ev-slider-step-wrapper').exists()).toBe(true);
+    });
+
+    it('mark가 설정되면 마크가 렌더링된다', () => {
+      const wrapper = mount(EvSlider, {
+        props: {
+          modelValue: 50,
+          mark: { 0: '0', 50: '50', 100: '100' },
+        },
+      });
+
+      expect(wrapper.find('.ev-slider.show-mark').exists()).toBe(true);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvSlider이다', () => {
+      expect(EvSlider.name).toBe('EvSlider');
+    });
+
+    it('기본 min은 0이다', () => {
+      expect(EvSlider.props.min.default).toBe(0);
+    });
+
+    it('기본 max는 100이다', () => {
+      expect(EvSlider.props.max.default).toBe(100);
+    });
+
+    it('기본 step은 1이다', () => {
+      expect(EvSlider.props.step.default).toBe(1);
+    });
+
+    it('기본 disabled는 false이다', () => {
+      expect(EvSlider.props.disabled.default).toBe(false);
+    });
+
+    it('기본 readonly는 false이다', () => {
+      expect(EvSlider.props.readonly.default).toBe(false);
+    });
+
+    it('기본 range는 false이다', () => {
+      expect(EvSlider.props.range.default).toBe(false);
+    });
+
+    it('기본 showTooltip은 true이다', () => {
+      expect(EvSlider.props.showTooltip.default).toBe(true);
+    });
+
+    it('기본 showInput은 false이다', () => {
+      expect(EvSlider.props.showInput.default).toBe(false);
+    });
+
+    it('기본 showStep은 false이다', () => {
+      expect(EvSlider.props.showStep.default).toBe(false);
+    });
+  });
+});

--- a/src/components/tabPanel/TabPanel.spec.js
+++ b/src/components/tabPanel/TabPanel.spec.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import EvTabPanel from './TabPanel.vue';
+
+describe('EvTabPanel Component', () => {
+  const mountWithTabs = (props = {}, selectedValue = 'tab1') => mount(EvTabPanel, {
+    props: { value: 'tab1', text: '탭1', ...props },
+    slots: { default: '<div class="panel-content">패널 내용</div>' },
+    global: {
+      provide: {
+        evTabs: ref(selectedValue),
+      },
+    },
+  });
+
+  describe('렌더링', () => {
+    it('선택된 탭 패널이 렌더링된다', () => {
+      const wrapper = mountWithTabs({ value: 'tab1' }, 'tab1');
+
+      expect(wrapper.find('.ev-tab-panel').exists()).toBe(true);
+      expect(wrapper.find('.ev-tab-panel').isVisible()).toBe(true);
+    });
+
+    it('선택되지 않은 탭 패널은 숨겨진다', () => {
+      const wrapper = mountWithTabs({ value: 'tab1' }, 'tab2');
+
+      expect(wrapper.find('.ev-tab-panel').exists()).toBe(true);
+      expect(wrapper.find('.ev-tab-panel').isVisible()).toBe(false);
+    });
+
+    it('slot 내용이 렌더링된다', () => {
+      const wrapper = mountWithTabs();
+
+      expect(wrapper.find('.panel-content').exists()).toBe(true);
+      expect(wrapper.text()).toContain('패널 내용');
+    });
+  });
+
+  describe('Props', () => {
+    it('value prop이 선택 상태를 결정한다', () => {
+      const wrapper = mountWithTabs({ value: 'tab2' }, 'tab2');
+
+      expect(wrapper.find('.ev-tab-panel').isVisible()).toBe(true);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvTabPanel이다', () => {
+      expect(EvTabPanel.name).toBe('EvTabPanel');
+    });
+
+    it('기본 disabled는 false이다', () => {
+      expect(EvTabPanel.props.disabled.default).toBe(false);
+    });
+  });
+});

--- a/src/components/tabs/Tabs.spec.js
+++ b/src/components/tabs/Tabs.spec.js
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvTabs from './Tabs.vue';
+
+describe('EvTabs Component', () => {
+  const defaultPanels = [
+    { text: '탭1', value: 'tab1' },
+    { text: '탭2', value: 'tab2' },
+    { text: '탭3', value: 'tab3' },
+  ];
+
+  const globalConfig = {
+    global: {
+      directives: {
+        resize: {},
+        observeVisibility: {},
+      },
+    },
+  };
+
+  describe('렌더링', () => {
+    it('기본 탭이 렌더링된다', () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: defaultPanels },
+        ...globalConfig,
+      });
+
+      expect(wrapper.find('.ev-tabs').exists()).toBe(true);
+      expect(wrapper.find('.ev-tabs-header').exists()).toBe(true);
+      expect(wrapper.find('.ev-tabs-body').exists()).toBe(true);
+    });
+
+    it('탭 목록이 렌더링된다', () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: defaultPanels },
+        ...globalConfig,
+      });
+
+      const tabs = wrapper.findAll('.ev-tabs-title');
+      expect(tabs).toHaveLength(3);
+      expect(tabs[0].text()).toContain('탭1');
+      expect(tabs[1].text()).toContain('탭2');
+    });
+
+    it('선택된 탭에 active 클래스가 적용된다', () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab2', panels: defaultPanels },
+        ...globalConfig,
+      });
+
+      const tabs = wrapper.findAll('.ev-tabs-title');
+      expect(tabs[0].classes()).not.toContain('active');
+      expect(tabs[1].classes()).toContain('active');
+    });
+  });
+
+  describe('Props', () => {
+    it('closable prop이 적용된다', () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: defaultPanels, closable: true },
+        ...globalConfig,
+      });
+
+      expect(wrapper.classes()).toContain('closable');
+      expect(wrapper.findAll('.close-icon').length).toBeGreaterThan(0);
+    });
+
+    it('stretch prop이 적용된다', () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: defaultPanels, stretch: true },
+        ...globalConfig,
+      });
+
+      expect(wrapper.classes()).toContain('stretch');
+    });
+  });
+
+  describe('Events', () => {
+    it('탭 클릭 시 update:modelValue 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: defaultPanels },
+        ...globalConfig,
+      });
+
+      const tabs = wrapper.findAll('.ev-tabs-title');
+      await tabs[1].trigger('click');
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+      expect(wrapper.emitted('update:modelValue')[0][0]).toBe('tab2');
+    });
+
+    it('탭 클릭 시 change 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: defaultPanels },
+        ...globalConfig,
+      });
+
+      const tabs = wrapper.findAll('.ev-tabs-title');
+      await tabs[1].trigger('click');
+
+      expect(wrapper.emitted('change')).toBeTruthy();
+      expect(wrapper.emitted('change')[0][0]).toBe('tab2');
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvTabs이다', () => {
+      expect(EvTabs.name).toBe('EvTabs');
+    });
+
+    it('기본 closable은 false이다', () => {
+      expect(EvTabs.props.closable.default).toBe(false);
+    });
+
+    it('기본 stretch는 false이다', () => {
+      expect(EvTabs.props.stretch.default).toBe(false);
+    });
+
+    it('기본 draggable은 false이다', () => {
+      expect(EvTabs.props.draggable.default).toBe(false);
+    });
+  });
+});

--- a/src/components/textField/TextField.spec.js
+++ b/src/components/textField/TextField.spec.js
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvTextField from './TextField.vue';
+
+describe('EvTextField Component', () => {
+  describe('렌더링', () => {
+    it('기본 텍스트 필드가 렌더링된다', () => {
+      const wrapper = mount(EvTextField);
+
+      expect(wrapper.find('.ev-text-field').exists()).toBe(true);
+      expect(wrapper.find('.ev-input').exists()).toBe(true);
+    });
+
+    it('type이 textarea이면 textarea가 렌더링된다', () => {
+      const wrapper = mount(EvTextField, {
+        props: { type: 'textarea' },
+      });
+
+      expect(wrapper.find('.ev-textarea').exists()).toBe(true);
+      expect(wrapper.find('.ev-input').exists()).toBe(false);
+    });
+  });
+
+  describe('Props', () => {
+    it('placeholder prop이 적용된다', () => {
+      const wrapper = mount(EvTextField, {
+        props: { placeholder: '입력하세요' },
+      });
+
+      expect(wrapper.find('.ev-input').attributes('placeholder')).toBe('입력하세요');
+    });
+
+    it('disabled prop이 적용된다', () => {
+      const wrapper = mount(EvTextField, {
+        props: { disabled: true },
+      });
+
+      expect(wrapper.classes()).toContain('disabled');
+      expect(wrapper.find('.ev-input').element.disabled).toBe(true);
+    });
+
+    it('readonly prop이 적용된다', () => {
+      const wrapper = mount(EvTextField, {
+        props: { readonly: true },
+      });
+
+      expect(wrapper.classes()).toContain('readonly');
+      expect(wrapper.find('.ev-input').element.readOnly).toBe(true);
+    });
+
+    it('clearable prop이 적용된다', () => {
+      const wrapper = mount(EvTextField, {
+        props: { type: 'text', clearable: true },
+      });
+
+      expect(wrapper.classes()).toContain('clearable');
+    });
+
+    it('errorMsg prop이 에러 메시지를 표시한다', () => {
+      const wrapper = mount(EvTextField, {
+        props: { errorMsg: '필수 입력입니다' },
+      });
+
+      expect(wrapper.classes()).toContain('error');
+      expect(wrapper.find('.ev-text-field-error').text()).toBe('필수 입력입니다');
+    });
+
+    it('type이 password이면 password input이 렌더링된다', () => {
+      const wrapper = mount(EvTextField, {
+        props: { type: 'password' },
+      });
+
+      expect(wrapper.find('.ev-input').attributes('type')).toBe('password');
+    });
+
+    it('showPassword prop이 적용된다', () => {
+      const wrapper = mount(EvTextField, {
+        props: { type: 'password', showPassword: true },
+      });
+
+      expect(wrapper.classes()).toContain('show-password');
+      expect(wrapper.find('.icon-password').exists()).toBe(true);
+    });
+
+    it('type이 search이면 검색 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvTextField, {
+        props: { type: 'search' },
+      });
+
+      expect(wrapper.find('.icon-search').exists()).toBe(true);
+    });
+
+    it('maxLength와 showMaxLength가 설정되면 길이 표시가 나타난다', () => {
+      const wrapper = mount(EvTextField, {
+        props: { maxLength: 100, showMaxLength: true, modelValue: 'hello' },
+      });
+
+      expect(wrapper.find('.ev-text-field-maxlength').exists()).toBe(true);
+    });
+  });
+
+  describe('Events', () => {
+    it('입력 시 update:modelValue 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvTextField, {
+        props: { modelValue: '' },
+      });
+
+      await wrapper.find('.ev-input').setValue('테스트');
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    });
+
+    it('focus 시 focus 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvTextField);
+
+      await wrapper.find('.ev-input').trigger('focus');
+
+      expect(wrapper.emitted('focus')).toBeTruthy();
+    });
+
+    it('blur 시 blur 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvTextField);
+
+      await wrapper.find('.ev-input').trigger('blur');
+
+      expect(wrapper.emitted('blur')).toBeTruthy();
+    });
+
+    it('clearable 클릭 시 값이 초기화된다', async () => {
+      const wrapper = mount(EvTextField, {
+        props: { type: 'text', clearable: true, modelValue: '테스트' },
+      });
+
+      await wrapper.find('.icon-clear').trigger('click');
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+      expect(wrapper.emitted('update:modelValue')[0][0]).toBe('');
+    });
+  });
+
+  describe('기본값', () => {
+    it('기본 type은 text이다', () => {
+      const wrapper = mount(EvTextField);
+
+      expect(wrapper.classes()).toContain('type-text');
+    });
+
+    it('기본 autocomplete는 off이다', () => {
+      const wrapper = mount(EvTextField);
+
+      expect(wrapper.find('.ev-input').attributes('autocomplete')).toBe('off');
+    });
+
+    it('컴포넌트 이름이 EvTextField이다', () => {
+      expect(EvTextField.name).toBe('EvTextField');
+    });
+  });
+});

--- a/src/components/timePicker/TimePicker.spec.js
+++ b/src/components/timePicker/TimePicker.spec.js
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvTimePicker from './TimePicker.vue';
+
+describe('EvTimePicker Component', () => {
+  describe('렌더링', () => {
+    it('기본 타임피커가 렌더링된다 (range 타입)', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: ['09:00', '18:00'] },
+      });
+
+      expect(wrapper.find('.ev-time-picker').exists()).toBe(true);
+      expect(wrapper.find('.ev-time-picker-range').exists()).toBe(true);
+    });
+
+    it('single 타입이면 single 레이아웃이 렌더링된다', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single' },
+      });
+
+      expect(wrapper.find('.ev-time-picker-single').exists()).toBe(true);
+    });
+
+    it('range 타입에서 물결표(~)가 렌더링된다', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: ['09:00', '18:00'] },
+      });
+
+      expect(wrapper.find('.tilde').exists()).toBe(true);
+      expect(wrapper.find('.tilde').text()).toBe('~');
+    });
+
+    it('range 타입에서 입력 필드가 2개 렌더링된다', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: ['09:00', '18:00'] },
+      });
+
+      const inputs = wrapper.findAll('.ev-input');
+      expect(inputs).toHaveLength(2);
+    });
+
+    it('single 타입에서 입력 필드가 1개 렌더링된다', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single' },
+      });
+
+      const inputs = wrapper.findAll('.ev-input');
+      expect(inputs).toHaveLength(1);
+    });
+  });
+
+  describe('Props', () => {
+    it('disabled이면 disabled 클래스가 적용된다', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single', disabled: true },
+      });
+
+      expect(wrapper.find('.ev-time-picker-wrapper.disabled').exists()).toBe(true);
+    });
+
+    it('readonly이면 readonly 클래스가 적용된다', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single', readonly: true },
+      });
+
+      expect(wrapper.find('.ev-time-picker-wrapper.readonly').exists()).toBe(true);
+    });
+
+    it('clearable이면 클리어 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single', clearable: true },
+      });
+
+      expect(wrapper.find('.ev-input-suffix').exists()).toBe(true);
+    });
+
+    it('placeholder가 적용된다 (single)', () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single', placeholder: '시간 입력' },
+      });
+
+      expect(wrapper.find('.ev-input').attributes('placeholder')).toBe('시간 입력');
+    });
+  });
+
+  describe('Events', () => {
+    it('single 타입에서 focus 시 focus 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single' },
+      });
+
+      await wrapper.find('.ev-input').trigger('focus');
+
+      expect(wrapper.emitted('focus')).toBeTruthy();
+    });
+
+    it('single 타입에서 blur 시 blur 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvTimePicker, {
+        props: { modelValue: '09:00', type: 'single' },
+      });
+
+      await wrapper.find('.ev-input').trigger('blur');
+
+      expect(wrapper.emitted('blur')).toBeTruthy();
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvTimePicker이다', () => {
+      expect(EvTimePicker.name).toBe('EvTimePicker');
+    });
+
+    it('기본 type은 range이다', () => {
+      expect(EvTimePicker.props.type.default).toBe('range');
+    });
+
+    it('기본 clearable은 false이다', () => {
+      expect(EvTimePicker.props.clearable.default).toBe(false);
+    });
+
+    it('기본 disabled는 false이다', () => {
+      expect(EvTimePicker.props.disabled.default).toBe(false);
+    });
+
+    it('기본 readonly는 false이다', () => {
+      expect(EvTimePicker.props.readonly.default).toBe(false);
+    });
+  });
+});

--- a/src/components/tree/Tree.spec.js
+++ b/src/components/tree/Tree.spec.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvTree from './Tree.vue';
+
+describe('EvTree Component', () => {
+  const sampleData = [
+    {
+      title: '루트',
+      children: [
+        { title: '자식1' },
+        { title: '자식2' },
+      ],
+    },
+  ];
+
+  describe('렌더링', () => {
+    it('기본 트리가 렌더링된다', () => {
+      const wrapper = mount(EvTree, {
+        props: { data: sampleData },
+      });
+
+      expect(wrapper.find('.ev-tree-view').exists()).toBe(true);
+    });
+
+    it('데이터가 없으면 빈 텍스트가 표시된다', () => {
+      const wrapper = mount(EvTree, {
+        props: { data: [] },
+      });
+
+      expect(wrapper.text()).toContain('No Data');
+    });
+
+    it('커스텀 emptyText가 표시된다', () => {
+      const wrapper = mount(EvTree, {
+        props: { data: [], emptyText: '데이터 없음' },
+      });
+
+      expect(wrapper.text()).toContain('데이터 없음');
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvTree이다', () => {
+      expect(EvTree.name).toBe('EvTree');
+    });
+
+    it('기본 data는 빈 배열이다', () => {
+      expect(EvTree.props.data.default()).toEqual([]);
+    });
+
+    it('기본 useCheckbox는 false이다', () => {
+      expect(EvTree.props.useCheckbox.default).toBe(false);
+    });
+
+    it('기본 emptyText는 No Data이다', () => {
+      expect(EvTree.props.emptyText.default).toBe('No Data');
+    });
+
+    it('기본 searchWord는 빈 문자열이다', () => {
+      expect(EvTree.props.searchWord.default).toBe('');
+    });
+
+    it('기본 searchIncludeChildren은 false이다', () => {
+      expect(EvTree.props.searchIncludeChildren.default).toBe(false);
+    });
+
+    it('기본 contextMenuItems는 빈 배열이다', () => {
+      expect(EvTree.props.contextMenuItems.default()).toEqual([]);
+    });
+  });
+});

--- a/src/components/treeGrid/TreeGrid.spec.js
+++ b/src/components/treeGrid/TreeGrid.spec.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import EvTreeGrid from './TreeGrid.vue';
+
+describe('EvTreeGrid Component', () => {
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvTreeGrid이다', () => {
+      expect(EvTreeGrid.name).toBe('EvTreeGrid');
+    });
+
+    it('기본 columns는 빈 배열이다', () => {
+      expect(EvTreeGrid.props.columns.default()).toEqual([]);
+    });
+
+    it('기본 rows는 null이다', () => {
+      expect(EvTreeGrid.props.rows.default()).toBeNull();
+    });
+
+    it('기본 width는 100%이다', () => {
+      expect(EvTreeGrid.props.width.default).toBe('100%');
+    });
+
+    it('기본 height는 100%이다', () => {
+      expect(EvTreeGrid.props.height.default).toBe('100%');
+    });
+
+    it('기본 selected는 빈 배열이다', () => {
+      expect(EvTreeGrid.props.selected.default()).toEqual([]);
+    });
+
+    it('기본 checked는 빈 배열이다', () => {
+      expect(EvTreeGrid.props.checked.default()).toEqual([]);
+    });
+
+    it('기본 option은 빈 객체이다', () => {
+      expect(EvTreeGrid.props.option.default()).toEqual({});
+    });
+
+    it('기본 expandIcon은 빈 문자열이다', () => {
+      expect(EvTreeGrid.props.expandIcon.default).toBe('');
+    });
+
+    it('기본 collapseIcon은 빈 문자열이다', () => {
+      expect(EvTreeGrid.props.collapseIcon.default).toBe('');
+    });
+  });
+});

--- a/src/components/treeGrid/uses.spec.js
+++ b/src/components/treeGrid/uses.spec.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { getUpdatedColumns } from './uses';
+
+describe('treeGrid getUpdatedColumns', () => {
+  it('originColumns만 있으면 그대로 반환한다', () => {
+    const stores = {
+      originColumns: [
+        { index: 0, field: 'name', width: 100 },
+        { index: 1, field: 'value', width: 80 },
+      ],
+      filteredColumns: [],
+    };
+    const result = getUpdatedColumns(stores);
+    expect(result).toEqual([
+      { index: 0, field: 'name', width: 100 },
+      { index: 1, field: 'value', width: 80 },
+    ]);
+  });
+
+  it('filteredColumns 정보가 병합된다', () => {
+    const stores = {
+      originColumns: [
+        { index: 0, field: 'name', width: 100 },
+        { index: 1, field: 'value', width: 80 },
+      ],
+      filteredColumns: [
+        { index: 0, width: 150 },
+      ],
+    };
+    const result = getUpdatedColumns(stores);
+    expect(result[0]).toEqual({ index: 0, field: 'name', width: 150 });
+    expect(result[1]).toEqual({ index: 1, field: 'value', width: 80 });
+  });
+
+  it('일치하는 filteredColumn이 없으면 원본 유지', () => {
+    const stores = {
+      originColumns: [{ index: 0, field: 'name' }],
+      filteredColumns: [{ index: 5, hidden: true }],
+    };
+    const result = getUpdatedColumns(stores);
+    expect(result[0]).toEqual({ index: 0, field: 'name' });
+  });
+
+  it('빈 stores를 처리한다', () => {
+    const stores = { originColumns: [], filteredColumns: [] };
+    expect(getUpdatedColumns(stores)).toEqual([]);
+  });
+});

--- a/src/components/window/Window.spec.js
+++ b/src/components/window/Window.spec.js
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EvWindow from './Window.vue';
+
+describe('EvWindow Component', () => {
+  const globalStubs = {
+    global: {
+      stubs: { teleport: true },
+    },
+  };
+
+  describe('렌더링', () => {
+    it('visible이 true이면 창이 렌더링된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window').exists()).toBe(true);
+    });
+
+    it('visible이 false이면 창이 렌더링되지 않는다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: false },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window').exists()).toBe(false);
+    });
+
+    it('title이 있으면 제목이 렌더링된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true, title: '창 제목' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window-title').exists()).toBe(true);
+      expect(wrapper.find('.ev-window-title').text()).toBe('창 제목');
+    });
+
+    it('닫기 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window-close').exists()).toBe(true);
+    });
+
+    it('slot 내용이 content 영역에 렌더링된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true },
+        slots: { default: '<div class="test-content">내용</div>' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window-content .test-content').exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('fullscreen이 true이면 fullscreen 클래스가 적용된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true, fullscreen: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window.fullscreen').exists()).toBe(true);
+    });
+
+    it('isModal이 true이면 dim 레이어가 렌더링된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true, isModal: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window-dim-layer').exists()).toBe(true);
+    });
+
+    it('isModal이 false이면 dim 레이어가 없다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true, isModal: false },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window-dim-layer').exists()).toBe(false);
+    });
+
+    it('iconClass가 설정되면 아이콘이 렌더링된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true, iconClass: 'ev-icon-setting' },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window-icon').exists()).toBe(true);
+    });
+
+    it('maximizable이 true이면 최대화 버튼이 렌더링된다', () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true, maximizable: true },
+        ...globalStubs,
+      });
+
+      expect(wrapper.find('.ev-window-maximizable').exists()).toBe(true);
+    });
+  });
+
+  describe('Events', () => {
+    it('닫기 버튼 클릭 시 update:visible 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvWindow, {
+        props: { visible: true },
+        ...globalStubs,
+      });
+
+      await wrapper.find('.ev-window-close').trigger('click');
+
+      expect(wrapper.emitted('update:visible')).toBeTruthy();
+      expect(wrapper.emitted('update:visible')[0][0]).toBe(false);
+    });
+  });
+
+  describe('기본값', () => {
+    it('컴포넌트 이름이 EvWindow이다', () => {
+      expect(EvWindow.name).toBe('EvWindow');
+    });
+
+    it('기본 isModal은 true이다', () => {
+      expect(EvWindow.props.isModal.default).toBe(true);
+    });
+
+    it('기본 draggable은 false이다', () => {
+      expect(EvWindow.props.draggable.default).toBe(false);
+    });
+
+    it('기본 resizable은 false이다', () => {
+      expect(EvWindow.props.resizable.default).toBe(false);
+    });
+
+    it('기본 fullscreen은 false이다', () => {
+      expect(EvWindow.props.fullscreen.default).toBe(false);
+    });
+  });
+});

--- a/src/directives/clickoutside.spec.js
+++ b/src/directives/clickoutside.spec.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { clickoutside } from './clickoutside';
+
+describe('clickoutside directive', () => {
+  it('mounted 시 document에 mousedown 이벤트가 등록된다', () => {
+    const el = document.createElement('div');
+    const handler = vi.fn();
+    const addSpy = vi.spyOn(document, 'addEventListener');
+
+    clickoutside.mounted(el, { value: handler, modifiers: {} });
+
+    expect(addSpy).toHaveBeenCalledWith('mousedown', expect.any(Function));
+    expect(el.vueClickOutside).toBeDefined();
+
+    addSpy.mockRestore();
+    clickoutside.unmounted(el);
+  });
+
+  it('unmounted 시 이벤트 리스너가 제거된다', () => {
+    const el = document.createElement('div');
+    const handler = vi.fn();
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+
+    clickoutside.mounted(el, { value: handler, modifiers: {} });
+    const boundHandler = el.vueClickOutside;
+    clickoutside.unmounted(el);
+
+    expect(removeSpy).toHaveBeenCalledWith('mousedown', boundHandler);
+    expect(el.vueClickOutside).toBeNull();
+
+    removeSpy.mockRestore();
+  });
+
+  it('외부 클릭 시 핸들러가 호출된다', () => {
+    const el = document.createElement('div');
+    const handler = vi.fn();
+    document.body.appendChild(el);
+
+    clickoutside.mounted(el, { value: handler, modifiers: {} });
+
+    // 외부 요소에서 클릭 이벤트 발생
+    const outsideEl = document.createElement('div');
+    document.body.appendChild(outsideEl);
+    const event = new MouseEvent('mousedown', { bubbles: true });
+    Object.defineProperty(event, 'target', { value: outsideEl });
+    el.vueClickOutside(event);
+
+    expect(handler).toHaveBeenCalledWith(event);
+
+    clickoutside.unmounted(el);
+    document.body.removeChild(el);
+    document.body.removeChild(outsideEl);
+  });
+
+  it('자신을 클릭하면 핸들러가 호출되지 않는다', () => {
+    const el = document.createElement('div');
+    const handler = vi.fn();
+
+    clickoutside.mounted(el, { value: handler, modifiers: {} });
+
+    // 자기 자신을 클릭
+    const event = new MouseEvent('mousedown', { bubbles: true });
+    Object.defineProperty(event, 'target', { value: el });
+    el.vueClickOutside(event);
+
+    expect(handler).not.toHaveBeenCalled();
+
+    clickoutside.unmounted(el);
+  });
+
+  it('자식 요소를 클릭하면 핸들러가 호출되지 않는다', () => {
+    const el = document.createElement('div');
+    const child = document.createElement('span');
+    el.appendChild(child);
+    document.body.appendChild(el);
+    const handler = vi.fn();
+
+    clickoutside.mounted(el, { value: handler, modifiers: {} });
+
+    const event = new MouseEvent('mousedown', { bubbles: true });
+    Object.defineProperty(event, 'target', { value: child });
+    el.vueClickOutside(event);
+
+    expect(handler).not.toHaveBeenCalled();
+
+    clickoutside.unmounted(el);
+    document.body.removeChild(el);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -20,5 +20,6 @@ export default defineConfig({
     alias: {
       '@': resolve(__dirname, 'src'),
     },
+    extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'],
   },
 });


### PR DESCRIPTION
## Summary
- 모든 컴포넌트(33개)에 대한 단위 테스트 추가
- 유틸리티, composable 순수 함수, chart scale/element/model 테스트 추가
- directive (clickoutside) 테스트 추가
- 총 **44개 테스트 파일**, **628개 테스트 케이스**, 전부 통과

## 테스트 범위

### 컴포넌트 테스트 (28개 신규)
buttonGroup, toggle, progress, loading, radio, radioGroup, checkbox, textField, inputNumber, select, tabPanel, tabs, pagination, message, notification, messageBox, scheduler, menu, contextMenu, window, slider, timePicker, calendar, datePicker, tree, grid, treeGrid, chartGroup

### 유틸리티/순수 함수 테스트 (14개 신규)
- `common/utils.table` — quantity, numberToPixel, isPercentValue, checkColSize
- `inputNumber/uses` — getValueCloseToStep
- `calendar/uses` — lpadToTwoDigits
- `grid/uses`, `treeGrid/uses` — getUpdatedColumns
- `chart/scale/scale.linear` — getInterval, getDecimalPointFromRange, getNiceInterval
- `chart/scale/scale.logarithmic` — getInterval, getLabelFormat
- `chart/scale/scale.step` — getIndexInterval
- `chart/scale/scale.time.category` — getInterval
- `chart/element/element.bar` — calculateBarSize, isPointInBar
- `chart/element/element.heatmap` — getAdjustedBounds, getFilteredLabel
- `chart/model/model.series` — getOverlappingSeriesKeys
- `chartBrush/uses`, `chartGroup/uses` — getNormalizedOptions
- `directives/clickoutside` — mounted/unmounted lifecycle

## Test plan
- [x] `npm run test:run` — 53개 파일, 628개 테스트 전부 통과
- [ ] CI 파이프라인 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)