### PR TITLE
test: 유틸리티, 순수 함수, chart 모듈 테스트 추가

### DIFF
--- a/src/common/utils.table.spec.js
+++ b/src/common/utils.table.spec.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import tableUtils from './utils.table';
+
+describe('utils.table', () => {
+  describe('quantity', () => {
+    it('숫자 문자열을 파싱한다', () => {
+      expect(tableUtils.quantity('100')).toEqual({ value: 100, unit: undefined });
+    });
+
+    it('px 단위를 파싱한다', () => {
+      expect(tableUtils.quantity('100px')).toEqual({ value: 100, unit: 'px' });
+    });
+
+    it('% 단위를 파싱한다', () => {
+      expect(tableUtils.quantity('50%')).toEqual({ value: 50, unit: '%' });
+    });
+
+    it('소수점을 파싱한다', () => {
+      expect(tableUtils.quantity('10.5px')).toEqual({ value: 10.5, unit: 'px' });
+    });
+
+    it('숫자 타입을 파싱한다', () => {
+      expect(tableUtils.quantity(100)).toEqual({ value: 100, unit: undefined });
+    });
+
+    it('유효하지 않은 문자열은 undefined를 반환한다', () => {
+      expect(tableUtils.quantity('abc')).toBeUndefined();
+    });
+
+    it('객체는 undefined를 반환한다', () => {
+      expect(tableUtils.quantity({})).toBeUndefined();
+    });
+
+    it('null은 undefined를 반환한다', () => {
+      expect(tableUtils.quantity(null)).toBeUndefined();
+    });
+  });
+
+  describe('numberToPixel', () => {
+    it('숫자 문자열을 px로 변환한다', () => {
+      expect(tableUtils.numberToPixel('100')).toBe('100px');
+    });
+
+    it('px 단위는 그대로 반환한다', () => {
+      expect(tableUtils.numberToPixel('100px')).toBe('100px');
+    });
+
+    it('% 단위는 그대로 반환한다', () => {
+      expect(tableUtils.numberToPixel('50%')).toBe('50%');
+    });
+
+    it('숫자 타입을 px로 변환한다', () => {
+      expect(tableUtils.numberToPixel(200)).toBe('200px');
+    });
+
+    it('유효하지 않은 값은 undefined를 반환한다', () => {
+      expect(tableUtils.numberToPixel('abc')).toBeUndefined();
+    });
+
+    it('객체는 undefined를 반환한다', () => {
+      expect(tableUtils.numberToPixel({})).toBeUndefined();
+    });
+  });
+
+  describe('isPercentValue', () => {
+    it('% 포함 문자열은 true를 반환한다', () => {
+      expect(tableUtils.isPercentValue('50%')).toBe(true);
+    });
+
+    it('% 없는 문자열은 false를 반환한다', () => {
+      expect(tableUtils.isPercentValue('50px')).toBe(false);
+    });
+
+    it('숫자 타입은 false를 반환한다', () => {
+      expect(tableUtils.isPercentValue(50)).toBe(false);
+    });
+
+    it('빈 문자열은 true를 반환한다 (edge case)', () => {
+      // indexOf('%') === -1, length - 1 === -1 이므로 true 반환
+      expect(tableUtils.isPercentValue('')).toBe(true);
+    });
+  });
+
+  describe('checkColSize', () => {
+    it('min보다 작으면 min을 반환한다', () => {
+      expect(tableUtils.checkColSize(10, 50, 200)).toBe(50);
+    });
+
+    it('max보다 크면 max를 반환한다', () => {
+      expect(tableUtils.checkColSize(300, 50, 200)).toBe(200);
+    });
+
+    it('범위 안이면 그대로 반환한다', () => {
+      expect(tableUtils.checkColSize(100, 50, 200)).toBe(100);
+    });
+
+    it('min이 없으면 min 체크를 건너뛴다', () => {
+      expect(tableUtils.checkColSize(10, null, 200)).toBe(10);
+    });
+
+    it('max가 없으면 max 체크를 건너뛴다', () => {
+      expect(tableUtils.checkColSize(300, 50, null)).toBe(300);
+    });
+  });
+});

