### PR TITLE
fix: Bar Chart Scrollbar 렌더링 버그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.154",
+  "version": "3.4.155",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -268,6 +268,11 @@ class EvChart {
 
     this.axesRange = this.getAxesRange();
     this.labelOffset = this.getLabelOffset();
+
+    if (this.scrollbar?.x?.use || this.scrollbar?.y?.use) {
+      this.updateScrollbarPosition();
+    }
+
     this.labelRange = this.getAxesLabelRange();
     this.axesSteps = this.calculateSteps();
 
@@ -275,10 +280,6 @@ class EvChart {
 
     this.drawAxis(hitInfo);
     this.drawSeries(hitInfo);
-
-    if (this.scrollbar?.x?.use || this.scrollbar?.y?.use) {
-      this.updateScrollbarPosition();
-    }
 
     this.drawTip();
 
@@ -856,12 +857,16 @@ class EvChart {
    * @param {boolean} updateData is update data
    * @returns {undefined}
    */
-  updateScrollbar(updateData) {
-    if (this.scrollbar?.x?.isInit || this.options.axesX?.[0]?.scrollbar?.use) {
+  updateScrollbar(updateData, updateByScrollbar) {
+    const isForceUpdate = updateByScrollbar || updateData;
+    const xUse = this.options.axesX?.[0]?.scrollbar?.use;
+    const yUse = this.options.axesY?.[0]?.scrollbar?.use;
+
+    if (xUse !== this.scrollbar?.x?.use || xUse || isForceUpdate) {
       this.updateScrollbarInfo('x', updateData);
     }
 
-    if (this.scrollbar?.y?.isInit || this.options.axesY?.[0]?.scrollbar?.use) {
+    if (yUse !== this.scrollbar?.y?.use || yUse || isForceUpdate) {
       this.updateScrollbarInfo('y', updateData);
     }
   }
@@ -886,13 +891,14 @@ class EvChart {
       updateData,
       updateTooltip,
       lightUpdate,
+      updateByScrollbar,
     } = updateInfo;
 
     if (!this.isInit) {
       return;
     }
 
-    this.updateScrollbar(updateData);
+    this.updateScrollbar(updateData, updateByScrollbar);
 
     this.resetProps();
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -269,11 +269,12 @@ class EvChart {
     this.axesRange = this.getAxesRange();
     this.labelOffset = this.getLabelOffset();
 
+    this.labelRange = this.getAxesLabelRange();
+
     if (this.scrollbar?.x?.use || this.scrollbar?.y?.use) {
       this.updateScrollbarPosition();
     }
 
-    this.labelRange = this.getAxesLabelRange();
     this.axesSteps = this.calculateSteps();
 
     this.adjustXAndYAxisWidth();

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -860,14 +860,16 @@ class EvChart {
    */
   updateScrollbar(updateData, updateByScrollbar) {
     const isForceUpdate = updateByScrollbar || updateData;
-    const xUse = this.options.axesX?.[0]?.scrollbar?.use;
-    const yUse = this.options.axesY?.[0]?.scrollbar?.use;
+    const xUse = this.options.axesX?.[0]?.scrollbar?.use ?? false;
+    const yUse = this.options.axesY?.[0]?.scrollbar?.use ?? false;
+    const prevXUse = this.scrollbar?.x?.use ?? false;
+    const prevYUse = this.scrollbar?.y?.use ?? false;
 
-    if (xUse !== this.scrollbar?.x?.use || xUse || (isForceUpdate && xUse)) {
+    if (xUse !== prevXUse || xUse || (isForceUpdate && xUse)) {
       this.updateScrollbarInfo('x', updateData);
     }
 
-    if (yUse !== this.scrollbar?.y?.use || yUse || (isForceUpdate && yUse)) {
+    if (yUse !== prevYUse || yUse || (isForceUpdate && yUse)) {
       this.updateScrollbarInfo('y', updateData);
     }
   }

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -862,11 +862,11 @@ class EvChart {
     const xUse = this.options.axesX?.[0]?.scrollbar?.use;
     const yUse = this.options.axesY?.[0]?.scrollbar?.use;
 
-    if (xUse !== this.scrollbar?.x?.use || xUse || isForceUpdate) {
+    if (xUse !== this.scrollbar?.x?.use || xUse || (isForceUpdate && xUse)) {
       this.updateScrollbarInfo('x', updateData);
     }
 
-    if (yUse !== this.scrollbar?.y?.use || yUse || isForceUpdate) {
+    if (yUse !== this.scrollbar?.y?.use || yUse || (isForceUpdate && yUse)) {
       this.updateScrollbarInfo('y', updateData);
     }
   }

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -115,13 +115,12 @@ class Bar {
     const startIndex = truthyNumber(minIndex) ? minIndex : 0;
     const endIndex = truthyNumber(maxIndex) ? maxIndex : this.data.length - 1;
 
-    // 스크롤 범위 내에서만 루프 돌림
-    for (let i = startIndex; i <= endIndex; i++) {
-      const screenIndex = i - startIndex; // 현재 화면상의 위치 인덱스
-      const item = this.data[i]; // 실제 데이터 인덱스에 해당하는 항목
-      if (item) {
-        // 스크롤 offset(minIndex)만큼 보정해서 그리기
+    this.visibleStartIndex = startIndex;
 
+    for (let i = startIndex; i <= endIndex; i++) {
+      const screenIndex = i - startIndex;
+      const item = this.data[i];
+      if (item) {
         const categoryPoint = isHorizontal
           ? ysp - (cArea * screenIndex) - cPad
           : xsp + (cArea * screenIndex) + cPad;
@@ -214,11 +213,7 @@ class Bar {
         item.yp = y; // eslint-disable-line
         item.w = w; // eslint-disable-line
         item.h = isHorizontal ? -h : h; // eslint-disable-line
-        item.index = i; // 실제 데이터 인덱스 (스크롤 offset 포함)
-
-        // 검색(hitInfo) 로직은 this.data[0..filteredCount-1] 범위만 검사하므로,
-        // 현재 화면에 그린 항목을 배열 앞쪽으로 매핑해준다.
-        this.data[screenIndex] = item;
+        item.index = i;
       }
     }
   }
@@ -326,10 +321,11 @@ class Bar {
     const [xp, yp] = offset;
     const item = { data: null, hit: false, color: this.color };
     const gdata = this.data;
+    const startIdx = this.visibleStartIndex ?? 0;
     const totalCount = this.filteredCount ?? gdata.length;
 
-    let s = 0;
-    let e = totalCount - 1;
+    let s = startIdx;
+    let e = startIdx + totalCount - 1;
 
     while (s <= e) {
       const m = Math.floor((s + e) / 2);

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -289,13 +289,18 @@ class Bar {
    */
   findGraphData(offset, isHorizontal, dataIndex, useIndicatorOnLabel) {
     if (typeof dataIndex === 'number' && this.show && useIndicatorOnLabel) {
-      const gdata = this.data;
+      const barData = this.data;
       const item = { data: null, hit: false, color: this.color };
 
-      if (gdata[dataIndex]) {
-        item.data = gdata[dataIndex];
-        item.index = dataIndex;
-        item.hit = this.isPointInBar(offset, gdata[dataIndex]);
+      // dataIndex를 현재 화면에 보이는 범위로 clamp하여 stale xp/yp 참조 방지
+      const visStart = this.visibleStartIndex ?? 0;
+      const visEnd = visStart + (this.filteredCount ?? barData.length) - 1;
+      const clampedIndex = Math.max(visStart, Math.min(dataIndex, visEnd));
+
+      if (barData[clampedIndex]) {
+        item.data = barData[clampedIndex];
+        item.index = clampedIndex;
+        item.hit = this.isPointInBar(offset, barData[clampedIndex]);
       }
 
       return item;

--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -339,7 +339,7 @@ const modules = {
         let labelCount = labelAxes.labels.length;
         if (scrollbarOpt?.use) {
           const { range, interval, type } = scrollbarOpt;
-          const [min, max] = range;
+          const [min, max] = range ?? [];
           if (truthyNumber(min) && truthyNumber(max)) {
             labelCount = Math.floor((+max - +min) / interval) + 1;
             startIndex = type === 'step' ? min : labelAxes.labels.findIndex(v => v === +min);

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -31,17 +31,13 @@ const module = {
 
     if (scrollbarOpt.resetPosition) {
       scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...axisOpt?.[0]?.range] : null;
-      delete scrollbarOpt.savedPositionRatio;
-      delete scrollbarOpt.savedAtStart;
-      delete scrollbarOpt.savedAtEnd;
+      this.resetScrollbarSavedPositions(dir);
     }
 
     if (!scrollbarOpt.isInit) {
       scrollbarOpt.type = axisOpt?.[0]?.type;
       scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...axisOpt?.[0]?.range] : null;
-      delete scrollbarOpt.savedPositionRatio;
-      delete scrollbarOpt.savedAtStart;
-      delete scrollbarOpt.savedAtEnd;
+      this.resetScrollbarSavedPositions(dir);
 
       this.initScrollbarRange(dir);
       this.createScrollbarLayout(dir);
@@ -121,9 +117,7 @@ const module = {
       }
 
       if (isResetPosition || updateData) {
-        delete this.scrollbar[dir].savedPositionRatio;
-        delete this.scrollbar[dir].savedAtStart;
-        delete this.scrollbar[dir].savedAtEnd;
+        this.resetScrollbarSavedPositions(dir);
       }
 
       this.initScrollbarRange(dir);
@@ -457,9 +451,7 @@ const module = {
       scrollbarOpt.range = [minValue, maxValue];
 
       // 사용자가 스크롤할 때는 저장된 위치를 초기화
-      delete scrollbarOpt.savedPositionRatio;
-      delete scrollbarOpt.savedAtStart;
-      delete scrollbarOpt.savedAtEnd;
+      this.resetScrollbarSavedPositions(dir);
 
       this.update({
         updateSeries: false,
@@ -468,6 +460,21 @@ const module = {
         updateByScrollbar: true,
       });
     }
+  },
+
+  /**
+   * reset scrollbar saved positions
+   * @param dir axis direction ('x' | 'y')
+   */
+  resetScrollbarSavedPositions(dir) {
+    const scrollbarOpt = this.scrollbar[dir];
+    if (!scrollbarOpt) {
+      return;
+    }
+
+    delete scrollbarOpt.savedPositionRatio;
+    delete scrollbarOpt.savedAtStart;
+    delete scrollbarOpt.savedAtEnd;
   },
 
   /**
@@ -684,9 +691,7 @@ const module = {
     this.scrollbar[dir].range = [movedMin, movedMax];
 
     // 사용자가 드래그로 스크롤할 때는 저장된 위치를 초기화
-    delete this.scrollbar[dir].savedPositionRatio;
-    delete this.scrollbar[dir].savedAtStart;
-    delete this.scrollbar[dir].savedAtEnd;
+    this.resetScrollbarSavedPositions(dir);
 
     this.update({
       updateSeries: false,

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -30,6 +30,7 @@ const module = {
     });
 
     if (scrollbarOpt.resetPosition) {
+      scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...axisOpt?.[0]?.range] : null;
       delete scrollbarOpt.savedPositionRatio;
       delete scrollbarOpt.savedAtStart;
       delete scrollbarOpt.savedAtEnd;
@@ -115,11 +116,13 @@ const module = {
       if (isUpdateAxesRange) {
         this.scrollbar[dir].range = newOpt?.[0]?.range?.length ? [...newOpt?.[0]?.range] : null;
       }
-      if (isResetPosition) {
+
+      if (isResetPosition || updateData) {
         delete this.scrollbar[dir].savedPositionRatio;
         delete this.scrollbar[dir].savedAtStart;
         delete this.scrollbar[dir].savedAtEnd;
       }
+
       this.initScrollbarRange(dir);
     }
     this.scrollbar[dir].use = !!newOpt?.[0].scrollbar?.use;
@@ -343,7 +346,6 @@ const module = {
    * get scrollbar thumb size
    * @param dir axis direction ('x' | 'y')
    * @param trackSize scrollbar track size
-   * @param savedThumbPosition 기존 위치를 보존해야 하는 경우 저장된 위치
    */
   getScrollbarThumbSize(dir, trackSize) {
     const scrollbarOpt = this.scrollbar[dir];

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -29,11 +29,18 @@ const module = {
       scrollbarOpt[key] = merged[key];
     });
 
-    delete scrollbarOpt.savedPosition;
+    if (scrollbarOpt.resetPosition) {
+      delete scrollbarOpt.savedPositionRatio;
+      delete scrollbarOpt.savedAtStart;
+      delete scrollbarOpt.savedAtEnd;
+    }
 
     if (!scrollbarOpt.isInit) {
       scrollbarOpt.type = axisOpt?.[0]?.type;
       scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...axisOpt?.[0]?.range] : null;
+      delete scrollbarOpt.savedPositionRatio;
+      delete scrollbarOpt.savedAtStart;
+      delete scrollbarOpt.savedAtEnd;
 
       this.initScrollbarRange(dir);
       this.createScrollbarLayout(dir);
@@ -105,14 +112,13 @@ const module = {
     const isUpdateAxesRange = !isEqual(newOpt?.[0]?.range, axisOpt?.[0]?.range);
     if (isUpdateAxesRange || updateData) {
       const isResetPosition = dir === 'x' ? this.options.axesX?.[0]?.scrollbar?.resetPosition : this.options.axesY?.[0]?.scrollbar?.resetPosition;
-      if (isUpdateAxesRange || isResetPosition) {
+      if (isUpdateAxesRange) {
         this.scrollbar[dir].range = newOpt?.[0]?.range?.length ? [...newOpt?.[0]?.range] : null;
-        // range가 업데이트되면 저장된 스크롤 위치를 초기화
-        delete this.scrollbar[dir].savedPosition;
-      } else if (updateData) {
-        // 데이터가 업데이트되면 저장된 픽셀 위치는 더 이상 유효하지 않으므로 삭제하여
-        // 논리적 범위에 따라 다시 계산하도록 합니다.
-        delete this.scrollbar[dir].savedPosition;
+      }
+      if (isResetPosition) {
+        delete this.scrollbar[dir].savedPositionRatio;
+        delete this.scrollbar[dir].savedAtStart;
+        delete this.scrollbar[dir].savedAtEnd;
       }
       this.initScrollbarRange(dir);
     }
@@ -244,16 +250,25 @@ const module = {
     const buttonSize = scrollbarOpt.showButton ? scrollHeight : 0;
     const trackSize = fullSize - (buttonSize * 2);
 
-    // 현재 위치를 보존해야 하는 경우 기존 위치를 저장
-    let savedThumbPosition = null;
-    if (preservePosition && scrollbarOpt.savedPosition !== undefined) {
-      savedThumbPosition = scrollbarOpt.savedPosition;
+    const thumbSize = this.getScrollbarThumbSize(dir, trackSize);
+
+    // 비율로 저장된 위치가 있으면 새 track 크기에 맞게 복원
+    if (preservePosition && scrollbarOpt.savedPositionRatio !== undefined) {
+      const maxPosition = Math.max(0, trackSize - thumbSize.size);
+      if (scrollbarOpt.savedAtStart) {
+        thumbSize.position = 0;
+      } else if (scrollbarOpt.savedAtEnd) {
+        thumbSize.position = maxPosition;
+      } else {
+        thumbSize.position = Math.min(scrollbarOpt.savedPositionRatio * trackSize, maxPosition);
+      }
     }
 
-    const thumbSize = this.getScrollbarThumbSize(dir, trackSize, savedThumbPosition);
-
-    // 새로 계산된 위치를 저장
-    scrollbarOpt.savedPosition = thumbSize.position;
+    // 위치를 비율 및 처음/끝 고정 여부로 저장
+    const currentMaxPosition = Math.max(0, trackSize - thumbSize.size);
+    scrollbarOpt.savedPositionRatio = trackSize > 0 ? thumbSize.position / trackSize : 0;
+    scrollbarOpt.savedAtStart = thumbSize.position <= 0;
+    scrollbarOpt.savedAtEnd = thumbSize.position >= currentMaxPosition;
 
     let scrollbarStyle = 'display: block;';
     let scrollbarTrackStyle;
@@ -330,7 +345,7 @@ const module = {
    * @param trackSize scrollbar track size
    * @param savedThumbPosition 기존 위치를 보존해야 하는 경우 저장된 위치
    */
-  getScrollbarThumbSize(dir, trackSize, savedThumbPosition) {
+  getScrollbarThumbSize(dir, trackSize) {
     const scrollbarOpt = this.scrollbar[dir];
     const [min, max] = scrollbarOpt.range;
     const axesType = scrollbarOpt.type;
@@ -373,11 +388,6 @@ const module = {
     scrollbarOpt.startValue = startValue;
     scrollbarOpt.steps = steps;
     scrollbarOpt.interval = interval;
-
-    // 기존 위치를 보존해야 하는 경우 저장된 위치를 사용
-    if (savedThumbPosition !== null) {
-      thumbPosition = savedThumbPosition;
-    }
 
     return {
       size: thumbSize,
@@ -438,12 +448,15 @@ const module = {
       scrollbarOpt.range = [minValue, maxValue];
 
       // 사용자가 스크롤할 때는 저장된 위치를 초기화
-      delete scrollbarOpt.savedPosition;
+      delete scrollbarOpt.savedPositionRatio;
+      delete scrollbarOpt.savedAtStart;
+      delete scrollbarOpt.savedAtEnd;
 
       this.update({
         updateSeries: false,
         updateSelTip: { update: false, keepDomain: false },
         lightUpdate: minValue > 1,
+        updateByScrollbar: true,
       });
     }
   },
@@ -662,7 +675,9 @@ const module = {
     this.scrollbar[dir].range = [movedMin, movedMax];
 
     // 사용자가 드래그로 스크롤할 때는 저장된 위치를 초기화
-    delete this.scrollbar[dir].savedPosition;
+    delete this.scrollbar[dir].savedPositionRatio;
+    delete this.scrollbar[dir].savedAtStart;
+    delete this.scrollbar[dir].savedAtEnd;
 
     this.update({
       updateSeries: false,

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -112,7 +112,10 @@ const module = {
     const axisOpt = dir === 'x' ? this.axesX : this.axesY;
     const isUpdateAxesRange = !isEqual(newOpt?.[0]?.range, axisOpt?.[0]?.range);
     if (isUpdateAxesRange || updateData) {
-      const isResetPosition = dir === 'x' ? this.options.axesX?.[0]?.scrollbar?.resetPosition : this.options.axesY?.[0]?.scrollbar?.resetPosition;
+      const isResetPosition = dir === 'x'
+        ? this.options.axesX?.[0]?.scrollbar?.resetPosition
+        : this.options.axesY?.[0]?.scrollbar?.resetPosition;
+
       if (isUpdateAxesRange) {
         this.scrollbar[dir].range = newOpt?.[0]?.range?.length ? [...newOpt?.[0]?.range] : null;
       }
@@ -688,6 +691,8 @@ const module = {
     this.update({
       updateSeries: false,
       updateSelTip: { update: false, keepDomain: false },
+      lightUpdate: movedMin > 1,
+      updateByScrollbar: true,
     });
   },
 

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -270,8 +270,11 @@ const module = {
     // 위치를 비율 및 처음/끝 고정 여부로 저장
     const currentMaxPosition = Math.max(0, trackSize - thumbSize.size);
     scrollbarOpt.savedPositionRatio = trackSize > 0 ? thumbSize.position / trackSize : 0;
-    scrollbarOpt.savedAtStart = thumbSize.position <= 0;
-    scrollbarOpt.savedAtEnd = thumbSize.position >= currentMaxPosition;
+
+    if (!preservePosition || scrollbarOpt.savedPositionRatio === undefined) {
+      scrollbarOpt.savedAtStart = thumbSize.position <= 0;
+      scrollbarOpt.savedAtEnd = thumbSize.position >= currentMaxPosition;
+    }
 
     let scrollbarStyle = 'display: block;';
     let scrollbarTrackStyle;

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -268,10 +268,11 @@ const module = {
     }
 
     // 위치를 비율 및 처음/끝 고정 여부로 저장
+    // currentMaxPosition === 0 (thumbSize >= trackSize) 인 경우 저장하지 않음
+    // → trackSize가 다시 커졌을 때 이전 savedAtEnd/savedAtStart/savedPositionRatio 상태를 유지
     const currentMaxPosition = Math.max(0, trackSize - thumbSize.size);
-    scrollbarOpt.savedPositionRatio = trackSize > 0 ? thumbSize.position / trackSize : 0;
-
-    if (!preservePosition || scrollbarOpt.savedPositionRatio === undefined) {
+    if (currentMaxPosition > 0) {
+      scrollbarOpt.savedPositionRatio = thumbSize.position / trackSize;
       scrollbarOpt.savedAtStart = thumbSize.position <= 0;
       scrollbarOpt.savedAtEnd = thumbSize.position >= currentMaxPosition;
     }


### PR DESCRIPTION
## 이슈 배경

1. **차트 리사이즈 시 scrollbar thumb 위치가 초기화되는 이슈**
   - 사용자가 스크롤한 위치에서 차트를 리사이즈하면 thumb이 처음/끝으로 초기화됨

2. **range min 값이 0이 아닐 때 bar 차트 시리즈가 이상하게 그려지는 현상**
   - scrollbar로 중간 범위를 표시할 때 bar 위치가 잘못 렌더링됨

---

## 변경 파일

- `src/components/chart/chart.core.js`
- `src/components/chart/element/element.bar.js`
- `src/components/chart/plugins/plugins.scrollbar.js`

---

## 변경 내용

### 1. `plugins.scrollbar.js` — thumb 위치 저장 방식 변경 (`savedPosition` → `savedPositionRatio`)

**원인**

`savedPosition`을 절대 픽셀로 저장하여, 리사이즈로 track 크기가 변경되면 이전 픽셀값이 유효하지 않아 thumb 위치가 틀어지고 경우에 따라 track 범위를 벗어나 그려졌다.

**변경 사항**

| 항목 | 이전 | 변경 후 |
|------|------|---------|
| 저장 값 | `savedPosition` (절대 픽셀) | `savedPositionRatio` (0~1 비율) |
| 처음/끝 고정 | 없음 | `savedAtStart`, `savedAtEnd` 플래그 |
| 복원 로직 | 픽셀값 그대로 사용 | `ratio × newTrackSize`, clamp to `[0, trackSize - thumbSize]` |

**복원 규칙**
- `savedAtStart = true` → 항상 position 0 (처음 고정 유지)
- `savedAtEnd = true` → 항상 `trackSize - thumbSize` (끝 고정 유지)
- 중간 위치 → `savedPositionRatio × newTrackSize`, 유효 범위 내로 clamp

**초기화 시점** (기존과 동일)
- 최초 생성 시
- 사용자 drag / wheel 스크롤 시
- `resetPosition: true` 옵션인 경우

---

### 2. `plugins.scrollbar.js` — `initScrollbarInfo` 리사이즈 시 위치 초기화 제거

**원인**

`resize()` → `initScrollbar()` → `initScrollbarInfo()` 호출 시 `isInit=true`여도 무조건 `savedPosition`을 삭제하여 매 리사이즈마다 thumb이 초기화됐다.

**변경 사항**

`isInit=true`인 경우(재초기화), `resetPosition` 옵션이 `true`일 때만 `savedPositionRatio` 삭제.

---

### 3. `chart.core.js` — scrollbar 관련 수정

**원인 및 변경 사항**

| 항목 | 원인 | 변경 사항 |
|------|------|-----------|
| `resize()` 호출 순서 | `initScrollbar()` 시점에 `chartRect`가 아직 계산되지 않아 scrollbar 초기화에 필요한 레이아웃 정보가 없었음 | `initScale()` / `getChartRect()`를 `initScrollbar()` 이전으로 순서 변경 |
| `resize()` range 미동기화 | `initScrollbarInfo(isInit=true)`가 `scrollbar.range`를 갱신하지 않아, `drawChart()`가 이전 range 기준의 minIndex/maxIndex로 bar를 그렸음 | `initScrollbar()` 이후 `updateScrollbar(false, false)` 추가 → resize 시점에 options range와 `scrollbar.range` 동기화 |
| `updateScrollbar()` 조건 | `use` 변경 또는 forceUpdate 시에만 `updateScrollbarInfo`를 호출해, 일반 `update()` 경로에서 options range 변경이 scrollbar에 반영되지 않았음 | scrollbar가 사용 중이면 항상 호출하도록 조건 변경 (내부에서 실제 변경 여부 판단) |
| `updateScrollbarPosition()` 타이밍 | `drawSeries()` 이후 DOM 위치를 업데이트하면 레이아웃 정보가 불일치할 수 있었음 | `getAxesRange()` / `getLabelOffset()` 직후로 호출 이동 |

---

### 4. `element.bar.js` — `this.data` in-place 오염으로 데이터 중복 발생

**원인**

`startIndex > 0`인 경우 `this.data[screenIndex] = this.data[i]` (screenIndex < i)로 원본 데이터를 앞 인덱스에 덮어써서 `this.data`가 오염됐다. 다음 렌더 사이클에 오염된 데이터로 bar가 잘못된 위치에 그려지는 현상 발생.

**변경 사항**

- `this.data[screenIndex] = item` 제거 → `this.data` 원본 보존
- `this.visibleStartIndex = startIndex` 저장
- `binarySearchBar()` 탐색 범위를 `[0..filteredCount-1]` → `[visibleStartIndex..visibleStartIndex + filteredCount - 1]`로 변경

---

### 5. `element.bar.js` — `findGraphData`의 화면 밖 항목 stale xp/yp 참조

**원인**

마우스가 차트 바깥으로 나가면 `model.store.js`에서 `dataIndex=0` 또는 `dataIndex=labels.length-1`로 고정하여 `findGraphData`를 호출한다. 스크롤로 중간 범위만 표시 중일 때 이 `dataIndex`가 화면 밖 항목을 가리켜, 이전 렌더 사이클에서 설정된 stale `xp`/`yp`가 hit detection에 사용되는 문제가 있었다.

**변경 사항**

`dataIndex`를 현재 화면에 보이는 범위 `[visibleStartIndex, visibleStartIndex + filteredCount - 1]`로 clamp하여 항상 유효한 항목을 참조하도록 수정.

```js
const visStart = this.visibleStartIndex ?? 0;
const visEnd = visStart + (this.filteredCount ?? barData.length) - 1;
const clampedIndex = Math.max(visStart, Math.min(dataIndex, visEnd));
```

## 이전 동작
![Mar-26-2026 09-29-25](https://github.com/user-attachments/assets/7669d9a4-3d85-4565-b221-a560badf905f)
![Mar-26-2026 09-28-59](https://github.com/user-attachments/assets/17257cec-2410-4b7e-9635-7e588bb48746)


## 이후 동작
![Mar-26-2026 09-25-20](https://github.com/user-attachments/assets/f0146adc-1c74-45e6-b439-6f47c9bb932d)
![Mar-26-2026 09-24-56](https://github.com/user-attachments/assets/1e045714-1eb0-44fd-ad04-360f076a9666)


## 테스트 방법
http://10.20.141.23:9999/barChart#scrollbar

1. 초기화 여부가 false 일때 scrollbar의 위치를 이동 후 리사이즈 시 초기화되는지 확인해주세요.
2. 리사이즈 후 range를 업데이트할때 range의 min 값이 0이 아닌 경우에도 bar가 정상적으로 그려지는지 확인해주세요.
