### PR TITLE
fix(chart): realTimeScatter autoScale 시 유효 시간 범위 밖 데이터 min/max 반영 문제 수정

### DIFF
--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -259,10 +259,18 @@ const modules = {
         }
       }
 
-      minMaxValues.maxY = Math.max(minMaxValues.maxY, tempMinMax.maxY);
-      minMaxValues.minY = Math.min(minMaxValues.minY, tempMinMax.minY);
+      const hasValidData = Number.isFinite(tempMinMax.minY);
+      if (hasValidData) {
+        minMaxValues.maxY = Math.max(minMaxValues.maxY, tempMinMax.maxY);
+        minMaxValues.minY = Math.min(minMaxValues.minY, tempMinMax.minY);
+      }
       minMaxValues.fromTime = dataset.fromTime;
       minMaxValues.toTime = dataset.toTime;
+    }
+
+    if (!Number.isFinite(minMaxValues.minY)) {
+      minMaxValues.minY = 0;
+      minMaxValues.maxY = 1;
     }
 
     this.seriesInfo.charts.scatter.forEach((seriesID) => {

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -240,13 +240,23 @@ const modules = {
         }
       }
 
-      // 12) series min/max 계산
+      // 12) series min/max 계산 (fromTime ~ toTime 범위 내 데이터만 포함)
+      const MS_PER_SECOND = 1000;
       const tempMinMax = { maxY: 0, minY: Infinity };
 
       for (let i = 0; i < length; i++) {
         const g = dataGroup[i];
-        if (g.max > tempMinMax.maxY) tempMinMax.maxY = g.max;
-        if (g.min < tempMinMax.minY) tempMinMax.minY = g.min;
+        for (let j = 0; j < g.data.length; j++) {
+          const point = g.data[j];
+          // point.x(ms)를 초 단위로 내림하여 슬롯 기준 시간(fromTime/toTime)과 비교 가능하게 맞춤
+          const pointTimeInSeconds = Math.floor(point.x / MS_PER_SECOND) * MS_PER_SECOND;
+          const isInTimeRange = pointTimeInSeconds >= dataset.fromTime
+            && pointTimeInSeconds <= dataset.toTime;
+          if (isInTimeRange && Number.isFinite(point.y)) {
+            if (point.y > tempMinMax.maxY) tempMinMax.maxY = point.y;
+            if (point.y < tempMinMax.minY) tempMinMax.minY = point.y;
+          }
+        }
       }
 
       minMaxValues.maxY = Math.max(minMaxValues.maxY, tempMinMax.maxY);


### PR DESCRIPTION
https://github.com/ex-em/EVUI/pull/2078 PR 3.4 브랜치에 적용한 MR입니다.

relate to https://github.com/ex-em/EVUI/issues/2077