--- a/src/components/calendar/uses.spec.js
+++ b/src/components/calendar/uses.spec.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { lpadToTwoDigits } from './uses';
+
+describe('lpadToTwoDigits', () => {
+  it('한 자리 숫자를 두 자리로 패딩한다', () => {
+    expect(lpadToTwoDigits(1)).toBe('01');
+    expect(lpadToTwoDigits(9)).toBe('09');
+    expect(lpadToTwoDigits(0)).toBe('00');
+  });
+
+  it('두 자리 이상 숫자는 그대로 반환한다', () => {
+    expect(lpadToTwoDigits(10)).toBe(10);
+    expect(lpadToTwoDigits(31)).toBe(31);
+    expect(lpadToTwoDigits(12)).toBe(12);
+  });
+
+  it('문자열 숫자도 처리한다', () => {
+    expect(lpadToTwoDigits('5')).toBe('05');
+    expect(lpadToTwoDigits('12')).toBe('12');
+  });
+
+  it('null이면 00을 반환한다', () => {
+    expect(lpadToTwoDigits(null)).toBe('00');
+  });
+});

--- a/src/components/chart/element/element.bar.spec.js
+++ b/src/components/chart/element/element.bar.spec.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import Bar from './element.bar';
+
+const createBar = (overrides = {}) => {
+  const bar = Object.create(Bar.prototype);
+  Object.assign(bar, overrides);
+  return bar;
+};
+
+describe('Bar Element', () => {
+  describe('calculateBarSize', () => {
+    it('px 문자열을 파싱하여 크기를 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize('30px', 50)).toBe(30);
+    });
+
+    it('px 값이 bArea보다 크면 bArea를 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize('100px', 50)).toBe(50);
+    });
+
+    it('0~1 사이 숫자는 비율로 계산한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize(0.5, 100)).toBe(50);
+    });
+
+    it('비율 0은 0을 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize(0, 100)).toBe(0);
+    });
+
+    it('비율 1은 전체 영역을 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize(1, 100)).toBe(100);
+    });
+
+    it('유효하지 않은 값은 bArea를 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize('auto', 80)).toBe(80);
+      expect(bar.calculateBarSize(null, 80)).toBe(80);
+      expect(bar.calculateBarSize(2, 80)).toBe(80);
+    });
+  });
+
+  describe('isPointInBar', () => {
+    it('바 영역 내 점은 true를 반환한다', () => {
+      const bar = createBar();
+      const barData = { xp: 10, yp: 50, w: 20, h: -30 };
+      // bar: x 10~30, y 20~50
+      expect(bar.isPointInBar([15, 40], barData)).toBe(true);
+    });
+
+    it('바 영역 밖 점은 false를 반환한다', () => {
+      const bar = createBar();
+      const barData = { xp: 10, yp: 50, w: 20, h: -30 };
+      expect(bar.isPointInBar([5, 40], barData)).toBe(false);
+      expect(bar.isPointInBar([35, 40], barData)).toBe(false);
+    });
+  });
+});

