### PR TITLE
fix: [3.4] interval을 증가시키는 방식을 2배에서, interval 배수로 변경하여 조금씩 증가하며 관찰하도록 함

### DIFF
--- a/src/components/chart/scale/scale.linear.js
+++ b/src/components/chart/scale/scale.linear.js
@@ -364,13 +364,14 @@ class LinearScale extends Scale {
       steps = safeSteps(graphRange, interval);
   
       while (steps > maxSteps) {
-        interval *= 2;
+        interval += resolvedInterval;
   
         ({ graphMin, graphMax } = expandByInterval({
           min: minValue,
           max: maxValue,
           interval,
         }));
+        
         graphRange = graphMax - graphMin;
         steps = safeSteps(graphRange, interval);
       }

--- a/src/components/chart/scale/scale.linear.spec.js
+++ b/src/components/chart/scale/scale.linear.spec.js
@@ -226,6 +226,12 @@ describe('LinearScale', () => {
       expect(scale.adjustedDecimalPoint).toBeTypeOf('number');
       expect(scale.adjustedDecimalPoint).toBeGreaterThanOrEqual(0);
     });
+
+    it('userInterval only에서 interval이 배수 단위로 증가한다', () => {
+      const scale = createScale({ interval: 10 });
+      const result = scale.calculateSteps({ minValue: 0, maxValue: 100, maxSteps: 3 });
+      expect(result.interval % 10).toBe(0); // 10의 배수
+    });
   });
 
   describe('getNiceInterval', () => {

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -106,7 +106,7 @@ class TimeScale extends Scale {
      * 2) userInterval only
      * Object(time, unit) interval에만 해당
      * interval을 시작값으로 사용하고,
-     * steps가 maxSteps를 넘으면 interval을 2배씩 증가
+     * steps가 maxSteps를 넘으면 interval을 배수로 증가
      */
     if (isValidInterval) {
       const graphRange = graphMax - graphMin;

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -56,11 +56,11 @@ class TimeScale extends Scale {
     const { maxValue, minValue } = range;
     const maxSteps = Math.max(1, range.maxSteps ?? 1);
   
+    const hasUserRange =
+    Array.isArray(this.range) && this.range.length === 2;
+    
     // 사용자 interval 옵션이 있는 경우, 사용자 interval 옵션을 우선 적용
     // 문자열('hour', 'second' 등)은 4)auto 분기로 처리
-    const hasUserRange =
-      Array.isArray(this.range) && this.range.length === 2;
-  
     const hasUserInterval =
       typeof this.interval === 'number' ||
       (typeof this.interval === 'object' && this.interval !== null);
@@ -114,7 +114,7 @@ class TimeScale extends Scale {
       let steps = Math.ceil(graphRange / interval);
   
       while (steps > maxSteps) {
-        interval *= 2;
+        interval += resolvedInterval;
         steps = Math.ceil(graphRange / interval);
       }
   


### PR DESCRIPTION
### 개요 
interval 만 사용할 경우, 표시가능한 라벨 개수를 넘지 않기 위해 interval을 조정하는 과정에서의 수식을 변경

### 기존 
- interval *= 2
- ex) interval: 1
   -  1 -> 2 -> 4 -> 6 -> 8

### 변경
- interval += userInterval
- ex) interval: 1
   - 1 -> 2 -> 3 -> 4 -> 5

### 결론
- 기존에는 maxSteps를 맞추기 위해 interval을 2배씩 증가시켜 step 수를 줄였는데, 
- 이 과정에서 interval과 graphMax가 필요 이상으로 크게 증가할 수 있었습니다.
- 이를 완화하기 위해 interval을 기존 resolvedInterval(User Interval) 단위로 점진적으로 증가시키도록 변경하여, 
- 사용자가 지정한 시간 단위를 더 자연스럽게 유지하면서 필요한 최소 수준으로만 축 범위를 확장하도록 조정했습니다.
