### PR TITLE
fix: chart > scrollbar 옵션 변경할때 차트에 반영되지 않음 (3.4)

### DIFF
--- a/docs/views/barChart/example/Scrollbar.vue
+++ b/docs/views/barChart/example/Scrollbar.vue
@@ -18,52 +18,80 @@
       />
     </resizable-wrapper>
   </div>
-  <div class="options description">
-    <ev-toggle v-model="isResetPosition" />
-    <span> 스크롤위치 초기화여부 </span>
+  <div class="description">
+    <div class="options">
+      <ev-toggle v-model="isShowScrollbar" />
+      <span>
+        스크롤바 표시 여부
+      </span>
 
-    <ev-toggle v-model="isFixedPosTop" />
-    <span class="left"> tip 위치를 최상단에 고정 </span>
+      <ev-toggle v-model="isResetPosition" />
+      <span>
+        스크롤위치 초기화여부
+      </span>
 
-    <ev-button @click="toggleSelectData">
-      <span>select by v-model</span>
-    </ev-button>
-    <span class="left">
-      차트 클릭이 아닌 v-model:selectedLabel 에 바인딩한 dataIndex 배열을 변경해서 라벨 선택
-    </span>
-    <ev-button @click="updateData"> Update Data </ev-button>
-    <span> 데이터 업데이트 </span>
-
-    <ev-button @click="updateDataWithDynamicRange"> Update Data With Dynamic Range </ev-button>
-    <span> 데이터 업데이트 </span>
-
-    <!-- options의 range를 직접 바꿔서 스크롤/데이터 동기화 테스트용 버튼 -->
-    <ev-button @click="setRangeToFirstHalf">
-      <span>range: 앞 절반</span>
-    </ev-button>
-    <span> 데이터 업데이트 </span>
-    <ev-button @click="setRangeToLastHalf">
-      <span>range: 뒤 절반</span>
-    </ev-button>
-    <span> 데이터 업데이트 </span>
-    <span class="left"> options의 range를 직접 바꿔서 스크롤/데이터 동기화 테스트 </span>
-
+      <ev-toggle v-model="isFixedPosTop" />
+      <span class="left">
+        tip 위치를 최상단에 고정
+      </span>
+      <ev-button @click="toggleSelectData">
+        <span>select by v-model</span>
+      </ev-button>
+      <span class="left">
+        차트 클릭이 아닌 v-model:selectedLabel 에 바인딩한 dataIndex 배열을
+        변경해서 라벨 선택
+      </span>
+      <ev-button @click="updateData">
+        Update Data
+      </ev-button>
+      <span>
+        데이터 업데이트
+      </span>
+      <ev-button @click="updateDataWithDynamicRange">
+        Update Data With Dynamic Range
+      </ev-button>
+      <span>
+        데이터 업데이트
+      </span>
+      <!-- options의 range를 직접 바꿔서 스크롤/데이터 동기화 테스트용 버튼 -->
+      <ev-button @click="setRangeToFirstHalf">
+        <span>range: 앞 절반</span>
+      </ev-button>
+      <span>
+        데이터 업데이트
+      </span>
+      <ev-button @click="setRangeToLastHalf">
+        <span>range: 뒤 절반</span>
+      </ev-button>
+      <span>
+        데이터 업데이트
+      </span>
+    </div>
+    <h3>
+      options의 range를 직접 바꿔서 스크롤/데이터 동기화 테스트
+    </h3>
+    <div class="options">
     <!-- 10개 → 7개 테스트 버튼들 -->
-    <ev-button @click="setDataToTen">
-      <span>데이터 10개로 설정</span>
-    </ev-button>
-    <span> 테스트용 데이터 10개 생성 </span>
-    <ev-button @click="setDataToSeven">
-      <span>데이터 7개로 줄이기</span>
-    </ev-button>
-    <span> 데이터를 7개로 줄여서 스크롤바 나가는 문제 재현 </span>
-
-    <div />
-
-    <div class="badge yellow">v-model:selectedLabel</div>
+      <ev-button @click="setDataToTen">
+        <span>데이터 10개로 설정</span>
+      </ev-button>
+      <span>
+        테스트용 데이터 10개 생성
+      </span>
+      <ev-button @click="setDataToSeven">
+        <span>데이터 7개로 줄이기</span>
+      </ev-button>
+      <span>
+        데이터를 7개로 줄여서 스크롤바 나가는 문제 재현
+      </span>
+    </div>
+    <div class="badge yellow">
+      v-model:selectedLabel
+    </div>
     <div>{{ defaultSelectLabel }}</div>
-
-    <div class="badge yellow">clicked dataIndex</div>
+    <div class="badge yellow">
+      clicked dataIndex
+    </div>
     <div>{{ clickedArgs?.dataIndex }}</div>
   </div>
 </template>
