### PR TITLE
fix: chart > scrollbar 옵션 변경할때 차트에 반영되지 않음

### DIFF
--- a/docs/views/barChart/example/Scrollbar.vue
+++ b/docs/views/barChart/example/Scrollbar.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="case">
-    <div
-      class="chart-wrapper"
-      :style="{ width: chartWidth, height: chartHeight }"
-    >
+    <div class="chart-wrapper">
       <ev-chart
         ref="chart"
         v-model:selectedLabel="defaultSelectLabel"
@@ -12,10 +9,7 @@
         @click="onClick"
       />
     </div>
-    <div
-      class="chart-wrapper"
-      :style="{ width: chartWidth, height: chartHeight }"
-    >
+    <div class="chart-wrapper">
       <ev-chart
         v-model:selectedLabel="defaultSelectLabel"
         :data="chartData2"

--- a/docs/views/barChart/example/Scrollbar.vue
+++ b/docs/views/barChart/example/Scrollbar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="case">
-    <div class="chart-wrapper">
+    <resizable-wrapper>
       <ev-chart
         ref="chart"
         v-model:selectedLabel="defaultSelectLabel"
@@ -8,15 +8,15 @@
         :options="chartOptions1"
         @click="onClick"
       />
-    </div>
-    <div class="chart-wrapper">
+    </resizable-wrapper>
+    <resizable-wrapper>
       <ev-chart
         v-model:selectedLabel="defaultSelectLabel"
-        :data="chartData2"
-        :options="chartOptions2"
-        @click="onClick"
-      />
-    </div>
+      :data="chartData2"
+      :options="chartOptions2"
+      @click="onClick"
+    />
+  </resizable-wrapper>
     <div class="description">
       <div class="options">
         <ev-toggle v-model="isShowScrollbar" />
