### PR TITLE
[#2134][3.4.120] Chart > Linear Axis > Range, Interval 옵션 보장 스펙으로 변경

### DIFF
--- a/docs/views/scatterChart/example/DisplayOverflow.vue
+++ b/docs/views/scatterChart/example/DisplayOverflow.vue
@@ -1,28 +1,106 @@
 <template>
   <div class="case">
-    <ev-chart
-      :data="chartData"
-      :options="chartOptions"
-    />
+    <resizable-wrapper>
+      <ev-chart
+        :data="chartData"
+        :options="chartOptions"
+      />
+    </resizable-wrapper>
+
     <div class="description">
       <div class="row">
-        <div class="row-item">
-          <span class="item-title">
-            Max Value
-          </span>
-            <ev-input-number
-              v-model="maxValue"
-              class="component"
-              :min="1"
-            />
-        </div>
         <div class="row-item">
           <span class="item-title">
             Display Overflow
           </span>
           <ev-checkbox
             v-model="displayOverflow"
-            class="check-box"
+            class="component"
+          />
+        </div>
+      </div>
+      <div class="row">
+        <h3> YAxis Options</h3>
+      </div>
+      <div class="row">
+        <div class="row-item">
+          <span class="item-title">
+            use Range
+          </span>
+          <ev-toggle
+            v-model="useRange"
+            class="component"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            Min Value
+          </span>
+          <ev-input-number
+            v-model="minValue"
+            class="component"
+            :min="0"
+            :disabled="!useRange"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            Max Value
+          </span>
+          <ev-input-number
+            v-model="maxValue"
+            class="component"
+            :min="0"
+            :disabled="!useRange"
+          />
+        </div>
+      </div>
+      <div class="row">
+        <div class="row-item">
+          <span class="item-title">
+            use Interval
+          </span>
+          <ev-toggle
+            v-model="useInterval"
+            class="component"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            Interval
+          </span>
+          <ev-input-number
+            v-model="interval"
+            class="component"
+            :min="0"
+            :disabled="!useInterval"
+          />
+        </div>
+      </div>
+      <div class="row">
+        <div class="sub-description">
+          range 옵션과 interval 옵션이 호환되지 않는다면, interval 옵션은 무시됩니다.
+        </div>
+      </div>
+      <div class="row">
+        <div class="row-item">
+          <span class="item-title">
+            is Auto Decimal
+          </span>
+          <ev-toggle
+            v-model="isAutoDecimal"
+            class="component"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            Decimal Point
+          </span>
+          <ev-input-number
+            v-model="decimalPoint"
+            class="component"
+            :disabled="isAutoDecimal"
+            :min="0"
           />
         </div>
       </div>
@@ -63,15 +141,21 @@ import EvCheckbox from '@/components/checkbox/Checkbox';
             { x: 184, y: 78 }, { x: 175, y: 62 }, { x: 184, y: 81 },
             { x: 180, y: 76 }, { x: 177, y: 83 }, { x: 192, y: 90, color: '#FF0000' },
             { x: 176, y: 74 }, { x: 174, y: 71 }, { x: 184, y: 79 },
-            { x: 192, y: 93, color: '#FF0000' }, { x: 171, y: 70 }, { x: 173, y: 72 },
+            { x: 10, y: 4, color: '#FF0000' }, { x: 171, y: 70 }, { x: 173, y: 72 },
             { x: 176, y: 85 }, { x: 176, y: 78 }, { x: 180, y: 77 },
             { x: 172, y: 66 }, { x: 176, y: 86 }, { x: 173, y: 81 },
           ],
         },
       });
 
-      const maxValue = ref(60);
+      const maxValue = ref(10);
+      const minValue = ref(0);
+      const decimalPoint = ref(0);
+      const isAutoDecimal = ref(true);
       const displayOverflow = ref(true);
