### PR TITLE
fix(chart): 런타임 scrollbar/axis range 옵션 변경 시 차트에 반영되지 않는 문제 수정 (#2184)

### DIFF
--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -179,6 +179,14 @@ export default {
         const isUpdateTooltip =
           newOpt.tooltip.use && !isEqual(newOpt.tooltip, evChart.options.tooltip);
 
+        const prevAxesX = evChart.options?.axesX;
+        const prevAxesY = evChart.options?.axesY;
+        const isUpdateScrollbar =
+          !isEqual(newOpt.axesX?.[0]?.range, prevAxesX?.[0]?.range) ||
+          !isEqual(newOpt.axesX?.[0]?.scrollbar, prevAxesX?.[0]?.scrollbar) ||
+          !isEqual(newOpt.axesY?.[0]?.range, prevAxesY?.[0]?.range) ||
+          !isEqual(newOpt.axesY?.[0]?.scrollbar, prevAxesY?.[0]?.scrollbar);
+
         evChart.options = cloneDeep(newOpt);
 
         evChart.update({
@@ -186,6 +194,7 @@ export default {
           updateSelTip: { update: false, keepDomain: false },
           updateLegend: isUpdateLegendType,
           updateTooltip: isUpdateTooltip,
+          updateByScrollbar: isUpdateScrollbar,
         });
 
         if (newOpt.legend.show && newOpt.legend.external && !prevLegendShow) {


### PR DESCRIPTION
## 요약
- 차트의 axesX/axesY 옵션에서 range나 scrollbar 설정을 런타임에 동적으로 변경해도 스크롤바가 갱신되지 않는 문제 수정
- options watcher에서 이전/새 축 옵션의 range, scrollbar 값을 비교하여 변경 감지 시 updateByScrollbar 플래그를 evChart.update()에 전달하도록 수정

## 변경 사항
- Chart.vue: options watcher에 isUpdateScrollbar 비교 로직 추가 및 updateByScrollbar 플래그 전달 

##  원인
기존에는 evChart.update() 호출 시 updateByScrollbar 플래그가 전달되지 않아, 외부에서 축의 range/scrollbar 옵션을 변경해도 차트 내부의 스크롤바 업데이트 로직(updateScrollbar)이 실행되지 않았음
                                                                                                                                                                    
##  테스트
1. Bar Chart > Scrollbar 예시 페이지 진입
2. "range: 앞 절반" / "range: 뒤 절반" 버튼 클릭 시 스크롤바 위치와 축 범위가 정상 갱신되는지 확인
3. 가로/세로 차트 모두 확인
4. 데이터 업데이트(Update Data) 후에도 스크롤바 동작 정상 여부 확인

![바차트스크롤수정후](https://github.com/user-attachments/assets/0b0a6a9e-cf33-42db-b88e-1c6388246579)