@@ -371,6 +371,7 @@ export default {
       type: 'bar',
       thickness: 0.8,
       width: '100%',
+      height: '100%',
       horizontal: true,
       title: {
         show: false,
@@ -614,11 +615,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.chart-wrapper {
-  overflow: hidden;
-  resize: both;
-  border: 1px dashed #CCCCCC;
-}
 .options {
   display: grid;
   grid-template-columns: 1fr 2fr;

--- a/docs/views/barChart/example/Scrollbar.vue
+++ b/docs/views/barChart/example/Scrollbar.vue
@@ -1,83 +1,98 @@
 <template>
   <div class="case">
-    <ev-chart
-      ref="chart"
-      v-model:selectedLabel="defaultSelectLabel"
-      :data="chartData1"
-      :options="chartOptions1"
-      @click="onClick"
-    />
-    <ev-chart
-      v-model:selectedLabel="defaultSelectLabel"
-      :data="chartData2"
-      :options="chartOptions2"
-      @click="onClick"
-    />
-    <div class="options description">
-      <ev-toggle v-model="isResetPosition" />
-      <span>
-        스크롤위치 초기화여부
-      </span>
+    <div
+      class="chart-wrapper"
+      :style="{ width: chartWidth, height: chartHeight }"
+    >
+      <ev-chart
+        ref="chart"
+        v-model:selectedLabel="defaultSelectLabel"
+        :data="chartData1"
+        :options="chartOptions1"
+        @click="onClick"
+      />
+    </div>
+    <div
+      class="chart-wrapper"
+      :style="{ width: chartWidth, height: chartHeight }"
+    >
+      <ev-chart
+        v-model:selectedLabel="defaultSelectLabel"
+        :data="chartData2"
+        :options="chartOptions2"
+        @click="onClick"
+      />
+    </div>
+    <div class="description">
+      <div class="options">
+        <ev-toggle v-model="isShowScrollbar" />
+        <span>
+          스크롤바 표시 여부
+        </span>
 
-      <ev-toggle v-model="isFixedPosTop" />
-      <span class="left">
-        tip 위치를 최상단에 고정
-      </span>
+        <ev-toggle v-model="isResetPosition" />
+        <span>
+          스크롤위치 초기화여부
+        </span>
 
-      <ev-button @click="toggleSelectData">
-        <span>select by v-model</span>
-      </ev-button>
-      <span class="left">
-        차트 클릭이 아닌 v-model:selectedLabel 에 바인딩한 dataIndex 배열을
-        변경해서 라벨 선택
-      </span>
-      <ev-button @click="updateData">
-        Update Data
-      </ev-button>
-      <span>
-        데이터 업데이트
-      </span>
+        <ev-toggle v-model="isFixedPosTop" />
+        <span class="left">
+          tip 위치를 최상단에 고정
+        </span>
 
-      <ev-button @click="updateDataWithDynamicRange">
-        Update Data With Dynamic Range
-      </ev-button>
-      <span>
-        데이터 업데이트
-      </span>
+        <ev-button @click="toggleSelectData">
+          <span>select by v-model</span>
+        </ev-button>
+        <span class="left">
+          차트 클릭이 아닌 v-model:selectedLabel 에 바인딩한 dataIndex 배열을
+          변경해서 라벨 선택
+        </span>
+        <ev-button @click="updateData">
+          Update Data
+        </ev-button>
+        <span>
+          데이터 업데이트
+        </span>
 
-      <!-- options의 range를 직접 바꿔서 스크롤/데이터 동기화 테스트용 버튼 -->
-      <ev-button @click="setRangeToFirstHalf">
-        <span>range: 앞 절반</span>
-      </ev-button>
-      <span>
-        데이터 업데이트
-      </span>
-      <ev-button @click="setRangeToLastHalf">
-        <span>range: 뒤 절반</span>
-      </ev-button>
-      <span>
-        데이터 업데이트
-      </span>
-      <span class="left">
+        <ev-button @click="updateDataWithDynamicRange">
+          Update Data With Dynamic Range
+        </ev-button>
+        <span>
+          데이터 업데이트
+        </span>
+
+        <!-- options의 range를 직접 바꿔서 스크롤/데이터 동기화 테스트용 버튼 -->
+        <ev-button @click="setRangeToFirstHalf">
+          <span>range: 앞 절반</span>
+        </ev-button>
+        <span>
+          데이터 업데이트
+        </span>
+        <ev-button @click="setRangeToLastHalf">
+          <span>range: 뒤 절반</span>
+        </ev-button>
+        <span>
+          데이터 업데이트
+        </span>
+      </div>
+      <h3>
         options의 range를 직접 바꿔서 스크롤/데이터 동기화 테스트
-      </span>
-
+      </h3>
+      <div class="options">
       <!-- 10개 → 7개 테스트 버튼들 -->
-      <ev-button @click="setDataToTen">
-        <span>데이터 10개로 설정</span>
-      </ev-button>
-      <span>
-        테스트용 데이터 10개 생성
-      </span>
-      <ev-button @click="setDataToSeven">
-        <span>데이터 7개로 줄이기</span>
-      </ev-button>
-      <span>
-        데이터를 7개로 줄여서 스크롤바 나가는 문제 재현
-      </span>
-
-      <div />
-
+        <ev-button @click="setDataToTen">
+          <span>데이터 10개로 설정</span>
+        </ev-button>
+        <span>
+          테스트용 데이터 10개 생성
+        </span>
+        <ev-button @click="setDataToSeven">
+          <span>데이터 7개로 줄이기</span>
+        </ev-button>
+        <span>
+          데이터를 7개로 줄여서 스크롤바 나가는 문제 재현
+        </span>
+      </div>
       <div class="badge yellow">
         v-model:selectedLabel
       </div>
@@ -123,6 +138,8 @@ export default {
     const isFixedPosTop = ref(false);
 
     const isResetPosition = ref(false);
+
+    const isShowScrollbar = ref(true);
 
     const chartData1 = shallowRef({
       series: {
@@ -296,6 +313,7 @@ export default {
       type: 'bar',
       thickness: 0.8,
       width: '100%',
+      height: '100%',
       horizontal: false,
       title: {
         show: false,
@@ -315,7 +333,7 @@ export default {
           },
           range: RANGE,
           scrollbar: {
-            use: true,
+            use: isShowScrollbar,
             showButton: true,
             resetPosition: isResetPosition,
           },
@@ -378,7 +396,7 @@ export default {
           },
           range: RANGE,
           scrollbar: {
-            use: true,
+            use: isShowScrollbar,
             showButton: true,
             resetPosition: isResetPosition,
           },
@@ -579,6 +597,7 @@ export default {
       chart,
       chartData1,
       chartData2,
+      isShowScrollbar,
       isFixedPosTop,
       isResetPosition,
       chartOptions1,
@@ -601,9 +620,17 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.chart-wrapper {
+  overflow: hidden;
+  resize: both;
+  border: 1px dashed #CCCCCC;
+}
 .options {
   display: grid;
   grid-template-columns: 1fr 2fr;
   gap: 10px;
+}
+h3 {
+  margin-top: 20px;
 }
 </style>

--- a/docs/views/heatMap/example/Scrollbar.vue
+++ b/docs/views/heatMap/example/Scrollbar.vue
@@ -52,14 +52,6 @@
           :max="LABEL_Y_COUNT - 1"
         />
       </div>
-      <div class="option">
-        <span>차트 크기 조절 (resize 테스트)</span>
-      </div>
-      <div class="option">
-        <ev-button @click="setChartSize('100%', '300px')">작게</ev-button>
-        <ev-button @click="setChartSize('100%', '500px')">기본</ev-button>
-        <ev-button @click="setChartSize('60%', '400px')">좁게</ev-button>
-      </div>
       <label class="badge yellow"> v-model:selectedLabel</label>
       <span>{{ selectedLabel }}</span>
     </div>

--- a/docs/views/heatMap/example/Scrollbar.vue
+++ b/docs/views/heatMap/example/Scrollbar.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="case">
-    <div
-      class="chart-wrapper"
-      :style="{ width: chartWidth, height: chartHeight }"
-    >
+    <div class="chart-wrapper">
       <ev-chart
         v-model:selectedLabel="selectedLabel"
         :data="chartData"

--- a/docs/views/heatMap/example/Scrollbar.vue
+++ b/docs/views/heatMap/example/Scrollbar.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="case">
-    <div class="chart-wrapper">
+    <resizable-wrapper>
       <ev-chart
         v-model:selectedLabel="selectedLabel"
         :data="chartData"
         :options="chartOptions"
       />
-    </div>
+    </resizable-wrapper>
     <div class="description">
       <div class="option">
         <span>scrollbar 사용</span>
@@ -107,7 +107,7 @@ export default {
     const chartOptions = reactive({
       type: 'heatMap',
       width: '100%',
-      height: '300px',
+      height: '100%',
       title: {
         text: 'Chart Title',
         show: true,
@@ -240,11 +240,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.chart-wrapper {
-  overflow: hidden;
-  resize: both;
-  border: 1px dashed #CCCCCC;
-}
 .description {
   position: relative;
 

--- a/docs/views/heatMap/example/Scrollbar.vue
+++ b/docs/views/heatMap/example/Scrollbar.vue
@@ -1,10 +1,15 @@
 <template>
   <div class="case">
-    <ev-chart
-      v-model:selectedLabel="selectedLabel"
-      :data="chartData"
-      :options="chartOptions"
-    />
+    <div
+      class="chart-wrapper"
+      :style="{ width: chartWidth, height: chartHeight }"
+    >
+      <ev-chart
+        v-model:selectedLabel="selectedLabel"
+        :data="chartData"
+        :options="chartOptions"
+      />
+    </div>
     <div class="description">
       <div class="option">
         <span>scrollbar 사용</span>
@@ -49,6 +54,14 @@
           :min="yMin + 1"
           :max="LABEL_Y_COUNT - 1"
         />
+      </div>
+      <div class="option">
+        <span>차트 크기 조절 (resize 테스트)</span>
+      </div>
+      <div class="option">
+        <ev-button @click="setChartSize('100%', '300px')">작게</ev-button>
+        <ev-button @click="setChartSize('100%', '500px')">기본</ev-button>
+        <ev-button @click="setChartSize('60%', '400px')">좁게</ev-button>
       </div>
       <label class="badge yellow"> v-model:selectedLabel</label>
       <span>{{ selectedLabel }}</span>
@@ -230,6 +243,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.chart-wrapper {
+  overflow: hidden;
+  resize: both;
+  border: 1px dashed #CCCCCC;
+}
 .description {
   position: relative;
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -892,6 +892,8 @@ class EvChart {
       return;
     }
 
+    this.updateScrollbar(updateData);
+
     this.resetProps();
 
     this.updateSeries = updateSeries;
@@ -1000,8 +1002,6 @@ class EvChart {
     this.axesY = this.createAxes('y', options.axesY);
 
     this.initDefaultSelectInfo();
-
-    this.updateScrollbar(updateData);
 
     let renderHitInfo = updateInfo?.hitInfo;
     if (!renderHitInfo?.legend && this.legendHover?.sId) {

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -127,6 +127,10 @@ class EvChart {
     this.axesX = this.createAxes('x', axesX);
     this.axesY = this.createAxes('y', axesY);
 
+    if (axesX?.[0]?.scrollbar?.use || axesY?.[0]?.scrollbar?.use) {
+      this.initScrollbar();
+    }
+
     this.initDefaultSelectInfo();
 
     this.drawChart();
@@ -160,10 +164,6 @@ class EvChart {
       }
 
       this.setLegendPosition();
-    }
-
-    if (opt.axesX?.[0]?.scrollbar?.use || opt.axesY?.[0]?.scrollbar?.use) {
-      this.initScrollbar();
     }
 
     this.chartRect = this.getChartRect();
@@ -277,7 +277,6 @@ class EvChart {
     this.drawSeries(hitInfo);
 
     if (this.scrollbar?.x?.use || this.scrollbar?.y?.use) {
-      this.initScrollbar();
       this.updateScrollbarPosition();
     }
 
@@ -853,6 +852,21 @@ class EvChart {
   }
 
   /**
+   * Update scrollbar information
+   * @param {boolean} updateData is update data
+   * @returns {undefined}
+   */
+  updateScrollbar(updateData) {
+    if (this.scrollbar?.x?.isInit || this.options.axesX?.[0]?.scrollbar?.use) {
+      this.updateScrollbarInfo('x', updateData);
+    }
+
+    if (this.scrollbar?.y?.isInit || this.options.axesY?.[0]?.scrollbar?.use) {
+      this.updateScrollbarInfo('y', updateData);
+    }
+  }
+
+  /**
    * To re-render chart, reset properties, canvas and then render chart.
    * @param {object} updateInfo   information for each components are needed to update
    *
@@ -871,16 +885,11 @@ class EvChart {
       updateLegend,
       updateData,
       updateTooltip,
-      updateByScrollbar,
       lightUpdate,
     } = updateInfo;
 
     if (!this.isInit) {
       return;
-    }
-
-    if (updateByScrollbar) {
-      this.updateScrollbar?.(updateData);
     }
 
     this.resetProps();
@@ -992,6 +1001,7 @@ class EvChart {
 
     this.initDefaultSelectInfo();
 
+    this.updateScrollbar(updateData);
 
     let renderHitInfo = updateInfo?.hitInfo;
     if (!renderHitInfo?.legend && this.legendHover?.sId) {
@@ -1065,20 +1075,16 @@ class EvChart {
    * @returns {undefined}
    */
   resize(promiseRes) {
-    // 차트 크기가 변경될 때 저장된 스크롤 픽셀 위치를 초기화하여
-    // 새로운 크기에 맞춰 스크롤바 크기/위치를 재계산하도록 함
-    if (this.scrollbar?.x) {
-      delete this.scrollbar.x.savedPosition;
-    }
-    if (this.scrollbar?.y) {
-      delete this.scrollbar.y.savedPosition;
-    }
-
     this.clear();
     this.bufferCtx.restore();
     this.bufferCtx.save();
 
     this.initRect();
+
+    if (this.options.axesX?.[0]?.scrollbar?.use || this.options.axesY?.[0]?.scrollbar?.use) {
+      this.initScrollbar();
+    }
+
     this.initScale();
     this.chartRect = this.getChartRect();
     this.drawChart();

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -29,6 +29,8 @@ const module = {
       scrollbarOpt[key] = merged[key];
     });
 
+    delete scrollbarOpt.savedPosition;
+
     if (!scrollbarOpt.isInit) {
       scrollbarOpt.type = axisOpt?.[0]?.type;
       scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...axisOpt?.[0]?.range] : null;
@@ -81,14 +83,6 @@ const module = {
         }
       }
     }
-  },
-
-  /**
-   * update scrollbar information
-   */
-  updateScrollbar(updateData) {
-    this.updateScrollbarInfo('x', updateData);
-    this.updateScrollbarInfo('y', updateData);
   },
 
   /**
@@ -449,7 +443,6 @@ const module = {
       this.update({
         updateSeries: false,
         updateSelTip: { update: false, keepDomain: false },
-        updateByScrollbar: true,
         lightUpdate: minValue > 1,
       });
     }


### PR DESCRIPTION
## 문제

`scrollbar.use` 옵션을 런타임에 변경해도 스크롤바가 표시되거나 사라지지 않는 문제.

- `initScrollbar` 호출 시점이 `setLayout` 내부에 있어, 초기화 이후 옵션 변경 시 반영되지 않음

---

## 변경 내용

### `src/components/chart/chart.core.js`

**`initScrollbar` 호출 시점 변경**

- 기존: `setLayout()` 내부에서 호출 → 초기화 이후 옵션 변경 미반영
- 변경: `init()` 내 `createAxes()` 직후 / `resize()` 내 `initRect()` 직후로 이동

**`updateScrollbar` 메서드 신규 추가 (plugin → core)**

- `plugins.scrollbar.js`의 `updateScrollbar`를 제거하고 `chart.core.js`의 클래스 메서드로 이관
- 축별로 진입 전에 가드 조건 추가 → 스크롤바 미사용 차트에서 불필요한 호출 차단

```js
updateScrollbar(updateData) {
  if (this.scrollbar?.x?.isInit || this.options.axesX?.[0]?.scrollbar?.use) {
    this.updateScrollbarInfo('x', updateData);
  }
  if (this.scrollbar?.y?.isInit || this.options.axesY?.[0]?.scrollbar?.use) {
    this.updateScrollbarInfo('y', updateData);
  }
}
```

| 케이스 | 동작 |
|---|---|
| 처음부터 미사용 | `updateScrollbarInfo` 호출 자체를 스킵 |
| 사용 중 | 기존대로 호출 |
| 사용 → 미사용 (옵션 변경) | 호출 → `destroyScrollbar`로 DOM 제거 |
| 미사용 → 사용 (옵션 변경) | 호출 → `initScrollbarInfo` 진입 |

**`update()` 경로에서 `updateScrollbar` 무조건 호출**

- 기존: `updateByScrollbar: true` 플래그가 있을 때만 호출
- 변경: 모든 `update` 경로에서 호출 (가드 조건으로 불필요한 연산은 차단)
- `updateByScrollbar` 플래그 및 관련 분기 제거

**`drawChart()` 내 `initScrollbar()` 제거**

- 매 드로우마다 스크롤바를 재초기화하던 불필요한 호출 제거

### `src/components/chart/plugins/plugins.scrollbar.js`

**`initScrollbarInfo`에서 `savedPosition` 삭제 통합**

- 기존: `resize()`에서 직접 `delete this.scrollbar.x.savedPosition` 처리
- 변경: `initScrollbar` 호출 시 `initScrollbarInfo` 내부에서 일괄 처리

```js
// initScrollbarInfo 내
delete scrollbarOpt.savedPosition;
```

**`updateScrollbar` 메서드 제거**

- `chart.core.js`로 이관

**스크롤바 드래그 시 `update` 호출에서 `updateByScrollbar` 플래그 제거**

```js
// 변경 전
this.update({ updateSeries: false, updateSelTip: {...}, updateByScrollbar: true, lightUpdate: ... });

// 변경 후
this.update({ updateSeries: false, updateSelTip: {...}, lightUpdate: ... });
```

---

### `docs/views/barChart/example/Scrollbar.vue`

- 스크롤바 표시 여부 토글(`isShowScrollbar`) 추가 → `use: true` 하드코딩 → `use: isShowScrollbar` reactive 바인딩으로 변경
- resizable-wrapper 컴포넌트로 감싸 차트 크기 조절 가능

### `docs/views/heatMap/example/Scrollbar.vue`

- resizable-wrapper 컴포넌트로 감싸 차트 크기 조절 가능

---

## 테스트 시나리오
http://localhost:9999/barChart#scrollbar

http://localhost:9999/heatMap#scrollbar

- [x] 스크롤바 표시 여부 토글 시 스크롤바가 나타나고 사라지는지 확인
- [x] 스크롤 중 데이터 업데이트 시 스크롤 위치 유지 여부 확인
- [x] 스크롤 중 차트 resize 후 스크롤바 위치/크기가 새 크기 기준으로 재계산되는지 확인
- [x] range 변경 시 스크롤바 위치 초기화 여부 확인
- [x] 데이터 개수 변경(10개 → 7개) 후 스크롤바가 범위를 벗어나지 않는지 확인
- [x] HeatMap > x축/y축 스크롤바 동시 사용 시 resize 후 정상 동작 확인
