### PR TITLE
fix: lastLabelStyle 기본값 제거. 사용자가 부여했을때만 적용되도록 함

### DIFF
--- a/src/components/chart/helpers/helpers.constant.js
+++ b/src/components/chart/helpers/helpers.constant.js
@@ -133,12 +133,7 @@ export const AXIS_OPTION = {
     padding: 0,
     fixWidth: undefined,
   },
-  lastLabelFontStyle: {
-    fontSize: 12,
-    color: '#808080',
-    fontFamily: 'Roboto',
-    fontWeight: 400,
-  },
+  lastLabelFontStyle: null,
   title: {
     use: false,
     text: null,


### PR DESCRIPTION
### 이슈 내용 
- 사용자가 Chart > Axis > lastLabelStyle 지정이 필요없어 설정 안했음에도 불구하고 기본값이 적용됨 

### 수정 내용 
- 기본값 제거 