### PR TITLE
fix: 차트 > 축 > decimalPoint 'auto' 이고 interval: 0.25 일때 소수점 자리 이상

### DIFF
--- a/src/components/chart/scale/scale.linear.js
+++ b/src/components/chart/scale/scale.linear.js
@@ -253,15 +253,15 @@ class LinearScale extends Scale {
   
     const EPS = 1e-10;
   
-    const setDecimal = (graphRange, steps, interval) => {
+    const setDecimal = (interval) => {
       if (this.decimalPoint === 'auto') {
-        const decimalFromRange = this.getDecimalPointFromInterval(interval);
+        const decimalFromInterval = this.getDecimalPointFromInterval(interval);
   
         if (
-          decimalFromRange != null &&
-          !Number.isNaN(decimalFromRange)
+          decimalFromInterval != null &&
+          !Number.isNaN(decimalFromInterval)
         ) {
-          this.adjustedDecimalPoint = decimalFromRange;
+          this.adjustedDecimalPoint = decimalFromInterval;
         } else if (typeof this.getAutoDecimalPointFromInterval === 'function') {
           this.adjustedDecimalPoint =
             this.getAutoDecimalPointFromInterval(interval);
@@ -310,7 +310,7 @@ class LinearScale extends Scale {
   
       if (isCompatible || this.fixedSteps) {
         const steps = Math.round(rawSteps);
-        setDecimal(graphRange, steps, interval);
+        setDecimal(interval);
         return {
           steps,
           interval,
@@ -332,7 +332,7 @@ class LinearScale extends Scale {
       const steps = maxSteps;
       const interval = graphRange / steps;
   
-      setDecimal(graphRange, steps, interval);
+      setDecimal(interval);
   
       return {
         steps,
@@ -375,7 +375,7 @@ class LinearScale extends Scale {
         steps = safeSteps(graphRange, interval);
       }
   
-      setDecimal(graphRange, steps, interval);
+      setDecimal(interval);
   
       return {
         steps,
@@ -401,11 +401,7 @@ class LinearScale extends Scale {
       maxSteps,
     });
   
-    setDecimal(
-      nice.max - nice.min,
-      nice.steps,
-      nice.interval,
-    );
+    setDecimal(nice.interval);
   
     return {
       steps: nice.steps,

--- a/src/components/chart/scale/scale.linear.js
+++ b/src/components/chart/scale/scale.linear.js
@@ -210,7 +210,7 @@ class LinearScale extends Scale {
     let decimals = 0;
     let temp = absInterval;
 
-    while (temp < 1 && decimals < 10) {
+    while (temp % 1 !== 0 && decimals < 10) {
       temp *= 10;
       decimals += 1;
     }

--- a/src/components/chart/scale/scale.linear.js
+++ b/src/components/chart/scale/scale.linear.js
@@ -177,45 +177,49 @@ class LinearScale extends Scale {
   }
 
   /**
-   * graphRange와 step 수를 기반으로 필요한 소수점 자릿수를 계산
-   * @param {object} params
-   * @param {number} params.graphRange
-   * @param {number} params.numberOfSteps
-   * @returns {number} decimal places (0 이상)
+   * 주어진 축 interval을 정확히 표현하기 위해 필요한 최소 소수점 자릿수를 반환한다.
+   *
+   * decimalPoint: 'auto' 모드에서 사용되며,
+   * 반올림으로 값이 왜곡되지 않도록 JS 부동소수점 오차를 고려해 계산한다.
+   *
+   * 예: 0.25 → 2, 0.125 → 3, 2.5 → 1
+   *
+   * @param {number} interval - 축 눈금 간격
+   * @returns {number} 필요한 소수점 자릿수 (0 이상)
    */
-  getDecimalPointFromRange({ graphRange, numberOfSteps }) {
-    if (
-      !Number.isFinite(graphRange) ||
-      !Number.isFinite(numberOfSteps) ||
-      graphRange <= 0 ||
-      numberOfSteps <= 0
-    ) {
-      return 0;
-    }
-
-    const interval = graphRange / numberOfSteps;
-
+  getDecimalPointFromInterval(interval) {
     if (!Number.isFinite(interval) || interval === 0) {
       return 0;
     }
-
+  
     const absInterval = Math.abs(interval);
-
-    // 1 이상이면 소수점 불필요
-    if (absInterval >= 1) {
+    const MAX_DECIMALS = 10;
+    const EPSILON = 1e-10;
+  
+    const roundTo = (value, decimals = 0) => {
+      const factor = 10 ** decimals;
+      return Math.round((value + Number.EPSILON) * factor) / factor;
+    };
+  
+    const isRepresentableAtDecimals = (value, decimals) => {
+      const rounded = roundTo(value, decimals);
+      return Math.abs(value - rounded) < EPSILON;
+    };
+  
+    if (absInterval >= 1 && isRepresentableAtDecimals(absInterval, 0)) {
       return 0;
     }
-
-    // 소수점 자리 계산 (최대 10자리 제한)
-    let decimals = 0;
-    let temp = absInterval;
-
-    while (temp % 1 !== 0 && decimals < 10) {
-      temp *= 10;
-      decimals += 1;
+  
+    const rough =
+      absInterval >= 1 ? 0 : Math.max(0, Math.ceil(-Math.log10(absInterval)));
+  
+    for (let decimals = rough; decimals <= MAX_DECIMALS; decimals += 1) {
+      if (isRepresentableAtDecimals(absInterval, decimals)) {
+        return decimals;
+      }
     }
-
-    return decimals;
+  
+    return MAX_DECIMALS;
   }
 
   /**
@@ -251,10 +255,7 @@ class LinearScale extends Scale {
   
     const setDecimal = (graphRange, steps, interval) => {
       if (this.decimalPoint === 'auto') {
-        const decimalFromRange = this.getDecimalPointFromRange?.({
-          graphRange,
-          numberOfSteps: steps,
-        });
+        const decimalFromRange = this.getDecimalPointFromInterval(interval);
   
         if (
           decimalFromRange != null &&

--- a/src/components/chart/scale/scale.linear.spec.js
+++ b/src/components/chart/scale/scale.linear.spec.js
@@ -89,6 +89,30 @@ describe('LinearScale', () => {
       const scale = createScale();
       expect(scale.getDecimalPointFromRange({ graphRange: 1e-15, numberOfSteps: 1 })).toBe(10);
     });
+
+    // 버그 재현: graphRange=0.5, numberOfSteps=2 → interval=0.25 → 소수점 2자리여야 함
+    it('graphRange=0.5, numberOfSteps=2이면 2를 반환한다 (interval=0.25)', () => {
+      const scale = createScale();
+      expect(scale.getDecimalPointFromRange({ graphRange: 0.5, numberOfSteps: 2 })).toBe(2);
+    });
+
+    it('interval이 0.5이면 1을 반환한다', () => {
+      const scale = createScale();
+      // graphRange=1, numberOfSteps=2 → interval=0.5
+      expect(scale.getDecimalPointFromRange({ graphRange: 1, numberOfSteps: 2 })).toBe(1);
+    });
+
+    it('interval이 0.125이면 3을 반환한다', () => {
+      const scale = createScale();
+      // graphRange=0.5, numberOfSteps=4 → interval=0.125
+      expect(scale.getDecimalPointFromRange({ graphRange: 0.5, numberOfSteps: 4 })).toBe(3);
+    });
+
+    it('interval이 정확히 1이면 0을 반환한다', () => {
+      const scale = createScale();
+      // graphRange=5, numberOfSteps=5 → interval=1
+      expect(scale.getDecimalPointFromRange({ graphRange: 5, numberOfSteps: 5 })).toBe(0);
+    });
   });
 
   describe('calculateSteps', () => {

--- a/src/components/chart/scale/scale.linear.spec.js
+++ b/src/components/chart/scale/scale.linear.spec.js
@@ -53,68 +53,6 @@ describe('LinearScale', () => {
     });
   });
 
-  describe('getDecimalPointFromRange', () => {
-    it('정수 범위는 0을 반환한다', () => {
-      const scale = createScale();
-      expect(scale.getDecimalPointFromRange({ graphRange: 100, numberOfSteps: 5 })).toBe(0);
-    });
-
-    it('소수점 범위의 자릿수를 반환한다', () => {
-      const scale = createScale();
-      expect(scale.getDecimalPointFromRange({ graphRange: 1, numberOfSteps: 10 })).toBe(1);
-    });
-
-    it('매우 작은 범위의 자릿수를 반환한다', () => {
-      const scale = createScale();
-      expect(scale.getDecimalPointFromRange({ graphRange: 0.01, numberOfSteps: 10 })).toBe(3);
-    });
-
-    it('numberOfSteps가 0이면 0을 반환한다', () => {
-      const scale = createScale();
-      expect(scale.getDecimalPointFromRange({ graphRange: 100, numberOfSteps: 0 })).toBe(0);
-    });
-
-    it('graphRange가 0이면 0을 반환한다', () => {
-      const scale = createScale();
-      expect(scale.getDecimalPointFromRange({ graphRange: 0, numberOfSteps: 5 })).toBe(0);
-    });
-
-    it('유효하지 않은 값(Infinity/NaN)이면 0을 반환한다', () => {
-      const scale = createScale();
-      expect(scale.getDecimalPointFromRange({ graphRange: Infinity, numberOfSteps: 5 })).toBe(0);
-      expect(scale.getDecimalPointFromRange({ graphRange: 1, numberOfSteps: NaN })).toBe(0);
-    });
-
-    it('소수점 계산은 최대 10자리까지만 반환한다', () => {
-      const scale = createScale();
-      expect(scale.getDecimalPointFromRange({ graphRange: 1e-15, numberOfSteps: 1 })).toBe(10);
-    });
-
-    // 버그 재현: graphRange=0.5, numberOfSteps=2 → interval=0.25 → 소수점 2자리여야 함
-    it('graphRange=0.5, numberOfSteps=2이면 2를 반환한다 (interval=0.25)', () => {
-      const scale = createScale();
-      expect(scale.getDecimalPointFromRange({ graphRange: 0.5, numberOfSteps: 2 })).toBe(2);
-    });
-
-    it('interval이 0.5이면 1을 반환한다', () => {
-      const scale = createScale();
-      // graphRange=1, numberOfSteps=2 → interval=0.5
-      expect(scale.getDecimalPointFromRange({ graphRange: 1, numberOfSteps: 2 })).toBe(1);
-    });
-
-    it('interval이 0.125이면 3을 반환한다', () => {
-      const scale = createScale();
-      // graphRange=0.5, numberOfSteps=4 → interval=0.125
-      expect(scale.getDecimalPointFromRange({ graphRange: 0.5, numberOfSteps: 4 })).toBe(3);
-    });
-
-    it('interval이 정확히 1이면 0을 반환한다', () => {
-      const scale = createScale();
-      // graphRange=5, numberOfSteps=5 → interval=1
-      expect(scale.getDecimalPointFromRange({ graphRange: 5, numberOfSteps: 5 })).toBe(0);
-    });
-  });
-
   describe('calculateSteps', () => {
     it('userRange + userInterval이 호환되면 그대로 사용한다', () => {
       const scale = createScale({
@@ -339,6 +277,159 @@ describe('LinearScale', () => {
       const scale = createScale();
       // 15 → exponent=1, normalized=1.5 → fraction=2 → 20
       expect(scale.getNiceInterval(15)).toBe(20);
+    });
+  });
+
+  describe('getDecimalFromInterval', () => {
+    describe('정수 interval', () => {
+      it('정수는 decimal 0을 반환한다', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+
+        expect(scale.getDecimalPointFromInterval(1)).toBe(0);
+        expect(scale.getDecimalPointFromInterval(10)).toBe(0);
+        expect(scale.getDecimalPointFromInterval(100)).toBe(0);
+      });
+    });
+  
+    describe('정확히 표현 가능한 소수 (2ⁿ 분모)', () => {
+      it('0.5 → 1', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(0.5)).toBe(1);
+      });
+  
+      it('0.25 → 2', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(0.25)).toBe(2);
+      });
+  
+      it('0.125 → 3', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(0.125)).toBe(3);
+      });
+  
+      it('2.5 → 1', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(2.5)).toBe(1);
+      });
+    });
+  
+    describe('부동소수점 표현 불가능 값', () => {
+      it('0.1 → 1', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(0.1)).toBe(1);
+      });
+  
+      it('0.2 → 1', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(0.2)).toBe(1);
+      });
+  
+      it('0.05 → 2', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(0.05)).toBe(2);
+      });
+  
+      it('0.01 → 2', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(0.01)).toBe(2);
+      });
+
+      it('0.25 interval은 2자리 decimal이 필요하다 (0.3 방지)', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(0.25)).toBe(2);
+      });
+
+      it('0.1 + 0.2 문제를 유발하는 interval', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(0.1)).toBe(1);
+      });
+    });
+  
+    describe('작은 값', () => {
+      it('0.001 → 3', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(0.001)).toBe(3);
+      });
+  
+      it('0.0001 → 4', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(0.0001)).toBe(4);
+      });
+    });
+  
+    describe('큰 값 + 소수 간격', () => {
+      it('100.5 → 1', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(100.5)).toBe(1);
+      });
+  
+      it('100.25 → 2', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(100.25)).toBe(2);
+      });
+    });
+  
+    describe('음수 interval', () => {
+      it('부호는 무시하고 절댓값 기준으로 계산한다', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(-0.25)).toBe(2);
+        expect(scale.getDecimalPointFromInterval(-2.5)).toBe(1);
+      });
+    });
+  
+    describe('경계값 / 예외', () => {
+      it('0 → 0', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(0)).toBe(0);
+      });
+  
+      it('NaN → 0', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(NaN)).toBe(0);
+      });
+  
+      it('Infinity → 0', () => {
+        const scale = createScale({
+          decimalPoint: 'auto',
+        });
+        expect(scale.getDecimalPointFromInterval(Infinity)).toBe(0);
+      });
     });
   });
 });


### PR DESCRIPTION
[이슈] 
axes 옵션으로 range [0, 0.5], interval: 0.25, decimalPoint가 'auto' 이고 fixesSteps: true 인경우 0.25가 아닌 0.3 으로 표현됨

[변경 사항]
decimal을 찾는 조건식에 1 미만이 아니라 정수 값일때까지 찾도록 변경

[기존 동작]

<img width="1072" height="662" alt="Image" src="https://github.com/user-attachments/assets/e91c1fbd-dcf9-441a-bdef-fceaad6d2681" />

[기대 동작]
<img width="1092" height="473" alt="image" src="https://github.com/user-attachments/assets/d2e8186b-d5da-4722-b819-2bca7752a990" />

[테스트 방법]
http://localhost:9999/EVUI/barChart Default 에서 아래와 같이 변경
- range [0, 0.5],
- interval: 0.25,
- fixesSteps: true
- decimalPoint: 'auto'