### PR TITLE
[refactor] Chart > Heatmap > Y Axis 라벨 표기 방식 변경

### DIFF
--- a/docs/views/heatMap/example/StepAxis.vue
+++ b/docs/views/heatMap/example/StepAxis.vue
@@ -15,7 +15,7 @@
       <ev-input-number v-model="decimalPoint" :min="0" :max="10" />
     </div>
     <div class="row">
-      <span>마지막 눈금 표시</span>
+      <span>마지막 라벨 표시</span>
       <ev-toggle v-model="showLastLabel" />
     </div>
   </div>
@@ -65,6 +65,11 @@ export default {
           showAxisTick: true,
           axisLineColor: '#25262E',
           showLastLabel,
+          lastLabelFontStyle: {
+            color: '#FF0000',
+            fontSize: 16,
+            fontWeight: 600,
+          },
         },
       ],
       heatMapColor: {

--- a/docs/views/heatMap/example/StepAxis.vue
+++ b/docs/views/heatMap/example/StepAxis.vue
@@ -14,6 +14,10 @@
       <span>소수점 자릿수</span>
       <ev-input-number v-model="decimalPoint" :min="0" :max="10" />
     </div>
+    <div class="row">
+      <span>마지막 눈금 표시</span>
+      <ev-toggle v-model="showLastLabel" />
+    </div>
   </div>
 </template>
 
@@ -23,7 +27,8 @@ import dayjs from 'dayjs';
 
 export default {
   setup() {
-    const chartOptions = {
+    const showLastLabel = ref(false);
+    const chartOptions = reactive({
       type: 'heatMap',
       width: '100%',
       height: '100%',
@@ -59,6 +64,7 @@ export default {
           },
           showAxisTick: true,
           axisLineColor: '#25262E',
+          showLastLabel,
         },
       ],
       heatMapColor: {
@@ -74,7 +80,7 @@ export default {
       tooltip: {
         use: true,
       },
-    };
+    });
 
     const yLabelCount = ref(20);
     const decimalPoint = ref(0);
@@ -148,6 +154,7 @@ export default {
       chartOptions,
       yLabelCount,
       decimalPoint,
+      showLastLabel,
     };
   },
 };

--- a/docs/views/heatMap/example/StepAxis.vue
+++ b/docs/views/heatMap/example/StepAxis.vue
@@ -22,12 +22,17 @@
 </template>
 
 <script>
-import { reactive, ref, watch } from 'vue';
+import { reactive, ref, watch, computed } from 'vue';
 import dayjs from 'dayjs';
 
 export default {
   setup() {
     const showLastLabel = ref(false);
+    const lastLabelFontStyle = computed(() => showLastLabel.value ? {
+      color: '#FF0000',
+      fontSize: 16,
+      fontWeight: 600,
+    }: null);
     const chartOptions = reactive({
       type: 'heatMap',
       width: '100%',
@@ -65,11 +70,7 @@ export default {
           showAxisTick: true,
           axisLineColor: '#25262E',
           showLastLabel,
-          lastLabelFontStyle: {
-            color: '#FF0000',
-            fontSize: 16,
-            fontWeight: 600,
-          },
+          lastLabelFontStyle,
         },
       ],
       heatMapColor: {

--- a/src/components/chart/helpers/helpers.constant.js
+++ b/src/components/chart/helpers/helpers.constant.js
@@ -133,6 +133,7 @@ export const AXIS_OPTION = {
     padding: 0,
     fixWidth: undefined,
   },
+  showLastLabel: false,
   lastLabelFontStyle: null,
   title: {
     use: false,

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -1,6 +1,5 @@
 import { defaultsDeep } from 'lodash-es';
 import { PLOT_BAND_OPTION, PLOT_LINE_OPTION } from '@/components/chart/helpers/helpers.constant';
-import { bnMinus, bnPlus } from '@/common/utils.bignumber';
 import { truthyNumber } from '@/common/utils';
 import Scale from './scale';
 import Util from '../helpers/helpers.util';
@@ -295,37 +294,6 @@ class StepScale extends Scale {
             ctx.lineTo(offsetCounterPoint, linePosition);
             ctx.stroke();
             ctx.closePath();
-          }
-        }
-        ctx.stroke();
-      }
-
-      if (alignToGridLine && index >= this.labels.length) {
-        const cellInterval = bnMinus(+labels[1], +labels[0]);
-        const lastLabelValue = bnPlus(+labels[labels.length - 1], cellInterval);
-        if (
-          isNaN(lastLabelValue) ||
-          (indexInterval !== 1 &&
-            bnMinus(lastLabelValue, drawnLabels[drawnLabels.length - 1]) <= cellInterval)
-        ) {
-          return;
-        }
-
-        labelCenter = Math.round(startPoint + labelGap * labels.length);
-        linePosition = labelCenter + aliasPixel;
-
-        const lastLabelText = this.getLabelFormat(`${lastLabelValue}`, maxWidth);
-        if (this.type === 'x') {
-          ctx.fillText(this.checkFixWidth(lastLabelText), labelCenter, labelPoint);
-          if (this.showGrid) {
-            ctx.moveTo(linePosition, offsetPoint);
-            ctx.lineTo(linePosition, offsetCounterPoint);
-          }
-        } else {
-          ctx.fillText(this.checkFixWidth(lastLabelText), labelPoint, labelCenter);
-          if (this.showGrid) {
-            ctx.moveTo(offsetPoint, linePosition);
-            ctx.lineTo(offsetCounterPoint, linePosition);
           }
         }
         ctx.stroke();

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -1,5 +1,6 @@
 import { defaultsDeep } from 'lodash-es';
 import { PLOT_BAND_OPTION, PLOT_LINE_OPTION } from '@/components/chart/helpers/helpers.constant';
+import { bnMinus, bnPlus } from '@/common/utils.bignumber';
 import { truthyNumber } from '@/common/utils';
 import Scale from './scale';
 import Util from '../helpers/helpers.util';
@@ -297,6 +298,74 @@ class StepScale extends Scale {
           }
         }
         ctx.stroke();
+      }
+
+      if (this.showLastLabel) {
+        const lastLabelIndex = startIndex + steps - 1;
+        const lastDrawnIndex = startIndex + Math.floor((steps - 1) / indexInterval) * indexInterval;
+
+        if (lastDrawnIndex !== lastLabelIndex) {
+          const lastLabelCenter = Math.round(startPoint + labelGap * (steps - 1));
+          const lastLabelPoint = alignToGridLine ? lastLabelCenter : lastLabelCenter + labelGap / 2;
+          const lastLabelText = this.getLabelFormat(labels[lastLabelIndex], maxWidth);
+
+          ctx.fillStyle = this.labelStyle.color;
+
+          if (this.type === 'x') {
+            ctx.fillText(this.checkFixWidth(lastLabelText), lastLabelPoint, labelPoint);
+          } else {
+            ctx.fillText(this.checkFixWidth(lastLabelText), labelPoint, lastLabelPoint);
+          }
+
+          if (this.showAxisTick) {
+            ctx.beginPath();
+            ctx.strokeStyle = this.axisLineColor;
+            if (this.type === 'x') {
+              ctx.moveTo(lastLabelPoint, offsetPoint);
+              ctx.lineTo(lastLabelPoint, offsetPoint + AXIS_TICK_LENGTH);
+            } else {
+              ctx.moveTo(offsetPoint + (this.axisLineWidth ?? 1), lastLabelPoint);
+              ctx.lineTo(offsetPoint - AXIS_TICK_LENGTH, lastLabelPoint);
+            }
+            ctx.stroke();
+            ctx.closePath();
+          }
+        }
+      }
+
+      if (alignToGridLine && !this.showLastLabel) {
+        const cellInterval = bnMinus(+labels[1], +labels[0]);
+        const maxValue = bnPlus(+labels[labels.length - 1], cellInterval);
+
+        if (isNaN(maxValue) || (indexInterval !== 1 && bnMinus(maxValue, drawnLabels[drawnLabels.length - 1]) <= cellInterval)) {
+          return;
+        }
+
+        labelCenter = Math.round(startPoint + labelGap * this.labels.length);
+        linePosition = labelCenter + aliasPixel;
+
+        const maxLabelText = this.getLabelFormat(`${maxValue}`, maxWidth);
+        const tickPoint = labelCenter + labelGap / 2;
+
+        if (this.type === 'x') {
+          ctx.fillText(this.checkFixWidth(maxLabelText), labelCenter, labelPoint);
+        } else {
+          ctx.fillText(this.checkFixWidth(maxLabelText), labelPoint, labelCenter);
+        }
+
+        if (this.showAxisTick) {
+          ctx.beginPath();
+          ctx.strokeStyle = this.axisLineColor;
+          if (this.type === 'x') {
+            ctx.moveTo(tickPoint, offsetPoint);
+            ctx.lineTo(tickPoint, offsetPoint + AXIS_TICK_LENGTH);
+          } else {
+            ctx.moveTo(offsetPoint + (this.axisLineWidth ?? 1), linePosition);
+            ctx.lineTo(offsetPoint - AXIS_TICK_LENGTH, linePosition);
+          }
+          ctx.stroke();
+          ctx.closePath();
+        }
       }
 
       ctx.closePath();

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -220,11 +220,17 @@ class StepScale extends Scale {
           selectedLabelInfo?.dataIndex?.length &&
           !selectedLabelInfo?.dataIndex?.includes(labelIndex);
 
-        const labelColor = this.labelStyle.color;
+        let labelColor = this.labelStyle.color;
         let defaultOpacity = 1;
 
         if (Util.getColorStringType(labelColor) === 'RGBA') {
           defaultOpacity = Util.getOpacity(labelColor);
+        }
+
+        const isLastDrawnLabel = index === steps - 1;
+        if (isLastDrawnLabel && this.lastLabelFontStyle) {
+          ctx.font = Util.getLabelStyle(this.lastLabelFontStyle);
+          labelColor = this.lastLabelFontStyle.color;
         }
 
         ctx.fillStyle = Util.colorStringToRgba(
@@ -338,7 +344,7 @@ class StepScale extends Scale {
         const cellInterval = bnMinus(+labels[1], +labels[0]);
         const maxValue = bnPlus(+labels[labels.length - 1], cellInterval);
 
-        if (isNaN(maxValue) || (indexInterval !== 1 && bnMinus(maxValue, drawnLabels[drawnLabels.length - 1]) <= cellInterval)) {
+        if (isNaN(maxValue)) {
           return;
         }
 

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -309,7 +309,8 @@ class StepScale extends Scale {
           const lastLabelPoint = alignToGridLine ? lastLabelCenter : lastLabelCenter + labelGap / 2;
           const lastLabelText = this.getLabelFormat(labels[lastLabelIndex], maxWidth);
 
-          ctx.fillStyle = this.labelStyle.color;
+          ctx.font = this.lastLabelFontStyle ? Util.getLabelStyle(this.lastLabelFontStyle) : Util.getLabelStyle(this.labelStyle);
+          ctx.fillStyle = this.lastLabelFontStyle ? this.lastLabelFontStyle.color : this.labelStyle.color;
 
           if (this.type === 'x') {
             ctx.fillText(this.checkFixWidth(lastLabelText), lastLabelPoint, labelPoint);
@@ -346,6 +347,9 @@ class StepScale extends Scale {
 
         const maxLabelText = this.getLabelFormat(`${maxValue}`, maxWidth);
         const tickPoint = labelCenter + labelGap / 2;
+
+        ctx.font = Util.getLabelStyle(this.labelStyle);
+        ctx.fillStyle = this.labelStyle.color;
 
         if (this.type === 'x') {
           ctx.fillText(this.checkFixWidth(maxLabelText), labelCenter, labelPoint);


### PR DESCRIPTION
## 배경

heatmap `axis: step` 일때 스펙이 아래와 같이 변경되었습니다.
기존의 label 축 + interval 표시하던 로직 그대로 유지
마지막 라벨 + interval 표시하지 않고 마지막 라벨 그대로를 표시하기를 원할때는 마지막 라벨을 표시

## 변경 내용
- Axes 옵션: showLastLabel 추가
  - 마지막 라벨 표시 여부
  - lastLabelFontStyle이 있으면 해당 style 적용 없으면 기본 labelStyle 적용
  - alignToGridLine일때 마지막 라벨 + 라벨 interval을 표시했지만 showLastLabel: true인 경우는 표시하지 않도록 처리

## 이전 동작
<img width="1013" height="334" alt="image" src="https://github.com/user-attachments/assets/5de537be-c2c1-428f-a090-5be2afd1ff78" />


## 이후 동작
<img width="1079" height="653" alt="image" src="https://github.com/user-attachments/assets/f44d3d71-15eb-4866-8b28-6a53a2626d1e" />

## 테스트 방법
http://localhost:9999/EVUI/heatMap#step-axis

stepAxis 예제에 마지막 라벨 표시 토글을 켰을때는 마지막 라벨이 표시되고 아닐 경우는 y축 마지막 눈금의 라벨이 표시되는지 확인부탁드립니다.