### PR TITLE
feat: 축의 스케일 계산 결과를 외부로 전달하는 `axes-scale-change` 이벤트 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -532,6 +532,6 @@ const chartOptions = {
 | dbl-click  | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                      |
 | mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환 |
 | click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
-| axes-scale-change | | 차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 정보를 반환한다.  단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다. <br><br> {<br> x: { graphMin, graphMax, step, interval }, <br>   y: { graphMin, graphMax, step, interval }<br>} | |
+| axes-scale-change | | 차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 정보를 반환한다. 단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다. ex)<br><br> {<br> x: { minSteps, maxSteps }, <br>   y: { minSteps, maxSteps }<br>} | |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -531,5 +531,6 @@ const chartOptions = {
 | dbl-click  | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                      |
 | mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환 |
 | click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
+| axes-scale-change | | 차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 정보를 반환한다. <br><br> {<br> x: { graphMin, graphMax, step, interval }, <br>   y: { graphMin, graphMax, step, interval }<br>} | |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -532,6 +532,6 @@ const chartOptions = {
 | dbl-click  | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                      |
 | mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환 |
 | click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
-| axes-scale-change | | 차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 정보를 반환한다. 단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다. ex)<br><br> {<br> x: { minSteps, maxSteps }, <br>   y: { minSteps, maxSteps }<br>} | |
+| axes-scale-change | | 차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 정보를 반환한다. 단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다. ex)<br><br> {<br> x: [{ minSteps, maxSteps }], <br>   y: [{ minSteps, maxSteps }]<br>} | |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -179,6 +179,7 @@ const chartData = {
 | showAxisTick   | Boolean   | true    | 보조 눈금 표시 여부                                     |                                                         |
 | fixedSteps  | Boolean  | false    | range와 interval로 설정한 값을 그대로 사용하여 step을 고정. 자동 스케일 조정을 비활성화하며, 원하는 간격으로 축을 표시할 때 사용  | |
 | niceScale   | Boolean  | false    | 축 타입이 linear 인 경우 nice scale 알고리즘을 적용하여 최적의 최대값과 간격을 계산하여 축을 그림                           | |
+| scaleChange | Boolean  | false    | scale 변경을 감지하여 emit 발생시킬때 사용, true일때 scale이 변경되면 axes-scale-range 이벤트가 발생된다. | | 
 
 ##### axesX
 
@@ -531,6 +532,6 @@ const chartOptions = {
 | dbl-click  | selectedItem | 더블 클릭된 series의 label, value, seriesID 값을 반환                                                                                                                      |
 | mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환 |
 | click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
-| axes-scale-change | | 차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 정보를 반환한다. <br><br> {<br> x: { graphMin, graphMax, step, interval }, <br>   y: { graphMin, graphMax, step, interval }<br>} | |
+| axes-scale-change | | 차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 정보를 반환한다.  단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다. <br><br> {<br> x: { graphMin, graphMax, step, interval }, <br>   y: { graphMin, graphMax, step, interval }<br>} | |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환

--- a/docs/views/barChart/example/AxesScaleChange.vue
+++ b/docs/views/barChart/example/AxesScaleChange.vue
@@ -1,0 +1,190 @@
+<template>
+  <div class="case">
+    <div class="chart-container" :style="{ width: chartWidth + 'px', height: chartHeight + 'px' }">
+      <ev-chart
+        :data="chartData"
+        :options="chartOptions"
+        @axes-scale-change="onStepsCalculated"
+      />
+    </div>
+    <div class="info-box">
+      <table v-if="axesSteps">
+        <thead>
+          <tr>
+            <th>축</th>
+            <th>steps</th>
+            <th>interval</th>
+            <th>graphMin</th>
+            <th>graphMax</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>X[0]</td>
+            <td>{{ axesSteps.x[0]?.steps }}</td>
+            <td>{{ axesSteps.x[0]?.interval }}</td>
+            <td>{{ axesSteps.x[0]?.graphMin }}</td>
+            <td>{{ axesSteps.x[0]?.graphMax }}</td>
+          </tr>
+          <tr>
+            <td>Y[0]</td>
+            <td>{{ axesSteps.y[0]?.steps }}</td>
+            <td>{{ axesSteps.y[0]?.interval }}</td>
+            <td>{{ axesSteps.y[0]?.graphMin }}</td>
+            <td>{{ axesSteps.y[0]?.graphMax }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="description">
+      <span class="toggle-label">너비 ({{ chartWidth }}px)</span>
+      <ev-input-number v-model="chartWidth" :step="50" :min="300" :max="1000" />
+      <span class="toggle-label">높이 ({{ chartHeight }}px)</span>
+      <ev-input-number v-model="chartHeight" :step="20" :min="150" :max="500" />
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, onMounted, reactive } from 'vue';
+import dayjs from 'dayjs';
+import EvInputNumber from '../../../../src/components/inputNumber/InputNumber';
+
+export default {
+  components: {
+    EvInputNumber,
+  },
+  setup() {
+    const chartData = reactive({
+      series: {
+        series1: { name: 'series#1', point: false },
+        series2: { name: 'series#2', point: false },
+      },
+      labels: [],
+      data: {
+        series1: [],
+        series2: [],
+      },
+    });
+
+    const chartWidth = ref(600);
+    const chartHeight = ref(280);
+    const axesSteps = ref(null);
+
+    const chartOptions = reactive({
+      type: 'bar',
+      width: '100%',
+      height: '100%',
+      padding: {
+        top: 20,
+        right: 2,
+        left: 2,
+        bottom: 4,
+      },
+      title: {
+        text: '리사이즈 시 axesSteps 변화',
+        show: true,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesX: [
+        {
+          type: 'time',
+          timeFormat: 'DD HH:mm',
+          interval: 'hour',
+          formatter: (value, data) => {
+            if (data?.prev) {
+              const curr = dayjs(value).format('yy-MM-DD');
+              const prev = dayjs(data?.prev).format('yy-MM-DD');
+              if (curr === prev) {
+                return dayjs(value).format('HH:mm');
+              }
+            }
+            return dayjs(value).format('DD HH:mm');
+          },
+          showAxisTick: true,
+        },
+      ],
+      axesY: [
+        {
+          type: 'linear',
+          showGrid: true,
+          showAxisTick: true,
+        },
+      ],
+    });
+
+    const onStepsCalculated = (result) => {
+      axesSteps.value = result;
+    };
+
+    let timeValue = dayjs().format('YYYY-MM-DD HH:mm:ss');
+
+    onMounted(() => {
+      const labels = [];
+      const series1 = [];
+      const series2 = [];
+
+      for (let ix = 0; ix < 30; ix++) {
+        timeValue = dayjs(timeValue).add(1, 'hour');
+        labels.push(dayjs(timeValue));
+        series1.push(Math.round(Math.random() * 100));
+        series2.push(Math.round(Math.random() * 100));
+      }
+
+      chartData.labels = labels;
+      chartData.data.series1 = series1;
+      chartData.data.series2 = series2;
+    });
+
+    return {
+      chartData,
+      chartOptions,
+      chartWidth,
+      chartHeight,
+      axesSteps,
+      onStepsCalculated,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.case {
+  height: 100%;
+}
+.chart-container {
+  transition: width 0.2s, height 0.2s;
+}
+.info-box {
+  margin-top: 10px;
+
+  table {
+    border-collapse: collapse;
+    font-size: 12px;
+
+    th, td {
+      border: 1px solid #ddd;
+      padding: 4px 10px;
+      text-align: center;
+    }
+
+    th {
+      background: #f5f5f5;
+      font-weight: bold;
+    }
+  }
+}
+.description {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+.toggle-label {
+  vertical-align: top;
+  margin-right: 7px;
+}
+</style>

--- a/docs/views/barChart/example/AxesScaleChange.vue
+++ b/docs/views/barChart/example/AxesScaleChange.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="case">
-    <div class="chart-container" :style="{ width: chartWidth + 'px', height: chartHeight + 'px' }">
+    <resizable-wrapper>
       <ev-chart
         :data="chartData"
         :options="chartOptions"
         @axes-scale-change="onStepsCalculated"
       />
-    </div>
+    </resizable-wrapper>
     <div class="info-box">
       <table v-if="axesSteps">
         <thead>
@@ -37,18 +37,10 @@
       </table>
     </div>
     <div class="description">
-      <div class="description-row">
-        <span class="toggle-label">너비 ({{ chartWidth }}px)</span>
-        <ev-input-number v-model="chartWidth" :step="50" :min="300" :max="1000" />
-        <span class="toggle-label">높이 ({{ chartHeight }}px)</span>
-        <ev-input-number v-model="chartHeight" :step="20" :min="150" :max="500" />
-      </div>
-      <div class="description-row">
-        <span class="toggle-label">X 감지</span>
-        <ev-toggle v-model="axesScaleChange.x" />
-        <span class="toggle-label">Y 감지</span>
-        <ev-toggle v-model="axesScaleChange.y" />
-      </div>
+      <span class="toggle-label">X 감지</span>
+      <ev-toggle v-model="axesScaleChange.x" />
+      <span class="toggle-label">Y 감지</span>
+      <ev-toggle v-model="axesScaleChange.y" />
     </div>
   </div>
 </template>
@@ -75,8 +67,6 @@ export default {
       },
     });
 
-    const chartWidth = ref(600);
-    const chartHeight = ref(280);
     const axesSteps = ref(null);
 
     const chartOptions = reactive({
@@ -152,8 +142,6 @@ export default {
     return {
       chartData,
       chartOptions,
-      chartWidth,
-      chartHeight,
       axesSteps,
       onStepsCalculated,
     };
@@ -164,9 +152,6 @@ export default {
 <style lang="scss" scoped>
 .case {
   height: 100%;
-}
-.chart-container {
-  transition: width 0.2s, height 0.2s;
 }
 .info-box {
   margin-top: 10px;
@@ -192,11 +177,6 @@ export default {
   flex-direction: column;
   gap: 8px;
   margin-top: 10px;
-}
-.description-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
 }
 .toggle-label {
   vertical-align: top;

--- a/docs/views/barChart/example/AxesScaleChange.vue
+++ b/docs/views/barChart/example/AxesScaleChange.vue
@@ -37,10 +37,18 @@
       </table>
     </div>
     <div class="description">
-      <span class="toggle-label">너비 ({{ chartWidth }}px)</span>
-      <ev-input-number v-model="chartWidth" :step="50" :min="300" :max="1000" />
-      <span class="toggle-label">높이 ({{ chartHeight }}px)</span>
-      <ev-input-number v-model="chartHeight" :step="20" :min="150" :max="500" />
+      <div class="description-row">
+        <span class="toggle-label">너비 ({{ chartWidth }}px)</span>
+        <ev-input-number v-model="chartWidth" :step="50" :min="300" :max="1000" />
+        <span class="toggle-label">높이 ({{ chartHeight }}px)</span>
+        <ev-input-number v-model="chartHeight" :step="20" :min="150" :max="500" />
+      </div>
+      <div class="description-row">
+        <span class="toggle-label">X 감지</span>
+        <ev-toggle v-model="axesScaleChange.x" />
+        <span class="toggle-label">Y 감지</span>
+        <ev-toggle v-model="axesScaleChange.y" />
+      </div>
     </div>
   </div>
 </template>
@@ -94,6 +102,7 @@ export default {
           type: 'time',
           timeFormat: 'DD HH:mm',
           interval: 'hour',
+          scaleChange: true,
           formatter: (value, data) => {
             if (data?.prev) {
               const curr = dayjs(value).format('yy-MM-DD');
@@ -112,6 +121,7 @@ export default {
           type: 'linear',
           showGrid: true,
           showAxisTick: true,
+          scaleChange: true,
         },
       ],
     });
@@ -179,9 +189,14 @@ export default {
 }
 .description {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 8px;
   margin-top: 10px;
+}
+.description-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 .toggle-label {
   vertical-align: top;

--- a/docs/views/barChart/example/AxesScaleChange.vue
+++ b/docs/views/barChart/example/AxesScaleChange.vue
@@ -12,35 +12,29 @@
         <thead>
           <tr>
             <th>축</th>
-            <th>steps</th>
-            <th>interval</th>
-            <th>graphMin</th>
-            <th>graphMax</th>
+            <th>minSteps</th>
+            <th>maxSteps</th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <td>X[0]</td>
-            <td>{{ axesSteps.x[0]?.steps }}</td>
-            <td>{{ axesSteps.x[0]?.interval }}</td>
-            <td>{{ axesSteps.x[0]?.graphMin }}</td>
-            <td>{{ axesSteps.x[0]?.graphMax }}</td>
+            <td>{{ axesSteps.x[0]?.minSteps }}</td>
+            <td>{{ axesSteps.x[0]?.maxSteps }}</td>
           </tr>
           <tr>
             <td>Y[0]</td>
-            <td>{{ axesSteps.y[0]?.steps }}</td>
-            <td>{{ axesSteps.y[0]?.interval }}</td>
-            <td>{{ axesSteps.y[0]?.graphMin }}</td>
-            <td>{{ axesSteps.y[0]?.graphMax }}</td>
+            <td>{{ axesSteps.y[0]?.minSteps }}</td>
+            <td>{{ axesSteps.y[0]?.maxSteps }}</td>
           </tr>
         </tbody>
       </table>
     </div>
     <div class="description">
       <span class="toggle-label">X 감지</span>
-      <ev-toggle v-model="axesScaleChange.x" />
+      <ev-toggle v-model="chartOptions.axesX[0].scaleChange" />
       <span class="toggle-label">Y 감지</span>
-      <ev-toggle v-model="axesScaleChange.y" />
+      <ev-toggle v-model="chartOptions.axesY[0].scaleChange" />
     </div>
   </div>
 </template>

--- a/docs/views/barChart/props.js
+++ b/docs/views/barChart/props.js
@@ -134,7 +134,7 @@ export default {
     },
     AxesScaleChange: {
       description:
-        '차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 확인할 수 있습니다.',
+        '차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 확인할 수 있습니다.',
       component: AxesScaleChange,
       parsedData: parse(AxesScaleChangeRaw).descriptor,
     },

--- a/docs/views/barChart/props.js
+++ b/docs/views/barChart/props.js
@@ -34,6 +34,8 @@ import LargeScrollbar from './example/LargeScrollbar';
 import LargeScrollbarRaw from './example/LargeScrollbar?raw';
 import UnSelectedOpacity from './example/UnSelectedOpacity';
 import UnSelectedOpacityRaw from './example/UnSelectedOpacity?raw';
+import AxesScaleChangeRaw from './example/AxesScaleChange?raw';
+import AxesScaleChange from './example/AxesScaleChange';
 
 export default {
   mdText,
@@ -129,6 +131,12 @@ export default {
       description: 'unSelectedOpacity 옵션으로 비선택 요소의 opacity를 설정할 수 있습니다',
       component: UnSelectedOpacity,
       parsedData: parse(UnSelectedOpacityRaw).descriptor,
+    },
+    AxesScaleChange: {
+      description:
+        '차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 확인할 수 있습니다.',
+      component: AxesScaleChange,
+      parsedData: parse(AxesScaleChangeRaw).descriptor,
     },
   },
 };

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -497,6 +497,7 @@ const chartOptions = {
 | mouse-move  |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                                                |
 | drag-select | data, range  | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
 | click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
+| axes-scale-change | | 차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 정보를 반환한다. <br><br> {<br> x: { graphMin, graphMax, step, interval }, <br>   y: { graphMin, graphMax, step, interval }<br>} | |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환
 

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -171,6 +171,7 @@ const chartData =
 | showAxisTick   | Boolean   | true    | 보조 눈금 표시 여부                                     |                                                         |
 | fixedSteps  | Boolean  | false    | range와 interval로 설정한 값을 그대로 사용하여 step을 고정. 자동 스케일 조정을 비활성화하며, 원하는 간격으로 축을 표시할 때 사용  | |
 | niceScale   | Boolean  | false    | 축 타입이 linear 인 경우 nice scale 알고리즘을 적용하여 최적의 최대값과 간격을 계산하여 축을 그림
+| scaleChange | Boolean  | false    | scale 변경을 감지하여 emit 발생시킬때 사용, true일때 scale이 변경되면 axes-scale-range 이벤트가 발생된다. | | 
 
 ##### axesX
 
@@ -497,7 +498,7 @@ const chartOptions = {
 | mouse-move  |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                                                |
 | drag-select | data, range  | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
 | click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
-| axes-scale-change | | 차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 정보를 반환한다. <br><br> {<br> x: { graphMin, graphMax, step, interval }, <br>   y: { graphMin, graphMax, step, interval }<br>} | |
+| axes-scale-change | | 차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 정보를 반환한다. 단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다. ax<br><br> {<br> x: { graphMin, graphMax, step, interval }, <br>   y: { graphMin, graphMax, step, interval }<br>} | |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환
 

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -498,7 +498,7 @@ const chartOptions = {
 | mouse-move  |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                                                |
 | drag-select | data, range  | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
 | click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
-| axes-scale-change | | 차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 정보를 반환한다. 단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다. ex)<br><br> {<br> x: { minSteps, maxSteps }, <br>   y: { minSteps, maxSteps }<br>} | |
+| axes-scale-change | | 차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 정보를 반환한다. 단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다. ex)<br><br> {<br> x: [{ minSteps, maxSteps }], <br>   y: [{ minSteps, maxSteps }]<br>} | |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환
 

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -498,7 +498,7 @@ const chartOptions = {
 | mouse-move  |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                                                |
 | drag-select | data, range  | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
 | click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
-| axes-scale-change | | 차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 정보를 반환한다. 단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다. ax<br><br> {<br> x: { graphMin, graphMax, step, interval }, <br>   y: { graphMin, graphMax, step, interval }<br>} | |
+| axes-scale-change | | 차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 정보를 반환한다. 단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다. ex)<br><br> {<br> x: { minSteps, maxSteps }, <br>   y: { minSteps, maxSteps }<br>} | |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환
 

--- a/docs/views/lineChart/example/AxesScaleChange.vue
+++ b/docs/views/lineChart/example/AxesScaleChange.vue
@@ -1,0 +1,190 @@
+<template>
+  <div class="case">
+    <div class="chart-container" :style="{ width: chartWidth + 'px', height: chartHeight + 'px' }">
+      <ev-chart
+        :data="chartData"
+        :options="chartOptions"
+        @axes-scale-change="onStepsCalculated"
+      />
+    </div>
+    <div class="info-box">
+      <table v-if="axesSteps">
+        <thead>
+          <tr>
+            <th>축</th>
+            <th>steps</th>
+            <th>interval</th>
+            <th>graphMin</th>
+            <th>graphMax</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>X[0]</td>
+            <td>{{ axesSteps.x[0]?.steps }}</td>
+            <td>{{ axesSteps.x[0]?.interval }}</td>
+            <td>{{ axesSteps.x[0]?.graphMin }}</td>
+            <td>{{ axesSteps.x[0]?.graphMax }}</td>
+          </tr>
+          <tr>
+            <td>Y[0]</td>
+            <td>{{ axesSteps.y[0]?.steps }}</td>
+            <td>{{ axesSteps.y[0]?.interval }}</td>
+            <td>{{ axesSteps.y[0]?.graphMin }}</td>
+            <td>{{ axesSteps.y[0]?.graphMax }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="description">
+      <span class="toggle-label">너비 ({{ chartWidth }}px)</span>
+      <ev-input-number v-model="chartWidth" :step="50" :min="300" :max="1000" />
+      <span class="toggle-label">높이 ({{ chartHeight }}px)</span>
+      <ev-input-number v-model="chartHeight" :step="20" :min="150" :max="500" />
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, onMounted, reactive } from 'vue';
+import dayjs from 'dayjs';
+import EvInputNumber from '../../../../src/components/inputNumber/InputNumber';
+
+export default {
+  components: {
+    EvInputNumber,
+  },
+  setup() {
+    const chartData = reactive({
+      series: {
+        series1: { name: 'series#1', point: false },
+        series2: { name: 'series#2', point: false },
+      },
+      labels: [],
+      data: {
+        series1: [],
+        series2: [],
+      },
+    });
+
+    const chartWidth = ref(600);
+    const chartHeight = ref(280);
+    const axesSteps = ref(null);
+
+    const chartOptions = reactive({
+      type: 'line',
+      width: '100%',
+      height: '100%',
+      padding: {
+        top: 20,
+        right: 2,
+        left: 2,
+        bottom: 4,
+      },
+      title: {
+        text: '리사이즈 시 axesSteps 변화',
+        show: true,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesX: [
+        {
+          type: 'time',
+          timeFormat: 'DD HH:mm',
+          interval: 'hour',
+          formatter: (value, data) => {
+            if (data?.prev) {
+              const curr = dayjs(value).format('yy-MM-DD');
+              const prev = dayjs(data?.prev).format('yy-MM-DD');
+              if (curr === prev) {
+                return dayjs(value).format('HH:mm');
+              }
+            }
+            return dayjs(value).format('DD HH:mm');
+          },
+          showAxisTick: true,
+        },
+      ],
+      axesY: [
+        {
+          type: 'linear',
+          showGrid: true,
+          showAxisTick: true,
+        },
+      ],
+    });
+
+    const onStepsCalculated = (result) => {
+      axesSteps.value = result;
+    };
+
+    let timeValue = dayjs().format('YYYY-MM-DD HH:mm:ss');
+
+    onMounted(() => {
+      const labels = [];
+      const series1 = [];
+      const series2 = [];
+
+      for (let ix = 0; ix < 30; ix++) {
+        timeValue = dayjs(timeValue).add(1, 'hour');
+        labels.push(dayjs(timeValue));
+        series1.push(Math.round(Math.random() * 100));
+        series2.push(Math.round(Math.random() * 100));
+      }
+
+      chartData.labels = labels;
+      chartData.data.series1 = series1;
+      chartData.data.series2 = series2;
+    });
+
+    return {
+      chartData,
+      chartOptions,
+      chartWidth,
+      chartHeight,
+      axesSteps,
+      onStepsCalculated,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.case {
+  height: 100%;
+}
+.chart-container {
+  transition: width 0.2s, height 0.2s;
+}
+.info-box {
+  margin-top: 10px;
+
+  table {
+    border-collapse: collapse;
+    font-size: 12px;
+
+    th, td {
+      border: 1px solid #ddd;
+      padding: 4px 10px;
+      text-align: center;
+    }
+
+    th {
+      background: #f5f5f5;
+      font-weight: bold;
+    }
+  }
+}
+.description {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+.toggle-label {
+  vertical-align: top;
+  margin-right: 7px;
+}
+</style>

--- a/docs/views/lineChart/example/AxesScaleChange.vue
+++ b/docs/views/lineChart/example/AxesScaleChange.vue
@@ -12,26 +12,20 @@
         <thead>
           <tr>
             <th>축</th>
-            <th>steps</th>
-            <th>interval</th>
-            <th>graphMin</th>
-            <th>graphMax</th>
+            <th>minSteps</th>
+            <th>maxSteps</th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <td>X[0]</td>
-            <td>{{ axesSteps.x[0]?.steps }}</td>
-            <td>{{ axesSteps.x[0]?.interval }}</td>
-            <td>{{ axesSteps.x[0]?.graphMin }}</td>
-            <td>{{ axesSteps.x[0]?.graphMax }}</td>
+            <td>{{ axesSteps.x[0]?.minSteps }}</td>
+            <td>{{ axesSteps.x[0]?.maxSteps }}</td>
           </tr>
           <tr>
             <td>Y[0]</td>
-            <td>{{ axesSteps.y[0]?.steps }}</td>
-            <td>{{ axesSteps.y[0]?.interval }}</td>
-            <td>{{ axesSteps.y[0]?.graphMin }}</td>
-            <td>{{ axesSteps.y[0]?.graphMax }}</td>
+            <td>{{ axesSteps.y[0]?.minSteps }}</td>
+            <td>{{ axesSteps.y[0]?.maxSteps }}</td>
           </tr>
         </tbody>
       </table>

--- a/docs/views/lineChart/example/AxesScaleChange.vue
+++ b/docs/views/lineChart/example/AxesScaleChange.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="case">
-    <div class="chart-container" :style="{ width: chartWidth + 'px', height: chartHeight + 'px' }">
+    <resizable-wrapper>
       <ev-chart
         :data="chartData"
         :options="chartOptions"
         @axes-scale-change="onStepsCalculated"
       />
-    </div>
+    </resizable-wrapper>
     <div class="info-box">
       <table v-if="axesSteps">
         <thead>
@@ -37,18 +37,10 @@
       </table>
     </div>
     <div class="description">
-      <div class="description-row">
-        <span class="toggle-label">너비 ({{ chartWidth }}px)</span>
-        <ev-input-number v-model="chartWidth" :step="50" :min="300" :max="1000" />
-        <span class="toggle-label">높이 ({{ chartHeight }}px)</span>
-        <ev-input-number v-model="chartHeight" :step="20" :min="150" :max="500" />
-      </div>
-      <div class="description-row">
-        <span class="toggle-label">X 감지</span>
-        <ev-toggle v-model="chartOptions.axesX[0].scaleChange" />
-        <span class="toggle-label">Y 감지</span>
-        <ev-toggle v-model="chartOptions.axesY[0].scaleChange" />
-      </div>
+      <span class="toggle-label">X 감지</span>
+      <ev-toggle v-model="chartOptions.axesX[0].scaleChange" />
+      <span class="toggle-label">Y 감지</span>
+      <ev-toggle v-model="chartOptions.axesY[0].scaleChange" />
     </div>
   </div>
 </template>
@@ -75,8 +67,6 @@ export default {
       },
     });
 
-    const chartWidth = ref(600);
-    const chartHeight = ref(280);
     const axesSteps = ref(null);
 
     const chartOptions = reactive({
@@ -152,8 +142,6 @@ export default {
     return {
       chartData,
       chartOptions,
-      chartWidth,
-      chartHeight,
       axesSteps,
       onStepsCalculated,
     };
@@ -164,9 +152,6 @@ export default {
 <style lang="scss" scoped>
 .case {
   height: 100%;
-}
-.chart-container {
-  transition: width 0.2s, height 0.2s;
 }
 .info-box {
   margin-top: 10px;
@@ -192,11 +177,6 @@ export default {
   flex-direction: column;
   gap: 8px;
   margin-top: 10px;
-}
-.description-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
 }
 .toggle-label {
   vertical-align: top;

--- a/docs/views/lineChart/example/AxesScaleChange.vue
+++ b/docs/views/lineChart/example/AxesScaleChange.vue
@@ -37,10 +37,18 @@
       </table>
     </div>
     <div class="description">
-      <span class="toggle-label">너비 ({{ chartWidth }}px)</span>
-      <ev-input-number v-model="chartWidth" :step="50" :min="300" :max="1000" />
-      <span class="toggle-label">높이 ({{ chartHeight }}px)</span>
-      <ev-input-number v-model="chartHeight" :step="20" :min="150" :max="500" />
+      <div class="description-row">
+        <span class="toggle-label">너비 ({{ chartWidth }}px)</span>
+        <ev-input-number v-model="chartWidth" :step="50" :min="300" :max="1000" />
+        <span class="toggle-label">높이 ({{ chartHeight }}px)</span>
+        <ev-input-number v-model="chartHeight" :step="20" :min="150" :max="500" />
+      </div>
+      <div class="description-row">
+        <span class="toggle-label">X 감지</span>
+        <ev-toggle v-model="chartOptions.axesX[0].scaleChange" />
+        <span class="toggle-label">Y 감지</span>
+        <ev-toggle v-model="chartOptions.axesY[0].scaleChange" />
+      </div>
     </div>
   </div>
 </template>
@@ -94,6 +102,7 @@ export default {
           type: 'time',
           timeFormat: 'DD HH:mm',
           interval: 'hour',
+          scaleChange: true,
           formatter: (value, data) => {
             if (data?.prev) {
               const curr = dayjs(value).format('yy-MM-DD');
@@ -112,6 +121,7 @@ export default {
           type: 'linear',
           showGrid: true,
           showAxisTick: true,
+          scaleChange: true,
         },
       ],
     });
@@ -179,9 +189,14 @@ export default {
 }
 .description {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 8px;
   margin-top: 10px;
+}
+.description-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 .toggle-label {
   vertical-align: top;

--- a/docs/views/lineChart/props.js
+++ b/docs/views/lineChart/props.js
@@ -166,7 +166,7 @@ export default {
     },
     AxesScaleChange: {
       description:
-        '차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 확인할 수 있습니다.',
+        '차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 확인할 수 있습니다.',
       component: AxesScaleChange,
       parsedData: parse(AxesScaleChangeRaw).descriptor,
     },

--- a/docs/views/lineChart/props.js
+++ b/docs/views/lineChart/props.js
@@ -40,6 +40,8 @@ import LegendClickMode from './example/LegendClickMode';
 import LegendClickModeRaw from './example/LegendClickMode?raw';
 import NiceScale from './example/NiceScale';
 import NiceScaleRaw from './example/NiceScale?raw';
+import AxesScaleChange from './example/AxesScaleChange';
+import AxesScaleChangeRaw from './example/AxesScaleChange?raw';
 import UnSelectedOpacity from './example/UnSelectedOpacity';
 import UnSelectedOpacityRaw from './example/UnSelectedOpacity?raw';
 
@@ -161,6 +163,12 @@ export default {
         '축 타입이 linear인 경우 자동으로 최적의 최대 값과 간격을 계산하여 축을 그립니다.',
       component: NiceScale,
       parsedData: parse(NiceScaleRaw).descriptor,
+    },
+    AxesScaleChange: {
+      description:
+        '차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 확인할 수 있습니다.',
+      component: AxesScaleChange,
+      parsedData: parse(AxesScaleChangeRaw).descriptor,
     },
   },
 };

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -391,7 +391,7 @@ const chartOptions = {
  | mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                 |
  | drag-select | data, range | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
 | click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
-| axes-scale-change | | 차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 정보를 반환한다. 단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다. ex)<br><br> {<br> x: { minSteps, maxSteps }, <br>   y: { minSteps, maxSteps }<br>} | |
+| axes-scale-change | | 차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 정보를 반환한다. 단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다. ex)<br><br> {<br> x: [{ minSteps, maxSteps }], <br>   y: [{ minSteps, maxSteps }]<br>} | |
 
 - drag-select는  `dragSelection` 옵션의 `use`값이 `true` 일 때 이벤트를 발생 시킬 수 있다.
  그리고 선택영역은 그래프에 표시된 데이터의 중앙이 포함 되어야 선택영역 내 데이터로 인식 한다.

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -391,7 +391,7 @@ const chartOptions = {
  | mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                 |
  | drag-select | data, range | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
 | click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
-| axes-scale-change | | 차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 정보를 반환한다. 단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다.<br><br> {<br> x: { graphMin, graphMax, step, interval }, <br>   y: { graphMin, graphMax, step, interval }<br>} | |
+| axes-scale-change | | 차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 정보를 반환한다. 단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다. ex)<br><br> {<br> x: { minSteps, maxSteps }, <br>   y: { minSteps, maxSteps }<br>} | |
 
 - drag-select는  `dragSelection` 옵션의 `use`값이 `true` 일 때 이벤트를 발생 시킬 수 있다.
  그리고 선택영역은 그래프에 표시된 데이터의 중앙이 포함 되어야 선택영역 내 데이터로 인식 한다.

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -390,6 +390,7 @@ const chartOptions = {
  | mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                 |
  | drag-select | data, range | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
 | click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
+| axes-scale-change | | 차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 정보를 반환한다. <br><br> {<br> x: { graphMin, graphMax, step, interval }, <br>   y: { graphMin, graphMax, step, interval }<br>} | |
 
 - drag-select는  `dragSelection` 옵션의 `use`값이 `true` 일 때 이벤트를 발생 시킬 수 있다.
  그리고 선택영역은 그래프에 표시된 데이터의 중앙이 포함 되어야 선택영역 내 데이터로 인식 한다.

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -124,7 +124,8 @@ const chartData =
   | title | Object | ([상세](#title)) | 라벨의 폰트 스타일을 설정 | |
   | showAxisTick   | Boolean   | true    | 보조 눈금 표시 여부                                     |                                                         |
   | fixedSteps  | Boolean  | false    | range와 interval로 설정한 값을 그대로 사용하여 step을 고정. 자동 스케일 조정을 비활성화하며, 원하는 간격으로 축을 표시할 때 사용  | |
-  | niceScale   | Boolean   | false   | 축 타입이 linear 인 경우 nice scale 알고리즘을 적용하여 최적의 최대값과 간격을 계산하여 축을 그림                     | |
+  | niceScale   | Boolean  | false    | 축 타입이 linear 인 경우 nice scale 알고리즘을 적용하여 최적의 최대값과 간격을 계산하여 축을 그림                     | |
+  | scaleChange | Boolean  | false    | scale 변경을 감지하여 emit 발생시킬때 사용, true일때 scale이 변경되면 axes-scale-range 이벤트가 발생된다. | | 
 
 ##### axesX
 
@@ -390,7 +391,7 @@ const chartOptions = {
  | mouse-move |              | 커서의 현재 location 과 axes에 있을 경우 labelIdx, labelVal 과 데이터 영역에 있을 경우 dataIdx, maxDataVal 과 labelVal 또는 maxDataVal를 가공하기 전의 originVal 값을 반환                                                                                                                                 |
  | drag-select | data, range | 그래프에서 드래그를 해서 선택영역 안의 데이터와 선택영역에 대한 범위 값을 얻을 수 있다. <br><br> ex) data : [{ seriesName, seriesId, items: [] }, {...}, {...}] <br> ex) range : { xMin, xMax, yMin, yMax } <br><br> data의 요소 propery중 items 는 해당 Series의 데이터 들이 있으며 x, y값은 데이터 기반 <xp, yp 는 Canvas기반의 좌표 값 |
 | click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
-| axes-scale-change | | 차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 정보를 반환한다. <br><br> {<br> x: { graphMin, graphMax, step, interval }, <br>   y: { graphMin, graphMax, step, interval }<br>} | |
+| axes-scale-change | | 차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 정보를 반환한다. 단, axes옵션에 scaleRange가 true이고 scale 정보가 변경될때만 이벤트를 발생시킨다.<br><br> {<br> x: { graphMin, graphMax, step, interval }, <br>   y: { graphMin, graphMax, step, interval }<br>} | |
 
 - drag-select는  `dragSelection` 옵션의 `use`값이 `true` 일 때 이벤트를 발생 시킬 수 있다.
  그리고 선택영역은 그래프에 표시된 데이터의 중앙이 포함 되어야 선택영역 내 데이터로 인식 한다.

--- a/docs/views/scatterChart/example/AxesScaleChange.vue
+++ b/docs/views/scatterChart/example/AxesScaleChange.vue
@@ -12,26 +12,20 @@
         <thead>
           <tr>
             <th>축</th>
-            <th>steps</th>
-            <th>interval</th>
-            <th>graphMin</th>
-            <th>graphMax</th>
+            <th>minSteps</th>
+            <th>maxSteps</th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <td>X[0]</td>
-            <td>{{ axesSteps.x[0]?.steps }}</td>
-            <td>{{ axesSteps.x[0]?.interval }}</td>
-            <td>{{ axesSteps.x[0]?.graphMin }}</td>
-            <td>{{ axesSteps.x[0]?.graphMax }}</td>
+            <td>{{ axesSteps.x[0]?.minSteps }}</td>
+            <td>{{ axesSteps.x[0]?.maxSteps }}</td>
           </tr>
           <tr>
             <td>Y[0]</td>
-            <td>{{ axesSteps.y[0]?.steps }}</td>
-            <td>{{ axesSteps.y[0]?.interval }}</td>
-            <td>{{ axesSteps.y[0]?.graphMin }}</td>
-            <td>{{ axesSteps.y[0]?.graphMax }}</td>
+            <td>{{ axesSteps.y[0]?.minSteps }}</td>
+            <td>{{ axesSteps.y[0]?.maxSteps }}</td>
           </tr>
         </tbody>
       </table>

--- a/docs/views/scatterChart/example/AxesScaleChange.vue
+++ b/docs/views/scatterChart/example/AxesScaleChange.vue
@@ -37,10 +37,18 @@
       </table>
     </div>
     <div class="description">
-      <span class="toggle-label">너비 ({{ chartWidth }}px)</span>
-      <ev-input-number v-model="chartWidth" :step="50" :min="300" :max="1000" />
-      <span class="toggle-label">높이 ({{ chartHeight }}px)</span>
-      <ev-input-number v-model="chartHeight" :step="20" :min="150" :max="500" />
+      <div class="description-row">
+        <span class="toggle-label">너비 ({{ chartWidth }}px)</span>
+        <ev-input-number v-model="chartWidth" :step="50" :min="300" :max="1000" />
+        <span class="toggle-label">높이 ({{ chartHeight }}px)</span>
+        <ev-input-number v-model="chartHeight" :step="20" :min="150" :max="500" />
+      </div>
+      <div class="description-row">
+        <span class="toggle-label">X 감지</span>
+        <ev-toggle v-model="chartOptions.axesX[0].scaleChange" />
+        <span class="toggle-label">Y 감지</span>
+        <ev-toggle v-model="chartOptions.axesY[0].scaleChange" />
+      </div>
     </div>
   </div>
 </template>
@@ -91,6 +99,7 @@ export default {
           type: 'time',
           timeFormat: 'HH:mm:ss',
           interval: 'second',
+          scaleChange: true,
         },
       ],
       axesY: [
@@ -99,6 +108,7 @@ export default {
           showGrid: true,
           startToZero: true,
           autoScaleRatio: 0.1,
+          scaleChange: true,
         },
       ],
     });
@@ -160,9 +170,14 @@ export default {
 }
 .description {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 8px;
   margin-top: 10px;
+}
+.description-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 .toggle-label {
   vertical-align: top;

--- a/docs/views/scatterChart/example/AxesScaleChange.vue
+++ b/docs/views/scatterChart/example/AxesScaleChange.vue
@@ -1,0 +1,171 @@
+<template>
+  <div class="case">
+    <div class="chart-container" :style="{ width: chartWidth + 'px', height: chartHeight + 'px' }">
+      <ev-chart
+        :data="chartData"
+        :options="chartOptions"
+        @axes-scale-change="onStepsCalculated"
+      />
+    </div>
+    <div class="info-box">
+      <table v-if="axesSteps">
+        <thead>
+          <tr>
+            <th>축</th>
+            <th>steps</th>
+            <th>interval</th>
+            <th>graphMin</th>
+            <th>graphMax</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>X[0]</td>
+            <td>{{ axesSteps.x[0]?.steps }}</td>
+            <td>{{ axesSteps.x[0]?.interval }}</td>
+            <td>{{ axesSteps.x[0]?.graphMin }}</td>
+            <td>{{ axesSteps.x[0]?.graphMax }}</td>
+          </tr>
+          <tr>
+            <td>Y[0]</td>
+            <td>{{ axesSteps.y[0]?.steps }}</td>
+            <td>{{ axesSteps.y[0]?.interval }}</td>
+            <td>{{ axesSteps.y[0]?.graphMin }}</td>
+            <td>{{ axesSteps.y[0]?.graphMax }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="description">
+      <span class="toggle-label">너비 ({{ chartWidth }}px)</span>
+      <ev-input-number v-model="chartWidth" :step="50" :min="300" :max="1000" />
+      <span class="toggle-label">높이 ({{ chartHeight }}px)</span>
+      <ev-input-number v-model="chartHeight" :step="20" :min="150" :max="500" />
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, onMounted, reactive } from 'vue';
+import dayjs from 'dayjs';
+import EvInputNumber from '../../../../src/components/inputNumber/InputNumber';
+
+export default {
+  components: {
+    EvInputNumber,
+  },
+  setup() {
+    const chartData = {
+      series: {
+        series1: { name: 'series#1' },
+      },
+      data: {
+        series1: [],
+      },
+    };
+
+    const chartWidth = ref(600);
+    const chartHeight = ref(280);
+    const axesSteps = ref(null);
+
+    const chartOptions = reactive({
+      type: 'scatter',
+      width: '100%',
+      height: '100%',
+      padding: {
+        top: 20,
+        right: 2,
+        left: 2,
+        bottom: 4,
+      },
+      title: {
+        text: '리사이즈 시 axesSteps 변화',
+        show: true,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesX: [
+        {
+          type: 'time',
+          timeFormat: 'HH:mm:ss',
+          interval: 'second',
+        },
+      ],
+      axesY: [
+        {
+          type: 'linear',
+          showGrid: true,
+          startToZero: true,
+          autoScaleRatio: 0.1,
+        },
+      ],
+    });
+
+    const onStepsCalculated = (result) => {
+      axesSteps.value = result;
+    };
+
+    let timeValue = dayjs();
+
+    onMounted(() => {
+      const series1 = [];
+
+      for (let ix = 0; ix < 30; ix++) {
+        timeValue = dayjs(timeValue).add(1, 'second');
+        series1.push({ x: timeValue, y: Math.round(Math.random() * 100) });
+      }
+
+      chartData.data.series1 = series1;
+    });
+
+    return {
+      chartData,
+      chartOptions,
+      chartWidth,
+      chartHeight,
+      axesSteps,
+      onStepsCalculated,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.case {
+  height: 100%;
+}
+.chart-container {
+  transition: width 0.2s, height 0.2s;
+}
+.info-box {
+  margin-top: 10px;
+
+  table {
+    border-collapse: collapse;
+    font-size: 12px;
+
+    th, td {
+      border: 1px solid #ddd;
+      padding: 4px 10px;
+      text-align: center;
+    }
+
+    th {
+      background: #f5f5f5;
+      font-weight: bold;
+    }
+  }
+}
+.description {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+.toggle-label {
+  vertical-align: top;
+  margin-right: 7px;
+}
+</style>

--- a/docs/views/scatterChart/example/AxesScaleChange.vue
+++ b/docs/views/scatterChart/example/AxesScaleChange.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="case">
-    <div class="chart-container" :style="{ width: chartWidth + 'px', height: chartHeight + 'px' }">
+    <resizable-wrapper>
       <ev-chart
         :data="chartData"
         :options="chartOptions"
         @axes-scale-change="onStepsCalculated"
       />
-    </div>
+    </resizable-wrapper>
     <div class="info-box">
       <table v-if="axesSteps">
         <thead>
@@ -37,18 +37,10 @@
       </table>
     </div>
     <div class="description">
-      <div class="description-row">
-        <span class="toggle-label">너비 ({{ chartWidth }}px)</span>
-        <ev-input-number v-model="chartWidth" :step="50" :min="300" :max="1000" />
-        <span class="toggle-label">높이 ({{ chartHeight }}px)</span>
-        <ev-input-number v-model="chartHeight" :step="20" :min="150" :max="500" />
-      </div>
-      <div class="description-row">
-        <span class="toggle-label">X 감지</span>
-        <ev-toggle v-model="chartOptions.axesX[0].scaleChange" />
-        <span class="toggle-label">Y 감지</span>
-        <ev-toggle v-model="chartOptions.axesY[0].scaleChange" />
-      </div>
+      <span class="toggle-label">X 감지</span>
+      <ev-toggle v-model="chartOptions.axesX[0].scaleChange" />
+      <span class="toggle-label">Y 감지</span>
+      <ev-toggle v-model="chartOptions.axesY[0].scaleChange" />
     </div>
   </div>
 </template>
@@ -72,8 +64,6 @@ export default {
       },
     };
 
-    const chartWidth = ref(600);
-    const chartHeight = ref(280);
     const axesSteps = ref(null);
 
     const chartOptions = reactive({
@@ -133,8 +123,6 @@ export default {
     return {
       chartData,
       chartOptions,
-      chartWidth,
-      chartHeight,
       axesSteps,
       onStepsCalculated,
     };
@@ -145,9 +133,6 @@ export default {
 <style lang="scss" scoped>
 .case {
   height: 100%;
-}
-.chart-container {
-  transition: width 0.2s, height 0.2s;
 }
 .info-box {
   margin-top: 10px;
@@ -173,11 +158,6 @@ export default {
   flex-direction: column;
   gap: 8px;
   margin-top: 10px;
-}
-.description-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
 }
 .toggle-label {
   vertical-align: top;

--- a/docs/views/scatterChart/props.js
+++ b/docs/views/scatterChart/props.js
@@ -12,6 +12,8 @@ import DisplayOverflow from './example/DisplayOverflow';
 import DisplayOverflowRaw from './example/DisplayOverflow?raw';
 import RealTimeScatter from './example/RealTimeScatter';
 import RealTimeScatterRaw from './example/RealTimeScatter?raw';
+import AxesScaleChange from './example/AxesScaleChange';
+import AxesScaleChangeRaw from './example/AxesScaleChange?raw';
 
 export default {
   mdText,
@@ -45,6 +47,12 @@ export default {
       description: '실시간으로 대량의 데이터를 처리합니다.',
       component: RealTimeScatter,
       parsedData: parse(RealTimeScatterRaw).descriptor,
+    },
+    AxesScaleChange: {
+      description:
+        '차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 확인할 수 있습니다.',
+      component: AxesScaleChange,
+      parsedData: parse(AxesScaleChangeRaw).descriptor,
     },
   },
 };

--- a/docs/views/scatterChart/props.js
+++ b/docs/views/scatterChart/props.js
@@ -50,7 +50,7 @@ export default {
     },
     AxesScaleChange: {
       description:
-        '차트 너비를 변경하면 axes-scale-change 이벤트로 재계산된 steps, interval, graphMin, graphMax를 확인할 수 있습니다.',
+        '차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 확인할 수 있습니다.',
       component: AxesScaleChange,
       parsedData: parse(AxesScaleChangeRaw).descriptor,
     },

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -87,6 +87,7 @@ export default {
     'update:realTimeScatterReset',
     'click-legend',
     'update:legendData',
+    'axes-scale-change',
   ],
   setup(props, { emit }) {
     let evChart = null;

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -260,6 +260,35 @@ class EvChart {
     this.axesSteps = this.calculateSteps();
   }
 
+  emitAxesScaleChange() {
+    if (typeof this.listeners?.['axes-scale-change'] !== 'function') {
+      return;
+    }
+
+    const prev = this._lastEmittedAxesSteps;
+    const curr = this.axesSteps;
+
+    const isSameAxis = (a, b) =>
+      a?.steps === b?.steps &&
+      a?.interval === b?.interval &&
+      a?.graphMin === b?.graphMin &&
+      a?.graphMax === b?.graphMax;
+
+    const isUnchanged =
+      prev &&
+      curr.x.length === prev.x.length &&
+      curr.y.length === prev.y.length &&
+      curr.x.every((ax, i) => isSameAxis(ax, prev.x[i])) &&
+      curr.y.every((ay, i) => isSameAxis(ay, prev.y[i]));
+
+    if (isUnchanged) {
+      return;
+    }
+
+    this._lastEmittedAxesSteps = curr;
+    this.listeners['axes-scale-change'](curr);
+  }
+
   /**
    * To draw canvas chart, it processes several sequential jobs
    * @param {any} [hitInfo=undefined]    from mousemove callback (object or object[] of undefined)
@@ -275,6 +304,8 @@ class EvChart {
     this.axesSteps = this.calculateSteps();
 
     this.adjustXAndYAxisWidth();
+
+    this.emitAxesScaleChange();
 
     this.drawAxis(hitInfo);
     this.drawSeries(hitInfo);

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -275,12 +275,12 @@ class EvChart {
     const toPayloadAxis = ({ min, max }) => ({ minSteps: min, maxSteps: max });
 
     const xSame = curr.x.every((ax, i) => {
-      const watch = this.options.axesX[i]?.scaleChange !== false;
+      const watch = !!this.options.axesX[i]?.scaleChange;
       return !watch || (!!prev && isSameAxis(ax, prev.x[i]));
     });
 
     const ySame = curr.y.every((ay, i) => {
-      const watch = this.options.axesY[i]?.scaleChange !== false;
+      const watch = !!this.options.axesY[i]?.scaleChange;
       return !watch || (!!prev && isSameAxis(ay, prev.y[i]));
     });
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -265,14 +265,14 @@ class EvChart {
       return;
     }
 
-    const prev = this._lastEmittedAxesSteps;
-    const curr = this.axesSteps;
+    const prev = this._lastEmittedAxesRange;
+    const curr = this.labelRange;
 
     const isSameAxis = (a, b) =>
-      a?.steps === b?.steps &&
-      a?.interval === b?.interval &&
-      a?.graphMin === b?.graphMin &&
-      a?.graphMax === b?.graphMax;
+      a?.min === b?.min &&
+      a?.max === b?.max;
+
+    const toPayloadAxis = ({ min, max }) => ({ minSteps: min, maxSteps: max });
 
     const xSame = curr.x.every((ax, i) => {
       const watch = this.options.axesX[i]?.scaleChange !== false;
@@ -288,8 +288,13 @@ class EvChart {
       return;
     }
 
-    this._lastEmittedAxesSteps = curr;
-    this.listeners['axes-scale-change'](curr);
+    this._lastEmittedAxesRange = curr;
+
+    const payload = {
+      x: curr.x.map(toPayloadAxis),
+      y: curr.y.map(toPayloadAxis),
+    };
+    this.listeners['axes-scale-change'](payload);
   }
 
   /**

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -274,14 +274,17 @@ class EvChart {
       a?.graphMin === b?.graphMin &&
       a?.graphMax === b?.graphMax;
 
-    const isUnchanged =
-      prev &&
-      curr.x.length === prev.x.length &&
-      curr.y.length === prev.y.length &&
-      curr.x.every((ax, i) => isSameAxis(ax, prev.x[i])) &&
-      curr.y.every((ay, i) => isSameAxis(ay, prev.y[i]));
+    const xSame = curr.x.every((ax, i) => {
+      const watch = this.options.axesX[i]?.scaleChange !== false;
+      return !watch || (!!prev && isSameAxis(ax, prev.x[i]));
+    });
 
-    if (isUnchanged) {
+    const ySame = curr.y.every((ay, i) => {
+      const watch = this.options.axesY[i]?.scaleChange !== false;
+      return !watch || (!!prev && isSameAxis(ay, prev.y[i]));
+    });
+
+    if (xSame && ySame) {
       return;
     }
 

--- a/src/components/chart/helpers/helpers.constant.js
+++ b/src/components/chart/helpers/helpers.constant.js
@@ -121,6 +121,7 @@ export const AXIS_OPTION = {
   decimalPoint: 'auto',
   fixedSteps: false, // range/interval 로 steps 사용, 자동 스케일 조정 비활성화
   niceScale: false, // nice scale 알고리즘 사용
+  scaleChange: false, // 축 스케일 변경 감지
   labelStyle: {
     show: true,
     fontSize: 12,

--- a/src/components/chart/helpers/helpers.constant.js
+++ b/src/components/chart/helpers/helpers.constant.js
@@ -119,9 +119,9 @@ export const AXIS_OPTION = {
   range: null,
   interval: null,
   decimalPoint: 'auto',
-  fixedSteps: false, // range/interval 로 steps 사용, 자동 스케일 조정 비활성화
-  niceScale: false, // nice scale 알고리즘 사용
-  scaleChange: false, // 축 스케일 변경 감지
+  fixedSteps: false,
+  niceScale: false,
+  scaleChange: false,
   labelStyle: {
     show: true,
     fontSize: 12,

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -406,6 +406,9 @@ export const useModel = (injectGroupSelectedLabel, injectGroupHoveredLabel) => {
       await nextTick();
       emit('update:legendData', legendData);
     },
+    'axes-scale-change': (result) => {
+      emit('axes-scale-change', result);
+    },
   };
 
   return {


### PR DESCRIPTION

## 개요

차트가 렌더링될 때마다 각 축의 스케일 계산 결과(`maxSteps, minSteps`)를 외부로 전달하는 `axes-scale-change` 이벤트를 추가했습니다.

---

## 변경 파일

### 소스 코드 (`src/`)

#### `src/components/chart/chart.core.js`
- `emitAxesScaleChange()` 메서드 추가
  - `drawChart()` 완료 시점에 1회 호출
  - **중복 emit 방지**: 이전에 emit한 값(`_lastEmittedAxesSteps`)과 현재 계산 결과를 비교하여 `minSteps`, `maxSteps`가 모두 동일하면 emit skip
  - consumer가 emit 수신 후 `chartOptions`를 수정하더라도 재계산된 steps가 동일하면 emit되지 않아 무한 루프 방지
 - axes 각 옵션의 `scaleRange`가 true일때만 변경사항을 감지하여 emit

#### `src/components/chart/Chart.vue`
- `emits` 배열에 `'axes-scale-change'` 추가 

#### `src/components/chart/uses.js`
- `eventListeners`에 `'axes-scale-change'` 핸들러 추가

#### `src/components/chart/helpers/helper.constant.js
- `AXES_OPTION`에 `scaleRange` 옵션 추가
---

### 문서 (`docs/`)

#### Line Chart
- `docs/views/lineChart/example/AxesScaleChange.vue` — 예제 추가
- `docs/views/lineChart/props.js` — 예제 컴포넌트 등록
- `docs/views/lineChart/api/lineChart.md` — 옵션, emit 설명 추가

#### Bar Chart
- `docs/views/barChart/example/AxesScaleChange.vue` — 예제 추가
- `docs/views/barChart/props.js` — 예제 컴포넌트 등록
- `docs/views/barChart/api/barChart.md` — 옵션, emit 설명 추가

#### Scatter Chart
- `docs/views/scatterChart/example/AxesScaleChange.vue` — 예제 추가
- `docs/views/scatterChart/props.js` — 예제 컴포넌트 등록
- `docs/views/scatterChart/api/scatterChart.md` — 옵션, emit 설명 추가

---

## emit 페이로드

```js
@axes-scale-change="(result) => { ... }"
```

```js
// result 구조
{
  x: [
    { minSteps: 1, maxSteps: 15 },
    // ...axesX 개수만큼
  ],
  y: [
    { minSteps: 1, maxSteps: 4 },
    // ...axesY 개수만큼
  ],
}
```

---

## 사용 예시

```vue
<ev-chart
  :data="chartData"
  :options="chartOptions"
  @axes-scale-change="onAxesScaleChange"
/>
```

```js
const onAxesScaleChange = (result) => {
  const yStep = result.y[0];
  console.log(yStep.minSteps, yStep.maxSteps);
};
```

### graphMin/graphMax를 range로 피드백하는 경우 (무한 루프 없음)

```js
const onAxesScaleChange = (result) => {
  const yStep = result.y[0];
  // axes-scale-change는 steps가 변경된 경우에만 emit되므로 루프 없음
  chartOptions.axesY[0].autoScaleRatio = null;
  chartOptions.axesY[0].range = [yStep.graphMin, yStep.graphMax];
};
```

##참고 사진
<img width="1183" height="662" alt="image" src="https://github.com/user-attachments/assets/cdca9937-ac7d-447a-adfa-19269345a606" />

##테스트 방법
lineChart, barChart, scatterChart의 AxesScaleChange 예제에서 차트의 넓이와 높이가 변경됐을때 scale 정보가 변경되는지 확인해주세요.