### PR TITLE
[fix] Chart > Line > Tooltip > 1번째 시리즈가 빈 값인 경우 다른 시리즈에 데이터 있어도 툴팁 표시 안 되는 현상(3.4.120)

### DIFF
--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1018,8 +1018,11 @@ const modules = {
     const isHorizontal = !!this.options.horizontal;
     const mousePos = isHorizontal ? yp : xp;
 
-    // 첫 번째 표시 중인 시리즈를 기준으로 라벨 위치 확인
-    const referenceSeries = sIds.find(sId => this.seriesList[sId]?.show);
+    // 데이터 있는 시리즈를 기준으로 라벨 위치 확인
+    const referenceSeries = sIds.find((sId) => {
+      const series = this.seriesList[sId];
+      return series?.show && series?.data?.length > 0;
+    });
     if (!referenceSeries || !this.seriesList[referenceSeries]?.data) {
       return -1;
     }


### PR DESCRIPTION
#2171 동일 작업 3.4.120 브랜치를 base로 하였습니다.