### PR TITLE
fix: chart props 직접 변경 6곳 수정 (#2114)

### DIFF
--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -130,6 +130,13 @@ export default {
           { wrapper, evChartGroupRef: null },
           props.selectedLabel ? selectedLabel : selectedItem,
           injectEvChartPropsInGroup,
+          (newValue) => {
+            if (props.selectedLabel) {
+              emit('update:selectedLabel', newValue);
+            } else {
+              emit('update:selectedItem', newValue);
+            }
+          },
         );
 
     const createChart = () => {
@@ -234,20 +241,18 @@ export default {
       watch(
         () => injectBrushIdx.start,
         (curBrushStartIdx, prevBrushStartIdx) => {
+          const delta = curBrushStartIdx - (prevBrushStartIdx ?? 0);
+
           if (selectedLabel?.value) {
-            for (let idx = 0; idx < selectedLabel.value.dataIndex.length; idx++) {
-              if (curBrushStartIdx >= (prevBrushStartIdx ?? 0)) {
-                selectedLabel.value.dataIndex[idx] -= curBrushStartIdx - (prevBrushStartIdx ?? 0);
-              } else {
-                selectedLabel.value.dataIndex[idx] += prevBrushStartIdx - curBrushStartIdx;
-              }
-            }
+            emit('update:selectedLabel', {
+              ...selectedLabel.value,
+              dataIndex: selectedLabel.value.dataIndex.map((val) => val - delta),
+            });
           } else if (selectedItem?.value) {
-            if (curBrushStartIdx >= (prevBrushStartIdx ?? 0)) {
-              selectedItem.value.dataIndex -= curBrushStartIdx - (prevBrushStartIdx ?? 0);
-            } else {
-              selectedItem.value.dataIndex += prevBrushStartIdx - curBrushStartIdx;
-            }
+            emit('update:selectedItem', {
+              ...selectedItem.value,
+              dataIndex: selectedItem.value.dataIndex - delta,
+            });
           }
         },
       );

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -308,7 +308,7 @@ export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
 
     return normalizedOptions;
   };
-  const getNormalizedData = (data) => defaultsDeep(data, DEFAULT_DATA);
+  const getNormalizedData = (data) => defaultsDeep({}, data, DEFAULT_DATA);
 
   const selectItemInfo = cloneDeep(props.selectedItem);
   const selectLabelInfo = cloneDeep(props.selectedLabel ?? injectGroupSelectedLabel?.value);
@@ -341,7 +341,7 @@ export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
 
           case 'label': {
             if (injectGroupSelectedLabel?.value) {
-              injectGroupSelectedLabel.value.dataIndex = dataIndex;
+              injectGroupSelectedLabel.value = { dataIndex, targetAxis };
             } else {
               emit('update:selectedLabel', {
                 dataIndex,
@@ -395,7 +395,7 @@ export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
     },
     'mouse-leave': () => {
       if (injectGroupHoveredLabel?.value) {
-        injectGroupHoveredLabel.value.label = null;
+        injectGroupHoveredLabel.value = { ...injectGroupHoveredLabel.value, label: null };
       }
     },
     'click-legend': async (e) => {
@@ -451,6 +451,7 @@ export const useZoomModel = (
   { wrapper: evChartWrapper, evChartGroupRef },
   selectedLabelOrItem,
   evChartPropsInGroup,
+  onUpdateSelectedLabelOrItem,
 ) => {
   const { props, emit } = getCurrentInstance();
 
@@ -661,22 +662,19 @@ export const useZoomModel = (
   watch(
     () => [brushIdx.start, brushIdx.end],
     ([curBrushStartIdx, curBrushEndIdx], [prevBrushStartIdx]) => {
-      if (selectedLabelOrItem?.value) {
+      if (selectedLabelOrItem?.value && onUpdateSelectedLabelOrItem) {
+        const delta = curBrushStartIdx - (prevBrushStartIdx ?? 0);
+
         if (typeof selectedLabelOrItem.value.dataIndex === 'number') {
-          if (curBrushStartIdx >= (prevBrushStartIdx ?? 0)) {
-            selectedLabelOrItem.value.dataIndex -= curBrushStartIdx - (prevBrushStartIdx ?? 0);
-          } else {
-            selectedLabelOrItem.value.dataIndex += prevBrushStartIdx - curBrushStartIdx;
-          }
+          onUpdateSelectedLabelOrItem({
+            ...selectedLabelOrItem.value,
+            dataIndex: selectedLabelOrItem.value.dataIndex - delta,
+          });
         } else {
-          for (let idx = 0; idx < selectedLabelOrItem.value.dataIndex.length; idx++) {
-            if (curBrushStartIdx >= (prevBrushStartIdx ?? 0)) {
-              selectedLabelOrItem.value.dataIndex[idx] -=
-                curBrushStartIdx - (prevBrushStartIdx ?? 0);
-            } else {
-              selectedLabelOrItem.value.dataIndex[idx] += prevBrushStartIdx - curBrushStartIdx;
-            }
-          }
+          onUpdateSelectedLabelOrItem({
+            ...selectedLabelOrItem.value,
+            dataIndex: selectedLabelOrItem.value.dataIndex.map((val) => val - delta),
+          });
         }
       }
 

--- a/src/components/chartGroup/ChartGroup.vue
+++ b/src/components/chartGroup/ChartGroup.vue
@@ -96,6 +96,9 @@ export default {
       { wrapper: null, evChartGroupRef },
       groupSelectedLabel,
       evChartPropsInGroup,
+      (newValue) => {
+        groupSelectedLabel.value = newValue;
+      },
     );
 
     provide('evChartClone', evChartClone);


### PR DESCRIPTION
## Summary
- `getNormalizedData`에서 `defaultsDeep`가 props.data를 직접 변경하던 문제 수정
- `groupSelectedLabel`, `groupHoveredLabel`의 내부 속성 직접 변경 대신 새 객체 할당
- `useZoomModel` watcher에서 props 직접 변경 대신 콜백 패턴으로 변경
- Chart.vue brushIdx watcher에서 props 직접 변경 대신 emit 패턴 적용

Closes #2114

## Test Plan
- [x] `npm run lint` 통과 (수정 파일 3개)
- [x] `npm run test:run` 통과 (197 tests passed)
- [ ] docs dev server에서 Chart 라벨 선택/해제 동작 확인
- [ ] ChartGroup 그룹 라벨 선택 동작 확인
- [ ] 줌/브러시 + 선택 기능 동작 확인
- [ ] hover 동기화 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)