### PR TITLE
[#2154] [3.4] Chart > step axis >  max width 로직 개선

### DIFF
--- a/docs/views/barChart/example/Horizontal.vue
+++ b/docs/views/barChart/example/Horizontal.vue
@@ -35,9 +35,9 @@ export default {
           },
         },
       },
-      labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+      labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'LONG_LONG_LONG_LABEL'],
       data: {
-        series1: [1500.123456, 180.123456, 30.123456, 10, 0],
+        series1: [1500.123456, 180.123456, 30.123456, 10, 0, 0],
       },
     };
 
@@ -69,6 +69,19 @@ export default {
         {
           type: 'step',
           showGrid: false,
+          labelStyle: {
+            show: true,
+            fontSize: 12,
+            color: '#25262E',
+            fontFamily: 'Roboto',
+            fontWeight: 400,
+            fitDir: 'right',
+            alignToGridLine: false,
+            padding: 0,
+            fitWidth: true,
+            // maxWidth: 300, // px
+            maxWidth: '10%',
+          }
         },
       ],
       indicator: {

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -238,6 +238,8 @@ export default {
       return { width: 2, height: 2 };
     }
 
+    textMeasureCtx.save();
+
     textMeasureCtx.font = fontStyle;
     const metrics = textMeasureCtx.measureText(text);
 
@@ -246,6 +248,8 @@ export default {
 
     // DOM 기본 line-height 보정 (대략 1.2 ~ 1.3)
     const lineHeight = fontSize * 1.2;
+
+    textMeasureCtx.restore();
 
     return {
       width: Math.max(Math.ceil(metrics.width), 2),

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -12,6 +12,26 @@ class StepScale extends Scale {
   }
 
   /**
+   * get max width from labelStyle
+   * maxWidth : number | string
+   * @param {object} chartRect chart size information
+   * @returns {number} max width
+   */
+  getMaxWidth(chartRect) {
+    let maxWidth = this.labelStyle?.maxWidth ?? chartRect.chartWidth * 0.5;
+
+    if (typeof this.labelStyle?.maxWidth === 'string') {
+      if (this.labelStyle?.maxWidth.includes('%')) {
+        maxWidth = chartRect.chartWidth * (parseInt(this.labelStyle?.maxWidth.replace('%', '')) / 100);
+      } else {
+        maxWidth = parseInt(this.labelStyle?.maxWidth);
+      }
+    }
+
+    return maxWidth;
+  }
+
+  /**
    * Calculate min/max value, label and size information for step scale
    * @param {object} minMax       min/max information (unused on step scale)
    * @param {object} scrollbarOpt    scroll bar option
@@ -26,7 +46,6 @@ class StepScale extends Scale {
 
     let minIndex = 0;
     let maxIndex = this.labels.length - 1;
-    let labelCount = this.labels.length;
 
     const range = scrollbarOpt?.use ? scrollbarOpt?.range : this.range;
     if (Array.isArray(range) && range?.length) {
@@ -36,7 +55,6 @@ class StepScale extends Scale {
         maxIndex = max > maxIndex ? maxIndex : max;
         maxValue = this.labels[maxIndex];
         minValue = this.labels[minIndex];
-        labelCount = maxIndex - minIndex + 1;
       }
     } else if (typeof range === 'function') {
       const [min, max] = range(minValue, maxValue);
@@ -44,10 +62,9 @@ class StepScale extends Scale {
       maxIndex = max > maxIndex ? maxIndex : max;
       maxValue = this.labels[maxIndex];
       minValue = this.labels[minIndex];
-      labelCount = maxIndex - minIndex + 1;
     }
 
-    const maxWidth = this.labelStyle?.maxWidth ?? chartRect.chartWidth / (labelCount + 2);
+    const maxWidth = this.getMaxWidth(chartRect);
 
     return {
       min: minValue,
@@ -129,7 +146,7 @@ class StepScale extends Scale {
     const endPoint = aPos[this.units.rectEnd];
     const offsetPoint = aPos[this.units.rectOffset(this.position)];
     const offsetCounterPoint = aPos[this.units.rectOffsetCounter(this.position)];
-    const maxWidth = this.labelStyle?.maxWidth ?? chartRect.chartWidth / (steps + 2);
+    const maxWidth = this.getMaxWidth(chartRect);
 
     const AXIS_TICK_LENGTH = 5;
 
@@ -414,7 +431,10 @@ class StepScale extends Scale {
     ctx.font = Util.getLabelStyle(this.labelStyle);
     const dir = this.labelStyle.fitDir;
 
-    return Util.truncateLabelWithEllipsis(value, maxWidth, ctx, dir);
+    const result = Util.truncateLabelWithEllipsis(value, maxWidth, ctx, dir);
+    ctx.restore();
+
+    return result;
   }
 
   /**
@@ -427,8 +447,7 @@ class StepScale extends Scale {
   getLabelWidthHasMaxLength(notFormattedLabels, chartRect) {
     // fontSize를 포함한 labelStyle 가져오기
     const labelStyle = Util.getLabelStyle(this.labelStyle);
-    const labelCount = notFormattedLabels?.length ?? 0;
-    const maxWidth = this.labelStyle?.maxWidth ?? chartRect?.chartWidth / (labelCount + 2);
+    const maxWidth = this.getMaxWidth(chartRect);
 
     return (notFormattedLabels ?? []).reduce((max, label) => {
       // ellipsis가 적용된 label의 width를 계산


### PR DESCRIPTION
### 개요 
- Step Axis > maxWidth 옵션이 number (px 단위) 로만 받을 수 있음
- 차트 너비에 기반한 Percentage 값도 수용 요청


### 수정 사항
- maxWidth 로직 개선 
   - '%' 가 포함된 문자열일 경우, 차트 너비를 기준으로 계산해서 값을 얻도록 하는 로직 추가 

### 결과 
- 기존 number 값
   - ![max_width_px](https://github.com/user-attachments/assets/b236eb07-f2e5-4069-acb2-10e7a4641982)
- Percentage 값
   - ![max_width_percentage](https://github.com/user-attachments/assets/64a168da-36b2-4cfa-b470-7beea0830127)
   
   
   
 ### 테스트 가이드 
 http://localhost:9999/EVUI/barChart#horizontal
 
 Horizontal.vue 예제의 maxWidth 값 및 labels 값을 수정하면서 테스트 부탁드립니다.
 