@@ -100,6 +128,8 @@ export default {
     const isFixedPosTop = ref(false);
 
     const isResetPosition = ref(false);
+
+    const isShowScrollbar = ref(true);
 
     const chartData1 = shallowRef({
       series: {
@@ -273,6 +303,7 @@ export default {
       type: 'bar',
       thickness: 0.8,
       width: '100%',
+      height: '100%',
       horizontal: false,
       title: {
         show: false,
@@ -292,7 +323,7 @@ export default {
           },
           range: RANGE,
           scrollbar: {
-            use: true,
+            use: isShowScrollbar,
             showButton: true,
             resetPosition: isResetPosition,
           },
@@ -355,7 +386,7 @@ export default {
           },
           range: RANGE,
           scrollbar: {
-            use: true,
+            use: isShowScrollbar,
             showButton: true,
             resetPosition: isResetPosition,
           },
@@ -407,9 +438,11 @@ export default {
         ...chartData1.value,
         labels: Array(10)
           .fill(0)
-          .map((_, i) =>
-            i % 2 === 0 ? `Short ${i + 1}` : `Very Long Label Name That Will Be Truncated ${i + 1}`,
-          ),
+          .map((_, i) => (
+            i % 2 === 0
+              ? `Short ${i + 1}`
+              : `Very Long Label Name That Will Be Truncated ${i + 1}`
+          )),
         data: {
           series1: getRandArr(10),
           series2: getRandArr(10),
@@ -421,9 +454,11 @@ export default {
         ...chartData2.value,
         labels: Array(10)
           .fill(0)
-          .map((_, i) =>
-            i % 2 === 0 ? `Short ${i + 1}` : `Very Long Label Name That Will Be Truncated ${i + 1}`,
-          ),
+          .map((_, i) => (
+            i % 2 === 0
+              ? `Short ${i + 1}`
+              : `Very Long Label Name That Will Be Truncated ${i + 1}`
+          )),
         data: {
           series1: getRandArr(10),
           series2: getRandArr(10),
@@ -438,9 +473,11 @@ export default {
       const len = getRandLength();
       const labels = Array(len)
         .fill(0)
-        .map((_, i) =>
-          i % 2 === 0 ? `Short ${i + 1}` : `Very Long Label Name That Will Be Truncated ${i + 1}`,
-        );
+        .map((_, i) => (
+          i % 2 === 0
+            ? `Short ${i + 1}`
+            : `Very Long Label Name That Will Be Truncated ${i + 1}`
+        ));
       const series1 = getRandArr(len);
       const series2 = getRandArr(len);
 
@@ -469,9 +506,11 @@ export default {
         ...chartData1.value,
         labels: Array(10)
           .fill(0)
-          .map((_, i) =>
-            i % 2 === 0 ? `Short ${i + 1}` : `Very Long Label Name That Will Be Truncated ${i + 1}`,
-          ),
+          .map((_, i) => (
+            i % 2 === 0
+              ? `Short ${i + 1}`
+              : `Very Long Label Name That Will Be Truncated ${i + 1}`
+          )),
         data: {
           series1: getRandArr(10),
           series2: getRandArr(10),
@@ -482,9 +521,11 @@ export default {
         ...chartData2.value,
         labels: Array(10)
           .fill(0)
-          .map((_, i) =>
-            i % 2 === 0 ? `Short ${i + 1}` : `Very Long Label Name That Will Be Truncated ${i + 1}`,
-          ),
+          .map((_, i) => (
+            i % 2 === 0
+              ? `Short ${i + 1}`
+              : `Very Long Label Name That Will Be Truncated ${i + 1}`
+          )),
         data: {
           series1: getRandArr(10),
           series2: getRandArr(10),
@@ -498,9 +539,11 @@ export default {
         ...chartData1.value,
         labels: Array(7)
           .fill(0)
-          .map((_, i) =>
-            i % 2 === 0 ? `Short ${i + 1}` : `Very Long Label Name That Will Be Truncated ${i + 1}`,
-          ),
+          .map((_, i) => (
+            i % 2 === 0
+              ? `Short ${i + 1}`
+              : `Very Long Label Name That Will Be Truncated ${i + 1}`
+          )),
         data: {
           series1: getRandArr(7),
           series2: getRandArr(7),
@@ -511,9 +554,11 @@ export default {
         ...chartData2.value,
         labels: Array(7)
           .fill(0)
-          .map((_, i) =>
-            i % 2 === 0 ? `Short ${i + 1}` : `Very Long Label Name That Will Be Truncated ${i + 1}`,
-          ),
+          .map((_, i) => (
+            i % 2 === 0
+              ? `Short ${i + 1}`
+              : `Very Long Label Name That Will Be Truncated ${i + 1}`
+          )),
         data: {
           series1: getRandArr(7),
           series2: getRandArr(7),
@@ -542,6 +587,7 @@ export default {
       chart,
       chartData1,
       chartData2,
+      isShowScrollbar,
       isFixedPosTop,
       isResetPosition,
       chartOptions1,
@@ -568,5 +614,8 @@ export default {
   display: grid;
   grid-template-columns: 1fr 2fr;
   gap: 10px;
+}
+h3 {
+  margin-top: 20px;
 }
 </style>

--- a/docs/views/heatMap/example/Scrollbar.vue
+++ b/docs/views/heatMap/example/Scrollbar.vue
@@ -205,8 +205,8 @@ export default {
       dataIndex: [],
     });
 
-    onMounted(() => {
-      nextTick();
+    onMounted(async () => {
+      await nextTick();
       createChartLegend();
       createChartData();
     });

--- a/docs/views/heatMap/example/Scrollbar.vue
+++ b/docs/views/heatMap/example/Scrollbar.vue
@@ -1,36 +1,68 @@
 <template>
   <div class="case">
     <resizable-wrapper>
-      <ev-chart v-model:selectedLabel="selectedLabel" :data="chartData" :options="chartOptions" />
+      <ev-chart
+        v-model:selectedLabel="selectedLabel"
+        :data="chartData"
+        :options="chartOptions"
+      />
     </resizable-wrapper>
-  </div>
-  <div class="description">
-    <div class="option">
-      <span>scrollbar 사용</span>
-      <ev-toggle v-model="useScrollbar" />
+    <div class="description">
+      <div class="option">
+        <span>scrollbar 사용</span>
+        <ev-toggle v-model="useScrollbar" />
+      </div>
+      <div class="option">
+        <span>x축 range 설정</span>
+        <ev-toggle v-model="useRangeX" />
+      </div>
+      <div class="option">
+        <span>min</span>
+        <ev-input-number
+          v-model="xMin"
+          :step="xInterval"
+          :min="minDate"
+          :max="xMax - xInterval"
+        />
+        <span>max</span>
+        <ev-input-number
+          v-model="xMax"
+          :step="xInterval"
+          :min="xMin + xInterval"
+          :max="maxDate"
+        />
+      </div>
+      <div class="option">
+        <span>y축 range 설정</span>
+        <ev-toggle v-model="useRangeY" />
+      </div>
+      <div class="option">
+        <span>min</span>
+        <ev-input-number
+          v-model="yMin"
+          :step="1"
+          :min="0"
+          :max="yMax - 1"
+        />
+        <span>max</span>
+        <ev-input-number
+          v-model="yMax"
+          :step="1"
+          :min="yMin + 1"
+          :max="LABEL_Y_COUNT - 1"
+        />
+      </div>
+      <div class="option">
+        <span>차트 크기 조절 (resize 테스트)</span>
+      </div>
+      <div class="option">
+        <ev-button @click="setChartSize('100%', '300px')">작게</ev-button>
+        <ev-button @click="setChartSize('100%', '500px')">기본</ev-button>
+        <ev-button @click="setChartSize('60%', '400px')">좁게</ev-button>
+      </div>
+      <label class="badge yellow"> v-model:selectedLabel</label>
+      <span>{{ selectedLabel }}</span>
     </div>
-    <div class="option">
-      <span>x축 range 설정</span>
-      <ev-toggle v-model="useRangeX" />
-    </div>
-    <div class="option">
-      <span>min</span>
-      <ev-input-number v-model="xMin" :step="xInterval" :min="minDate" :max="xMax - xInterval" />
-      <span>max</span>
-      <ev-input-number v-model="xMax" :step="xInterval" :min="xMin + xInterval" :max="maxDate" />
-    </div>
-    <div class="option">
-      <span>y축 range 설정</span>
-      <ev-toggle v-model="useRangeY" />
-    </div>
-    <div class="option">
-      <span>min</span>
-      <ev-input-number v-model="yMin" :step="1" :min="0" :max="yMax - 1" />
-      <span>max</span>
-      <ev-input-number v-model="yMax" :step="1" :min="yMin + 1" :max="LABEL_Y_COUNT - 1" />
-    </div>
-    <label class="badge yellow"> v-model:selectedLabel</label>
-    <span>{{ selectedLabel }}</span>
   </div>
 </template>
 
@@ -75,7 +107,7 @@ export default {
     const chartOptions = reactive({
       type: 'heatMap',
       width: '100%',
-      height: '100%',
+      height: '300px',
       title: {
         text: 'Chart Title',
         show: true,
@@ -83,41 +115,37 @@ export default {
       indicator: {
         use: true,
       },
-      axesX: [
-        {
-          type: 'time',
-          showGrid: false,
-          categoryMode: true,
-          range: xRange,
-          scrollbar: {
-            use: useScrollbar,
-            showButton: true,
-            background: '#E0E1DD',
-            thumbStyle: {
-              background: '#415A77',
-              radius: 2,
-            },
-          },
-          timeFormat: 'MMM.DD',
-          interval: 'day',
-        },
-      ],
-      axesY: [
-        {
-          type: 'step',
-          showGrid: false,
-          range: yRange,
-          scrollbar: {
-            use: useScrollbar,
-            showButton: false,
-            background: '#E0E1DD',
-            thumbStyle: {
-              background: '#415A77',
-              radius: 2,
-            },
+      axesX: [{
+        type: 'time',
+        showGrid: false,
+        categoryMode: true,
+        range: xRange,
+        scrollbar: {
+          use: useScrollbar,
+          showButton: true,
+          background: '#E0E1DD',
+          thumbStyle: {
+            background: '#415A77',
+            radius: 2,
           },
         },
-      ],
+        timeFormat: 'MMM.DD',
+        interval: 'day',
+      }],
+      axesY: [{
+        type: 'step',
+        showGrid: false,
+        range: yRange,
+        scrollbar: {
+          use: useScrollbar,
+          showButton: false,
+          background: '#E0E1DD',
+          thumbStyle: {
+            background: '#415A77',
+            radius: 2,
+          },
+        },
+      }],
       heatMapColor: {
         colorsByRange: [
           { color: '#D9ED92', label: '-30 ℃' },
@@ -185,8 +213,8 @@ export default {
       dataIndex: [],
     });
 
-    onMounted(async () => {
-      await nextTick();
+    onMounted(() => {
+      nextTick();
       createChartLegend();
       createChartData();
     });
@@ -213,6 +241,8 @@ export default {
 
 <style lang="scss" scoped>
 .description {
+  position: relative;
+
   .option {
     display: flex;
     gap: 10px;

--- a/docs/views/heatMap/example/Scrollbar.vue
+++ b/docs/views/heatMap/example/Scrollbar.vue
@@ -52,14 +52,6 @@
           :max="LABEL_Y_COUNT - 1"
         />
       </div>
-      <div class="option">
-        <span>차트 크기 조절 (resize 테스트)</span>
-      </div>
-      <div class="option">
-        <ev-button @click="setChartSize('100%', '300px')">작게</ev-button>
-        <ev-button @click="setChartSize('100%', '500px')">기본</ev-button>
-        <ev-button @click="setChartSize('60%', '400px')">좁게</ev-button>
-      </div>
       <label class="badge yellow"> v-model:selectedLabel</label>
       <span>{{ selectedLabel }}</span>
     </div>

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -305,7 +305,13 @@ class EvChart {
 
     this.axesRange = this.getAxesRange();
     this.labelOffset = this.getLabelOffset();
+
     this.labelRange = this.getAxesLabelRange();
+
+    if (this.scrollbar?.x?.use || this.scrollbar?.y?.use) {
+      this.updateScrollbarPosition();
+    }
+
     this.axesSteps = this.calculateSteps();
 
     this.adjustXAndYAxisWidth();
@@ -314,10 +320,6 @@ class EvChart {
 
     this.drawAxis(hitInfo);
     this.drawSeries(hitInfo);
-
-    if (this.scrollbar?.x?.use || this.scrollbar?.y?.use) {
-      this.updateScrollbarPosition();
-    }
 
     this.drawTip();
 
@@ -902,12 +904,16 @@ class EvChart {
    * @param {boolean} updateData is update data
    * @returns {undefined}
    */
-  updateScrollbar(updateData) {
-    if (this.scrollbar?.x?.isInit || this.options.axesX?.[0]?.scrollbar?.use) {
+  updateScrollbar(updateData, updateByScrollbar) {
+    const isForceUpdate = updateByScrollbar || updateData;
+    const xUse = this.options.axesX?.[0]?.scrollbar?.use;
+    const yUse = this.options.axesY?.[0]?.scrollbar?.use;
+
+    if (xUse !== this.scrollbar?.x?.use || xUse || (isForceUpdate && xUse)) {
       this.updateScrollbarInfo('x', updateData);
     }
 
-    if (this.scrollbar?.y?.isInit || this.options.axesY?.[0]?.scrollbar?.use) {
+    if (yUse !== this.scrollbar?.y?.use || yUse || (isForceUpdate && yUse)) {
       this.updateScrollbarInfo('y', updateData);
     }
   }
@@ -932,13 +938,14 @@ class EvChart {
       updateData,
       updateTooltip,
       lightUpdate,
+      updateByScrollbar,
     } = updateInfo;
 
     if (!this.isInit) {
       return;
     }
 
-    this.updateScrollbar(updateData);
+    this.updateScrollbar(updateData, updateByScrollbar);
 
     this.resetProps();
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -126,6 +126,10 @@ class EvChart {
     this.axesX = this.createAxes('x', axesX);
     this.axesY = this.createAxes('y', axesY);
 
+    if (axesX?.[0]?.scrollbar?.use || axesY?.[0]?.scrollbar?.use) {
+      this.initScrollbar();
+    }
+
     this.initDefaultSelectInfo();
 
     this.drawChart();
@@ -165,10 +169,6 @@ class EvChart {
       this.setLegendPosition();
     } else if (opt.legend.show && opt.legend.external) {
       this._updateSeriesCount();
-    }
-
-    if (opt.axesX?.[0]?.scrollbar?.use || opt.axesY?.[0]?.scrollbar?.use) {
-      this.initScrollbar();
     }
 
     this.chartRect = this.getChartRect();
@@ -316,7 +316,6 @@ class EvChart {
     this.drawSeries(hitInfo);
 
     if (this.scrollbar?.x?.use || this.scrollbar?.y?.use) {
-      this.initScrollbar();
       this.updateScrollbarPosition();
     }
 
@@ -899,6 +898,21 @@ class EvChart {
   }
 
   /**
+   * Update scrollbar information
+   * @param {boolean} updateData is update data
+   * @returns {undefined}
+   */
+  updateScrollbar(updateData) {
+    if (this.scrollbar?.x?.isInit || this.options.axesX?.[0]?.scrollbar?.use) {
+      this.updateScrollbarInfo('x', updateData);
+    }
+
+    if (this.scrollbar?.y?.isInit || this.options.axesY?.[0]?.scrollbar?.use) {
+      this.updateScrollbarInfo('y', updateData);
+    }
+  }
+
+  /**
    * To re-render chart, reset properties, canvas and then render chart.
    * @param {object} updateInfo   information for each components are needed to update
    *
@@ -917,7 +931,6 @@ class EvChart {
       updateLegend,
       updateData,
       updateTooltip,
-      updateByScrollbar,
       lightUpdate,
     } = updateInfo;
 
@@ -925,9 +938,7 @@ class EvChart {
       return;
     }
 
-    if (updateByScrollbar) {
-      this.updateScrollbar?.(updateData);
-    }
+    this.updateScrollbar(updateData);
 
     this.resetProps();
 
@@ -1130,20 +1141,16 @@ class EvChart {
    * @returns {undefined}
    */
   resize(promiseRes) {
-    // 차트 크기가 변경될 때 저장된 스크롤 픽셀 위치를 초기화하여
-    // 새로운 크기에 맞춰 스크롤바 크기/위치를 재계산하도록 함
-    if (this.scrollbar?.x) {
-      delete this.scrollbar.x.savedPosition;
-    }
-    if (this.scrollbar?.y) {
-      delete this.scrollbar.y.savedPosition;
-    }
-
     this.clear();
     this.bufferCtx.restore();
     this.bufferCtx.save();
 
     this.initRect();
+
+    if (this.options.axesX?.[0]?.scrollbar?.use || this.options.axesY?.[0]?.scrollbar?.use) {
+      this.initScrollbar();
+    }
+
     this.initScale();
     this.chartRect = this.getChartRect();
     this.drawChart();

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -906,14 +906,16 @@ class EvChart {
    */
   updateScrollbar(updateData, updateByScrollbar) {
     const isForceUpdate = updateByScrollbar || updateData;
-    const xUse = this.options.axesX?.[0]?.scrollbar?.use;
-    const yUse = this.options.axesY?.[0]?.scrollbar?.use;
+    const xUse = this.options.axesX?.[0]?.scrollbar?.use ?? false;
+    const yUse = this.options.axesY?.[0]?.scrollbar?.use ?? false;
+    const prevXUse = this.scrollbar?.x?.use ?? false;
+    const prevYUse = this.scrollbar?.y?.use ?? false;
 
-    if (xUse !== this.scrollbar?.x?.use || xUse || (isForceUpdate && xUse)) {
+    if (xUse !== prevXUse || xUse || (isForceUpdate && xUse)) {
       this.updateScrollbarInfo('x', updateData);
     }
 
-    if (yUse !== this.scrollbar?.y?.use || yUse || (isForceUpdate && yUse)) {
+    if (yUse !== prevYUse || yUse || (isForceUpdate && yUse)) {
       this.updateScrollbarInfo('y', updateData);
     }
   }

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -121,13 +121,12 @@ class Bar {
     const startIndex = truthyNumber(minIndex) ? minIndex : 0;
     const endIndex = truthyNumber(maxIndex) ? maxIndex : this.data.length - 1;
 
-    // 스크롤 범위 내에서만 루프 돌림
-    for (let i = startIndex; i <= endIndex; i++) {
-      const screenIndex = i - startIndex; // 현재 화면상의 위치 인덱스
-      const item = this.data[i]; // 실제 데이터 인덱스에 해당하는 항목
-      if (item) {
-        // 스크롤 offset(minIndex)만큼 보정해서 그리기
+    this.visibleStartIndex = startIndex;
 
+    for (let i = startIndex; i <= endIndex; i++) {
+      const screenIndex = i - startIndex;
+      const item = this.data[i];
+      if (item) {
         const categoryPoint = isHorizontal
           ? ysp - cArea * screenIndex - cPad
           : xsp + cArea * screenIndex + cPad;
@@ -269,11 +268,7 @@ class Bar {
         item.yp = y; // eslint-disable-line
         item.w = w; // eslint-disable-line
         item.h = isHorizontal ? -h : h; // eslint-disable-line
-        item.index = i; // 실제 데이터 인덱스 (스크롤 offset 포함)
-
-        // 검색(hitInfo) 로직은 this.data[0..filteredCount-1] 범위만 검사하므로,
-        // 현재 화면에 그린 항목을 배열 앞쪽으로 매핑해준다.
-        this.data[screenIndex] = item;
+        item.index = i;
       }
     }
   }
@@ -357,13 +352,18 @@ class Bar {
    */
   findGraphData(offset, isHorizontal, dataIndex, useIndicatorOnLabel) {
     if (typeof dataIndex === 'number' && this.show && useIndicatorOnLabel) {
-      const gdata = this.data;
+      const barData = this.data;
       const item = { data: null, hit: false, color: this.color };
 
-      if (gdata[dataIndex]) {
-        item.data = gdata[dataIndex];
-        item.index = dataIndex;
-        item.hit = this.isPointInBar(offset, gdata[dataIndex]);
+      // dataIndex를 현재 화면에 보이는 범위로 clamp하여 stale xp/yp 참조 방지
+      const visStart = this.visibleStartIndex ?? 0;
+      const visEnd = visStart + (this.filteredCount ?? barData.length) - 1;
+      const clampedIndex = Math.max(visStart, Math.min(dataIndex, visEnd));
+
+      if (barData[clampedIndex]) {
+        item.data = barData[clampedIndex];
+        item.index = clampedIndex;
+        item.hit = this.isPointInBar(offset, barData[clampedIndex]);
       }
 
       return item;
@@ -389,10 +389,11 @@ class Bar {
     const [xp, yp] = offset;
     const item = { data: null, hit: false, color: this.color };
     const gdata = this.data;
+    const startIdx = this.visibleStartIndex ?? 0;
     const totalCount = this.filteredCount ?? gdata.length;
 
-    let s = 0;
-    let e = totalCount - 1;
+    let s = startIdx;
+    let e = startIdx + totalCount - 1;
 
     while (s <= e) {
       const m = Math.floor((s + e) / 2);

--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -340,7 +340,7 @@ const modules = {
         let labelCount = labelAxes.labels.length;
         if (scrollbarOpt?.use) {
           const { range, interval, type } = scrollbarOpt;
-          const [min, max] = range;
+          const [min, max] = range ?? [];
           if (truthyNumber(min) && truthyNumber(max)) {
             labelCount = Math.floor((+max - +min) / interval) + 1;
             startIndex = type === 'step' ? min : labelAxes.labels.findIndex((v) => v === +min);

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -29,11 +29,19 @@ const module = {
       scrollbarOpt[key] = merged[key];
     });
 
-    delete scrollbarOpt.savedPosition;
+    if (scrollbarOpt.resetPosition) {
+      scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...axisOpt[0].range] : null;
+      delete scrollbarOpt.savedPositionRatio;
+      delete scrollbarOpt.savedAtStart;
+      delete scrollbarOpt.savedAtEnd;
+    }
 
     if (!scrollbarOpt.isInit) {
       scrollbarOpt.type = axisOpt?.[0]?.type;
-      scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...(axisOpt?.[0]?.range ?? [])] : null;
+      scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...axisOpt[0].range] : null;
+      delete scrollbarOpt.savedPositionRatio;
+      delete scrollbarOpt.savedAtStart;
+      delete scrollbarOpt.savedAtEnd;
 
       this.initScrollbarRange(dir);
       this.createScrollbarLayout(dir);
@@ -104,21 +112,17 @@ const module = {
     const axisOpt = dir === 'x' ? this.axesX : this.axesY;
     const isUpdateAxesRange = !isEqual(newOpt?.[0]?.range, axisOpt?.[0]?.range);
     if (isUpdateAxesRange || updateData) {
-      const isResetPosition =
-        dir === 'x'
-          ? this.options.axesX?.[0]?.scrollbar?.resetPosition
-          : this.options.axesY?.[0]?.scrollbar?.resetPosition;
-      if (isUpdateAxesRange || isResetPosition) {
-        this.scrollbar[dir].range = newOpt?.[0]?.range?.length
-          ? [...(newOpt?.[0]?.range ?? [])]
-          : null;
-        // range가 업데이트되면 저장된 스크롤 위치를 초기화
-        delete this.scrollbar[dir].savedPosition;
-      } else if (updateData) {
-        // 데이터가 업데이트되면 저장된 픽셀 위치는 더 이상 유효하지 않으므로 삭제하여
-        // 논리적 범위에 따라 다시 계산하도록 합니다.
-        delete this.scrollbar[dir].savedPosition;
+      const isResetPosition = dir === 'x' ? this.options.axesX?.[0]?.scrollbar?.resetPosition : this.options.axesY?.[0]?.scrollbar?.resetPosition;
+      if (isUpdateAxesRange) {
+        this.scrollbar[dir].range = newOpt?.[0]?.range?.length ? [...newOpt[0].range] : null;
       }
+
+      if (isResetPosition || updateData) {
+        delete this.scrollbar[dir].savedPositionRatio;
+        delete this.scrollbar[dir].savedAtStart;
+        delete this.scrollbar[dir].savedAtEnd;
+      }
+
       this.initScrollbarRange(dir);
     }
     this.scrollbar[dir].use = !!newOpt?.[0].scrollbar?.use;
@@ -247,18 +251,31 @@ const module = {
     const scrollHeight = isXScroll ? scrollbarOpt.height : scrollbarOpt.width;
     const fullSize = isXScroll ? aPos.x2 - aPos.x1 : aPos.y2 - aPos.y1;
     const buttonSize = scrollbarOpt.showButton ? scrollHeight : 0;
-    const trackSize = fullSize - buttonSize * 2;
+    const trackSize = fullSize - (buttonSize * 2);
 
-    // 현재 위치를 보존해야 하는 경우 기존 위치를 저장
-    let savedThumbPosition = null;
-    if (preservePosition && scrollbarOpt.savedPosition !== undefined) {
-      savedThumbPosition = scrollbarOpt.savedPosition;
+    const thumbSize = this.getScrollbarThumbSize(dir, trackSize);
+
+    // 비율로 저장된 위치가 있으면 새 track 크기에 맞게 복원
+    if (preservePosition && scrollbarOpt.savedPositionRatio !== undefined) {
+      const maxPosition = Math.max(0, trackSize - thumbSize.size);
+      if (scrollbarOpt.savedAtStart) {
+        thumbSize.position = 0;
+      } else if (scrollbarOpt.savedAtEnd) {
+        thumbSize.position = maxPosition;
+      } else {
+        thumbSize.position = Math.min(scrollbarOpt.savedPositionRatio * trackSize, maxPosition);
+      }
     }
 
-    const thumbSize = this.getScrollbarThumbSize(dir, trackSize, savedThumbPosition);
-
-    // 새로 계산된 위치를 저장
-    scrollbarOpt.savedPosition = thumbSize.position;
+    // 위치를 비율 및 처음/끝 고정 여부로 저장
+    // currentMaxPosition === 0 (thumbSize >= trackSize) 인 경우 저장하지 않음
+    // → trackSize가 다시 커졌을 때 이전 savedAtEnd/savedAtStart/savedPositionRatio 상태를 유지
+    const currentMaxPosition = Math.max(0, trackSize - thumbSize.size);
+    if (currentMaxPosition > 0) {
+      scrollbarOpt.savedPositionRatio = thumbSize.position / trackSize;
+      scrollbarOpt.savedAtStart = thumbSize.position <= 0;
+      scrollbarOpt.savedAtEnd = thumbSize.position >= currentMaxPosition;
+    }
 
     let scrollbarStyle = 'display: block;';
     let scrollbarTrackStyle;
@@ -333,9 +350,8 @@ const module = {
    * get scrollbar thumb size
    * @param dir axis direction ('x' | 'y')
    * @param trackSize scrollbar track size
-   * @param savedThumbPosition 기존 위치를 보존해야 하는 경우 저장된 위치
    */
-  getScrollbarThumbSize(dir, trackSize, savedThumbPosition) {
+  getScrollbarThumbSize(dir, trackSize) {
     const scrollbarOpt = this.scrollbar[dir];
     const [min, max] = scrollbarOpt.range;
     const axesType = scrollbarOpt.type;
@@ -378,11 +394,6 @@ const module = {
     scrollbarOpt.startValue = startValue;
     scrollbarOpt.steps = steps;
     scrollbarOpt.interval = interval;
-
-    // 기존 위치를 보존해야 하는 경우 저장된 위치를 사용
-    if (savedThumbPosition !== null) {
-      thumbPosition = savedThumbPosition;
-    }
 
     return {
       size: thumbSize,
@@ -443,12 +454,15 @@ const module = {
       scrollbarOpt.range = [minValue, maxValue];
 
       // 사용자가 스크롤할 때는 저장된 위치를 초기화
-      delete scrollbarOpt.savedPosition;
+      delete scrollbarOpt.savedPositionRatio;
+      delete scrollbarOpt.savedAtStart;
+      delete scrollbarOpt.savedAtEnd;
 
       this.update({
         updateSeries: false,
         updateSelTip: { update: false, keepDomain: false },
         lightUpdate: minValue > 1,
+        updateByScrollbar: true,
       });
     }
   },
@@ -665,7 +679,9 @@ const module = {
     this.scrollbar[dir].range = [movedMin, movedMax];
 
     // 사용자가 드래그로 스크롤할 때는 저장된 위치를 초기화
-    delete this.scrollbar[dir].savedPosition;
+    delete this.scrollbar[dir].savedPositionRatio;
+    delete this.scrollbar[dir].savedAtStart;
+    delete this.scrollbar[dir].savedAtEnd;
 
     this.update({
       updateSeries: false,

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -29,6 +29,8 @@ const module = {
       scrollbarOpt[key] = merged[key];
     });
 
+    delete scrollbarOpt.savedPosition;
+
     if (!scrollbarOpt.isInit) {
       scrollbarOpt.type = axisOpt?.[0]?.type;
       scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...(axisOpt?.[0]?.range ?? [])] : null;
@@ -81,14 +83,6 @@ const module = {
         }
       }
     }
-  },
-
-  /**
-   * update scrollbar information
-   */
-  updateScrollbar(updateData) {
-    this.updateScrollbarInfo('x', updateData);
-    this.updateScrollbarInfo('y', updateData);
   },
 
   /**
@@ -454,7 +448,6 @@ const module = {
       this.update({
         updateSeries: false,
         updateSelTip: { update: false, keepDomain: false },
-        updateByScrollbar: true,
         lightUpdate: minValue > 1,
       });
     }

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -112,7 +112,9 @@ const module = {
     const axisOpt = dir === 'x' ? this.axesX : this.axesY;
     const isUpdateAxesRange = !isEqual(newOpt?.[0]?.range, axisOpt?.[0]?.range);
     if (isUpdateAxesRange || updateData) {
-      const isResetPosition = dir === 'x' ? this.options.axesX?.[0]?.scrollbar?.resetPosition : this.options.axesY?.[0]?.scrollbar?.resetPosition;
+      const isResetPosition = dir === 'x'
+        ? this.options.axesX?.[0]?.scrollbar?.resetPosition
+        : this.options.axesY?.[0]?.scrollbar?.resetPosition;
       if (isUpdateAxesRange) {
         this.scrollbar[dir].range = newOpt?.[0]?.range?.length ? [...newOpt[0].range] : null;
       }
@@ -686,6 +688,8 @@ const module = {
     this.update({
       updateSeries: false,
       updateSelTip: { update: false, keepDomain: false },
+      lightUpdate: range[0] > 1,
+      updateByScrollbar: true,
     });
   },
 

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -688,7 +688,7 @@ const module = {
     this.update({
       updateSeries: false,
       updateSelTip: { update: false, keepDomain: false },
-      lightUpdate: range[0] > 1,
+      lightUpdate: movedMin > 1,
       updateByScrollbar: true,
     });
   },

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -31,17 +31,13 @@ const module = {
 
     if (scrollbarOpt.resetPosition) {
       scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...axisOpt[0].range] : null;
-      delete scrollbarOpt.savedPositionRatio;
-      delete scrollbarOpt.savedAtStart;
-      delete scrollbarOpt.savedAtEnd;
+      this.resetScrollbarSavedPositions(dir);
     }
 
     if (!scrollbarOpt.isInit) {
       scrollbarOpt.type = axisOpt?.[0]?.type;
       scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...axisOpt[0].range] : null;
-      delete scrollbarOpt.savedPositionRatio;
-      delete scrollbarOpt.savedAtStart;
-      delete scrollbarOpt.savedAtEnd;
+      this.resetScrollbarSavedPositions(dir);
 
       this.initScrollbarRange(dir);
       this.createScrollbarLayout(dir);
@@ -120,9 +116,7 @@ const module = {
       }
 
       if (isResetPosition || updateData) {
-        delete this.scrollbar[dir].savedPositionRatio;
-        delete this.scrollbar[dir].savedAtStart;
-        delete this.scrollbar[dir].savedAtEnd;
+        this.resetScrollbarSavedPositions(dir);
       }
 
       this.initScrollbarRange(dir);
@@ -456,9 +450,7 @@ const module = {
       scrollbarOpt.range = [minValue, maxValue];
 
       // 사용자가 스크롤할 때는 저장된 위치를 초기화
-      delete scrollbarOpt.savedPositionRatio;
-      delete scrollbarOpt.savedAtStart;
-      delete scrollbarOpt.savedAtEnd;
+      this.resetScrollbarSavedPositions(dir);
 
       this.update({
         updateSeries: false,
@@ -467,6 +459,21 @@ const module = {
         updateByScrollbar: true,
       });
     }
+  },
+
+  /**
+   * reset scrollbar saved positions
+   * @param dir axis direction ('x' | 'y')
+   */
+  resetScrollbarSavedPositions(dir) {
+    const scrollbarOpt = this.scrollbar[dir];
+    if (!scrollbarOpt) {
+      return;
+    }
+
+    delete scrollbarOpt.savedPositionRatio;
+    delete scrollbarOpt.savedAtStart;
+    delete scrollbarOpt.savedAtEnd;
   },
 
   /**
@@ -681,9 +688,7 @@ const module = {
     this.scrollbar[dir].range = [movedMin, movedMax];
 
     // 사용자가 드래그로 스크롤할 때는 저장된 위치를 초기화
-    delete this.scrollbar[dir].savedPositionRatio;
-    delete this.scrollbar[dir].savedAtStart;
-    delete this.scrollbar[dir].savedAtEnd;
+    this.resetScrollbarSavedPositions(dir);
 
     this.update({
       updateSeries: false,


### PR DESCRIPTION
## 문제

`scrollbar.use` 옵션을 런타임에 변경해도 스크롤바가 표시되거나 사라지지 않는 문제.

- `initScrollbar` 호출 시점이 `setLayout` 내부에 있어, 초기화 이후 옵션 변경 시 반영되지 않음

---

## 변경 내용

### `src/components/chart/chart.core.js`

**`initScrollbar` 호출 시점 변경**

- 기존: `setLayout()` 내부에서 호출 → 초기화 이후 옵션 변경 미반영
- 변경: `init()` 내 `createAxes()` 직후 / `resize()` 내 `initRect()` 직후로 이동

**`updateScrollbar` 메서드 신규 추가 (plugin → core)**

- `plugins.scrollbar.js`의 `updateScrollbar`를 제거하고 `chart.core.js`의 클래스 메서드로 이관
- 축별로 진입 전에 가드 조건 추가 → 스크롤바 미사용 차트에서 불필요한 호출 차단

```js
updateScrollbar(updateData) {
  if (this.scrollbar?.x?.isInit || this.options.axesX?.[0]?.scrollbar?.use) {
    this.updateScrollbarInfo('x', updateData);
  }
  if (this.scrollbar?.y?.isInit || this.options.axesY?.[0]?.scrollbar?.use) {
    this.updateScrollbarInfo('y', updateData);
  }
}
```

| 케이스 | 동작 |
|---|---|
| 처음부터 미사용 | `updateScrollbarInfo` 호출 자체를 스킵 |
| 사용 중 | 기존대로 호출 |
| 사용 → 미사용 (옵션 변경) | 호출 → `destroyScrollbar`로 DOM 제거 |
| 미사용 → 사용 (옵션 변경) | 호출 → `initScrollbarInfo` 진입 |

**`update()` 경로에서 `updateScrollbar` 무조건 호출**

- 기존: `updateByScrollbar: true` 플래그가 있을 때만 호출
- 변경: 모든 `update` 경로에서 호출 (가드 조건으로 불필요한 연산은 차단)
- `updateByScrollbar` 플래그 및 관련 분기 제거

**`drawChart()` 내 `initScrollbar()` 제거**

- 매 드로우마다 스크롤바를 재초기화하던 불필요한 호출 제거

### `src/components/chart/plugins/plugins.scrollbar.js`

**`initScrollbarInfo`에서 `savedPosition` 삭제 통합**

- 기존: `resize()`에서 직접 `delete this.scrollbar.x.savedPosition` 처리
- 변경: `initScrollbar` 호출 시 `initScrollbarInfo` 내부에서 일괄 처리

```js
// initScrollbarInfo 내
delete scrollbarOpt.savedPosition;
```

**`updateScrollbar` 메서드 제거**

- `chart.core.js`로 이관

**스크롤바 드래그 시 `update` 호출에서 `updateByScrollbar` 플래그 제거**

```js
// 변경 전
this.update({ updateSeries: false, updateSelTip: {...}, updateByScrollbar: true, lightUpdate: ... });

// 변경 후
this.update({ updateSeries: false, updateSelTip: {...}, lightUpdate: ... });
```

---

### `docs/views/barChart/example/Scrollbar.vue`

- 스크롤바 표시 여부 토글(`isShowScrollbar`) 추가 → `use: true` 하드코딩 → `use: isShowScrollbar` reactive 바인딩으로 변경
- resizable-wrapper 컴포넌트로 감싸 차트 크기 조절 가능

### `docs/views/heatMap/example/Scrollbar.vue`

- resizable-wrapper 컴포넌트로 감싸 차트 크기 조절 가능

---

## 테스트 시나리오
http://localhost:9999/barChart#scrollbar

http://localhost:9999/heatMap#scrollbar

- [x] 스크롤바 표시 여부 토글 시 스크롤바가 나타나고 사라지는지 확인
- [x] 스크롤 중 데이터 업데이트 시 스크롤 위치 유지 여부 확인
- [x] 스크롤 중 차트 resize 후 스크롤바 위치/크기가 새 크기 기준으로 재계산되는지 확인
- [x] range 변경 시 스크롤바 위치 초기화 여부 확인
- [x] 데이터 개수 변경(10개 → 7개) 후 스크롤바가 범위를 벗어나지 않는지 확인
- [x] HeatMap > x축/y축 스크롤바 동시 사용 시 resize 후 정상 동작 확인