### PR TITLE
feat: legend click emit 추가(3.4.120)

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -129,6 +129,7 @@ const chartData = {
 | selectLabel  | Object                    | ([상세](#selectlabel))                    | 차트 라벨 선택 기능 활성화 여부 및 속성                                                                                                                                                |                                 |
 | padding      | Object                    | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값                                                                                                                                                                   |                                 |
 | syncHover    | boolean                   | true                                      | options.syncHover가 true인 EvChartGroup으로 감싼경우, 해당 차트에서는 그룹으로 묶긴 차트들 사이의 syncHover선을 그리고싶지 않을 때 사용하는 속성 (time관련된 축을 가질때만 적용됩니다) |                                 |
+| eventBehavior | Object                    | ([상세](#eventbehavior))                  | 이벤트별 동작 설정 | | 
 
 #### axesX axesY
 
@@ -433,6 +434,14 @@ const chartOptions = {
 | tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  |            |
 | tipTextColor  | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상 |            |
 
+#### eventBehavior
+
+이벤트별 동작을 설정하는 옵션 객체.
+
+| 이름         | 타입   | 디폴트   | 설명                                                                 | 종류(예시)           |
+| ----------- | ------ | -------- | -------------------------------------------------------------------- | -------------------- |
+| legendClick | String | 'update' | 범례 클릭 시 동작. 'update': 차트 즉시 갱신, 'emitOnly': click-legend만 emit(이중 렌더 방지) | 'update' \| 'emitOnly' |
+
 - 3.4 버전부터 없어지는 옵션입니다.
 
 #### selectItem
@@ -497,5 +506,6 @@ const chartOptions = {
 | click      | selectedItem | 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                           |
 | dbl-click  | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                      |
 | mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환 |
+| click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환

--- a/docs/views/barChart/example/LegendClickMode.vue
+++ b/docs/views/barChart/example/LegendClickMode.vue
@@ -25,10 +25,11 @@
         inactive, 처음 클릭시 해당 시리즈만 감춤, 마지막 남은 범례 클릭시 무시
       </p>
     </div>
-    <ev-chart
-      :data="chartData"
-      :options="chartOptions"
-    />
+    <ev-chart :data="chartData" :options="chartOptions" @click-legend="handleClickLegend" />
+    <div class="result">
+      <div class="badge yellow">클릭된 시리즈 ID</div>
+      {{ clickedSeriesIds }}
+    </div>
   </div>
 </template>
 
@@ -85,10 +86,18 @@ export default {
       }],
     }));
 
+    const clickedSeriesIds = ref([]);
+
+    const handleClickLegend = (e) => {
+      clickedSeriesIds.value = e.data.seriesIds;
+    };
+
     return {
       legendClickMode,
       chartData,
       chartOptions,
+      clickedSeriesIds,
+      handleClickLegend,
     };
   },
 };

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -104,6 +104,7 @@ const chartData =
 | heatMapColor  | Object          | ([상세](#heatmap-color))                  | color 옵션                                                      |                                 |
 | selectItem    | Object          | ([상세](#selectitem))                     | 차트 아이템 선택 기능 활성화 여부 및 속성                       |                                 |
 | selectLabel   | Object          | ([상세](#selectlabel))                    | 차트 라벨 선택 기능 활성화 여부 및 속성                         |                                 |
+| eventBehavior | Object          | ([상세](#eventbehavior))                  | 이벤트별 동작 설정 | | 
 
 #### axesX axesY
 
@@ -364,6 +365,14 @@ const chartOptions = {
 | useBothAxis         | Boolean                     | false     | X축, Y축 두개 모두 이벤트 적용할지의 여부                                  |            |
 | tipBackground       | Hex, RGB, RGBA Code(String) | '#000000' | tip 배경색상                                                               |            |
 
+#### eventBehavior
+
+이벤트별 동작을 설정하는 옵션 객체.
+
+| 이름         | 타입   | 디폴트   | 설명                                                                 | 종류(예시)           |
+| ----------- | ------ | -------- | -------------------------------------------------------------------- | -------------------- |
+| legendClick | String | 'update' | 범례 클릭 시 동작. 'update': 차트 즉시 갱신, 'emitOnly': click-legend만 emit(이중 렌더 방지) | 'update' \| 'emitOnly' |
+
 ### 3. resize-timeout
 
 - Default : 0
@@ -375,6 +384,7 @@ const chartOptions = {
 | ----------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | drag-select | data, range | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
 | mouse-move  |             | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                                                |
+| click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 Index 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIndices: [0, 1,..], isActiveAll: false } <br><br> seriesIndices는 현재 활성화(highlight: true)된 시리즈의 Index 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
 
 - drag-select는 `dragSelection` 옵션의 `use`값이 `true` 일 때 이벤트를 발생 시킬 수 있다.
   그리고 선택영역은 그래프에 표시된 데이터의 중앙이 포함 되어야 선택영역 내 데이터로 인식 한다.

--- a/docs/views/heatMap/example/LegendClickMode.vue
+++ b/docs/views/heatMap/example/LegendClickMode.vue
@@ -25,10 +25,11 @@
         inactive, 처음 클릭시 해당 시리즈만 감춤, 마지막 남은 범례 클릭시 무시
       </p>
     </div>
-    <ev-chart
-      :data="chartData"
-      :options="chartOptions"
-    />
+    <ev-chart :data="chartData" :options="chartOptions" @click-legend="handleClickLegend" />
+    <div class="result">
+      <div class="badge yellow">클릭된 시리즈 ID</div>
+      {{ clickedSeriesIndices }}
+    </div>
   </div>
 </template>
 
@@ -91,10 +92,18 @@ import { reactive, ref, computed } from 'vue';
         },
       }));
 
+      const clickedSeriesIndices = ref([]);
+
+      const handleClickLegend = (e) => {
+        clickedSeriesIndices.value = e.data.seriesIndices;
+      };
+
       return {
         chartData,
         chartOptions,
         legendClickMode,
+        clickedSeriesIndices,
+        handleClickLegend,
       };
     },
   };

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -124,6 +124,7 @@ const chartData =
 | selectItem | Object          | ([상세](#selectitem))                     | 차트 아이템 선택 기능 활성화 여부 및 속성                                                                                                                                              |                                 |
 | padding    | Object          | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값                                                                                                                                                                   |
 | syncHover  | boolean         | true                                      | options.syncHover가 true인 EvChartGroup으로 감싼경우, 해당 차트에서는 그룹으로 묶긴 차트들 사이의 syncHover선을 그리고싶지 않을 때 사용하는 속성 (time관련된 축을 가질때만 적용됩니다) |
+| eventBehavior | Object                    | ([상세](#eventbehavior))                  | 이벤트별 동작 설정 | | 
 
 #### axesX axesY
 
@@ -428,6 +429,14 @@ const chartOptions = {
 | tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  |            |
 | tipTextColor  | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상 |            |
 
+#### eventBehavior
+
+이벤트별 동작을 설정하는 옵션 객체.
+
+| 이름         | 타입   | 디폴트   | 설명                                                                 | 종류(예시)           |
+| ----------- | ------ | -------- | -------------------------------------------------------------------- | -------------------- |
+| legendClick | String | 'update' | 범례 클릭 시 동작. 'update': 차트 즉시 갱신, 'emitOnly': click-legend만 emit(이중 렌더 방지) | 'update' \| 'emitOnly' |
+
 - 3.4 버전부터 없어지는 옵션입니다.
 
 #### selectLabel
@@ -492,5 +501,7 @@ const chartOptions = {
 | dbl-click   | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                                                                                                                                                                                     |
 | mouse-move  |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                                                |
 | drag-select | data, range  | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
+| click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
+
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환

--- a/docs/views/lineChart/example/LegendClickMode.vue
+++ b/docs/views/lineChart/example/LegendClickMode.vue
@@ -17,7 +17,11 @@
         inactive, 처음 클릭시 해당 시리즈만 감춤, 마지막 남은 범례 클릭시 무시
       </p>
     </div>
-    <ev-chart :data="chartData" :options="chartOptions" />
+    <ev-chart :data="chartData" :options="chartOptions" @click-legend="handleClickLegend" />
+    <div class="result">
+      <div class="badge yellow">클릭된 시리즈 ID</div>
+      {{ clickedSeriesIds }}
+    </div>
   </div>
 </template>
 
@@ -97,10 +101,18 @@ export default {
       }],
     }));
 
+    const clickedSeriesIds = ref([]);
+
+    const handleClickLegend = (e) => {
+      clickedSeriesIds.value = e.data.seriesIds;
+    };
+
     return {
       legendClickMode,
       chartData,
       chartOptions,
+      clickedSeriesIds,
+      handleClickLegend,
     };
   },
 };

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -79,6 +79,7 @@ const chartData =
 | doughnutHoleSize | number          | 0                                              | 내부 hole 사이즈                                                | 0 ~ 1                           |
 | pieStroke        | Object          | { show: true, color: '#FFFFFF', lineWidth: 2 } | 차트의 테두리선 표시 여부 및 색상, 두께를 설정하는 옵션         |                                 |
 | tooltip          | Object          | ([상세](#tooltip))                             | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성                |                                 |
+| eventBehavior    | Object          | ([상세](#eventbehavior))                       | 이벤트별 동작 설정 | | 
 
 #### title
 
@@ -205,6 +206,14 @@ const chartOptions = {
 | ---- | ------- | ------ | --------------------- | ---------- |
 | use  | Boolean | false  | 차트 아이템 선택 기능 |            |
 
+#### eventBehavior
+
+이벤트별 동작을 설정하는 옵션 객체.
+
+| 이름         | 타입   | 디폴트   | 설명                                                                 | 종류(예시)           |
+| ----------- | ------ | -------- | -------------------------------------------------------------------- | -------------------- |
+| legendClick | String | 'update' | 범례 클릭 시 동작. 'update': 차트 즉시 갱신, 'emitOnly': click-legend만 emit(이중 렌더 방지) | 'update' \| 'emitOnly' |
+
 ### 4. resize-timeout
 
 - Default : 0
@@ -216,5 +225,6 @@ const chartOptions = {
 | --------- | ------------ | ---------------------------------------------- |
 | click     | selectedItem | 클릭된 series의 value, seriesID 값을 반환      |
 | dbl-click | selectedItem | 더블 클릭된 series의 value, seriesID 값을 반환 |
+| click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -80,6 +80,7 @@ const chartData =
   | realTimeScatter | Object | ([상세](#realtimescatter)) | 실시간으로 데이터를 처리하는 real time scatter로 변경 여부 및 속성 | |
   | seriesReverse | Boolean | false | 시리즈 순서 반대로 표시 여부 | |
   | coordinateDedupe | Boolean | true | 좌표 중복 제거 여부 | |
+  | eventBehavior | Object | ([상세](#eventbehavior)) | 이벤트별 동작 설정 | | 
 
 #### axesX axesY
 
@@ -333,6 +334,14 @@ const chartOptions = {
 | tipBackground | Hex, RGB, RGBA Code(String) | '#000000' | maxTip 배경색상  | |
 | tipTextColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | maxTip 글자 색상  | |
 
+#### eventBehavior
+
+이벤트별 동작을 설정하는 옵션 객체.
+
+| 이름         | 타입   | 디폴트   | 설명                                                                 | 종류(예시)           |
+| ----------- | ------ | -------- | -------------------------------------------------------------------- | -------------------- |
+| legendClick | String | 'update' | 범례 클릭 시 동작. 'update': 차트 즉시 갱신, 'emitOnly': click-legend만 emit(이중 렌더 방지) | 'update' \| 'emitOnly' |
+
 - 3.4 버전부터 없어지는 옵션입니다.
 
 ##### tipStyle
@@ -357,6 +366,7 @@ const chartOptions = {
  |------|----------|------|
  | mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                 |
  | drag-select | data, range | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
+| click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
 
 - drag-select는  `dragSelection` 옵션의 `use`값이 `true` 일 때 이벤트를 발생 시킬 수 있다.
  그리고 선택영역은 그래프에 표시된 데이터의 중앙이 포함 되어야 선택영역 내 데이터로 인식 한다.

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -34,70 +34,71 @@
   import EvChartToolbar from './ChartToolbar';
   import { useModel, useWrapper, useZoomModel } from './uses';
 
-  export default {
-    name: 'EvChart',
-    components: {
-      EvChartToolbar,
+export default {
+  name: 'EvChart',
+  components: {
+    EvChartToolbar,
+  },
+  props: {
+    selectedItem: {
+      type: Object,
+      default: null,
     },
-    props: {
-      selectedItem: {
-        type: Object,
-        default: null,
-      },
-      selectedLabel: {
-        type: Object,
-        default: null,
-      },
-      selectedSeries: {
-        type: Object,
-        default: null,
-      },
-      options: {
-        type: Object,
-        default: () => ({}),
-      },
-      data: {
-        type: Object,
-        default: () => ({}),
-      },
-      resizeTimeout: {
-        type: Number,
-        default: 0,
-      },
-      zoomStartIdx: {
-        type: Number,
-        default: 0,
-      },
-      zoomEndIdx: {
-        type: Number,
-        default: 0,
-      },
-      realTimeScatterReset: {
-        type: Boolean,
-        default: false,
-      },
+    selectedLabel: {
+      type: Object,
+      default: null,
     },
-    emits: [
-      'click',
-      'dbl-click',
-      'drag-select',
-      'mouse-move',
-      'update:selectedItem',
-      'update:selectedLabel',
-      'update:selectedSeries',
-      'update:zoomStartIdx',
-      'update:zoomEndIdx',
-      'update:realTimeScatterReset',
-    ],
-    setup(props, { emit }) {
-      let evChart = null;
-      const isMounted = ref(false);
-      const injectIsChartGroup = inject('isChartGroup', false);
-      const injectBrushSeries = inject('brushSeries', { list: [], chartIdx: null });
-      const injectGroupSelectedLabel = inject('groupSelectedLabel', null);
-      const injectGroupHoveredLabel = inject('groupHoveredLabel', null);
-      const injectBrushIdx = inject('brushIdx', { start: 0, end: -1 });
-      const injectEvChartPropsInGroup = inject('evChartPropsInGroup', []);
+    selectedSeries: {
+      type: Object,
+      default: null,
+    },
+    options: {
+      type: Object,
+      default: () => ({}),
+    },
+    data: {
+      type: Object,
+      default: () => ({}),
+    },
+    resizeTimeout: {
+      type: Number,
+      default: 0,
+    },
+    zoomStartIdx: {
+      type: Number,
+      default: 0,
+    },
+    zoomEndIdx: {
+      type: Number,
+      default: 0,
+    },
+    realTimeScatterReset: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: [
+    'click',
+    'dbl-click',
+    'drag-select',
+    'mouse-move',
+    'update:selectedItem',
+    'update:selectedLabel',
+    'update:selectedSeries',
+    'update:zoomStartIdx',
+    'update:zoomEndIdx',
+    'update:realTimeScatterReset',
+    'click-legend',
+  ],
+  setup(props, { emit }) {
+    let evChart = null;
+    const isMounted = ref(false);
+    const injectIsChartGroup = inject('isChartGroup', false);
+    const injectBrushSeries = inject('brushSeries', { list: [], chartIdx: null });
+    const injectGroupSelectedLabel = inject('groupSelectedLabel', null);
+    const injectGroupHoveredLabel = inject('groupHoveredLabel', null);
+    const injectBrushIdx = inject('brushIdx', { start: 0, end: -1 });
+    const injectEvChartPropsInGroup = inject('evChartPropsInGroup', []);
 
       const {
         eventListeners,
@@ -269,9 +270,12 @@
 
           emit('update:realTimeScatterReset', false);
         }
-      });
+      },
+    );
 
-      watch(() => props.options.realTimeScatter?.use, (use) => {
+    watch(
+      () => props.options.realTimeScatter?.use,
+      (use) => {
         evChart.options.realTimeScatter.use = use ?? false;
 
         evChart.update({

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -550,8 +550,8 @@ const modules = {
       }
 
       // click-legend event 발생
-      const activeSeries = Object.values(this.seriesList).filter((series) => series.show);
-      const activeSeriesIds = activeSeries.map((series) => series.sId);
+      const activeSeries = Object.values(this.seriesList).filter(series => series.show);
+      const activeSeriesIds = activeSeries.map(series => series.sId);
       const isActiveAll = activeSeriesIds.length === Object.values(this.seriesList).length;
       const args = {
         e,
@@ -775,9 +775,9 @@ const modules = {
         });
       }
 
-      //click-legend event 발생
-      const activeSeries = series.colorState.filter((colorItem) => colorItem.show);
-      const activeSerieIndices = activeSeries.map((colorItem) => +colorItem.id.split('#')[1]);
+      // click-legend event 발생
+      const activeSeries = series.colorState.filter(colorItem => colorItem.show);
+      const activeSerieIndices = activeSeries.map(colorItem => +colorItem.id.split('#')[1]);
       const isActiveAll = series.colorState.length === activeSeries.length;
       const args = {
         e,

--- a/src/components/chart/plugins/plugins.legend.js
+++ b/src/components/chart/plugins/plugins.legend.js
@@ -542,10 +542,28 @@ const modules = {
         this.brushSeries.chartIdx = chartIdx;
       }
 
-      this.update({
-        updateSeries: false,
-        updateSelTip: { update: true, keepDomain: true },
-      });
+      if (this.options.eventBehavior?.legendClick !== 'emitOnly') {
+        this.update({
+          updateSeries: false,
+          updateSelTip: { update: true, keepDomain: true },
+        });
+      }
+
+      // click-legend event 발생
+      const activeSeries = Object.values(this.seriesList).filter((series) => series.show);
+      const activeSeriesIds = activeSeries.map((series) => series.sId);
+      const isActiveAll = activeSeriesIds.length === Object.values(this.seriesList).length;
+      const args = {
+        e,
+        data: {
+          seriesIds: isActiveAll ? [] : activeSeriesIds,
+          isActiveAll,
+        },
+      };
+
+      if (typeof this.listeners['click-legend'] === 'function') {
+        this.listeners['click-legend'](args);
+      }
     };
 
     /**
@@ -750,10 +768,28 @@ const modules = {
         }
       }
 
-      this.update({
-        updateSeries: false,
-        updateSelTip: { update: true, keepDomain: true },
-      });
+      if (this.options.eventBehavior?.legendClick !== 'emitOnly') {
+        this.update({
+          updateSeries: false,
+          updateSelTip: { update: true, keepDomain: true },
+        });
+      }
+
+      //click-legend event 발생
+      const activeSeries = series.colorState.filter((colorItem) => colorItem.show);
+      const activeSerieIndices = activeSeries.map((colorItem) => +colorItem.id.split('#')[1]);
+      const isActiveAll = series.colorState.length === activeSeries.length;
+      const args = {
+        e,
+        data: {
+          seriesIndices: isActiveAll ? [] : activeSerieIndices,
+          isActiveAll,
+        },
+      };
+
+      if (typeof this.listeners['click-legend'] === 'function') {
+        this.listeners['click-legend'](args);
+      }
     };
 
     /**

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -248,6 +248,9 @@ const DEFAULT_OPTIONS = {
   },
   seriesReverse: false,
   coordinateDedupe: true,
+  eventBehavior: {
+    legendClick: 'update',
+  },
 };
 
 const DEFAULT_DATA = {
@@ -401,6 +404,10 @@ export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
       if (injectGroupHoveredLabel?.value) {
         injectGroupHoveredLabel.value.label = null;
       }
+    },
+    'click-legend': async (e) => {
+      await nextTick();
+      emit('click-legend', e);
     },
   };
 


### PR DESCRIPTION
[이슈]
범례 클릭했을 때 차트 내부에서 컨트롤 하기 때문에 emit 이벤트가 따로 없음
차트 외부에서도 현재 활성화된 범례를 알 수 있도록 하기 위해 emit 이벤트 추가 필요

[변경 사항]

- click-legend 이벤트 추가
  - 반환값
     1. seriesIds: 활성화된 시리즈 ID
     2. isActiveAll: 모두 활성 여부 
  - 단, 모두 활성화됐을 때 seriesIds를 빈배열로 보냄
  

<img width="1374" height="902" alt="image" src="https://github.com/user-attachments/assets/cb072157-5d42-43fb-ac43-4a9ac1c10820" />

- eventBehavior 옵션 추가
   - 이벤트별 동작 설정
   - legendClick: 'update' | 'emitOnly' 
      - 'update' : 범례 클릭시 차트 즉시 갱신
      - 'emitOnly': 범례 클릭시 emit만 올림, 차트 갱신 x  
      
 
<img width="1110" height="479" alt="image" src="https://github.com/user-attachments/assets/725bb22e-427a-4371-9f50-544fd9938c70" />


[테스트 방법]
Line, Bar, Heatmap LegendClickMode 예제에서 범례를 클릭했을 때 활성화된 시리즈 id가 반환되는지 확인해주세요.