### PR TITLE
[fix] Chart > Line > Tooltip > 1번째 시리즈가 빈 값인 경우 다른 시리즈에 데이터 있어도 툴팁 표시 안 되는 현상 

### DIFF
--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1019,7 +1019,10 @@ const modules = {
     const mousePos = isHorizontal ? yp : xp;
 
     // 첫 번째 표시 중인 시리즈를 기준으로 라벨 위치 확인
-    const referenceSeries = sIds.find((sId) => this.seriesList[sId]?.show);
+    const referenceSeries = sIds.find((sId) => {
+      const series = this.seriesList[sId];
+      return series?.show && series?.data?.length > 0;
+    });
     if (!referenceSeries || !this.seriesList[referenceSeries]?.data) {
       return -1;
     }

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1018,7 +1018,7 @@ const modules = {
     const isHorizontal = !!this.options.horizontal;
     const mousePos = isHorizontal ? yp : xp;
 
-    // 첫 번째 표시 중인 시리즈를 기준으로 라벨 위치 확인
+    // 데이터 있는 시리즈를 기준으로 라벨 위치 확인
     const referenceSeries = sIds.find((sId) => {
       const series = this.seriesList[sId];
       return series?.show && series?.data?.length > 0;


### PR DESCRIPTION
### 이슈
1번째 시리즈가 빈 값(ex. 빈 배열)인 경우 다른 시리즈에 데이터 있어도 툴팁 표시 안 되는 현상 
![line tooltip](https://github.com/user-attachments/assets/d198ecf4-94dd-4691-ad4e-616b86c25a19)

### 해결
데이터 있는 시리즈 찾아서 사용하도록 수정하였습니다.
![line tooltip-fix](https://github.com/user-attachments/assets/22709523-3ceb-49c9-88f2-7e5ef9b8593a)
