### PR TITLE
fix: Combo 차트에서 hit detection이 "값이 큰 시리즈"를 우선 선택하는 문제

### DIFF
--- a/docs/views/comboChart/example/AreaLine.vue
+++ b/docs/views/comboChart/example/AreaLine.vue
@@ -1,0 +1,177 @@
+<template>
+  <div class="case">
+    <resizable-wrapper>
+      <ev-chart
+        :data="chartData"
+        :options="chartOptions"
+        @click="onClick"
+        @dbl-click="onDblClick"
+      />
+    </resizable-wrapper>
+  </div>
+
+  <div class="description">
+    <b>Area(fill=true)와 일반 Line을 combo로 구성한 예제</b>
+    <br />
+    <span class="hint">
+      exemONE 대시보드에서 사용하는 area + line combo 패턴을 재현합니다.
+      area 시리즈(series#1)와 line 시리즈(series#2)의 포인트를 각각 클릭했을 때
+      의도한 시리즈가 선택되는지 확인하세요.
+    </span>
+    <br /><br />
+    <b>Combo 차트 hit detection 테스트</b>
+    <br />
+    <span class="hint">
+      두 시리즈가 겹치는 구간에서도 실제로 클릭한 포인트에 가장 가까운 시리즈가
+      선택되어야 합니다. 포인트 중심에서 조금 떨어진 곳을 클릭하면 라벨 기준
+      가장 가까운 hit 시리즈가 선택됩니다.
+    </span>
+    <br /><br />
+    <div class="badge yellow">클릭 이벤트 결과 (single click)</div>
+    <pre class="event-result">{{ clickedInfo }}</pre>
+    <div class="badge yellow">더블클릭 이벤트 결과 (double click)</div>
+    <pre class="event-result">{{ dblClickedInfo }}</pre>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+import dayjs from 'dayjs';
+
+export default {
+  setup() {
+    const baseTime = dayjs('2026-01-01 00:00:00');
+    const labels = Array.from({ length: 8 }, (_, i) => baseTime.add(i, 'day'));
+
+    const chartData = {
+      series: {
+        series1: {
+          name: 'series#1 (area)',
+          show: true,
+          type: 'line',
+          fill: { gradient: true },
+          fillColor: '#6AA9F2',
+          color: '#6AA9F2',
+        },
+        series2: {
+          name: 'series#2 (line)',
+          show: true,
+          type: 'line',
+          color: '#FF6B6B',
+        },
+      },
+      labels,
+      // 두 시리즈가 여러 지점에서 교차하도록 구성
+      data: {
+        series1: [20, 45, 60, 35, 80, 55, 30, 50],
+        series2: [55, 30, 40, 70, 45, 25, 65, 40],
+      },
+    };
+
+    const chartOptions = {
+      type: 'line',
+      width: '100%',
+      height: '100%',
+      title: {
+        text: 'Area + Line Combo',
+        show: true,
+      },
+      legend: {
+        show: true,
+        position: 'right',
+      },
+      axesX: [
+        {
+          type: 'time',
+          showGrid: false,
+          timeFormat: 'MM/DD',
+          interval: 'day',
+        },
+      ],
+      axesY: [
+        {
+          type: 'linear',
+          showGrid: true,
+          startToZero: true,
+          autoScaleRatio: 0.1,
+        },
+      ],
+      selectItem: {
+        use: true,
+        useClick: true,
+        showTip: true,
+      },
+    };
+
+    const clickedInfo = ref('(아직 클릭 안 됨)');
+    const dblClickedInfo = ref('(아직 더블클릭 안 됨)');
+
+    const formatEventInfo = (e) =>
+      JSON.stringify(
+        {
+          seriesId: e?.seriesId,
+          value: e?.value,
+          label: e?.label,
+          dataIndex: e?.dataIndex,
+          eventTarget: e?.selected?.eventTarget,
+        },
+        null,
+        2,
+      );
+
+    const onClick = (e) => {
+      clickedInfo.value = formatEventInfo(e);
+    };
+
+    const onDblClick = (e) => {
+      dblClickedInfo.value = formatEventInfo(e);
+    };
+
+    return {
+      chartData,
+      chartOptions,
+      clickedInfo,
+      dblClickedInfo,
+      onClick,
+      onDblClick,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.hint {
+  display: inline-block;
+  color: #666;
+  font-size: 12px;
+  line-height: 1.5;
+  max-width: 640px;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  margin-bottom: 4px;
+
+  &.yellow {
+    background-color: #fff3cd;
+    color: #856404;
+  }
+}
+
+.event-result {
+  display: block;
+  padding: 8px 12px;
+  margin: 0 0 12px;
+  background-color: #f5f5f5;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  max-width: 480px;
+}
+</style>

--- a/docs/views/comboChart/example/LineBar.vue
+++ b/docs/views/comboChart/example/LineBar.vue
@@ -1,7 +1,12 @@
 <template>
   <div class="case">
     <resizable-wrapper>
-      <ev-chart :data="chartData" :options="chartOptions" />
+      <ev-chart
+        :data="chartData"
+        :options="chartOptions"
+        @click="onClick"
+        @dbl-click="onDblClick"
+      />
     </resizable-wrapper>
   </div>
 
@@ -10,6 +15,19 @@
     <br />
     <span class="toggle-label">데이터 자동 업데이트</span>
     <ev-toggle v-model="isLive" />
+    <br /><br />
+    <b>Combo 차트 hit detection 테스트</b>
+    <br />
+    <span class="hint">
+      작은 값의 <b>bar</b>를 클릭했을 때 bar(series#1)가 선택되는지 확인하세요.
+      기존에는 같은 x 라벨 위를 지나가는 line이 더 큰 값이면 항상 line(series#2)이
+      선택되는 버그가 있었습니다.
+    </span>
+    <br /><br />
+    <div class="badge yellow">클릭 이벤트 결과 (single click)</div>
+    <pre class="event-result">{{ clickedInfo }}</pre>
+    <div class="badge yellow">더블클릭 이벤트 결과 (double click)</div>
+    <pre class="event-result">{{ dblClickedInfo }}</pre>
   </div>
 </template>
 
@@ -59,11 +77,40 @@ export default {
           autoScaleRatio: 0.1,
         },
       ],
+      selectItem: {
+        use: true,
+        useClick: true,
+        showTip: true,
+      },
     };
 
     const isLive = ref(false);
     const liveInterval = ref();
     let timeValue = dayjs().format('YYYY-MM-DD HH:mm:ss');
+
+    const clickedInfo = ref('(아직 클릭 안 됨)');
+    const dblClickedInfo = ref('(아직 더블클릭 안 됨)');
+
+    const formatEventInfo = (e) =>
+      JSON.stringify(
+        {
+          seriesId: e?.seriesId,
+          value: e?.value,
+          label: e?.label,
+          dataIndex: e?.dataIndex,
+          eventTarget: e?.selected?.eventTarget,
+        },
+        null,
+        2,
+      );
+
+    const onClick = (e) => {
+      clickedInfo.value = formatEventInfo(e);
+    };
+
+    const onDblClick = (e) => {
+      dblClickedInfo.value = formatEventInfo(e);
+    };
 
     const addRandomChartData = () => {
       if (isLive.value) {
@@ -110,6 +157,10 @@ export default {
       chartData,
       chartOptions,
       isLive,
+      clickedInfo,
+      dblClickedInfo,
+      onClick,
+      onDblClick,
     };
   },
 };
@@ -119,5 +170,40 @@ export default {
 .toggle-label {
   vertical-align: top;
   margin-right: 7px;
+}
+
+.hint {
+  display: inline-block;
+  color: #666;
+  font-size: 12px;
+  line-height: 1.5;
+  max-width: 640px;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  margin-bottom: 4px;
+
+  &.yellow {
+    background-color: #fff3cd;
+    color: #856404;
+  }
+}
+
+.event-result {
+  display: block;
+  padding: 8px 12px;
+  margin: 0 0 12px;
+  background-color: #f5f5f5;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  max-width: 480px;
 }
 </style>

--- a/docs/views/comboChart/example/LineBar.vue
+++ b/docs/views/comboChart/example/LineBar.vue
@@ -40,12 +40,12 @@ export default {
     const chartData = reactive({
       series: {
         series1: { name: 'series#1', show: true, type: 'bar', showValue: { use: true } },
-        series3: { name: 'series#2', show: true, type: 'line', combo: true },
+        series2: { name: 'series#2', show: true, type: 'line', combo: true },
       },
       labels: [],
       data: {
         series1: [],
-        series3: [],
+        series2: [],
       },
     });
 

--- a/docs/views/comboChart/example/LineBarSelectLabel.vue
+++ b/docs/views/comboChart/example/LineBarSelectLabel.vue
@@ -33,12 +33,12 @@ export default {
     const chartData = reactive({
       series: {
         series1: { name: 'series#1', show: true, type: 'bar', showValue: { use: true } },
-        series3: { name: 'series#2', show: true, type: 'line', combo: true },
+        series2: { name: 'series#2', show: true, type: 'line', combo: true },
       },
       labels: [],
       data: {
         series1: [],
-        series3: [],
+        series2: [],
       },
     });
 

--- a/docs/views/comboChart/props.js
+++ b/docs/views/comboChart/props.js
@@ -12,6 +12,8 @@ import TableTypeLegend from './example/TableTypeLegend';
 import TableTypeLegendRaw from './example/TableTypeLegend?raw';
 import LineBarSelectLabel from './example/LineBarSelectLabel';
 import LineBarSelectLabelRaw from './example/LineBarSelectLabel?raw';
+import AreaLine from './example/AreaLine';
+import AreaLineRaw from './example/AreaLine?raw';
 
 export default {
   mdText,
@@ -21,6 +23,12 @@ export default {
         'Line과 Bar를 조합하여 2가지 계열을 나타냅니다. Bar 차트가 들어가므로 Step Axis의 TimeMode를 사용하여 구현합니다.',
       component: LineBar,
       parsedData: parse(LineBarRaw).descriptor,
+    },
+    'Area & Line': {
+      description:
+        'Area(fill 옵션을 준 line)와 일반 Line을 조합합니다. 두 시리즈 모두 포인트 기반이므로 hit detection은 line 포인트 directHit 규칙을 따릅니다.',
+      component: AreaLine,
+      parsedData: parse(AreaLineRaw).descriptor,
     },
     'Line & StackBar': {
       description: 'Line과 StackBar를 조합하여 2가지 계열을 나타냅니다.',

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -493,10 +493,10 @@ class EvChart {
               const lastHitInfo = this.lastHitInfo;
               const defaultSelectInfo = this.defaultSelectItemInfo;
 
-              if (lastHitInfo?.maxIndex || lastHitInfo?.maxIndex === 0) {
+              if (lastHitInfo?.dataIndex || lastHitInfo?.dataIndex === 0) {
                 selectInfo = {
                   seriesID: lastHitInfo.sId,
-                  dataIndex: lastHitInfo.maxIndex,
+                  dataIndex: lastHitInfo.dataIndex,
                 };
               } else if (defaultSelectInfo?.dataIndex || defaultSelectInfo?.dataIndex === 0) {
                 selectInfo = { ...defaultSelectInfo };

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -364,6 +364,9 @@ class Bar {
         item.data = barData[clampedIndex];
         item.index = clampedIndex;
         item.hit = this.isPointInBar(offset, barData[clampedIndex]);
+        // bar 박스 내부 클릭은 "직접 박스 히트"로 표시.
+        // findHitItem에서 line 포인트 근접 히트보다 우선 선택되도록 하기 위함.
+        item.directHit = item.hit;
       }
 
       return item;
@@ -408,6 +411,8 @@ class Bar {
         item.data = barData;
         item.index = barData.index;
         item.hit = this.isPointInBar(offset, barData);
+        // bar 박스 내부 클릭은 "직접 박스 히트"로 표시 (findHitItem 우선순위용).
+        item.directHit = item.hit;
         return item;
       }
 

--- a/src/components/chart/element/element.bar.spec.js
+++ b/src/components/chart/element/element.bar.spec.js
@@ -57,4 +57,49 @@ describe('Bar Element', () => {
       expect(bar.isPointInBar([35, 40], barData)).toBe(false);
     });
   });
+
+  describe('findGraphData directHit 플래그', () => {
+    // bar: x 10~30, y 20~50
+    const barData = { xp: 10, yp: 50, w: 20, h: -30, index: 0 };
+
+    const createBarWithData = () =>
+      createBar({
+        data: [barData],
+        show: true,
+        color: '#000',
+        visibleStartIndex: 0,
+        filteredCount: 1,
+      });
+
+    it('bar 박스 내부 클릭은 hit=true, directHit=true를 반환한다', () => {
+      const bar = createBarWithData();
+      const item = bar.findGraphData([15, 40], false, 0, true);
+      expect(item.hit).toBe(true);
+      expect(item.directHit).toBe(true);
+    });
+
+    it('bar 박스 밖 클릭은 hit=false, directHit=false를 반환한다', () => {
+      const bar = createBarWithData();
+      const item = bar.findGraphData([5, 40], false, 0, true);
+      expect(item.hit).toBe(false);
+      expect(item.directHit).toBe(false);
+    });
+
+    it('binarySearchBar 경로(findGraphRange)에서도 directHit를 세팅한다', () => {
+      // useIndicatorOnLabel=false로 두면 findGraphRange → binarySearchBar 경로 진입
+      const bar = createBarWithData();
+      const item = bar.findGraphData([15, 40], false, undefined, false);
+      expect(item.hit).toBe(true);
+      expect(item.directHit).toBe(true);
+    });
+
+    it('binarySearchBar에서 x범위 밖 클릭은 directHit가 세팅되지 않는다', () => {
+      // binarySearchBar는 inRange 조건을 만족해야 item이 세팅됨.
+      // 범위 밖이면 초기값 { hit: false } 유지 (directHit 없음 = falsy).
+      const bar = createBarWithData();
+      const item = bar.findGraphData([50, 40], false, undefined, false);
+      expect(item.hit).toBe(false);
+      expect(item.directHit).toBeFalsy();
+    });
+  });
 });

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -364,7 +364,12 @@ class Line {
     // line 포인트 "정확 히트" 판정용 반경.
     // combo 차트에서 line 포인트 중심을 직격한 경우, 같은 좌표의 bar(directHit)보다
     // line이 우선되도록 item.directHit = true로 표시한다. 그 외(단순 Y축 근접)는 기존처럼 hit만.
-    const directHitRadius = Math.max((this.pointSize ?? 3) + 3, 6);
+    // 포인트 반지름에 기본 포인트 크기(LINE_OPTION.pointSize)만큼의 클릭 여유 마진을 더하고,
+    // 시각적으로 하이라이트되는 포인트 반경(highlight.maxSize)을 최소 보장값으로 사용한다.
+    const directHitRadius = Math.max(
+      (this.pointSize ?? LINE_OPTION.pointSize) + LINE_OPTION.pointSize,
+      LINE_OPTION.highlight.maxSize,
+    );
     const isLinePointDirectHit = (point) => {
       if (!point || point.xp === undefined || point.yp === undefined) {
         return false;

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -361,6 +361,19 @@ class Line {
     const gdata = this.data.filter((data) => !Util.isNullOrUndefined(data.x));
     const isLinearInterpolation = this.useLinearInterpolation();
 
+    // line 포인트 "정확 히트" 판정용 반경.
+    // combo 차트에서 line 포인트 중심을 직격한 경우, 같은 좌표의 bar(directHit)보다
+    // line이 우선되도록 item.directHit = true로 표시한다. 그 외(단순 Y축 근접)는 기존처럼 hit만.
+    const directHitRadius = Math.max((this.pointSize ?? 3) + 3, 6);
+    const isLinePointDirectHit = (point) => {
+      if (!point || point.xp === undefined || point.yp === undefined) {
+        return false;
+      }
+      const dx = xp - point.xp;
+      const dy = yp - point.yp;
+      return dx * dx + dy * dy <= directHitRadius * directHitRadius;
+    };
+
     if (gdata?.length) {
       if (typeof dataIndex === 'number' && this.show) {
         item.data = gdata[dataIndex];
@@ -372,6 +385,10 @@ class Line {
 
           if (yDist <= directHitThreshold) {
             item.hit = true;
+          }
+          if (isLinePointDirectHit(point)) {
+            item.hit = true;
+            item.directHit = true;
           }
         }
       } else if (
@@ -511,6 +528,10 @@ class Line {
 
             if (yDist <= directHitThreshold) {
               item.hit = true;
+            }
+            if (isLinePointDirectHit(point)) {
+              item.hit = true;
+              item.directHit = true;
             }
           }
         }

--- a/src/components/chart/element/element.line.spec.js
+++ b/src/components/chart/element/element.line.spec.js
@@ -84,4 +84,38 @@ describe('Chart Interpolation', () => {
       expect(line.useLinearInterpolation()).toBe(true);
     });
   });
+
+  describe('findGraphData directHit 판정', () => {
+    // 라인 포인트를 "직격"한 경우(포인트 중심 근처)에는 item.directHit=true로 표시되어,
+    // 같은 좌표에 겹친 bar의 directHit보다 우선되어야 한다.
+    const makeLine = () => {
+      const line = new Line('s1', { interpolation: 'none' }, 0);
+      line.show = true;
+      line.pointSize = 3;
+      line.data = [{ x: 0, y: 100, xp: 50, yp: 100, o: 100 }];
+      return line;
+    };
+
+    it('라인 포인트 중심을 정확히 클릭하면 hit=true, directHit=true', () => {
+      const line = makeLine();
+      const item = line.findGraphData([50, 100], false, 0, false);
+      expect(item.hit).toBe(true);
+      expect(item.directHit).toBe(true);
+    });
+
+    it('포인트에서 먼 Y(15px 이내)는 기존처럼 hit=true, directHit=false', () => {
+      const line = makeLine();
+      // y만 10px 떨어진 위치: yDist < 15이지만 유클리드 거리가 directHitRadius(= 6) 초과
+      const item = line.findGraphData([50, 110], false, 0, false);
+      expect(item.hit).toBe(true);
+      expect(item.directHit).toBeFalsy();
+    });
+
+    it('포인트에서 Y/X 모두 크게 떨어지면 hit=false, directHit=false', () => {
+      const line = makeLine();
+      const item = line.findGraphData([50, 200], false, 0, false);
+      expect(item.hit).toBeFalsy();
+      expect(item.directHit).toBeFalsy();
+    });
+  });
 });

--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -158,7 +158,7 @@ const modules = {
 
     if (tipType === 'sel') {
       if (hitInfo && hitInfo.label !== null) {
-        lastTip.pos = type === 'bar' ? hitInfo.maxIndex : hitInfo.label;
+        lastTip.pos = type === 'bar' ? hitInfo.dataIndex : hitInfo.label;
         ldata = lastTip.pos;
       } else if (lastTip.pos !== null) {
         ldata = lastTip.pos;

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -810,7 +810,7 @@ const modules = {
       }
 
       itemPosition = [
-        this.getItemByPosition([dataInfo.xp, dataInfo.yp], useApproximate, dataIndex, true),
+        this.getHitItemByPosition([dataInfo.xp, dataInfo.yp], useApproximate, dataIndex, true),
       ];
     } else {
       const seriesList = Object.entries(this.seriesList);
@@ -832,7 +832,7 @@ const modules = {
           return null;
         }
 
-        return this.getItemByPosition(
+        return this.getHitItemByPosition(
           [dataInfo?.xp ?? 0, dataInfo?.yp ?? 0],
           useApproximate,
           idx,
@@ -860,26 +860,48 @@ const modules = {
   },
 
   /**
-   * Find graph item by position x and y
+   * Find the hit item at the given position (x, y).
+   *
+   * 선택 우선순위:
+   *   1. directHit (bar 박스 내부 클릭) — 가장 가까운 것
+   *   2. hit (line 포인트 근접 등) — 가장 가까운 것
+   *   3. hit이 전혀 없으면 데이터가 있는 첫 시리즈로 fallback (기존 동작 호환)
+   *
+   * 과거에는 "같은 라벨 위에서 값이 가장 큰 시리즈"를 돌려주는 max-value 덮어쓰기 방식이었으나,
+   * bar + line combo 차트에서 작은 bar를 클릭해도 큰 값의 line이 선택되는 버그의 원인이었다.
+   * 이번 수정으로 사용자가 실제로 가리킨 시리즈(hit)가 선택되도록 바뀐다.
+   *
    * @param {array}   offset          position x and y
    * @param {boolean} useApproximate  if it's true. it'll look for closed item on mouse position
    * @param {number} dataIndex        selected data index
    * @param {boolean}  useSelectLabelOrItem   used to display select label/item at tooltip location
    *
-   * @returns {object} clicked item information
+   * @returns {object} hit item information
    */
-  getItemByPosition(offset, useApproximate = false, dataIndex, useSelectLabelOrItem = false) {
+  getHitItemByPosition(offset, useApproximate = false, dataIndex, useSelectLabelOrItem = false) {
     const seriesIDs = Object.keys(this.seriesList);
     const isHorizontal = !!this.options.horizontal;
 
-    let maxType = null;
-    let maxLabel = null;
-    let maxValuePos = null;
-    let maxValue = null;
-    let maxSeriesID = '';
+    // hit 기반 결과 (최우선)
+    let hitType = null;
+    let hitLabel = null;
+    let hitValuePos = null;
+    let hitValue = null;
+    let hitSeriesID = '';
+    let hitDataIndex = null;
+    let hitDistance = Infinity;
+    let hasDirectHit = false;
+
+    // fallback: hit이 전혀 없을 때 사용할 "데이터 있는 첫 시리즈" 정보
+    let fallbackType = null;
+    let fallbackLabel = null;
+    let fallbackValuePos = null;
+    let fallbackValue = null;
+    let fallbackSeriesID = '';
+    let fallbackDataIndex = null;
+
     let acc = 0;
     let useStack = false;
-    let maxIndex = null;
 
     for (let ix = 0; ix < seriesIDs.length; ix++) {
       const seriesID = seriesIDs[ix];
@@ -893,12 +915,13 @@ const modules = {
 
         if (data) {
           if (Util.isPieType(item.type)) {
-            maxLabel = seriesID;
-            maxSeriesID = seriesID;
-            maxValuePos = (data.ea - data.sa) / 2;
-            maxValue = data.o;
-            maxIndex = data.index;
-            maxType = item.type;
+            // pie 차트는 hit detection 체계가 달라 기존 동작 유지 (단일 pie 시리즈가 일반적)
+            hitType = item.type;
+            hitLabel = seriesID;
+            hitSeriesID = seriesID;
+            hitValuePos = (data.ea - data.sa) / 2;
+            hitValue = data.o;
+            hitDataIndex = data.index;
           } else {
             const ldata = isHorizontal ? data.y : data.x;
             const lp = isHorizontal ? data.yp : data.xp;
@@ -913,22 +936,45 @@ const modules = {
                 acc += data.y;
               }
 
-              if (maxType === 'bar' && useStack) {
-                if (item.hit) {
-                  maxValue = g;
-                  maxSeriesID = seriesID;
-                  maxIndex = index;
-                  maxLabel = ldata;
-                  maxValuePos = lp;
-                  maxType = series.type;
+              // fallback 기록: 데이터가 있는 첫 시리즈를 저장
+              if (fallbackSeriesID === '') {
+                fallbackType = series.type;
+                fallbackLabel = ldata;
+                fallbackValuePos = lp;
+                fallbackValue = g;
+                fallbackSeriesID = seriesID;
+                fallbackDataIndex = index;
+              }
+
+              // hit 기반 선택: item.hit이 true이고 유효한 좌표가 있을 때만 고려
+              if (item.hit && data.xp !== undefined && data.yp !== undefined) {
+                const distance = (data.xp - offset[0]) ** 2 + (data.yp - offset[1]) ** 2;
+
+                if (item.directHit) {
+                  // 직접 박스 히트는 최우선. 여러 개이면 가장 가까운 것.
+                  if (!hasDirectHit || distance < hitDistance) {
+                    hitDistance = distance;
+                    hitType = series.type;
+                    hitLabel = ldata;
+                    hitValuePos = lp;
+                    hitValue = g;
+                    hitSeriesID = seriesID;
+                    hitDataIndex = index;
+                  }
+                  hasDirectHit = true;
+                } else if (!hasDirectHit) {
+                  // directHit가 없을 때만 일반 hit 거리 비교 참여
+                  // (라인 근접 히트가 박스 직접 히트를 이기지 못하도록)
+                  if (distance < hitDistance) {
+                    hitDistance = distance;
+                    hitType = series.type;
+                    hitLabel = ldata;
+                    hitValuePos = lp;
+                    hitValue = g;
+                    hitSeriesID = seriesID;
+                    hitDataIndex = index;
+                  }
                 }
-              } else if (maxValue === null || maxValue <= g) {
-                maxValue = g;
-                maxSeriesID = seriesID;
-                maxLabel = ldata;
-                maxValuePos = lp;
-                maxIndex = index;
-                maxType = series.type;
               }
             }
           }
@@ -936,22 +982,24 @@ const modules = {
       }
     }
 
+    const hasHit = hitSeriesID !== '';
+
     return {
-      type: maxType,
-      label: maxLabel,
-      pos: maxValuePos,
-      value: maxValue ?? 0,
-      sId: maxSeriesID,
+      type: hasHit ? hitType : fallbackType,
+      label: hasHit ? hitLabel : fallbackLabel,
+      pos: hasHit ? hitValuePos : fallbackValuePos,
+      value: (hasHit ? hitValue : fallbackValue) ?? 0,
+      sId: hasHit ? hitSeriesID : fallbackSeriesID,
       acc,
       useStack,
-      maxIndex,
+      dataIndex: hasHit ? hitDataIndex : fallbackDataIndex,
     };
   },
 
   /**
    * @typedef {Object} LabelInfoResult
    * @property {number} labelIndex - 선택된 라벨의 인덱스
-   * @property {object} hitInfo - 해당 위치에서의 히트 정보 (getItemByPosition 반환값)
+   * @property {object} hitInfo - 해당 위치에서의 히트 정보 (getHitItemByPosition 반환값)
    */
   /**
    * Find label info by position x and y
@@ -1025,13 +1073,13 @@ const modules = {
         offsetX = x;
       }
 
-      hitInfo = this.getItemByPosition(
+      hitInfo = this.getHitItemByPosition(
         [offsetX, y],
         selectLabel?.useApproximateValue,
         dataIndex,
         true,
       );
-      labelIndex = hitInfo.maxIndex ?? -1;
+      labelIndex = hitInfo.dataIndex ?? -1;
     }
 
     return {

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -72,6 +72,29 @@ describe('model.store getHitItemByPosition', () => {
 
       expect(result.sId).toBe('near');
     });
+
+    it('같은 좌표에서 line 포인트 directHit는 bar 박스 directHit를 거리로 이긴다', () => {
+      // combo 차트에서 line 포인트가 bar 박스 내부에 있어 둘 다 directHit인 경우.
+      // bar.(xp,yp)는 박스 꼭짓점이라 클릭 좌표와 거리가 크고,
+      // line.(xp,yp)는 포인트 중심이라 거의 0. 따라서 line이 이겨야 한다.
+      const bar = mockSeries({
+        type: 'bar',
+        data: { x: 0, y: 10, xp: 30, yp: 20, o: 10, index: 0 },
+        hit: true,
+        directHit: true,
+      });
+      const line = mockSeries({
+        type: 'line',
+        data: { x: 0, y: 50, xp: 50, yp: 50, o: 50, index: 0 },
+        hit: true,
+        directHit: true,
+      });
+
+      const store = createStore({ bar, line });
+      const result = store.getHitItemByPosition([50, 50]);
+
+      expect(result.sId).toBe('line');
+    });
   });
 
   describe('hit 없음 + directHit 없음', () => {

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import modules from './model.store';
+
+/**
+ * model.store의 메서드들은 차트 인스턴스의 this에 바인딩되어 사용됨.
+ * 테스트에서는 필요한 속성만 주입한 가짜 컨텍스트를 만들어 메서드를 직접 호출한다.
+ */
+const createStore = (seriesList, options = {}) =>
+  Object.assign(Object.create(modules), {
+    seriesList,
+    options: { horizontal: false, ...options },
+  });
+
+/**
+ * findGraphData mock을 만드는 헬퍼.
+ * 실제 Bar/Line 클래스 대신 필요한 필드만 가진 객체를 리턴한다.
+ */
+const mockSeries = ({ type, data, hit = false, directHit = false, stackIndex = null }) => ({
+  type,
+  stackIndex,
+  findGraphData: () => ({
+    data,
+    hit,
+    directHit,
+    index: data?.index ?? 0,
+  }),
+});
+
+describe('model.store getHitItemByPosition', () => {
+  describe('directHit 우선순위', () => {
+    it('bar 박스 내부 클릭(directHit=true)은 좌표가 더 가까운 line(hit=true)보다 우선 선택된다', () => {
+      // bar 시리즈: 클릭 좌표 [50, 100]에서 좀 떨어진 xp=10, yp=90 (박스 꼭짓점 기준)
+      // line 시리즈: 클릭 좌표에 아주 가까운 xp=51, yp=101 (포인트 기준)
+      // 기존 로직이면 line이 거리 기준 승자였음. directHit 도입 후 bar가 선택되어야 한다.
+      const barSeries = mockSeries({
+        type: 'bar',
+        data: { x: 0, y: 10, xp: 10, yp: 90, o: 10, index: 0 },
+        hit: true,
+        directHit: true,
+      });
+      const lineSeries = mockSeries({
+        type: 'line',
+        data: { x: 0, y: 100, xp: 51, yp: 101, o: 100, index: 0 },
+        hit: true,
+        directHit: false,
+      });
+
+      const store = createStore({ bar1: barSeries, line1: lineSeries });
+      const result = store.getHitItemByPosition([50, 100]);
+
+      expect(result.sId).toBe('bar1');
+      expect(result.type).toBe('bar');
+    });
+
+    it('여러 bar에 directHit가 겹치면 클릭 좌표에 가장 가까운 bar가 선택된다', () => {
+      // 두 bar 모두 directHit=true. 거리 기준으로 더 가까운 쪽이 승자.
+      const barFar = mockSeries({
+        type: 'bar',
+        data: { x: 0, y: 10, xp: 10, yp: 20, o: 10, index: 0 },
+        hit: true,
+        directHit: true,
+      });
+      const barNear = mockSeries({
+        type: 'bar',
+        data: { x: 0, y: 20, xp: 48, yp: 52, o: 20, index: 0 },
+        hit: true,
+        directHit: true,
+      });
+
+      const store = createStore({ far: barFar, near: barNear });
+      const result = store.getHitItemByPosition([50, 50]);
+
+      expect(result.sId).toBe('near');
+    });
+  });
+
+  describe('hit 없음 + directHit 없음', () => {
+    it('bar/line 모두 hit=false면 데이터 있는 첫 시리즈로 fallback 한다', () => {
+      const s1 = mockSeries({
+        type: 'bar',
+        data: { x: 0, y: 10, xp: 10, yp: 20, o: 10, index: 0 },
+        hit: false,
+        directHit: false,
+      });
+      const s2 = mockSeries({
+        type: 'line',
+        data: { x: 0, y: 20, xp: 30, yp: 40, o: 20, index: 0 },
+        hit: false,
+      });
+
+      const store = createStore({ s1, s2 });
+      const result = store.getHitItemByPosition([1000, 1000]);
+
+      expect(result.sId).toBe('s1');
+    });
+  });
+
+  describe('일반 line 차트 회귀 방지', () => {
+    it('directHit가 하나도 없는 경우 거리 기반으로 가장 가까운 hit 시리즈가 선택된다', () => {
+      const lineFar = mockSeries({
+        type: 'line',
+        data: { x: 0, y: 10, xp: 10, yp: 10, o: 10, index: 0 },
+        hit: true,
+        directHit: false,
+      });
+      const lineNear = mockSeries({
+        type: 'line',
+        data: { x: 0, y: 20, xp: 49, yp: 51, o: 20, index: 0 },
+        hit: true,
+        directHit: false,
+      });
+
+      const store = createStore({ far: lineFar, near: lineNear });
+      const result = store.getHitItemByPosition([50, 50]);
+
+      expect(result.sId).toBe('near');
+    });
+  });
+
+  describe('리턴 객체 형태', () => {
+    it('dataIndex 키로 데이터 인덱스를 반환한다 (기존 maxIndex → dataIndex)', () => {
+      const barSeries = mockSeries({
+        type: 'bar',
+        data: { x: 0, y: 10, xp: 10, yp: 20, o: 10, index: 3 },
+        hit: true,
+        directHit: true,
+      });
+
+      const store = createStore({ bar1: barSeries });
+      const result = store.getHitItemByPosition([10, 20]);
+
+      expect(result.dataIndex).toBe(3);
+      expect(result.maxIndex).toBeUndefined();
+    });
+  });
+});

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -301,13 +301,13 @@ const modules = {
       const useSelectSeries = selectSeriesOpt?.use && selectSeriesOpt?.useClick;
 
       const setSelectedItemInfo = () => {
-        const hitInfo = this.getItemByPosition(offset, false);
+        const hitInfo = this.getHitItemByPosition(offset, false);
 
         ({
           label: args.label,
           value: args.value,
           sId: args.seriesId,
-          maxIndex: args.dataIndex,
+          dataIndex: args.dataIndex,
           acc: args.acc,
         } = hitInfo);
 
@@ -315,7 +315,7 @@ const modules = {
           args.selected = {
             eventTarget: 'item',
             seriesId: this.isDeselectItem(hitInfo) ? null : hitInfo.sId,
-            dataIndex: this.isDeselectItem(hitInfo) ? null : hitInfo.maxIndex,
+            dataIndex: this.isDeselectItem(hitInfo) ? null : hitInfo.dataIndex,
           };
         }
       };
@@ -1631,9 +1631,9 @@ const modules = {
   isDeselectItem(hitInfo) {
     return (
       this.options.selectItem.useDeselectItem &&
-      hitInfo?.maxIndex === this.defaultSelectItemInfo?.dataIndex &&
+      hitInfo?.dataIndex === this.defaultSelectItemInfo?.dataIndex &&
       hitInfo?.sId === this.defaultSelectItemInfo?.seriesID &&
-      !isNaN(hitInfo?.maxIndex)
+      !isNaN(hitInfo?.dataIndex)
     );
   },
 

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -918,6 +918,9 @@ const modules = {
     let maxg = null;
     let maxSID = null;
     let minDistance = Infinity;
+    // directHit(bar 박스 내부 클릭/hover) 시리즈가 발견되었는지 추적.
+    // 한 번이라도 directHit가 있으면 line의 근접 포인트 히트는 hitId 후보에서 배제된다.
+    let hasDirectHit = false;
 
     // 1. 먼저 공통으로 사용할 데이터 인덱스 결정
     const targetDataIndex = this.findClosestDataIndex(offset, sIds);
@@ -987,11 +990,22 @@ const modules = {
               maxSID = sId;
             }
 
-            // 마우스 위치와의 거리 계산하여 가장 가까운 시리즈 선택
+            // 마우스 위치와의 거리 계산하여 가장 가까운 시리즈 선택.
+            // directHit(bar 박스 내부)가 하나라도 있으면 그중에서만 선택하고,
+            // 라인의 근접 포인트 히트(item.hit=true, directHit=false)는 hitId 후보에서 배제한다.
+            // bar + line combo 차트에서 작은 bar 클릭 시 큰 값의 line이 잡히던 버그 방지.
             if (item.hit && item.data.xp !== undefined && item.data.yp !== undefined) {
               const distance = (item.data.xp - offset[0]) ** 2 + (item.data.yp - offset[1]) ** 2;
 
-              if (distance < minDistance) {
+              if (item.directHit) {
+                // directHit는 최우선. 여러 directHit 중에서는 가장 가까운 것 선택.
+                if (!hasDirectHit || distance < minDistance) {
+                  minDistance = distance;
+                  hitId = sId;
+                }
+                hasDirectHit = true;
+              } else if (!hasDirectHit && distance < minDistance) {
+                // directHit가 없을 때만 일반 hit 거리 비교
                 minDistance = distance;
                 hitId = sId;
               }

--- a/src/components/chart/plugins/plugins.interaction.spec.js
+++ b/src/components/chart/plugins/plugins.interaction.spec.js
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import modules from './plugins.interaction';
+
+/**
+ * findHitItem 테스트를 위한 가짜 차트 컨텍스트.
+ * plugins.interaction의 메서드들은 차트 인스턴스의 this에 바인딩되어 사용되므로,
+ * 필요한 속성과 최소한의 의존 메서드를 주입한 컨텍스트를 만들어 직접 호출한다.
+ */
+const createChart = (seriesList, opts = {}) =>
+  Object.assign(Object.create(modules), {
+    seriesList,
+    options: { horizontal: false, ...opts },
+    tooltipCtx: null,
+    getFormattedTooltipLabel: ({ seriesName }) => seriesName,
+    getFormattedTooltipValue: ({ value }) => String(value),
+    findClosestDataIndex: () => 0,
+    isNotUseIndicator: () => false,
+  });
+
+/**
+ * findGraphData가 고정된 item을 리턴하는 mock 시리즈.
+ */
+const mockSeries = ({
+  show = true,
+  data,
+  hit = false,
+  directHit = false,
+  interpolation = 'linear',
+  isExistGrp = false,
+}) => ({
+  show,
+  id: 'mock-id',
+  name: 'mock-name',
+  xAxisIndex: 0,
+  yAxisIndex: 0,
+  interpolation,
+  isExistGrp,
+  findGraphData: () => ({
+    data,
+    hit,
+    directHit,
+    index: data?.index ?? 0,
+  }),
+});
+
+describe('plugins.interaction findHitItem', () => {
+  describe('directHit 우선순위', () => {
+    it('bar directHit는 더 가까운 line 포인트보다 우선 선택된다', () => {
+      // bar: directHit=true, 좌표는 클릭 지점에서 멀리 있음 (박스 꼭짓점 기준)
+      // line: hit=true (directHit 아님), 좌표는 클릭 지점에 매우 가까움 (포인트)
+      // 기존엔 거리만 봐서 line이 이겼으나, directHit 도입 후 bar가 이겨야 한다.
+      const chart = createChart({
+        bar1: mockSeries({
+          data: { x: 0, y: 10, xp: 10, yp: 90, o: 10 },
+          hit: true,
+          directHit: true,
+        }),
+        line1: mockSeries({
+          data: { x: 0, y: 100, xp: 51, yp: 101, o: 100 },
+          hit: true,
+          directHit: false,
+        }),
+      });
+
+      const result = chart.findHitItem([50, 100]);
+      expect(result.hitId).toBe('bar1');
+    });
+
+    it('여러 bar에 directHit가 겹치면 클릭 좌표에 가장 가까운 bar가 선택된다', () => {
+      const chart = createChart({
+        far: mockSeries({
+          data: { x: 0, y: 10, xp: 10, yp: 20, o: 10 },
+          hit: true,
+          directHit: true,
+        }),
+        near: mockSeries({
+          data: { x: 0, y: 20, xp: 48, yp: 52, o: 20 },
+          hit: true,
+          directHit: true,
+        }),
+      });
+
+      const result = chart.findHitItem([50, 50]);
+      expect(result.hitId).toBe('near');
+    });
+  });
+
+  describe('일반 line 차트 회귀 방지', () => {
+    it('directHit가 없으면 거리 기반으로 가장 가까운 hit 시리즈가 선택된다', () => {
+      const chart = createChart({
+        far: mockSeries({
+          data: { x: 0, y: 10, xp: 10, yp: 10, o: 10 },
+          hit: true,
+        }),
+        near: mockSeries({
+          data: { x: 0, y: 20, xp: 49, yp: 51, o: 20 },
+          hit: true,
+        }),
+      });
+
+      const result = chart.findHitItem([50, 50]);
+      expect(result.hitId).toBe('near');
+    });
+  });
+
+  describe('hit 없을 때 fallback', () => {
+    it('모든 시리즈가 hit=false면 items의 첫 번째 키로 fallback 한다', () => {
+      const chart = createChart({
+        s1: mockSeries({
+          data: { x: 0, y: 10, xp: 10, yp: 20, o: 10 },
+          hit: false,
+        }),
+        s2: mockSeries({
+          data: { x: 0, y: 20, xp: 30, yp: 40, o: 20 },
+          hit: false,
+        }),
+      });
+
+      const result = chart.findHitItem([1000, 1000]);
+      expect(result.hitId).toBe('s1');
+    });
+  });
+
+  describe('items 수집', () => {
+    it('hit 여부와 무관하게 유효한 data를 가진 모든 시리즈가 items에 포함된다 (tooltip용)', () => {
+      const chart = createChart({
+        bar1: mockSeries({
+          data: { x: 0, y: 10, xp: 10, yp: 20, o: 10 },
+          hit: true,
+          directHit: true,
+        }),
+        line1: mockSeries({
+          data: { x: 0, y: 100, xp: 30, yp: 40, o: 100 },
+          hit: true,
+          directHit: false,
+        }),
+      });
+
+      const result = chart.findHitItem([10, 20]);
+      expect(Object.keys(result.items).sort()).toEqual(['bar1', 'line1']);
+      expect(result.hitId).toBe('bar1');
+    });
+  });
+});

--- a/src/components/chart/plugins/plugins.interaction.spec.js
+++ b/src/components/chart/plugins/plugins.interaction.spec.js
@@ -83,6 +83,26 @@ describe('plugins.interaction findHitItem', () => {
       const result = chart.findHitItem([50, 50]);
       expect(result.hitId).toBe('near');
     });
+
+    it('같은 좌표에서 line 포인트 directHit는 bar 박스 directHit를 거리로 이긴다', () => {
+      // combo 차트에서 line 포인트가 bar 박스 내부에 있어 둘 다 directHit인 경우.
+      // line 포인트 중심이 클릭 좌표에 더 가까우므로 line이 선택되어야 한다.
+      const chart = createChart({
+        bar: mockSeries({
+          data: { x: 0, y: 10, xp: 30, yp: 20, o: 10 },
+          hit: true,
+          directHit: true,
+        }),
+        line: mockSeries({
+          data: { x: 0, y: 50, xp: 50, yp: 50, o: 50 },
+          hit: true,
+          directHit: true,
+        }),
+      });
+
+      const result = chart.findHitItem([50, 50]);
+      expect(result.hitId).toBe('line');
+    });
   });
 
   describe('일반 line 차트 회귀 방지', () => {


### PR DESCRIPTION
## 배경
combo 차트에서 사용자가 실제로 클릭/hover한 시리즈가 아니라, 같은 라벨 위에서 값이 가장 큰 시리즈가 항상 선택되던 문제. bar + line, area + line 등 combo 전 조합에서 동일하게 발생.

## 원인
- `model.store.js` `getItemByPosition` — `maxValue <= g` 덮어쓰기 방식이라 hit 여부와 무관하게 값이 큰 시리즈가 승자가 됨.
- `plugins.interaction.js` `findHitItem` — 거리 기반 선택이지만 비교 기준이 시리즈 타입마다 달라(bar는 박스 꼭짓점, line/area는 포인트 중심) 겹치는 구간에서 의도치 않은 시리즈가 선택됨.

## 동작 변화
시리즈 타입에 관계없이 **"직격(directHit)"** 우선 규칙으로 통일:

| 우선순위 | 조건 |
|---|---|
| 1 | directHit (bar 박스 내부 클릭, line/area 포인트 중심 근접) — 여러 개면 클릭 좌표에 더 가까운 쪽 |
| 2 | 일반 hit (포인트 라벨 근접) — 가장 가까운 시리즈 |
| 3 | fallback — 데이터 있는 첫 시리즈 (기존 호환) |

결과적으로 bar + line, area + line, stacked 조합 등 combo 전 케이스에서 **사용자가 실제로 가리킨 시리즈**가 선택됨.

![bar+line click](https://github.com/user-attachments/assets/c4baf6bc-0431-42a4-8ea2-ebb4349f6a8f)

![line+area click](https://github.com/user-attachments/assets/0c8eebdc-1f96-4fbb-ae70-653274ff1842)

## 테스트
- `npm run test`
- ComboChart docs 페이지에서 Line & Bar, Area & Line 예제의 단일/더블 클릭 결과 확인

close #2198