### PR TITLE
[#2201] [fix] Chart > data, label 빈배열일 때 축에 보이는 값 이전 스펙과 동일 시 함

### DIFF
--- a/src/components/chart/scale/scale.linear.js
+++ b/src/components/chart/scale/scale.linear.js
@@ -223,6 +223,32 @@ class LinearScale extends Scale {
   }
 
   /**
+   * maxValue가 1일 때, 특수 처리 (기존 로직)
+   * @param {number} maxSteps 
+   * @returns {object} interval, steps
+   */
+  getLegacyOneMaxScale(maxSteps) {
+    if (!this.decimalPoint) {
+      return {
+        interval: 1,
+        steps: 1,
+      };
+    }
+
+    if (maxSteps > 2) {
+      return {
+        interval: 0.2,
+        steps: 5,
+      };
+    }
+
+    return {
+      interval: 0.5,
+      steps: 2,
+    };
+  }
+
+  /**
    * With range information, calculate how many labels in axis
    * @param {object} range    min/max information
    *
@@ -395,6 +421,18 @@ class LinearScale extends Scale {
   
     const normalizedMax =
       this.startToZero && maxValue <= 0 ? 0 : maxValue;
+
+    if (normalizedMin === 0 && normalizedMax === 1) {
+      const legacy = this.getLegacyOneMaxScale(maxSteps);
+      setDecimal(legacy.interval);
+
+      return {
+        steps: legacy.steps,
+        interval: legacy.interval,
+        graphMin: normalizedMin,
+        graphMax: normalizedMax,
+      };
+    }
   
     const nice = this.getStepsWithNiceScale({
       min: normalizedMin,
@@ -425,6 +463,23 @@ class LinearScale extends Scale {
     let isDefaultMaxSameAsMin = false;
 
     const range = scrollbarOpt?.use ? scrollbarOpt?.range : this.range;
+    const hasRangeOverride = Array.isArray(range) || typeof range === 'function';
+
+    if (!hasRangeOverride && (minMax?.min == null || minMax?.max == null)) {
+      const minLabel = this.getLabelFormat(0);
+      const maxLabel = this.getLabelFormat(1, {
+        isMaxValueSameAsMin: true,
+      });
+
+      return {
+        min: 0,
+        max: 1,
+        minLabel,
+        maxLabel,
+        size: Util.calcTextSizeCanvas(maxLabel, Util.getLabelStyle(this.labelStyle)),
+      };
+    }
+
     if (Array.isArray(range) && range?.length === 2) {
       if (this.options.type === 'heatMap') {
         maxValue = range[1] > +minMax.max ? +minMax.max : range[1];

--- a/src/components/chart/scale/scale.linear.spec.js
+++ b/src/components/chart/scale/scale.linear.spec.js
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Util from '../helpers/helpers.util';
 import LinearScale from './scale.linear';
 
 // LinearScale의 순수 계산 메서드를 테스트하기 위해 최소 mock 생성
@@ -9,9 +10,18 @@ const createScale = (overrides = {}) => {
   scale.startToZero = false;
   scale.fixedSteps = false;
   scale.formatter = null;
+  scale.options = { type: 'line' };
   Object.assign(scale, overrides);
   return scale;
 };
+
+beforeEach(() => {
+  vi.spyOn(Util, 'calcTextSizeCanvas').mockReturnValue({ width: 2, height: 2 });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('LinearScale', () => {
   describe('getInterval', () => {
@@ -227,10 +237,109 @@ describe('LinearScale', () => {
       expect(scale.adjustedDecimalPoint).toBeGreaterThanOrEqual(0);
     });
 
+    it('auto 모드에서 0~1 범위는 기존 특례를 복원한다', () => {
+      const scale = createScale();
+
+      const result = scale.calculateSteps({ minValue: 0, maxValue: 1, maxSteps: 4 });
+
+      expect(result).toEqual({
+        steps: 1,
+        interval: 1,
+        graphMin: 0,
+        graphMax: 1,
+      });
+    });
+
+    it('auto 모드에서 소수 축의 0~1 범위는 0.2 간격 특례를 사용한다', () => {
+      const scale = createScale({
+        decimalPoint: 2,
+      });
+
+      const result = scale.calculateSteps({ minValue: 0, maxValue: 1, maxSteps: 4 });
+
+      expect(result).toEqual({
+        steps: 5,
+        interval: 0.2,
+        graphMin: 0,
+        graphMax: 1,
+      });
+    });
+
     it('userInterval only에서 interval이 배수 단위로 증가한다', () => {
       const scale = createScale({ interval: 10 });
       const result = scale.calculateSteps({ minValue: 0, maxValue: 100, maxSteps: 3 });
       expect(result.interval % 10).toBe(0); // 10의 배수
+    });
+  });
+
+  describe('getLegacyOneMaxScale', () => {
+    it('정수 축이면 1 간격 1 step을 반환한다', () => {
+      const scale = createScale();
+
+      expect(scale.getLegacyOneMaxScale(4)).toEqual({
+        interval: 1,
+        steps: 1,
+      });
+    });
+
+    it('소수 축이고 maxSteps가 충분하면 0.2 간격 5 step을 반환한다', () => {
+      const scale = createScale({
+        decimalPoint: 2,
+      });
+
+      expect(scale.getLegacyOneMaxScale(4)).toEqual({
+        interval: 0.2,
+        steps: 5,
+      });
+    });
+
+    it('소수 축이고 maxSteps가 작으면 0.5 간격 2 step을 반환한다', () => {
+      const scale = createScale({
+        decimalPoint: 2,
+      });
+
+      expect(scale.getLegacyOneMaxScale(2)).toEqual({
+        interval: 0.5,
+        steps: 2,
+      });
+    });
+  });
+
+  describe('calculateScaleRange', () => {
+    it('데이터 범위가 없고 사용자 range도 없으면 0~1 기본 축 범위를 반환한다', () => {
+      const scale = createScale({
+        labelStyle: {},
+      });
+
+      const result = scale.calculateScaleRange({ min: null, max: null });
+
+      expect(result.min).toBe(0);
+      expect(result.max).toBe(1);
+      expect(result.minLabel).toBe('0');
+      expect(result.maxLabel).toBe('1');
+    });
+
+    it('사용자 range가 있으면 빈 데이터여도 사용자 range를 유지한다', () => {
+      const scale = createScale({
+        labelStyle: {},
+        range: [10, 20],
+      });
+
+      const result = scale.calculateScaleRange({ min: null, max: null });
+
+      expect(result.min).toBe(10);
+      expect(result.max).toBe(20);
+    });
+
+    it('min과 max가 같으면 max를 1 증가시킨다', () => {
+      const scale = createScale({
+        labelStyle: {},
+      });
+
+      const result = scale.calculateScaleRange({ min: 3, max: 3 });
+
+      expect(result.min).toBe(3);
+      expect(result.max).toBe(4);
     });
   });
 

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -1,8 +1,95 @@
 import dayjs from 'dayjs';
 import { TIME_INTERVALS } from '../helpers/helpers.constant';
+import Util from '../helpers/helpers.util';
 import Scale from './scale';
 
 class TimeScale extends Scale {
+  /**
+   * value를 dayjs 객체로 변환하고, 숫자로 변환
+   * 
+   * @param {*} value 
+   * @returns {number} normalized value
+   */
+  normalizeTimeValue(value) {
+    if (value == null) {
+      return null;
+    }
+
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? value : null;
+    }
+
+    const normalized = dayjs(value).valueOf();
+    return Number.isFinite(normalized) ? normalized : null;
+  }
+
+  /**
+   * min/max value를 정규화하고, super.calculateScaleRange를 호출
+   * @param {object} minMax    min/max information
+   * @param {object} scrollbarOpt scrollbar option
+   *
+   * @returns {object} min/max value and label
+   */
+  calculateScaleRange(minMax, scrollbarOpt) {
+    const range = scrollbarOpt?.use ? scrollbarOpt?.range : this.range;
+    const hasRangeOverride = Array.isArray(range) || typeof range === 'function';
+
+    if (!hasRangeOverride && (minMax?.min == null || minMax?.max == null)) {
+      return {
+        min: null,
+        max: null,
+        minLabel: '',
+        maxLabel: '',
+        size: Util.calcTextSizeCanvas('', Util.getLabelStyle(this.labelStyle)),
+      };
+    }
+
+    let normalizedRange = range;
+
+    if (Array.isArray(range) && range.length === 2) {
+      normalizedRange = [
+        this.normalizeTimeValue(range[0]),
+        this.normalizeTimeValue(range[1]),
+      ];
+    } else if (typeof range === 'function') {
+      normalizedRange = (...args) => {
+        const [min, max] = range(...args);
+        return [
+          this.normalizeTimeValue(min),
+          this.normalizeTimeValue(max),
+        ];
+      };
+    }
+
+    const originalRange = this.range;
+    const originalScrollbarRange = scrollbarOpt?.range;
+
+    if (scrollbarOpt?.use) {
+      scrollbarOpt.range = normalizedRange;
+    } else {
+      this.range = normalizedRange;
+    }
+
+    const normalizedMinMax = {
+      ...minMax,
+      min: this.normalizeTimeValue(minMax?.min),
+      max: this.normalizeTimeValue(minMax?.max),
+    };
+
+    const result = super.calculateScaleRange(normalizedMinMax, scrollbarOpt);
+
+    this.range = originalRange;
+    if (scrollbarOpt?.use) {
+      scrollbarOpt.range = originalScrollbarRange;
+    }
+
+    return {
+      ...result,
+      min: this.normalizeTimeValue(result.min),
+      max: this.normalizeTimeValue(result.max),
+    };
+  }
+
   /**
    * Transforming label by designated format
    * @param {number} value                   label value
@@ -29,8 +116,8 @@ class TimeScale extends Scale {
    * @returns {number} interval
    */
   getInterval(range) {
-    const max = range.maxValue;
-    const min = range.minValue;
+    const max = this.normalizeTimeValue(range.maxValue);
+    const min = this.normalizeTimeValue(range.minValue);
     const step = range.maxSteps;
 
     if (this.interval) {
@@ -53,32 +140,46 @@ class TimeScale extends Scale {
    * @returns {object} steps, interval, min/max graph value
   */
   calculateSteps(range) {
-    const { maxValue, minValue } = range;
+    const minValue = this.normalizeTimeValue(range.minValue);
+    const maxValue = this.normalizeTimeValue(range.maxValue);
     const maxSteps = Math.max(1, range.maxSteps ?? 1);
-  
-    const hasUserRange =
-    Array.isArray(this.range) && this.range.length === 2;
-    
+    const normalizedRange = {
+      ...range,
+      minValue,
+      maxValue,
+    };
+
+    if (minValue == null || maxValue == null) {
+      return {
+        steps: 0,
+        interval: 0,
+        graphMin: null,
+        graphMax: null,
+      };
+    }
+
+    const hasUserRange = Array.isArray(this.range) && this.range.length === 2;
+
     // 사용자 interval 옵션이 있는 경우, 사용자 interval 옵션을 우선 적용
     // 문자열('hour', 'second' 등)은 4)auto 분기로 처리
     const hasUserInterval =
       typeof this.interval === 'number' ||
       (typeof this.interval === 'object' && this.interval !== null);
-  
+
     const resolvedInterval = hasUserInterval
-      ? this.getInterval(range)
+      ? this.getInterval(normalizedRange)
       : null;
-  
+
     const isValidInterval =
       resolvedInterval != null &&
       resolvedInterval > 0 &&
       Number.isFinite(resolvedInterval);
-  
+
     const EPS = 1e-10;
-  
+
     const graphMin = +minValue;
     let graphMax = +maxValue;
-  
+
     /**
      * 1) userRange + userInterval
      * 호환되면 그대로 사용
@@ -90,7 +191,7 @@ class TimeScale extends Scale {
       const rawSteps = graphRange / interval;
       const isCompatible =
         Math.abs(rawSteps - Math.round(rawSteps)) < EPS;
-  
+
       if ((isCompatible && rawSteps <= maxSteps) || this.fixedSteps) {
         const steps = Math.round(rawSteps);
         return {
@@ -112,15 +213,15 @@ class TimeScale extends Scale {
       const graphRange = graphMax - graphMin;
       let interval = resolvedInterval;
       let steps = Math.ceil(graphRange / interval);
-  
+
       while (steps > maxSteps) {
         interval += resolvedInterval;
         steps = Math.ceil(graphRange / interval);
       }
-  
+
       // interval을 유지하기 위해 graphMax 확장
       graphMax = graphMin + (interval * steps);
-  
+
       return {
         steps,
         interval,
@@ -133,26 +234,26 @@ class TimeScale extends Scale {
      * 3) auto
      * 문자열 interval('hour', 'second' 등)도 여기서 처리
      */
-    let interval = this.getInterval(range);
-    let increase = minValue;
-  
+    let interval = this.getInterval(normalizedRange);
+    let increase = graphMin;
+
     while (increase < maxValue) {
       increase += interval;
     }
-  
+
     graphMax = increase;
-  
+
     const graphRange = graphMax - graphMin;
     let steps = Math.round(graphRange / interval);
-  
+
     while (steps > maxSteps) {
       interval *= 2;
       steps = Math.round(graphRange / interval);
-  
+
       const tempInterval = graphRange / steps;
       interval = this.decimalPoint ? tempInterval : Math.ceil(tempInterval);
     }
-  
+
     if (graphRange > (steps * interval)) {
       const tempInterval = graphRange / steps;
       interval = this.decimalPoint ? tempInterval : Math.ceil(tempInterval);

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -62,13 +62,9 @@ class TimeScale extends Scale {
     }
 
     const originalRange = this.range;
-    const originalScrollbarRange = scrollbarOpt?.range;
-
-    if (scrollbarOpt?.use) {
-      scrollbarOpt.range = normalizedRange;
-    } else {
-      this.range = normalizedRange;
-    }
+    const safeScrollbarOpt = scrollbarOpt?.use
+      ? { ...scrollbarOpt, range: normalizedRange }
+      : scrollbarOpt;
 
     const normalizedMinMax = {
       ...minMax,
@@ -76,11 +72,14 @@ class TimeScale extends Scale {
       max: this.normalizeTimeValue(minMax?.max),
     };
 
-    const result = super.calculateScaleRange(normalizedMinMax, scrollbarOpt);
-
-    this.range = originalRange;
-    if (scrollbarOpt?.use) {
-      scrollbarOpt.range = originalScrollbarRange;
+    let result;
+    try {
+      if (!scrollbarOpt?.use) {
+        this.range = normalizedRange;
+      }
+      result = super.calculateScaleRange(normalizedMinMax, safeScrollbarOpt);
+    } finally {
+      this.range = originalRange;
     }
 
     return {

--- a/src/components/chart/scale/scale.time.spec.js
+++ b/src/components/chart/scale/scale.time.spec.js
@@ -1,0 +1,96 @@
+import dayjs from 'dayjs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Util from '../helpers/helpers.util';
+import TimeScale from './scale.time';
+
+const createScale = (overrides = {}) => {
+  const scale = Object.create(TimeScale.prototype);
+  scale.interval = null;
+  scale.range = null;
+  scale.labelStyle = {};
+  scale.options = { type: 'line' };
+  Object.assign(scale, overrides);
+  return scale;
+};
+
+beforeEach(() => {
+  vi.spyOn(Util, 'calcTextSizeCanvas').mockReturnValue({ width: 2, height: 2 });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('TimeScale', () => {
+  describe('calculateScaleRange', () => {
+    it('데이터 범위가 없고 사용자 range도 없으면 빈 축 범위를 반환한다', () => {
+      const scale = createScale();
+
+      const result = scale.calculateScaleRange({ min: null, max: null });
+
+      expect(result.min).toBeNull();
+      expect(result.max).toBeNull();
+      expect(result.minLabel).toBe('');
+      expect(result.maxLabel).toBe('');
+    });
+
+    it('사용자 range가 있으면 데이터가 없어도 지정 범위를 유지한다', () => {
+      const scale = createScale({
+        range: [0, 3600000],
+        timeFormat: 'DD HH:mm',
+      });
+
+      const result = scale.calculateScaleRange({ min: null, max: null });
+
+      expect(result.min).toBe(0);
+      expect(result.max).toBe(3600000);
+    });
+
+    it('사용자 range가 dayjs 객체여도 timestamp로 정규화한다', () => {
+      const start = dayjs().subtract(1, 'hour');
+      const end = dayjs();
+      const scale = createScale({
+        range: [start, end],
+        timeFormat: 'DD HH:mm',
+      });
+
+      const result = scale.calculateScaleRange({ min: null, max: null });
+
+      expect(result.min).toBe(start.valueOf());
+      expect(result.max).toBe(end.valueOf());
+    });
+
+    it('사용자 range가 문자열이어도 timestamp로 정규화한다', () => {
+      const start = '2026-04-07 13:00:00';
+      const end = '2026-04-07 14:00:00';
+      const scale = createScale({
+        range: [start, end],
+        timeFormat: 'DD HH:mm',
+      });
+
+      const result = scale.calculateScaleRange({ min: null, max: null });
+
+      expect(result.min).toBe(dayjs(start).valueOf());
+      expect(result.max).toBe(dayjs(end).valueOf());
+    });
+  });
+
+  describe('calculateSteps', () => {
+    it('축 범위가 비어 있으면 tick을 생성하지 않는다', () => {
+      const scale = createScale({ interval: 'hour' });
+
+      const result = scale.calculateSteps({
+        minValue: null,
+        maxValue: null,
+        maxSteps: 5,
+      });
+
+      expect(result).toEqual({
+        steps: 0,
+        interval: 0,
+        graphMin: null,
+        graphMax: null,
+      });
+    });
+  });
+});


### PR DESCRIPTION
### 개요 
- chartData > label 과 data 가 빈배열일 경우, 이전 버전과 동일하게 표시가 필요한 상황 

### 이전 버전 
- time 축이 빈배열일 경우 -> 축에 아무런 라벨도 표시하지 않음 
- linear 축이 빈배열일 경우 -> 축의 최대값을 1로 설정하여 표시 

### 변경 사항 
1. `scale.time.js`
   1) 타입 안정성 추가 
      - normalizeTimeValue()가 추가돼 시간 값이 숫자든 날짜 문자열이든 내부적으로 일관된 timestamp 값으로 정규화
      - range 값에 timestamp 가 아닌 string, Date, dayjs 값이 오더라도 처리 
   2) min/max가 아예 없는 경우 처리 
      - calculateSteps()가 steps: 0, interval: 0, graphMin/graphMax: null을 반환하여 처리 

2. `scale.linear.js`
   - min/max가 없는 경우 처리 
      - calculateScaleRange()에 예외 처리가 추가돼, range 오버라이드가 없고 min/max가 비어 있으면 기본 축 범위를 0 ~ 1로 반환
      
 ### Before
 - <img width="700" height="286" alt="image" src="https://github.com/user-attachments/assets/552cb945-cc90-485f-8888-49e8cd6c91ba" />

 ### After
 - <img width="700" height="282" alt="image" src="https://github.com/user-attachments/assets/e8c021ab-b47a-42f1-b91c-956210c443eb" />

### 테스트 가이드 
- docs/views/lineChart/example/Default.vue:123
<img width="302" height="119" alt="image" src="https://github.com/user-attachments/assets/5cb93c0d-59a6-4b7e-a5be-50ca312e3903" />
위 로직 주석 처리 후 차트의 x, y 축 라벨 확인

### 비고 
- 3.4.120 버전에는 해당사항 없음