--- a/src/components/chart/element/element.heatmap.spec.js
+++ b/src/components/chart/element/element.heatmap.spec.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import HeatMap from './element.heatmap';
+
+const createHeatMap = (overrides = {}) => {
+  const hm = Object.create(HeatMap.prototype);
+  Object.assign(hm, overrides);
+  return hm;
+};
+
+describe('HeatMap Element', () => {
+  describe('getAdjustedBounds', () => {
+    it('기본 범위를 조정한다', () => {
+      const hm = createHeatMap();
+      const result = hm.getAdjustedBounds({
+        xp: 10,
+        yp: 20,
+        width: 30,
+        height: 40,
+      });
+      expect(result.xsp).toBe(10);
+      expect(result.xep).toBe(40);
+      expect(result.ysp).toBe(20);
+      expect(result.yep).toBe(60);
+    });
+
+    it('음수 width/height는 0으로 조정된다', () => {
+      const hm = createHeatMap();
+      const result = hm.getAdjustedBounds({
+        xp: 10,
+        yp: 20,
+        width: -5,
+        height: -10,
+      });
+      expect(result.xep).toBeGreaterThanOrEqual(result.xsp);
+      expect(result.yep).toBeGreaterThanOrEqual(result.ysp);
+    });
+
+    it('소수점 값의 부동소수점 오차를 보정한다', () => {
+      const hm = createHeatMap();
+      const result = hm.getAdjustedBounds({
+        xp: 10.123,
+        yp: 20.456,
+        width: 5.789,
+        height: 3.012,
+      });
+      // xsp는 floor, xep는 ceil 처리
+      expect(result.xsp).toBeLessThanOrEqual(10.123);
+      expect(result.xep).toBeGreaterThanOrEqual(10.123 + 5.789);
+    });
+  });
+
+  describe('getFilteredLabel', () => {
+    it('count가 일치하면 labels을 그대로 반환한다', () => {
+      const hm = createHeatMap();
+      const labels = [1, 2, 3, 4, 5];
+      expect(hm.getFilteredLabel(labels, 5, 1, 5)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('count가 다르면 min/max 범위로 필터링한다', () => {
+      const hm = createHeatMap();
+      const labels = [1, 2, 3, 4, 5];
+      expect(hm.getFilteredLabel(labels, 10, 2, 4)).toEqual([2, 3, 4]);
+    });
+
+    it('범위에 맞는 레이블이 없으면 빈 배열을 반환한다', () => {
+      const hm = createHeatMap();
+      const labels = [1, 2, 3];
+      expect(hm.getFilteredLabel(labels, 10, 10, 20)).toEqual([]);
+    });
+  });
+});

--- a/src/components/chart/model/model.series.spec.js
+++ b/src/components/chart/model/model.series.spec.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import modules from './model.series';
+
+describe('model.series', () => {
+  describe('getOverlappingSeriesKeys', () => {
+    it('bar 시리즈를 groups 역순으로 정렬한다', () => {
+      const series = {
+        s1: { type: 'bar' },
+        s2: { type: 'bar' },
+        s3: { type: 'bar' },
+      };
+      const groups = [['s1', 's2', 's3']];
+      const result = modules.getOverlappingSeriesKeys(series, 'bar', groups);
+      expect(result).toEqual(['s3', 's2', 's1']);
+    });
+
+    it('non-bar 시리즈는 bar 뒤에 위치한다', () => {
+      const series = {
+        line1: { type: 'line' },
+        bar1: { type: 'bar' },
+        bar2: { type: 'bar' },
+      };
+      const groups = [['bar1', 'bar2']];
+      const result = modules.getOverlappingSeriesKeys(series, 'bar', groups);
+      expect(result[result.length - 1]).toBe('line1');
+    });
+
+    it('groups가 비어있으면 모든 시리즈가 other로 분류된다', () => {
+      const series = {
+        s1: { type: 'bar' },
+        s2: { type: 'bar' },
+      };
+      const result = modules.getOverlappingSeriesKeys(series, 'bar', []);
+      expect(result).toHaveLength(2);
+    });
+
+    it('defaultType으로 타입이 결정된다', () => {
+      const series = {
+        s1: {},
+        s2: { type: 'line' },
+      };
+      const groups = [['s1']];
+      const result = modules.getOverlappingSeriesKeys(series, 'bar', groups);
+      // s1은 default type이 bar이므로 bar로 분류
+      expect(result[0]).toBe('s1');
+      expect(result[1]).toBe('s2');
+    });
+  });
+});

--- a/src/components/chart/scale/scale.linear.spec.js
+++ b/src/components/chart/scale/scale.linear.spec.js
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import LinearScale from './scale.linear';
+
+// LinearScale의 순수 계산 메서드를 테스트하기 위해 최소 mock 생성
+const createScale = (overrides = {}) => {
+  const scale = Object.create(LinearScale.prototype);
+  scale.interval = null;
+  scale.decimalPoint = null;
+  scale.startToZero = false;
+  scale.fixedSteps = false;
+  scale.niceScale = false;
+  scale.formatter = null;
+  Object.assign(scale, overrides);
+  return scale;
+};
+
+describe('LinearScale', () => {
+  describe('getInterval', () => {
+    it('기본 interval을 계산한다', () => {
+      const scale = createScale();
+      const result = scale.getInterval({ maxValue: 100, minValue: 0, maxSteps: 5 });
+      expect(result).toBe(20);
+    });
+
+    it('사용자 지정 interval이 있으면 그대로 반환한다', () => {
+      const scale = createScale({ interval: 25 });
+      const result = scale.getInterval({ maxValue: 100, minValue: 0, maxSteps: 5 });
+      expect(result).toBe(25);
+    });
+
+    it('steps가 0이면 0을 반환한다', () => {
+      const scale = createScale();
+      const result = scale.getInterval({ maxValue: 100, minValue: 0, maxSteps: 0 });
+      expect(result).toBe(0);
+    });
+
+    it('소수점이 없으면 ceil 처리한다', () => {
+      const scale = createScale();
+      const result = scale.getInterval({ maxValue: 100, minValue: 0, maxSteps: 3 });
+      // 100/3 = 33.33... → ceil → 34
+      expect(result).toBe(34);
+    });
+
+    it('소수점이 있으면 그대로 반환한다', () => {
+      const scale = createScale({ decimalPoint: 2 });
+      const result = scale.getInterval({ maxValue: 1, minValue: 0, maxSteps: 3 });
+      expect(result).toBeCloseTo(0.333, 2);
+    });
+
+    it('startToZero이고 음수 포함 시 올바르게 계산한다', () => {
+      const scale = createScale({ startToZero: true });
+      const result = scale.getInterval({ maxValue: 80, minValue: -20, maxSteps: 5 });
+      expect(result).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getDecimalPointFromRange', () => {
+    it('정수 범위는 0을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getDecimalPointFromRange({ graphRange: 100, numberOfSteps: 5 })).toBe(0);
+    });
+
+    it('소수점 범위의 자릿수를 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getDecimalPointFromRange({ graphRange: 1, numberOfSteps: 10 })).toBe(1);
+    });
+
+    it('매우 작은 범위의 자릿수를 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getDecimalPointFromRange({ graphRange: 0.01, numberOfSteps: 10 })).toBe(3);
+    });
+
+    it('numberOfSteps가 0이면 0을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getDecimalPointFromRange({ graphRange: 100, numberOfSteps: 0 })).toBe(0);
+    });
+
+    it('graphRange가 0이면 0을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getDecimalPointFromRange({ graphRange: 0, numberOfSteps: 5 })).toBe(0);
+    });
+  });
+
+  describe('getNiceInterval', () => {
+    it('양수 값에 대해 nice interval을 반환한다', () => {
+      const scale = createScale();
+      const result = scale.getNiceInterval(33);
+      // 33 → exponent=1, normalized=3.3 → fraction=5 → 50
+      expect(result).toBe(50);
+    });
+
+    it('작은 양수에 대해 동작한다', () => {
+      const scale = createScale();
+      const result = scale.getNiceInterval(0.7);
+      expect(result).toBe(1);
+    });
+
+    it('음수 값에 대해 음수 nice interval을 반환한다', () => {
+      const scale = createScale();
+      const result = scale.getNiceInterval(-33);
+      expect(result).toBe(-50);
+    });
+
+    it('0은 0을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getNiceInterval(0)).toBe(0);
+    });
+
+    it('Infinity는 0을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getNiceInterval(Infinity)).toBe(0);
+    });
+
+    it('NaN은 0을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getNiceInterval(NaN)).toBe(0);
+    });
+
+    it('1에 대해 1을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getNiceInterval(1)).toBe(1);
+    });
+
+    it('10에 대해 10을 반환한다', () => {
+      const scale = createScale();
+      expect(scale.getNiceInterval(10)).toBe(10);
+    });
+
+    it('15에 대해 20을 반환한다', () => {
+      const scale = createScale();
+      // 15 → exponent=1, normalized=1.5 → fraction=2 → 20
+      expect(scale.getNiceInterval(15)).toBe(20);
+    });
+  });
+});

