### PR TITLE
[#2134][3.4.120] Chart > Linear Axis > Range, Interval 옵션 보장 스펙으로 변경

### DIFF
--- a/docs/views/lineChart/example/Default.vue
+++ b/docs/views/lineChart/example/Default.vue
@@ -1,9 +1,11 @@
 <template>
   <div class="case">
-    <ev-chart
+    <resizable-wrapper>
+      <ev-chart
       :data="chartData"
       :options="chartOptions"
     />
+    </resizable-wrapper>
     <div class="description">
       <span class="toggle-label">데이터 자동 업데이트</span>
       <ev-toggle
@@ -40,7 +42,7 @@
       const chartOptions = reactive({
         type: 'line',
         width: '100%',
-        height: '80%',
+        height: '100%',
         padding: {
           top: 20,
           right: 2,
@@ -58,7 +60,10 @@
         axesX: [{
           type: 'time',
           timeFormat: 'DD HH:mm',
-          interval: 'hour',
+          interval: {
+            time: 1,
+            unit: 'hour',
+          },
           formatter: (value, data) => {
             if (data?.prev) {
               const curr = dayjs(value).format('yy-MM-DD');

--- a/docs/views/scatterChart/example/DisplayOverflow.vue
+++ b/docs/views/scatterChart/example/DisplayOverflow.vue
@@ -26,7 +26,22 @@
             class="component"
             :min="1"
           />
+          <span class="item-title">
+            Interval
+          </span>
+          <ev-input-number
+            v-model="interval"
+            class="component"
+            :min="0"
+          />
         </div>
+      </div>
+      <div class="row">
+        <div class="sub-description">
+          range 옵션과 interval 옵션이 호환되지 않는다면, interval 옵션은 무시됩니다.
+        </div>
+      </div>
+      <div class="row">
         <div class="row-item">
           <span class="item-title">
             Decimal Point
@@ -47,13 +62,15 @@
             />
           </div>
         </div>
+      </div>
+      <div class="row">
         <div class="row-item">
           <span class="item-title">
             Display Overflow
           </span>
           <ev-checkbox
             v-model="displayOverflow"
-            class="check-box"
+            class="component"
           />
         </div>
       </div>
@@ -101,11 +118,12 @@ import EvCheckbox from '@/components/checkbox/Checkbox';
         },
       });
 
-      const maxValue = ref(7);
+      const maxValue = ref(10);
       const minValue = ref(0);
       const decimalPoint = ref(0);
       const isAutoDecimal = ref(true);
       const displayOverflow = ref(true);
+      const interval = ref(5);
 
       const chartOptions = computed(() => ({
         type: 'scatter',
@@ -154,6 +172,7 @@ import EvCheckbox from '@/components/checkbox/Checkbox';
           plotBands: [],
           formatter: null,
           range: [minValue.value, maxValue.value],
+          interval: interval.value,
         }],
         title: {
           text: '',
@@ -191,6 +210,7 @@ import EvCheckbox from '@/components/checkbox/Checkbox';
         isAutoDecimal,
         displayOverflow,
         chartOptions,
+        interval,
       };
     },
   };
@@ -226,6 +246,12 @@ import EvCheckbox from '@/components/checkbox/Checkbox';
       .component {
         max-width: 200px;
       }
+    }
+
+    .sub-description {
+      font-size: 12px;
+      color: #666;
+      text-align: right;
     }
   }
 </style>

--- a/docs/views/scatterChart/example/DisplayOverflow.vue
+++ b/docs/views/scatterChart/example/DisplayOverflow.vue
@@ -1,20 +1,51 @@
 <template>
   <div class="case">
-    <ev-chart
-      :data="chartData"
-      :options="chartOptions"
-    />
+    <resizable-wrapper>
+      <ev-chart
+        :data="chartData"
+        :options="chartOptions"
+      />
+    </resizable-wrapper>
+
     <div class="description">
       <div class="row">
         <div class="row-item">
           <span class="item-title">
+            Min Value
+          </span>
+          <ev-input-number
+            v-model="minValue"
+            class="component"
+            :min="0"
+          />
+          <span class="item-title">
             Max Value
           </span>
-            <ev-input-number
-              v-model="maxValue"
+          <ev-input-number
+            v-model="maxValue"
+            class="component"
+            :min="1"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            Decimal Point
+          </span>
+          <ev-input-number
+            v-model="decimalPoint"
+            class="component"
+            :disabled="isAutoDecimal"
+            :min="0"
+          />
+          <div class="row-item">
+            <span class="item-title">
+            is Auto
+            </span>
+            <ev-toggle
+              v-model="isAutoDecimal"
               class="component"
-              :min="1"
             />
+          </div>
         </div>
         <div class="row-item">
           <span class="item-title">
@@ -63,14 +94,17 @@ import EvCheckbox from '@/components/checkbox/Checkbox';
             { x: 184, y: 78 }, { x: 175, y: 62 }, { x: 184, y: 81 },
             { x: 180, y: 76 }, { x: 177, y: 83 }, { x: 192, y: 90, color: '#FF0000' },
             { x: 176, y: 74 }, { x: 174, y: 71 }, { x: 184, y: 79 },
-            { x: 192, y: 93, color: '#FF0000' }, { x: 171, y: 70 }, { x: 173, y: 72 },
+            { x: 10, y: 4, color: '#FF0000' }, { x: 171, y: 70 }, { x: 173, y: 72 },
             { x: 176, y: 85 }, { x: 176, y: 78 }, { x: 180, y: 77 },
             { x: 172, y: 66 }, { x: 176, y: 86 }, { x: 173, y: 81 },
           ],
         },
       });
 
