### PR TITLE
[fix]: range, interval 옵션을 같이쓰고 fixedStep을 사용하지 않을 경우, maxStep을 넘을 수 없도록 함

### DIFF
--- a/src/components/chart/scale/scale.linear.js
+++ b/src/components/chart/scale/scale.linear.js
@@ -308,7 +308,7 @@ class LinearScale extends Scale {
       const isCompatible =
         Math.abs(rawSteps - Math.round(rawSteps)) < EPS;
   
-      if (isCompatible || this.fixedSteps) {
+      if ((isCompatible && rawSteps <= maxSteps) || this.fixedSteps) {
         const steps = Math.round(rawSteps);
         setDecimal(interval);
         return {

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -91,7 +91,7 @@ class TimeScale extends Scale {
       const isCompatible =
         Math.abs(rawSteps - Math.round(rawSteps)) < EPS;
   
-      if (isCompatible && this.fixedSteps) {
+      if ((isCompatible && rawSteps <= maxSteps) || this.fixedSteps) {
         const steps = Math.round(rawSteps);
         return {
           steps,
@@ -108,7 +108,7 @@ class TimeScale extends Scale {
      * interval을 시작값으로 사용하고,
      * steps가 maxSteps를 넘으면 interval을 2배씩 증가
      */
-    if (isValidInterval) {
+    if (!hasUserRange && isValidInterval) {
       const graphRange = graphMax - graphMin;
       let interval = resolvedInterval;
       let steps = Math.ceil(graphRange / interval);
@@ -118,6 +118,7 @@ class TimeScale extends Scale {
         steps = Math.ceil(graphRange / interval);
       }
   
+      // interval을 유지하기 위해 graphMax 확장
       graphMax = graphMin + (interval * steps);
   
       return {


### PR DESCRIPTION
### Issue
- `range: [0, 60]`, `interval: 1` , `fixedStep: false` 옵션 조합에 대해 라벨이 과하게 표시되는 현상 발생

### Before
   - <img width="413" height="102" alt="image" src="https://github.com/user-attachments/assets/20cd4630-2406-440b-ab54-8912c28d271a" />

### After
   - <img width="503" height="128" alt="image" src="https://github.com/user-attachments/assets/479cf863-5884-498c-bc3a-fa5eff2d2068" />