--- a/src/components/chart/scale/scale.logarithmic.spec.js
+++ b/src/components/chart/scale/scale.logarithmic.spec.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import LogarithmicScale from './scale.logarithmic';
+
+const createScale = (overrides = {}) => {
+  const scale = Object.create(LogarithmicScale.prototype);
+  scale.interval = null;
+  scale.decimalPoint = null;
+  scale.startToZero = false;
+  scale.range = null;
+  scale.formatter = null;
+  Object.assign(scale, overrides);
+  return scale;
+};
+
+describe('LogarithmicScale', () => {
+  describe('getInterval', () => {
+    it('범위에 따라 로그 스케일 인터벌을 계산한다', () => {
+      const scale = createScale();
+      const result = scale.getInterval({ maxValue: 1000, minValue: 0 });
+      // 10^calculateMagnitude(1000) = 10^3 = 1000 or similar
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it('작은 범위에 대해 작은 인터벌을 반환한다', () => {
+      const scale = createScale();
+      const small = scale.getInterval({ maxValue: 10, minValue: 0 });
+      const large = scale.getInterval({ maxValue: 1000, minValue: 0 });
+      expect(small).toBeLessThan(large);
+    });
+
+    it('같은 min/max는 0을 반환한다', () => {
+      const scale = createScale();
+      const result = scale.getInterval({ maxValue: 50, minValue: 50 });
+      // calculateMagnitude(0) = -Infinity → 10^(-Infinity) = 0
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('getLabelFormat', () => {
+    it('formatter가 없으면 기본 포맷을 사용한다', () => {
+      const scale = createScale();
+      const result = scale.getLabelFormat(1000);
+      expect(typeof result).toBe('string');
+    });
+
+    it('formatter가 있으면 formatter를 사용한다', () => {
+      const scale = createScale({
+        formatter: (v) => `${v}K`,
+      });
+      expect(scale.getLabelFormat(100)).toBe('100K');
+    });
+
+    it('formatter가 문자열을 반환하지 않으면 기본 포맷을 사용한다', () => {
+      const scale = createScale({
+        formatter: () => 123,
+      });
+      const result = scale.getLabelFormat(100);
+      expect(typeof result).toBe('string');
+    });
+  });
+});

--- a/src/components/chart/scale/scale.step.spec.js
+++ b/src/components/chart/scale/scale.step.spec.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import StepScale from './scale.step';
+
+const createScale = (overrides = {}) => {
+  const scale = Object.create(StepScale.prototype);
+  scale.labels = [];
+  scale.interval = null;
+  Object.assign(scale, overrides);
+  return scale;
+};
+
+describe('StepScale', () => {
+  describe('getIndexInterval', () => {
+    it('labels 수를 step으로 나눈 인터벌을 반환한다', () => {
+      const scale = createScale({
+        labels: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
+      });
+      const result = scale.getIndexInterval({ maxSteps: 5 });
+      expect(result).toBe(2);
+    });
+
+    it('사용자 지정 interval이 있으면 그대로 반환한다', () => {
+      const scale = createScale({
+        labels: ['a', 'b', 'c', 'd', 'e'],
+        interval: 3,
+      });
+      expect(scale.getIndexInterval({ maxSteps: 5 })).toBe(3);
+    });
+
+    it('labels가 step보다 적으면 1을 반환한다', () => {
+      const scale = createScale({
+        labels: ['a', 'b'],
+      });
+      expect(scale.getIndexInterval({ maxSteps: 5 })).toBe(1);
+    });
+
+    it('labels가 비어있으면 0을 반환한다', () => {
+      const scale = createScale({ labels: [] });
+      expect(scale.getIndexInterval({ maxSteps: 5 })).toBe(0);
+    });
+  });
+});

--- a/src/components/chart/scale/scale.time.category.spec.js
+++ b/src/components/chart/scale/scale.time.category.spec.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import TimeCategoryScale from './scale.time.category';
+
+const createScale = (overrides = {}) => {
+  const scale = Object.create(TimeCategoryScale.prototype);
+  scale.interval = null;
+  scale.labels = [];
+  Object.assign(scale, overrides);
+  return scale;
+};
+
+describe('TimeCategoryScale', () => {
+  describe('getInterval', () => {
+    it('사용자 지정 interval이 숫자이면 그대로 반환한다', () => {
+      const scale = createScale({ interval: 3600000 });
+      const result = scale.getInterval({ maxValue: 100000, minValue: 0, maxSteps: 5 });
+      expect(result).toBe(3600000);
+    });
+
+    it('사용자 지정 interval이 문자열이면 TIME_INTERVALS에서 조회한다', () => {
+      const scale = createScale({ interval: 'second' });
+      const result = scale.getInterval({ maxValue: 10000, minValue: 0, maxSteps: 5 });
+      expect(result).toBe(1000);
+    });
+
+    it('사용자 지정 interval이 객체이면 time * unit size로 계산한다', () => {
+      const scale = createScale({ interval: { time: 5, unit: 'minute' } });
+      const result = scale.getInterval({ maxValue: 600000, minValue: 0, maxSteps: 5 });
+      expect(result).toBe(5 * 60000);
+    });
+
+    it('interval이 없으면 범위/step으로 계산한다', () => {
+      const scale = createScale();
+      const result = scale.getInterval({ maxValue: 100, minValue: 0, maxSteps: 5 });
+      expect(result).toBe(20);
+    });
+
+    it('나누어 떨어지지 않으면 ceil 처리한다', () => {
+      const scale = createScale();
+      const result = scale.getInterval({ maxValue: 100, minValue: 0, maxSteps: 3 });
+      expect(result).toBe(34);
+    });
+  });
+});

--- a/src/components/chartBrush/uses.spec.js
+++ b/src/components/chartBrush/uses.spec.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { useBrushModel } from './uses';
+
+describe('chartBrush uses', () => {
+  describe('getNormalizedBrushOptions', () => {
+    const { getNormalizedBrushOptions } = useBrushModel();
+
+    it('빈 옵션에 기본값을 적용한다', () => {
+      const result = getNormalizedBrushOptions({});
+      expect(result.show).toBe(true);
+      expect(result.useDebounce).toBe(true);
+      expect(result.chartIdx).toBe(0);
+      expect(result.height).toBe(100);
+      expect(result.showLabel).toBe(false);
+      expect(result.useWheelMove).toBe(true);
+    });
+
+    it('사용자 옵션이 기본값을 덮어쓴다', () => {
+      const result = getNormalizedBrushOptions({
+        show: false,
+        height: 200,
+        chartIdx: 2,
+      });
+      expect(result.show).toBe(false);
+      expect(result.height).toBe(200);
+      expect(result.chartIdx).toBe(2);
+    });
+
+    it('selection 기본값이 적용된다', () => {
+      const result = getNormalizedBrushOptions({});
+      expect(result.selection.fillColor).toBe('#38ACEC');
+      expect(result.selection.opacity).toBe(0.65);
+    });
+
+    it('selection 부분 덮어쓰기가 동작한다', () => {
+      const result = getNormalizedBrushOptions({
+        selection: { opacity: 0.8 },
+      });
+      expect(result.selection.fillColor).toBe('#38ACEC');
+      expect(result.selection.opacity).toBe(0.8);
+    });
+  });
+});

--- a/src/components/chartGroup/uses.spec.js
+++ b/src/components/chartGroup/uses.spec.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { useGroupModel } from './uses';
+
+describe('chartGroup uses', () => {
+  describe('getNormalizedOptions', () => {
+    const { getNormalizedOptions } = useGroupModel();
+
+    it('빈 옵션에 기본값을 적용한다', () => {
+      const result = getNormalizedOptions({});
+      expect(result.zoom).toBeDefined();
+      expect(result.zoom.bufferMemoryCnt).toBe(100);
+      expect(result.zoom.keepZoomStatus).toBe(false);
+      expect(result.zoom.useAnimation).toBe(true);
+      expect(result.zoom.useWheelMove).toBe(true);
+    });
+
+    it('사용자 옵션이 기본값을 덮어쓴다', () => {
+      const result = getNormalizedOptions({
+        zoom: { bufferMemoryCnt: 50, keepZoomStatus: true },
+      });
+      expect(result.zoom.bufferMemoryCnt).toBe(50);
+      expect(result.zoom.keepZoomStatus).toBe(true);
+      expect(result.zoom.useAnimation).toBe(true);
+    });
+
+    it('toolbar 기본값이 적용된다', () => {
+      const result = getNormalizedOptions({});
+      expect(result.zoom.toolbar.show).toBe(false);
+      expect(result.zoom.toolbar.items.reset).toBeDefined();
+      expect(result.zoom.toolbar.items.reset.icon).toBe('ev-icon-redo');
+    });
+
+    it('toolbar 부분 덮어쓰기가 동작한다', () => {
+      const result = getNormalizedOptions({
+        zoom: { toolbar: { show: true } },
+      });
+      expect(result.zoom.toolbar.show).toBe(true);
+      expect(result.zoom.toolbar.items.reset.icon).toBe('ev-icon-redo');
+    });
+  });
+});

--- a/src/components/grid/uses.spec.js
+++ b/src/components/grid/uses.spec.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { getUpdatedColumns } from './uses';
+
+describe('getUpdatedColumns', () => {
+  it('originColumns만 있으면 그대로 반환한다', () => {
+    const stores = {
+      originColumns: [
+        { index: 0, field: 'name', width: 100 },
+        { index: 1, field: 'age', width: 80 },
+      ],
+      filteredColumns: [],
+    };
+    const result = getUpdatedColumns(stores);
+    expect(result).toEqual([
+      { index: 0, field: 'name', width: 100 },
+      { index: 1, field: 'age', width: 80 },
+    ]);
+  });
+
+  it('filteredColumns 정보가 병합된다', () => {
+    const stores = {
+      originColumns: [
+        { index: 0, field: 'name', width: 100 },
+        { index: 1, field: 'age', width: 80 },
+      ],
+      filteredColumns: [
+        { index: 1, width: 120, hidden: true },
+      ],
+    };
+    const result = getUpdatedColumns(stores);
+    expect(result[0]).toEqual({ index: 0, field: 'name', width: 100 });
+    expect(result[1]).toEqual({ index: 1, field: 'age', width: 120, hidden: true });
+  });
+
+  it('movedColumns가 있으면 originColumns 대신 사용한다', () => {
+    const stores = {
+      originColumns: [
+        { index: 0, field: 'name' },
+        { index: 1, field: 'age' },
+      ],
+      movedColumns: [
+        { index: 1, field: 'age' },
+        { index: 0, field: 'name' },
+      ],
+      filteredColumns: [],
+    };
+    const result = getUpdatedColumns(stores);
+    expect(result[0].field).toBe('age');
+    expect(result[1].field).toBe('name');
+  });
+
+  it('빈 stores를 처리한다', () => {
+    const stores = {
+      originColumns: [],
+      filteredColumns: [],
+    };
+    expect(getUpdatedColumns(stores)).toEqual([]);
+  });
+});

--- a/src/components/inputNumber/uses.spec.js
+++ b/src/components/inputNumber/uses.spec.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { getValueCloseToStep } from './uses';
+
+describe('getValueCloseToStep', () => {
+  describe('정수 step', () => {
+    it('정확한 step 값은 그대로 반환한다', () => {
+      expect(getValueCloseToStep(50, { min: 0, max: 100, step: 10 })).toBe(50);
+    });
+
+    it('step 절반보다 큰 나머지는 다음 step으로 올린다', () => {
+      expect(getValueCloseToStep(56, { min: 0, max: 100, step: 10 })).toBe(60);
+    });
+
+    it('step 절반보다 작은 나머지는 이전 step으로 내린다', () => {
+      expect(getValueCloseToStep(54, { min: 0, max: 100, step: 10 })).toBe(50);
+    });
+
+    it('min보다 작으면 min을 반환한다', () => {
+      expect(getValueCloseToStep(-5, { min: 0, max: 100, step: 10 })).toBe(0);
+    });
+
+    it('max보다 크면 max에 가장 가까운 step 값을 반환한다', () => {
+      expect(getValueCloseToStep(105, { min: 0, max: 100, step: 10 })).toBe(100);
+    });
+
+    it('min이 0이 아닌 경우에도 올바르게 계산한다', () => {
+      expect(getValueCloseToStep(15, { min: 10, max: 50, step: 10 })).toBe(10);
+      expect(getValueCloseToStep(26, { min: 10, max: 50, step: 10 })).toBe(30);
+    });
+
+    it('step이 1인 경우 값을 그대로 반환한다', () => {
+      expect(getValueCloseToStep(7, { min: 0, max: 100, step: 1 })).toBe(7);
+    });
+  });
+
+  describe('소수 step', () => {
+    it('소수점 step을 올바르게 계산한다', () => {
+      expect(getValueCloseToStep(0.3, { min: 0, max: 1, step: 0.1 })).toBe(0.3);
+    });
+
+    it('소수점에서 반올림이 올바르게 동작한다', () => {
+      const result = getValueCloseToStep(0.15, { min: 0, max: 1, step: 0.1 });
+      expect(result).toBe(0.1);
+    });
+
+    it('소수점 min과 함께 동작한다', () => {
+      expect(getValueCloseToStep(0.5, { min: 0.1, max: 1, step: 0.2 })).toBe(0.5);
+    });
+  });
+});

--- a/src/components/treeGrid/uses.spec.js
+++ b/src/components/treeGrid/uses.spec.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { getUpdatedColumns } from './uses';
+
+describe('treeGrid getUpdatedColumns', () => {
+  it('originColumns만 있으면 그대로 반환한다', () => {
+    const stores = {
+      originColumns: [
+        { index: 0, field: 'name', width: 100 },
+        { index: 1, field: 'value', width: 80 },
+      ],
+      filteredColumns: [],
+    };
+    const result = getUpdatedColumns(stores);
+    expect(result).toEqual([
+      { index: 0, field: 'name', width: 100 },
+      { index: 1, field: 'value', width: 80 },
+    ]);
+  });
+
+  it('filteredColumns 정보가 병합된다', () => {
+    const stores = {
+      originColumns: [
+        { index: 0, field: 'name', width: 100 },
+        { index: 1, field: 'value', width: 80 },
+      ],
+      filteredColumns: [
+        { index: 0, width: 150 },
+      ],
+    };
+    const result = getUpdatedColumns(stores);
+    expect(result[0]).toEqual({ index: 0, field: 'name', width: 150 });
+    expect(result[1]).toEqual({ index: 1, field: 'value', width: 80 });
+  });
+
+  it('일치하는 filteredColumn이 없으면 원본 유지', () => {
+    const stores = {
+      originColumns: [{ index: 0, field: 'name' }],
+      filteredColumns: [{ index: 5, hidden: true }],
+    };
+    const result = getUpdatedColumns(stores);
+    expect(result[0]).toEqual({ index: 0, field: 'name' });
+  });
+
+  it('빈 stores를 처리한다', () => {
+    const stores = { originColumns: [], filteredColumns: [] };
+    expect(getUpdatedColumns(stores)).toEqual([]);
+  });
+});

--- a/src/directives/clickoutside.spec.js
+++ b/src/directives/clickoutside.spec.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { clickoutside } from './clickoutside';
+
+describe('clickoutside directive', () => {
+  it('mounted 시 document에 mousedown 이벤트가 등록된다', () => {
+    const el = document.createElement('div');
+    const handler = vi.fn();
+    const addSpy = vi.spyOn(document, 'addEventListener');
+
+    clickoutside.mounted(el, { value: handler, modifiers: {} });
+
+    expect(addSpy).toHaveBeenCalledWith('mousedown', expect.any(Function));
+    expect(el.vueClickOutside).toBeDefined();
+
+    addSpy.mockRestore();
+    clickoutside.unmounted(el);
+  });
+
+  it('unmounted 시 이벤트 리스너가 제거된다', () => {
+    const el = document.createElement('div');
+    const handler = vi.fn();
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+
+    clickoutside.mounted(el, { value: handler, modifiers: {} });
+    const boundHandler = el.vueClickOutside;
+    clickoutside.unmounted(el);
+
+    expect(removeSpy).toHaveBeenCalledWith('mousedown', boundHandler);
+    expect(el.vueClickOutside).toBeNull();
+
+    removeSpy.mockRestore();
+  });
+
+  it('외부 클릭 시 핸들러가 호출된다', () => {
+    const el = document.createElement('div');
+    const handler = vi.fn();
+    document.body.appendChild(el);
+
+    clickoutside.mounted(el, { value: handler, modifiers: {} });
+
+    // 외부 요소에서 클릭 이벤트 발생
+    const outsideEl = document.createElement('div');
+    document.body.appendChild(outsideEl);
+    const event = new MouseEvent('mousedown', { bubbles: true });
+    Object.defineProperty(event, 'target', { value: outsideEl });
+    el.vueClickOutside(event);
+
+    expect(handler).toHaveBeenCalledWith(event);
+
+    clickoutside.unmounted(el);
+    document.body.removeChild(el);
+    document.body.removeChild(outsideEl);
+  });
+
+  it('자신을 클릭하면 핸들러가 호출되지 않는다', () => {
+    const el = document.createElement('div');
+    const handler = vi.fn();
+
+    clickoutside.mounted(el, { value: handler, modifiers: {} });
+
+    // 자기 자신을 클릭
+    const event = new MouseEvent('mousedown', { bubbles: true });
+    Object.defineProperty(event, 'target', { value: el });
+    el.vueClickOutside(event);
+
+    expect(handler).not.toHaveBeenCalled();
+
+    clickoutside.unmounted(el);
+  });
+
+  it('자식 요소를 클릭하면 핸들러가 호출되지 않는다', () => {
+    const el = document.createElement('div');
+    const child = document.createElement('span');
+    el.appendChild(child);
+    document.body.appendChild(el);
+    const handler = vi.fn();
+
+    clickoutside.mounted(el, { value: handler, modifiers: {} });
+
+    const event = new MouseEvent('mousedown', { bubbles: true });
+    Object.defineProperty(event, 'target', { value: child });
+    el.vueClickOutside(event);
+
+    expect(handler).not.toHaveBeenCalled();
+
+    clickoutside.unmounted(el);
+    document.body.removeChild(el);
+  });
+});


### PR DESCRIPTION
## Summary
- 컴포넌트 테스트와 별도로, 유틸리티/순수 함수/chart 모듈에 대한 단위 테스트 추가
- 총 **15개 신규 테스트 파일**, **111개 테스트 케이스**

## 테스트 범위

### Common 유틸리티
- `common/utils.table` — quantity, numberToPixel, isPercentValue, checkColSize (23개)

### Composable 순수 함수
- `inputNumber/uses` — getValueCloseToStep (10개)
- `calendar/uses` — lpadToTwoDigits (4개)
- `grid/uses` — getUpdatedColumns (4개)
- `treeGrid/uses` — getUpdatedColumns (4개)
- `chartBrush/uses` — getNormalizedBrushOptions (4개)
- `chartGroup/uses` — getNormalizedOptions (4개)

### Chart Scale
- `scale.linear` — getInterval, getDecimalPointFromRange, getNiceInterval (20개)
- `scale.logarithmic` — getInterval, getLabelFormat (6개)
- `scale.step` — getIndexInterval (4개)
- `scale.time.category` — getInterval (5개)

### Chart Element
- `element.bar` — calculateBarSize, isPointInBar (8개)
- `element.heatmap` — getAdjustedBounds, getFilteredLabel (6개)

### Chart Model
- `model.series` — getOverlappingSeriesKeys (4개)

### Directive
- `clickoutside` — mounted/unmounted lifecycle, 클릭 핸들링 (5개)

## Test plan
- [x] `npm run test:run` — 전체 테스트 통과
- [ ] CI 파이프라인 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #2113