### PR TITLE
fix: 트리쉐이킹 환경 컴포넌트 등록 및 import 수정

### DIFF
--- a/src/components/checkboxGroup/CheckboxGroup.integration.spec.js
+++ b/src/components/checkboxGroup/CheckboxGroup.integration.spec.js
@@ -5,32 +5,8 @@ import EvCheckboxGroup from './CheckboxGroup.vue';
 import EvCheckbox from '../checkbox/Checkbox.vue';
 
 describe('EvCheckboxGroup + EvCheckbox Integration', () => {
-  // 헬퍼: 체크박스 그룹 마운트
-  const mountCheckboxGroup = (props = {}, checkboxes = []) => {
-    return mount(EvCheckboxGroup, {
-      props: {
-        modelValue: [],
-        ...props,
-      },
-      slots: {
-        default: checkboxes.map(
-          (cb) => `<EvCheckbox label="${cb.label}" ${cb.disabled ? 'disabled' : ''} />`
-        ).join(''),
-      },
-      global: {
-        components: { EvCheckbox },
-      },
-    });
-  };
-
   // 헬퍼: 실제 컴포넌트로 마운트 (slots 문자열 대신)
-  const mountWithRealCheckboxes = (groupProps = {}, checkboxConfigs = []) => {
-    const checkboxSlots = checkboxConfigs.map((config) => ({
-      component: EvCheckbox,
-      props: config,
-    }));
-
-    return mount({
+  const mountWithRealCheckboxes = (groupProps = {}, checkboxConfigs = []) => mount({
       template: `
         <EvCheckboxGroup v-model="selected" @change="onChange">
           <EvCheckbox
@@ -52,7 +28,6 @@ describe('EvCheckboxGroup + EvCheckbox Integration', () => {
         onChange: groupProps.onChange || (() => {}),
       },
     });
-  };
 
   describe('기본 연동', () => {
     it('체크박스 클릭 시 그룹의 modelValue가 업데이트된다', async () => {

--- a/src/components/grid/Grid.vue
+++ b/src/components/grid/Grid.vue
@@ -584,7 +584,7 @@ import {
   onUnmounted,
 } from 'vue';
 import { cloneDeep } from 'lodash-es';
-import { ObserveVisibility as vObserveVisibility } from 'vue3-observe-visibility';
+import vObserveVisibility from 'vue3-observe-visibility';
 import resize from 'vue-resize-observer';
 import { clickoutside } from '@/directives/clickoutside';
 import Toolbar from './GridToolbar';

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -64,7 +64,7 @@
 
 <script>
 import { ref, reactive, computed, provide, triggerRef, onBeforeUpdate, nextTick } from 'vue';
-import { ObserveVisibility as vObserveVisibility } from 'vue3-observe-visibility';
+import vObserveVisibility from 'vue3-observe-visibility';
 import resize from 'vue-resize-observer';
 
 export default {

--- a/src/components/treeGrid/TreeGrid.vue
+++ b/src/components/treeGrid/TreeGrid.vue
@@ -273,7 +273,7 @@ import {
   onUnmounted,
 } from 'vue';
 import { cloneDeep } from 'lodash-es';
-import { ObserveVisibility as vObserveVisibility } from 'vue3-observe-visibility';
+import vObserveVisibility from 'vue3-observe-visibility';
 import resize from 'vue-resize-observer';
 import TreeGridNode from './TreeGridNode';
 import Toolbar from './TreeGridToolbar';

--- a/src/main.js
+++ b/src/main.js
@@ -33,48 +33,28 @@ import EvTreeGrid from '@/components/treeGrid/';
 import EvPagination from '@/components/pagination/';
 import { version } from '../package.json';
 
-const components = [
-  EvTabs,
-  EvTabPanel,
-  EvButton,
-  EvButtonGroup,
-  EvCheckbox,
-  EvCheckboxGroup,
-  EvRadio,
-  EvRadioGroup,
-  EvSelect,
-  EvToggle,
-  EvTextField,
-  EvInputNumber,
-  EvSlider,
-  EvIcon,
-  EvCalendar,
-  EvDatePicker,
-  EvScheduler,
-  EvContextMenu,
-  EvWindow,
-  EvLoading,
-  EvProgress,
-  EvMenu,
-  EvTree,
-  EvTimePicker,
-  EvGrid,
-  EvChart,
-  EvChartGroup,
-  EvChartBrush,
-  EvMessage,
-  EvNotification,
-  EvMessageBox,
-  EvTreeGrid,
-  EvPagination,
-];
-
 const install = (app) => {
   if (!app) {
     return;
   }
-  components.forEach((component) => {
-    app.use(component);
+
+  const regularComponents = [
+    EvTabs, EvTabPanel, EvButton, EvButtonGroup,
+    EvCheckbox, EvCheckboxGroup, EvRadio, EvRadioGroup,
+    EvSelect, EvToggle, EvTextField, EvInputNumber,
+    EvSlider, EvIcon, EvCalendar, EvDatePicker,
+    EvScheduler, EvContextMenu, EvWindow, EvLoading,
+    EvProgress, EvMenu, EvTree, EvTimePicker,
+    EvGrid, EvChart, EvChartGroup, EvChartBrush,
+    EvTreeGrid, EvPagination,
+  ];
+
+  regularComponents.forEach((component) => {
+    app.component(component.name, component);
+  });
+
+  [EvMessage, EvNotification, EvMessageBox].forEach((plugin) => {
+    app.use(plugin);
   });
 };
 


### PR DESCRIPTION
## Summary
- `app.use(EVUI)` 사용 시 트리쉐이킹으로 인해 컴포넌트가 등록되지 않는 문제 수정
- `vue3-observe-visibility` named import → default import 변경 (트리쉐이킹 호환)
- CheckboxGroup 테스트 미사용 헬퍼 함수 제거

## Test plan
- [ ] `app.use(EVUI)`로 전체 컴포넌트 등록 후 정상 렌더링 확인
- [ ] Grid, Tabs, TreeGrid 컴포넌트에서 `v-observe-visibility` 디렉티브 정상 동작 확인
- [ ] 트리쉐이킹 빌드 후 개별 컴포넌트 import 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)