-      const maxValue = ref(60);
+      const maxValue = ref(7);
+      const minValue = ref(0);
+      const decimalPoint = ref(0);
+      const isAutoDecimal = ref(true);
       const displayOverflow = ref(true);
 
       const chartOptions = computed(() => ({
@@ -102,12 +136,12 @@ import EvCheckbox from '@/components/checkbox/Checkbox';
         axesY: [{
           type: 'linear',
           showAxis: true,
-          startToZero: false,
+          startToZero: true,
           autoScaleRatio: null,
           showGrid: true,
           axisLineColor: '#C9CFDC',
           gridLineColor: '#C9CFDC',
-          interval: 1,
+          decimalPoint: isAutoDecimal.value ? 'auto' : decimalPoint.value,
           labelStyle: {
             show: true,
             fontSize: 12,
@@ -119,7 +153,7 @@ import EvCheckbox from '@/components/checkbox/Checkbox';
           plotLines: [],
           plotBands: [],
           formatter: null,
-          range: [0, maxValue.value],
+          range: [minValue.value, maxValue.value],
         }],
         title: {
           text: '',
@@ -152,6 +186,9 @@ import EvCheckbox from '@/components/checkbox/Checkbox';
       return {
         chartData,
         maxValue,
+        minValue,
+        decimalPoint,
+        isAutoDecimal,
         displayOverflow,
         chartOptions,
       };
@@ -167,20 +204,28 @@ import EvCheckbox from '@/components/checkbox/Checkbox';
 
   .row {
     display: flex;
+    flex-direction: column;
     margin-top: 15px;
     justify-content: space-between;
+    gap: 30px;
+
     .row-item {
       flex: 1;
       display: flex;
+      justify-content: flex-start;
+      align-items: center;
+
       .item-title {
         line-height: 33px;
         margin-right: 3px;
         min-width: 80px;
+        text-align: right;
+        white-space: nowrap;
       }
-    }
-    .check-box {
-      display: flex;
-      margin-left: 4px;
+
+      .component {
+        max-width: 200px;
+      }
     }
   }
 </style>

--- a/docs/views/scatterChart/example/TimeAxis.vue
+++ b/docs/views/scatterChart/example/TimeAxis.vue
@@ -43,6 +43,25 @@
           />
         </div>
       </div>
+      <div class="row">
+        <div class="sub-description">
+          range 옵션과 interval 옵션이 호환되지 않는다면, interval 옵션은 무시됩니다.
+        </div>
+      </div>
+      <div class="row">
+        <div class="row-item">
+          <span class="item-title">
+            Range
+          </span>
+          <ev-date-picker
+            v-model="rangeDateTimes"
+            mode="dateTimeRange"
+            :options="{
+              timeFormat: ['HH:mm:ss', 'HH:mm:ss'],
+            }"
+        />
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -53,21 +72,25 @@ import dayjs from 'dayjs';
 
 export default {
   setup() {
+    const now = dayjs();
+    const threeHoursAgo = now.subtract(3, 'hour');
+    const sixHoursAgo = now.subtract(6, 'hour');
+    const twelveHoursAgo = now.subtract(12, 'hour');
+    const twentyFourHoursAgo = now.subtract(24, 'hour');
+    const threeDaysAgo = now.subtract(3, 'day');
+
     // 최근 3시간 이내의 10초 간격 데이터 생성
-    const generateTimeSeriesData = () => {
-      const now = dayjs();
-      const threeHoursAgo = now.subtract(3, 'hour');
+    const generateTimeSeriesData = (start, end) => {
       const dataPoints = [];
 
-      // 3시간 = 10800초, 10초 간격이면 1080개의 데이터 포인트
-      let currentTime = threeHoursAgo;
-      while (currentTime.isBefore(now) || currentTime.isSame(now)) {
-        const y = Math.floor(Math.random() * 100) + 1; // 1-100 사이의 랜덤 값
+      let currentTime = end;
+      while (currentTime.isBefore(start) || currentTime.isSame(start)) {
+        const y = Math.floor(Math.random() * 100) + 1;
         dataPoints.push({
           x: currentTime.valueOf(),
           y,
         });
-        currentTime = currentTime.add(10, 'second');
+        currentTime = currentTime.add(1, 'minute');
       }
 
       return dataPoints;
@@ -75,14 +98,24 @@ export default {
 
     const chartData = reactive({
       series: {
-        series1: { name: 'series#1' },
-        series2: { name: 'series#2' },
+        series1: { name: '현재~3시간전' },
+        series2: { name: '3시간전~6시간전' },
+        series3: { name: '6시간~12시간전' },
+        series4: { name: '12시간~24시간전' },
+        series5: { name: '24시간~3일전' },
       },
       data: {
-        series1: generateTimeSeriesData(),
+        series1: generateTimeSeriesData(now, threeHoursAgo),
+        series2: generateTimeSeriesData(threeHoursAgo, sixHoursAgo),
+        series3: generateTimeSeriesData(sixHoursAgo, twelveHoursAgo),
+        series4: generateTimeSeriesData(twelveHoursAgo, twentyFourHoursAgo),
+        series5: generateTimeSeriesData(twentyFourHoursAgo, threeDaysAgo),
       },
     });
 
+    console.log('chartData', chartData);
+
+    const rangeDateTimes = ref([threeHoursAgo.format('YYYY-MM-DD HH:mm:ss'), now.format('YYYY-MM-DD HH:mm:ss')]);
     const intervalValue = ref(10);
     const intervalUnit = ref('second');
 
@@ -92,11 +125,15 @@ export default {
       height: '100%',
       axesX: [{
         type: 'time',
-        timeFormat: 'HH:mm:ss',
+        timeFormat: 'DD HH:mm:ss',
         interval: {
           time: intervalValue.value,
           unit: intervalUnit.value,
         },
+        range: [
+          dayjs(rangeDateTimes.value[0]).valueOf(),
+          dayjs(rangeDateTimes.value[1]).valueOf(),
+        ],
       }],
       axesY: [{
         type: 'linear',
@@ -123,13 +160,8 @@ export default {
         show: false,
       },
       legend: {
-        show: false,
-        position: 'right',
-        color: '#353740',
-        inactive: '#aaa',
-        width: 140,
-        height: 24,
-        padding: { top: 0, right: 0, bottom: 0, left: 0 },
+        show: true,
+        position: 'bottom',
       },
       tooltip: {
         use: false,
@@ -150,6 +182,7 @@ export default {
       intervalValue,
       intervalUnit,
       chartOptions,
+      rangeDateTimes,
     };
   },
 };
@@ -177,9 +210,10 @@ export default {
         text-align: right;
       }
     }
-    .check-box {
-      display: flex;
-      margin-left: 4px;
+    .sub-description {
+      font-size: 12px;
+      color: #666;
+      text-align: right;
     }
   }
 </style>

--- a/docs/views/scatterChart/example/TimeAxis.vue
+++ b/docs/views/scatterChart/example/TimeAxis.vue
@@ -1,0 +1,185 @@
+<template>
+  <div class="case">
+    <resizable-wrapper>
+      <ev-chart
+        :data="chartData"
+        :options="chartOptions"
+      />
+    </resizable-wrapper>
+
+    <div class="description">
+      <div class="row">
+        <div class="row-item">
+          <span class="item-title">
+            Interval Value
+          </span>
+          <ev-input-number
+            v-model="intervalValue"
+            class="component"
+            :min="0"
+          />
+          <span class="item-title">
+            Interval Unit
+          </span>
+          <ev-select
+            v-model="intervalUnit"
+            class="component"
+            :items="[{
+              name: 'second',
+              value: 'second',
+            }, {
+              name: 'minute',
+              value: 'minute',
+            }, {
+              name: 'hour',
+              value: 'hour',
+            }, {
+              name: 'day',
+              value: 'day',
+            }, {
+              name: 'week',
+              value: 'week',
+            }]"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, reactive, computed } from 'vue';
+import dayjs from 'dayjs';
+
+export default {
+  setup() {
+    // 최근 3시간 이내의 10초 간격 데이터 생성
+    const generateTimeSeriesData = () => {
+      const now = dayjs();
+      const threeHoursAgo = now.subtract(3, 'hour');
+      const dataPoints = [];
+
+      // 3시간 = 10800초, 10초 간격이면 1080개의 데이터 포인트
+      let currentTime = threeHoursAgo;
+      while (currentTime.isBefore(now) || currentTime.isSame(now)) {
+        const y = Math.floor(Math.random() * 100) + 1; // 1-100 사이의 랜덤 값
+        dataPoints.push({
+          x: currentTime.valueOf(),
+          y,
+        });
+        currentTime = currentTime.add(10, 'second');
+      }
+
+      return dataPoints;
+    };
+
+    const chartData = reactive({
+      series: {
+        series1: { name: 'series#1' },
+        series2: { name: 'series#2' },
+      },
+      data: {
+        series1: generateTimeSeriesData(),
+      },
+    });
+
+    const intervalValue = ref(10);
+    const intervalUnit = ref('second');
+
+    const chartOptions = computed(() => ({
+      type: 'scatter',
+      width: '100%',
+      height: '100%',
+      axesX: [{
+        type: 'time',
+        timeFormat: 'HH:mm:ss',
+        interval: {
+          time: intervalValue.value,
+          unit: intervalUnit.value,
+        },
+      }],
+      axesY: [{
+        type: 'linear',
+        showAxis: true,
+        startToZero: true,
+        autoScaleRatio: null,
+        showGrid: true,
+        axisLineColor: '#C9CFDC',
+        gridLineColor: '#C9CFDC',
+        labelStyle: {
+          show: true,
+          fontSize: 12,
+          color: '#25262E',
+          fontFamily: 'Roboto',
+          fitWidth: false,
+          fitDir: 'right',
+        },
+        plotLines: [],
+        plotBands: [],
+        formatter: null,
+      }],
+      title: {
+        text: '',
+        show: false,
+      },
+      legend: {
+        show: false,
+        position: 'right',
+        color: '#353740',
+        inactive: '#aaa',
+        width: 140,
+        height: 24,
+        padding: { top: 0, right: 0, bottom: 0, left: 0 },
+      },
+      tooltip: {
+        use: false,
+      },
+      selectItem: {
+        use: false,
+      },
+      dragSelection: {
+        use: false,
+        keepDisplay: true,
+        fillColor: '#38ACEC',
+        opacity: 0.65,
+      },
+    }));
+
+    return {
+      chartData,
+      intervalValue,
+      intervalUnit,
+      chartOptions,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+  .description-label {
+    vertical-align: top;
+    margin-right: 3px;
+  }
+
+  .row {
+    display: flex;
+    flex-direction: column;
+    margin-top: 15px;
+    justify-content: space-between;
+    gap: 30px;
+    .row-item {
+      flex: 1;
+      display: flex;
+      .item-title {
+        line-height: 33px;
+        margin-right: 3px;
+        min-width: 80px;
+        text-align: right;
+      }
+    }
+    .check-box {
+      display: flex;
+      margin-left: 4px;
+    }
+  }
+</style>

--- a/docs/views/scatterChart/props.js
+++ b/docs/views/scatterChart/props.js
@@ -12,6 +12,8 @@ import DisplayOverflow from './example/DisplayOverflow';
 import DisplayOverflowRaw from '!!raw-loader!./example/DisplayOverflow';
 import RealTimeScatter from './example/RealTimeScatter';
 import RealTimeScatterRaw from '!!raw-loader!./example/RealTimeScatter';
+import TimeAxis from './example/TimeAxis';
+import TimeAxisRaw from '!!raw-loader!./example/TimeAxis';
 
 export default {
   mdText,
@@ -40,6 +42,11 @@ export default {
       description: 'range 옵션으로 지정한 Y축의 최댓값을 표시합니다.',
       component: DisplayOverflow,
       parsedData: parseComponent(DisplayOverflowRaw),
+    },
+    'Time Axis': {
+      description: 'Time Axis를 표시합니다.',
+      component: TimeAxis,
+      parsedData: parseComponent(TimeAxisRaw),
     },
     RealTimeScatter: {
       description: '실시간으로 대량의 데이터를 처리합니다.',

--- a/docs/views/scatterChart/props.js
+++ b/docs/views/scatterChart/props.js
@@ -39,12 +39,12 @@ export default {
       parsedData: parseComponent(PlotLineRaw),
     },
     'Display Overflow': {
-      description: 'range 옵션으로 지정한 Y축의 최댓값을 표시합니다.',
+      description: '축의 max값보다 큰 값을 표시할지의 여부를 결정합니다.',
       component: DisplayOverflow,
       parsedData: parseComponent(DisplayOverflowRaw),
     },
     'Time Axis': {
-      description: 'Time Axis를 표시합니다.',
+      description: 'Time Axis를 표시합니다. range, interval 옵션을 사용하여 축의 범위와 간격을 지정할 수 있습니다.',
       component: TimeAxis,
       parsedData: parseComponent(TimeAxisRaw),
     },

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -97,7 +97,8 @@ class Scale {
       }
     }
 
-    if (this.startToZero) {
+    const hasUserRange = Array.isArray(this.range) && this.range.length === 2;
+    if (this.startToZero && !hasUserRange) {
       minValue = 0;
     }
 
@@ -153,16 +154,117 @@ class Scale {
     const { maxValue, minValue } = range;
     let { maxSteps } = range;
 
+    const hasUserRange = Array.isArray(this.range) && this.range.length === 2;
+
+    // 사용자 interval로 인식하는 경우: 숫자 또는 객체({ time, unit }) 형태만
+    // 문자열('hour', 'second' 등)은 기존 로직(분기 D)으로 처리
+    const hasUserInterval = typeof this.interval === 'number'
+      || (typeof this.interval === 'object' && this.interval !== null);
+
+    // range와 interval 충돌 여부 판별
+    // graphRange가 interval로 정수 분할되지 않으면 충돌 -> interval 무시
+    let useUserInterval = hasUserInterval;
+    const resolvedInterval = hasUserInterval ? this.getInterval(range) : null;
+    if (hasUserRange && hasUserInterval && resolvedInterval != null && resolvedInterval !== 0) {
+      const rangeSize = maxValue - minValue;
+      const stepsFromInterval = rangeSize / resolvedInterval;
+      if (Math.abs(stepsFromInterval - Math.round(stepsFromInterval)) > 1e-10) {
+        useUserInterval = false;
+      }
+    }
+
+    // 분기 A/B: range가 배열로 설정된 경우
+    // graphMin/graphMax를 minValue/maxValue에 정확히 고정
+    if (hasUserRange) {
+      const graphMin = minValue;
+      const graphMax = maxValue;
+      const graphRange = graphMax - graphMin;
+
+      let interval;
+      let numberOfSteps;
+
+      if (useUserInterval && resolvedInterval != null && resolvedInterval !== 0) {
+        // 분기 B: Range + Interval 호환 -> 둘 다 적용
+        interval = resolvedInterval;
+        numberOfSteps = Math.round(graphRange / interval);
+      } else {
+        // 분기 A: Range 전용 -> steps에서 interval 계산
+        numberOfSteps = Math.max(1, maxSteps);
+        interval = graphRange / numberOfSteps;
+      }
+
+      // 최소 2 steps 보장 (range 양 끝 + 중간 최소 1개)
+      numberOfSteps = Math.max(1, numberOfSteps);
+
+      if (this.decimalPoint === 'auto') {
+        this.decimalPoint = this?.getDecimalPointFromRange?.({
+          graphRange,
+          numberOfSteps,
+        });
+      }
+
+      return {
+        steps: numberOfSteps,
+        interval,
+        graphMin,
+        graphMax,
+      };
+    }
+
+    // 분기 C: interval만 설정된 경우 (range 미설정)
+    // interval 고정, numberOfSteps는 maxSteps를 초과할 수 없음
+    if (useUserInterval) {
+      let interval = resolvedInterval;
+      const numMinValue = +minValue;
+      const numMaxValue = +maxValue;
+      let increase = numMinValue;
+
+      while (increase < numMaxValue) {
+        increase += interval;
+      }
+
+      const graphMax = increase;
+      const graphMin = numMinValue;
+      const graphRange = graphMax - graphMin;
+      let numberOfSteps = Math.round(graphRange / interval);
+
+      // numberOfSteps가 maxSteps를 초과하면 interval을 배수로 늘려 맞춤
+      let iterationCount = 0;
+      const MAX_ITERATIONS = 100;
+      while (numberOfSteps > maxSteps && interval > 0 && iterationCount < MAX_ITERATIONS) {
+        interval *= 2;
+        numberOfSteps = Math.round(graphRange / interval);
+        iterationCount++;
+      }
+
+      if (this.decimalPoint === 'auto') {
+        this.decimalPoint = this?.getDecimalPointFromRange?.({
+          graphRange,
+          numberOfSteps,
+        });
+      }
+
+      return {
+        steps: numberOfSteps,
+        interval,
+        graphMin,
+        graphMax,
+      };
+    }
+
+    // 분기 D: 기존 로직 (range, interval 모두 미설정)
     let interval = this.getInterval(range);
-    let increase = minValue;
+    const numMinValue = +minValue;
+    const numMaxValue = +maxValue;
+    let increase = numMinValue;
     let numberOfSteps;
 
-    while (increase < maxValue) {
+    while (increase < numMaxValue) {
       increase += interval;
     }
 
     const graphMax = increase;
-    const graphMin = minValue;
+    const graphMin = numMinValue;
     const graphRange = graphMax - graphMin;
 
     numberOfSteps = Math.round(graphRange / interval);
@@ -339,7 +441,7 @@ class Scale {
 
       if (this.type === 'x' && options?.axesX[0].flow && dataLabels.length !== steps + 1) {
         const axisMinByMinutes = Math.floor(axisMin / size) * size;
-        if (axisMinByMinutes !== +axisMin) {
+        if (axisMinByMinutes !== +axisMin && (axisMax - axisMin) !== 0) {
           axisMinForLabel = axisMinByMinutes + size;
           offsetStartPoint += (distance / (axisMax - axisMin)) * (axisMinForLabel - axisMin);
         }

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -187,6 +187,11 @@ class Scale {
         // 분기 B: Range + Interval 호환 -> 둘 다 적용
         interval = resolvedInterval;
         numberOfSteps = Math.round(graphRange / interval);
+        // numberOfSteps가 maxSteps를 초과하면 interval을 증가시켜 조정
+        while (numberOfSteps > maxSteps) {
+          interval *= 2;
+          numberOfSteps = Math.round(graphRange / interval);
+        }
       } else {
         // 분기 A: Range 전용 -> steps에서 interval 계산
         numberOfSteps = Math.max(1, maxSteps);


### PR DESCRIPTION
# 개요 
- 사용자 정의 Axis > `interval`, `range` 옵션이 보장되지 않고 EVUI 내부 로직에 의해 값이 변경됨 

# Before
### Range
- Y축에 `range` > max 값을 부여하였지만, max 값보다 크게 잡힘 
- <img width="720" height="243" alt="image" src="https://github.com/user-attachments/assets/e3c84522-069e-4526-b682-9e1fb8b56c69" />


### Interval
- X축에 `interval` 값으로 3분을 부여하였지만, 표시된 라벨의 초단위를 보면 3분 interval 이 아닌것을 알 수 있음 
- <img width="732" height="161" alt="image" src="https://github.com/user-attachments/assets/7a18797c-00b2-4d5d-9b1b-ff0bc42a1ead" />


# After
### range 보장
- <img width="718" height="242" alt="image" src="https://github.com/user-attachments/assets/0561a805-1bf3-4f35-9047-d5ec233ab4e5" />


### interval 보장
- <img width="724" height="193" alt="image" src="https://github.com/user-attachments/assets/5a0dac92-ff39-4691-8d28-9581ad5fbbf6" />

# 변경사항 
- 일부 예제 변경 
- scatter > Time Axis 신규 예제 추가 
- scale.js > calculateSteps 함수 변경 
   - linear, time 축 공용 
   
# 테스트 가이드
- [ Axis linear Type > Range, Interval 테스트 ](http://localhost:9999/scatterChart#display-overflow)
- [Axis Time Type > Range, Interval 테스트 ](http://localhost:9999/scatterChart#time-axis)