+      const interval = ref(5);
+      const useInterval = ref(false);
+      const useRange = ref(true);
 
       const chartOptions = computed(() => ({
         type: 'scatter',
@@ -80,46 +164,13 @@ import EvCheckbox from '@/components/checkbox/Checkbox';
         padding: { top: 20, right: 2, bottom: 4, left: 2 },
         axesX: [{
           type: 'linear',
-          showAxis: true,
-          startToZero: true,
-          autoScaleRatio: null,
-          showGrid: true,
-          axisLineColor: '#C9CFDC',
-          gridLineColor: '#C9CFDC',
-          interval: null,
-          labelStyle: {
-            show: true,
-            fontSize: 12,
-            color: '#25262E',
-            fontFamily: 'Roboto',
-            fitWidth: false,
-            fitDir: 'right',
-          },
-          plotLines: [],
-          plotBands: [],
-          formatter: null,
         }],
         axesY: [{
           type: 'linear',
-          showAxis: true,
-          startToZero: false,
-          autoScaleRatio: null,
-          showGrid: true,
-          axisLineColor: '#C9CFDC',
-          gridLineColor: '#C9CFDC',
-          interval: 1,
-          labelStyle: {
-            show: true,
-            fontSize: 12,
-            color: '#25262E',
-            fontFamily: 'Roboto',
-            fitWidth: false,
-            fitDir: 'right',
-          },
-          plotLines: [],
-          plotBands: [],
-          formatter: null,
-          range: [0, maxValue.value],
+          startToZero: true,
+          decimalPoint: isAutoDecimal.value ? 'auto' : decimalPoint.value,
+          range: useRange.value ? [minValue.value, maxValue.value] : null,
+          interval: useInterval.value ? interval.value : null,
         }],
         title: {
           text: '',
@@ -152,8 +203,14 @@ import EvCheckbox from '@/components/checkbox/Checkbox';
       return {
         chartData,
         maxValue,
+        minValue,
+        decimalPoint,
+        isAutoDecimal,
         displayOverflow,
         chartOptions,
+        interval,
+        useInterval,
+        useRange,
       };
     },
   };
@@ -167,20 +224,32 @@ import EvCheckbox from '@/components/checkbox/Checkbox';
 
   .row {
     display: flex;
+    flex-direction: row;
     margin-top: 15px;
-    justify-content: space-between;
+    gap: 10px;
+
     .row-item {
-      flex: 1;
       display: flex;
+      align-items: center;
+      gap: 3px;
+
       .item-title {
         line-height: 33px;
         margin-right: 3px;
         min-width: 80px;
+        text-align: right;
+        white-space: nowrap;
+      }
+
+      .component {
+        max-width: 200px;
       }
     }
-    .check-box {
-      display: flex;
-      margin-left: 4px;
+
+    .sub-description {
+      font-size: 12px;
+      color: #666;
+      text-align: right;
     }
   }
 </style>

--- a/docs/views/scatterChart/example/DisplayOverflow.vue
+++ b/docs/views/scatterChart/example/DisplayOverflow.vue
@@ -248,7 +248,7 @@ import EvCheckbox from '@/components/checkbox/Checkbox';
 
     .sub-description {
       font-size: 12px;
-      color: #666;
+      color: #666666;
       text-align: right;
     }
   }

--- a/docs/views/scatterChart/example/TimeAxis.vue
+++ b/docs/views/scatterChart/example/TimeAxis.vue
@@ -1,0 +1,238 @@
+<template>
+  <div class="case">
+    <resizable-wrapper>
+      <ev-chart
+        :data="chartData"
+        :options="chartOptions"
+      />
+    </resizable-wrapper>
+
+    <div class="description">
+      <div class="row">
+        <h3> X Axis Options</h3>
+      </div>
+      <div class="row">
+        <div class="row-item">
+          <span class="item-title">
+            use Interval
+          </span>
+          <ev-toggle
+            v-model="useInterval"
+            class="component"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            Interval Value
+          </span>
+          <ev-input-number
+            v-model="intervalValue"
+            class="component"
+            :min="0"
+            :disabled="!useInterval"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            Interval Unit
+          </span>
+          <ev-select
+            v-model="intervalUnit"
+            class="component"
+            :items="[{
+              name: 'second',
+              value: 'second',
+            }, {
+              name: 'minute',
+              value: 'minute',
+            }, {
+              name: 'hour',
+              value: 'hour',
+            }, {
+              name: 'day',
+              value: 'day',
+            }, {
+              name: 'week',
+              value: 'week',
+            }]"
+            :disabled="!useInterval"
+          />
+        </div>
+      </div>
+      <div class="row">
+        <div class="sub-description">
+          range 옵션과 interval 옵션이 호환되지 않는다면, interval 옵션은 무시됩니다.
+        </div>
+      </div>
+      <div class="row">
+        <div class="row-item">
+          <span class="item-title">
+            use Range
+          </span>
+          <ev-toggle
+            v-model="useRange"
+            class="component"
+          />
+        </div>
+        <div class="row-item">
+          <span class="item-title">
+            Range
+          </span>
+          <ev-date-picker
+            v-model="rangeDateTimes"
+            mode="dateTimeRange"
+            :options="{
+              timeFormat: ['HH:mm:ss', 'HH:mm:ss'],
+            }"
+            :disabled="!useRange"
+        />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, reactive, computed } from 'vue';
+import dayjs from 'dayjs';
+
+export default {
+  setup() {
+    const now = dayjs();
+    const threeHoursAgo = now.subtract(3, 'hour');
+    const sixHoursAgo = now.subtract(6, 'hour');
+    const twelveHoursAgo = now.subtract(12, 'hour');
+    const twentyFourHoursAgo = now.subtract(24, 'hour');
+    const threeDaysAgo = now.subtract(3, 'day');
+
+    // 최근 3시간 이내의 10초 간격 데이터 생성
+    const generateTimeSeriesData = (start, end) => {
+      const dataPoints = [];
+
+      let currentTime = end;
+      while (currentTime.isBefore(start) || currentTime.isSame(start)) {
+        const y = Math.floor(Math.random() * 100) + 1;
+        dataPoints.push({
+          x: currentTime.valueOf(),
+          y,
+        });
+        currentTime = currentTime.add(1, 'minute');
+      }
+
+      return dataPoints;
+    };
+
+    const chartData = reactive({
+      series: {
+        series1: { name: '현재~3시간전' },
+        series2: { name: '3시간전~6시간전' },
+        series3: { name: '6시간~12시간전' },
+        series4: { name: '12시간~24시간전' },
+        series5: { name: '24시간~3일전' },
+      },
+      data: {
+        series1: generateTimeSeriesData(now, threeHoursAgo),
+        series2: generateTimeSeriesData(threeHoursAgo, sixHoursAgo),
+        series3: generateTimeSeriesData(sixHoursAgo, twelveHoursAgo),
+        series4: generateTimeSeriesData(twelveHoursAgo, twentyFourHoursAgo),
+        series5: generateTimeSeriesData(twentyFourHoursAgo, threeDaysAgo),
+      },
+    });
+
+    const rangeDateTimes = ref([threeHoursAgo.format('YYYY-MM-DD HH:mm:ss'), now.format('YYYY-MM-DD HH:mm:ss')]);
+    const intervalValue = ref(10);
+    const intervalUnit = ref('minute');
+    const useInterval = ref(true);
+    const useRange = ref(false);
+
+    const chartOptions = computed(() => ({
+      type: 'scatter',
+      width: '100%',
+      height: '100%',
+      axesX: [{
+        type: 'time',
+        timeFormat: 'DD HH:mm:ss',
+        interval: useInterval.value ? {
+          time: intervalValue.value,
+          unit: intervalUnit.value,
+        } : 'second',
+        range: useRange.value ? [
+          dayjs(rangeDateTimes.value[0]).valueOf(),
+          dayjs(rangeDateTimes.value[1]).valueOf(),
+        ] : null,
+      }],
+      axesY: [{
+        type: 'linear',
+      }],
+      title: {
+        text: '',
+        show: false,
+      },
+      legend: {
+        show: true,
+        position: 'bottom',
+      },
+      tooltip: {
+        use: false,
+      },
+      selectItem: {
+        use: false,
+      },
+      dragSelection: {
+        use: false,
+        keepDisplay: true,
+        fillColor: '#38ACEC',
+        opacity: 0.65,
+      },
+    }));
+
+    return {
+      chartData,
+      intervalValue,
+      intervalUnit,
+      chartOptions,
+      rangeDateTimes,
+      useInterval,
+      useRange,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+  .description-label {
+    vertical-align: top;
+    margin-right: 3px;
+  }
+
+  .row {
+    display: flex;
+    flex-direction: row;
+    margin-top: 15px;
+    gap: 10px;
+
+    .row-item {
+      display: flex;
+      align-items: center;
+      gap: 3px;
+
+      .item-title {
+        line-height: 33px;
+        margin-right: 3px;
+        min-width: 80px;
+        text-align: right;
+        white-space: nowrap;
+      }
+
+      .component {
+        max-width: 200px;
+      }
+    }
+
+    .sub-description {
+      font-size: 12px;
+      color: #666;
+      text-align: right;
+    }
+  }
+</style>

--- a/docs/views/scatterChart/example/TimeAxis.vue
+++ b/docs/views/scatterChart/example/TimeAxis.vue
@@ -231,7 +231,7 @@ export default {
 
     .sub-description {
       font-size: 12px;
-      color: #666;
+      color: #666666;
       text-align: right;
     }
   }

--- a/docs/views/scatterChart/props.js
+++ b/docs/views/scatterChart/props.js
@@ -12,6 +12,8 @@ import DisplayOverflow from './example/DisplayOverflow';
 import DisplayOverflowRaw from '!!raw-loader!./example/DisplayOverflow';
 import RealTimeScatter from './example/RealTimeScatter';
 import RealTimeScatterRaw from '!!raw-loader!./example/RealTimeScatter';
+import TimeAxis from './example/TimeAxis';
+import TimeAxisRaw from '!!raw-loader!./example/TimeAxis';
 
 export default {
   mdText,
@@ -37,9 +39,14 @@ export default {
       parsedData: parseComponent(PlotLineRaw),
     },
     'Display Overflow': {
-      description: 'range 옵션으로 지정한 Y축의 최댓값을 표시합니다.',
+      description: '축의 max값보다 큰 값을 표시할지의 여부를 결정합니다.',
       component: DisplayOverflow,
       parsedData: parseComponent(DisplayOverflowRaw),
+    },
+    'Time Axis': {
+      description: 'Time Axis를 표시합니다. range, interval 옵션을 사용하여 축의 범위와 간격을 지정할 수 있습니다.',
+      component: TimeAxis,
+      parsedData: parseComponent(TimeAxisRaw),
     },
     RealTimeScatter: {
       description: '실시간으로 대량의 데이터를 처리합니다.',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.151",
+  "version": "3.4.152",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/scale/scale.linear.js
+++ b/src/components/chart/scale/scale.linear.js
@@ -11,7 +11,8 @@ class LinearScale extends Scale {
    * @returns {string} formatted label
    */
   getTruthyValue(value) {
-    return truthyNumber(value) ? Number(value.toFixed(this.decimalPoint)) : value;
+    const decimalPoint = this.adjustedDecimalPoint ?? this.decimalPoint;
+    return truthyNumber(value) ? Number(value.toFixed(decimalPoint)) : value;
   }
 
   getLabelFormat(value, data = {}) {
@@ -31,8 +32,8 @@ class LinearScale extends Scale {
       }
     }
 
-
-    return Util.labelSignFormat(value, this.decimalPoint);
+    const decimalPoint = this.adjustedDecimalPoint ?? this.decimalPoint;
+    return Util.labelSignFormat(value, decimalPoint);
   }
 
 
@@ -58,41 +59,171 @@ class LinearScale extends Scale {
     return Math.ceil((max - min) / step);
   }
 
-    /**
-   * Get decimal point from range
-   * @param {object} {
-   *  graphRange: number,
-   *  numberOfSteps: number,
-   *  interval: number,
-   * }
+
+  /**
+   * Get auto decimal point from interval
+   * interval을 표현할 수 있는 최소 decimal 반환
+   * 너무 긴 decimal은 제한
+   * @param {number} interval
    * @returns {number} decimal point
    */
-  getDecimalPointFromRange({
-    graphRange,
-    numberOfSteps,
-  }) {
-    if (numberOfSteps <= 0 || graphRange === 0) {
+  getAutoDecimalPointFromInterval(interval) {
+    if (!isFinite(interval) || interval === 0) {
       return 0;
     }
 
-    const interval = graphRange / numberOfSteps;
-    if (interval === 0) {
-      return 0;
+    const absInterval = Math.abs(interval);
+
+    // 1 미만 값 처리 (소수점 최대 10자리 제한)
+    if (absInterval < 1) {
+      let decimals = 0;
+      let temp = absInterval;
+
+      while (temp < 1) {
+        temp *= 10;
+        decimals++;
+
+        if (decimals > 10) {
+          break;
+        }
+      }
+
+      return decimals;
     }
 
-    let decimals = 0;
-    let temp = interval;
+    // 1 이상 값 처리 (소수점 최대 2자리 제한)
+    for (let decimal = 0; decimal <= 6; decimal++) {
+      const rounded = Number(absInterval.toFixed(decimal));
 
-    while (temp < 1) {
-      temp *= 10;
-      decimals++;
-
-      if (decimals > 10) {
-        break;
+      if (Math.abs(rounded - absInterval) < 1e-10) {
+        return Math.min(decimal, 2);
       }
     }
 
-    return decimals;
+    return 2;
+  }
+
+  /**
+   * axis interval을 nice number로 변환
+   * (1, 2, 5 × 10^n)
+   *
+   * @param {Object} params
+   * @param {number} params.range
+   * @param {boolean} params.round
+   * @returns {number}
+   */
+  getNiceNumber({ range, round = false }) {
+    if (!isFinite(range) || range <= 0) {
+      return 0;
+    }
+
+    const exponent = Math.floor(Math.log10(range));
+    const fraction = range / (10 ** exponent);
+
+    let niceFraction;
+
+    if (round) {
+      if (fraction < 1.5) {
+        niceFraction = 1;
+      } else if (fraction < 3) {
+        niceFraction = 2;
+      } else if (fraction < 7) {
+        niceFraction = 5;
+      } else {
+        niceFraction = 10;
+      }
+    } else if (fraction <= 1) {
+      niceFraction = 1;
+    } else if (fraction <= 2) {
+      niceFraction = 2;
+    } else if (fraction <= 5) {
+      niceFraction = 5;
+    } else {
+      niceFraction = 10;
+    }
+
+    return niceFraction * (10 ** exponent);
+  }
+
+  /**
+   * With range information, calculate how many labels in axis
+   * @param {object} range    min/max information
+   *
+   * @returns {object} steps, interval, min/max graph value
+   */
+  calculateSteps(range) {
+    const { minValue, maxValue } = range;
+    const maxSteps = Math.max(1, range.maxSteps);
+
+    const hasUserRange = Array.isArray(this.range) && this.range.length === 2;
+    const hasUserInterval = (
+      typeof this.interval === 'number'
+      || (typeof this.interval === 'object' && this.interval !== null)
+    );
+
+    const resolvedInterval = hasUserInterval ? this.getInterval(range) : null;
+    const isValidInterval = (
+      resolvedInterval != null
+      && resolvedInterval > 0
+      && isFinite(resolvedInterval)
+    );
+
+    const graphMin = +minValue;
+    let graphMax = +maxValue;
+    const graphRange = graphMax - graphMin;
+
+    let interval;
+    let steps;
+
+    if (hasUserRange && isValidInterval) {
+      // 1) user range + interval
+      const candidateSteps = graphRange / resolvedInterval;
+      const isExactlyDividable = Math.abs(candidateSteps - Math.round(candidateSteps)) < 1e-10;
+
+      if (isExactlyDividable && candidateSteps <= maxSteps) {
+        interval = resolvedInterval;
+        steps = Math.round(candidateSteps);
+      } else {
+        // interval 호환되지 않음 -> 사용자 interval을 사용하지 않음
+        steps = maxSteps;
+        interval = graphRange / steps;
+      }
+    } else if (hasUserRange) {
+      // 2) user range only
+      steps = maxSteps;
+      interval = graphRange / steps;
+    } else if (isValidInterval) {
+      // 3) user interval only
+      interval = resolvedInterval;
+      steps = Math.ceil(graphRange / interval);
+
+      while (steps > maxSteps) {
+        interval *= 2;
+        steps = Math.ceil(graphRange / interval);
+      }
+
+      graphMax = graphMin + (interval * steps);
+    } else {
+      // 4) auto
+      interval = this.getNiceNumber({
+        range: graphRange / maxSteps,
+        round: true,
+      });
+
+      steps = Math.ceil(graphRange / interval);
+      graphMax = graphMin + (interval * steps);
+    }
+
+    this.adjustedDecimalPoint = this.decimalPoint === 'auto'
+      ? this.getAutoDecimalPointFromInterval(interval)
+      : this.decimalPoint;
+
+    return {
+      steps,
+      interval,
+      graphMin,
+      graphMax,
+    };
   }
 }
 

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -44,6 +44,100 @@ class TimeScale extends Scale {
     }
     return Math.ceil((max - min) / step);
   }
+
+  /**
+   * With range information, calculate how many labels in axis
+   * @param {object} range    min/max information
+   *
+   * @returns {object} steps, interval, min/max graph value
+  */
+  calculateSteps(range) {
+    const { maxValue, minValue, maxSteps } = range;
+
+    // 사용자 interval로 인식하는 경우: 숫자 또는 객체({ time, unit }) 형태만
+    // 문자열('hour', 'second' 등)은 기존 로직(분기 D)으로 처리
+    const hasUserRange = Array.isArray(this.range) && this.range.length === 2;
+    const hasUserInterval = (
+      typeof this.interval === 'number'
+      || (typeof this.interval === 'object' && this.interval !== null)
+    );
+
+    const resolvedInterval = hasUserInterval ? this.getInterval(range) : null;
+    const isValidInterval = (
+      resolvedInterval != null
+      && resolvedInterval > 0
+      && isFinite(resolvedInterval)
+    );
+
+    const graphMin = +minValue;
+    let graphMax = +maxValue;
+    const graphRange = graphMax - graphMin;
+
+    let interval;
+    let steps;
+
+    if (hasUserRange && isValidInterval) {
+      // 1) user range + interval
+      const candidateSteps = graphRange / resolvedInterval;
+      const isExactlyDividable = Math.abs(candidateSteps - Math.round(candidateSteps)) < 1e-10;
+      if (isExactlyDividable && candidateSteps <= maxSteps) {
+        // 1-1) interval 호환되는 경우
+        interval = resolvedInterval;
+        steps = Math.round(candidateSteps);
+      } else {
+        // 1-2) interval 호환되지 않음 -> 사용자 interval을 사용하지 않음
+        steps = maxSteps;
+        interval = graphRange / steps;
+      }
+    } else if (hasUserRange) {
+      // 2) user range only
+      steps = maxSteps;
+      interval = graphRange / steps;
+    } else if (isValidInterval) {
+      // 3) user interval only
+      interval = resolvedInterval;
+      steps = Math.ceil(graphRange / interval);
+      while (steps > maxSteps) {
+        interval *= 2;
+        steps = Math.ceil(graphRange / interval);
+      }
+      graphMax = graphMin + (interval * steps);
+    } else {
+      // 4) 기존 로직
+      interval = this.getInterval(range);
+      let increase = minValue;
+      let numberOfSteps;
+
+      while (increase < maxValue) {
+        increase += interval;
+      }
+
+      graphMax = increase;
+
+      numberOfSteps = Math.round(graphRange / interval);
+
+      while (numberOfSteps > maxSteps) {
+        interval *= 2;
+        numberOfSteps = Math.round(graphRange / interval);
+        const tempInterval = graphRange / numberOfSteps;
+        interval = this.decimalPoint ? tempInterval : Math.ceil(tempInterval);
+      }
+
+      if (graphMax - graphMin > (numberOfSteps * interval)) {
+        const tempInterval = (graphMax - graphMin) / numberOfSteps;
+        interval = this.decimalPoint ? tempInterval : Math.ceil(tempInterval);
+      }
+
+      steps = numberOfSteps;
+    }
+
+    return {
+      steps,
+      interval,
+      graphMin,
+      graphMax,
+    };
+  }
 }
 
 export default TimeScale;


### PR DESCRIPTION
# 이슈 원인
기존 로직은 steps를 우선 기준으로 axis를 계산하여 사용자 range 및 interval이 변경되는 경우가 있었습니다.
이번 변경에서는 사용자 설정(range, interval)을 우선 보장하도록 계산 순서를 조정했습니다.

# 변경내용 
1. `calculateSteps` 로직을 부모 클래스인 scale.js은 기존을 유지하고 scale.linear , scale.time 각각 구현 
   - <img width="843" height="233" alt="image" src="https://github.com/user-attachments/assets/5c296272-6fa5-4898-871a-736d09f4942e" />
2. linear 축 decimalPoint: auto 로직 일부 수정 

   - 1미만의 수 최대 10자리까지 보장 (기존 스펙)
   
   - 1이상의 수 최대 2자리까지 보장 (추가) 

# Before
1. Linear Scale > Range > Max Value 가 차트 크기에 따라 보장되지 않는 현상 발생 
   - <img width="731" height="369" alt="image" src="https://github.com/user-attachments/assets/974cdfcf-4e01-4b57-ac36-428fccedb4d7" />

 4. Time Scale > Interval 이 차트 크기에 따라 보장되지 않는 현상 발생 
    - <img width="746" height="337" alt="image" src="https://github.com/user-attachments/assets/d7fc15da-79e5-49c5-bd65-642949ac116f" />


# After
1. Range 보장
   - <img width="728" height="357" alt="image" src="https://github.com/user-attachments/assets/fdaeffd3-eee4-416b-b39f-9a1c6668bbeb" />

3. Interval 보장 
   - <img width="717" height="297" alt="image" src="https://github.com/user-attachments/assets/34777f32-5bdd-49fe-9daa-2b6064f98450" />
   
   
   
  # 테스트 가이드 
  
  http://localhost:9999/scatterChart#display-overflow
http://localhost:9999/scatterChart#time-axis


차트의 하단 및 우측에 Resize handler를 넣어두었습니다. 

옵션을 변경하면서 차트의 사이즈도 변경하여 축을 관찰해주세요

