### PR TITLE
fix: 다중 시리즈 차트에서 hit detection fallback 이 잘못된 시리즈를 선택하는 문제

### DIFF
--- a/docs/views/comboChart/example/AreaLine.vue
+++ b/docs/views/comboChart/example/AreaLine.vue
@@ -26,7 +26,7 @@
       </li>
       <li>
         <b>두 시리즈 모두 null</b> 인 라벨(01/04)의 어느 영역을 클릭하든 →
-        <b>아무것도 선택되지 않아야</b> 합니다. (이벤트 selected 미발생)
+        hover/dblclick 과 동일하게 <b>nearest valid 라벨(01/03 또는 01/05)</b>이 선택되어야 합니다.
       </li>
       <li>
         두 시리즈 모두 값이 있는 라벨에서 포인트가 아닌 중간 영역을 클릭 →
@@ -70,7 +70,7 @@ export default {
       },
       labels,
       // - index 2, 6 (01/03, 01/07): series1 만 null → series2 선택되어야 함
-      // - index 3 (01/04): 두 시리즈 모두 null → 아무것도 선택되지 않아야 함
+      // - index 3 (01/04): 두 시리즈 모두 null → nearest valid 라벨(01/03 또는 01/05) 선택
       // - 나머지: 두 시리즈 모두 값 → 클릭 좌표에 가까운 쪽이 선택
       data: {
         series1: [20, 45, null, null, 80, 55, null, 50],

--- a/docs/views/comboChart/example/AreaLine.vue
+++ b/docs/views/comboChart/example/AreaLine.vue
@@ -25,8 +25,10 @@
         <b>series2</b> 가 선택되어야 합니다. (기존 버그: series1 이 고정으로 리턴)
       </li>
       <li>
-        <b>두 시리즈 모두 null</b> 인 라벨(01/04)의 어느 영역을 클릭하든 →
-        hover/dblclick 과 동일하게 <b>nearest valid 라벨(01/03 또는 01/05)</b>이 선택되어야 합니다.
+        <b>두 시리즈 모두 null</b> 인 라벨(01/04)을 클릭/더블클릭 →
+        <code>seriesId=""</code>, <code>value=0</code> 또는 <code>undefined</code>,
+        <code>label/dataIndex</code> 는 <b>01/04</b> 가 그대로 반환되어야 합니다.
+        (hover 는 여전히 nearest valid 라벨로 snap 되어 tooltip 이 표시됩니다.)
       </li>
       <li>
         두 시리즈 모두 값이 있는 라벨에서 포인트가 아닌 중간 영역을 클릭 →

--- a/docs/views/comboChart/props.js
+++ b/docs/views/comboChart/props.js
@@ -26,7 +26,7 @@ export default {
     },
     'Area & Line': {
       description:
-        'Area(fill 옵션을 준 line)와 일반 Line을 조합합니다. 두 시리즈 모두 포인트 기반이므로 hit detection은 line 포인트 directHit 규칙을 따릅니다.',
+        'Area(fill 옵션을 준 line)와 일반 Line을 조합합니다. 일부 라벨에 null 값이 섞여 있을 때, null 라벨의 빈 영역을 클릭하면 값이 없는 시리즈가 아니라 실제로 값이 있는 시리즈가 선택되어야 합니다.',
       component: AreaLine,
       parsedData: parse(AreaLineRaw).descriptor,
     },

--- a/docs/views/lineChart/example/FillWithNull.vue
+++ b/docs/views/lineChart/example/FillWithNull.vue
@@ -11,9 +11,10 @@
   </div>
 
   <div class="description">
-    <b>Area(fill=true)와 일반 Line을 combo로 구성한 예제 — null 섞임</b>
+    <b>null 값이 섞인 Area(Fill) 2개 시리즈 — fallback 선택 버그 재현 예제</b>
     <br />
     <span class="hint">
+      두 area 시리즈 모두 fill 옵션을 사용합니다.
       01/03, 01/07: series#1 만 null / 01/04: 두 시리즈 모두 null.
     </span>
     <br /><br />
@@ -28,11 +29,11 @@
         <b>두 시리즈 모두 null</b> 인 라벨(01/04)의 어느 영역을 클릭하든 →
         <b>아무것도 선택되지 않아야</b> 합니다. (이벤트 selected 미발생)
       </li>
+      <li>series#2 포인트 중심을 정확히 클릭 → <b>series2</b> (directHit).</li>
       <li>
         두 시리즈 모두 값이 있는 라벨에서 포인트가 아닌 중간 영역을 클릭 →
         <b>클릭 좌표에 가까운</b> 시리즈가 선택되어야 합니다.
       </li>
-      <li>각 시리즈 포인트 중심을 정확히 클릭 → 해당 시리즈 (directHit).</li>
     </ol>
     <br />
     <div class="badge yellow">클릭 이벤트 결과 (single click)</div>
@@ -54,23 +55,23 @@ export default {
     const chartData = {
       series: {
         series1: {
-          name: 'series#1 (area)',
+          name: 'series#1 (area, null 포함)',
           show: true,
-          type: 'line',
           fill: { gradient: true },
           fillColor: '#6AA9F2',
           color: '#6AA9F2',
         },
         series2: {
-          name: 'series#2 (line)',
+          name: 'series#2 (area)',
           show: true,
-          type: 'line',
+          fill: { gradient: true },
+          fillColor: '#FF6B6B',
           color: '#FF6B6B',
         },
       },
       labels,
-      // - index 2, 6 (01/03, 01/07): series1 만 null → series2 선택되어야 함
-      // - index 3 (01/04): 두 시리즈 모두 null → 아무것도 선택되지 않아야 함
+      // - index 2, 6: series1 만 null → series2 선택되어야 함
+      // - index 3: 두 시리즈 모두 null → 아무것도 선택되지 않아야 함
       // - 나머지: 두 시리즈 모두 값 → 클릭 좌표에 가까운 쪽이 선택
       data: {
         series1: [20, 45, null, null, 80, 55, null, 50],
@@ -83,7 +84,7 @@ export default {
       width: '100%',
       height: '100%',
       title: {
-        text: 'Area + Line Combo',
+        text: 'Area Fill x 2 (series#1 에 null 포함)',
         show: true,
       },
       legend: {

--- a/docs/views/lineChart/example/FillWithNull.vue
+++ b/docs/views/lineChart/example/FillWithNull.vue
@@ -26,8 +26,10 @@
         <b>series2</b> 가 선택되어야 합니다. (기존 버그: series1 이 고정으로 리턴)
       </li>
       <li>
-        <b>두 시리즈 모두 null</b> 인 라벨(01/04)의 어느 영역을 클릭하든 →
-        <b>아무것도 선택되지 않아야</b> 합니다. (이벤트 selected 미발생)
+        <b>두 시리즈 모두 null</b> 인 라벨(01/04)을 클릭/더블클릭 →
+        <code>seriesId=""</code>, <code>value=0</code> 또는 <code>undefined</code>,
+        <code>label/dataIndex</code> 는 <b>01/04</b> 가 그대로 반환되어야 합니다.
+        (hover 는 여전히 nearest valid 라벨로 snap 되어 tooltip 이 표시됩니다.)
       </li>
       <li>series#2 포인트 중심을 정확히 클릭 → <b>series2</b> (directHit).</li>
       <li>
@@ -71,7 +73,7 @@ export default {
       },
       labels,
       // - index 2, 6: series1 만 null → series2 선택되어야 함
-      // - index 3: 두 시리즈 모두 null → 아무것도 선택되지 않아야 함
+      // - index 3: 두 시리즈 모두 null → seriesId='', label/dataIndex 그대로 반환
       // - 나머지: 두 시리즈 모두 값 → 클릭 좌표에 가까운 쪽이 선택
       data: {
         series1: [20, 45, null, null, 80, 55, null, 50],

--- a/docs/views/lineChart/example/SelectSeries.vue
+++ b/docs/views/lineChart/example/SelectSeries.vue
@@ -121,6 +121,7 @@ export default {
       ],
       selectSeries: {
         use: true,
+        useClick: true,
         limit: 1,
         useDeselectOverflow: true,
       },
@@ -153,6 +154,7 @@ export default {
       ],
       selectSeries: {
         use: true,
+        useClick: true,
         limit: 1,
         useDeselectOverflow: true,
       },
@@ -160,13 +162,21 @@ export default {
 
     const clickedSeries = ref();
     const onClick = (e) => {
-      clickedSeries.value = e;
+      // 'series' 모드 click 은 setSelectedSeriesInfo → findHitItem 경로.
+      // 두 라인 사이 빈 영역 클릭 시 fallback 으로 선택된 seriesId 를 여기서 확인.
+      clickedSeries.value = {
+        'selected.seriesId': e?.selected?.seriesId,
+        'selected.eventTarget': e?.selected?.eventTarget,
+        label: e?.label,
+        dataIndex: e?.dataIndex,
+      };
     };
 
     const dblclickedSeries = ref();
     const dblclickedValue = ref();
     const onDblClick = (e) => {
-      dblclickedSeries.value = e.seriesId;
+      // 'series' 모드에서는 선택된 seriesId 가 e.selected.seriesId 에 배열로 담김
+      dblclickedSeries.value = e.selected?.seriesId ?? e.seriesId;
       dblclickedValue.value = e.value;
     };
 

--- a/docs/views/lineChart/props.js
+++ b/docs/views/lineChart/props.js
@@ -4,6 +4,8 @@ import Default from './example/Default';
 import DefaultRaw from './example/Default?raw';
 import Fill from './example/Fill';
 import FillRaw from './example/Fill?raw';
+import FillWithNull from './example/FillWithNull';
+import FillWithNullRaw from './example/FillWithNull?raw';
 import Stack from './example/Stack';
 import StackRaw from './example/Stack?raw';
 import Event from './example/Event';
@@ -59,6 +61,12 @@ export default {
         'Line Chart의 Fill 옵션을 이용하여 각 계열 데이터의 양을 좀 더 쉽게 인지할 수 있도록 합니다.',
       component: Fill,
       parsedData: parse(FillRaw).descriptor,
+    },
+    'Fill (with null)': {
+      description:
+        'Area(fill) 시리즈 2개 중 한쪽에 null 값이 섞여 있을 때, 해당 라벨의 빈 영역을 클릭하면 null 시리즈가 아닌 값이 존재하는 시리즈가 선택되는지 검증하는 예제입니다.',
+      component: FillWithNull,
+      parsedData: parse(FillWithNullRaw).descriptor,
     },
     Stack: {
       description:

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -430,4 +430,27 @@ export default {
 
     return `${color}80`;
   },
+
+  /**
+   * 클릭 좌표(cx, cy)에서 데이터 포인트까지의 거리²를 반환한다.
+   * w/h 가 있으면 박스 외벽까지의 거리(내부면 0), 없으면 포인트까지의 유클리드 거리².
+   * @param {object} data - 데이터 포인트 (xp, yp, w?, h?)
+   * @param {number} cx - 클릭 x 좌표
+   * @param {number} cy - 클릭 y 좌표
+   * @returns {number}
+   */
+  calcBoxDistance(data, cx, cy) {
+    if (data.w !== null && data.w !== undefined && data.h !== null && data.h !== undefined) {
+      const sx = data.xp;
+      const sy = data.yp;
+      const xMin = Math.min(sx, sx + data.w);
+      const xMax = Math.max(sx, sx + data.w);
+      const yMin = Math.min(sy, sy + data.h);
+      const yMax = Math.max(sy, sy + data.h);
+      const dx = Math.max(0, xMin - cx, cx - xMax);
+      const dy = Math.max(0, yMin - cy, cy - yMax);
+      return dx * dx + dy * dy;
+    }
+    return (data.xp - cx) ** 2 + (data.yp - cy) ** 2;
+  },
 };

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -903,9 +903,8 @@ const modules = {
       return (data.xp - cx) ** 2 + (data.yp - cy) ** 2;
     };
 
-    // dataIndex 미지정 시 클릭에 가장 가까운 라벨 인덱스를 직접 계산해 모든 시리즈에 전달.
-    // findClosestDataIndex 는 "모든 시리즈가 null 인 라벨" 을 건너뛰기 때문에
-    // 해당 라벨 클릭 시 이웃 라벨의 값이 잘못 선택되는 문제가 있어 여기선 쓰지 않는다.
+    // dataIndex 미지정 시 클릭 좌표에 가장 가까운 valid 라벨 인덱스를 결정한다.
+    // 모든 시리즈가 null 인 라벨은 제외한다.
     let resolvedDataIndex = dataIndex;
     if (resolvedDataIndex === undefined && !useApproximate) {
       const refSeriesID = seriesIDs.find((sId) => {
@@ -918,8 +917,13 @@ const modules = {
         let nearestDistance = Infinity;
         let nearestIndex = -1;
         for (let i = 0; i < refData.length; i++) {
+          const hasValidData = seriesIDs.some((sId) => {
+            const s = this.seriesList[sId];
+            return s?.show && s.data?.[i]?.o !== null && s.data?.[i]?.o !== undefined;
+          });
+
           const p = refData[i];
-          if (p) {
+          if (hasValidData && p) {
             let labelPos;
             if (isHorizontal) {
               labelPos = p.h ? p.yp + p.h / 2 : p.yp;

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -865,11 +865,7 @@ const modules = {
    * 선택 우선순위:
    *   1. directHit (bar 박스 내부 클릭) — 가장 가까운 것
    *   2. hit (line 포인트 근접 등) — 가장 가까운 것
-   *   3. hit이 전혀 없으면 데이터가 있는 첫 시리즈로 fallback (기존 동작 호환)
-   *
-   * 과거에는 "같은 라벨 위에서 값이 가장 큰 시리즈"를 돌려주는 max-value 덮어쓰기 방식이었으나,
-   * bar + line combo 차트에서 작은 bar를 클릭해도 큰 값의 line이 선택되는 버그의 원인이었다.
-   * 이번 수정으로 사용자가 실제로 가리킨 시리즈(hit)가 선택되도록 바뀐다.
+   *   3. hit 없으면 클릭 좌표에 가장 가까운 시리즈로 fallback (distance 기반)
    *
    * @param {array}   offset          position x and y
    * @param {boolean} useApproximate  if it's true. it'll look for closed item on mouse position

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -875,10 +875,7 @@ const modules = {
    * @param {boolean} useApproximate  if it's true. it'll look for closed item on mouse position
    * @param {number} dataIndex        selected data index
    * @param {boolean}  useSelectLabelOrItem   used to display select label/item at tooltip location
-   * @param {boolean}  disableNullLabelSnap   true 이면 모든 시리즈가 null 인 라벨도
-   *                                          후보로 인정한다 (click/dblclick 경로용).
-   *                                          이 경우 hit/fallback 모두 비면 해당 라벨의
-   *                                          label/dataIndex 만 채워서 반환한다 (sId='').
+   * @param {boolean}  disableNullLabelSnap   true 이면 all-null 라벨도 그대로 반환 (click/dblclick 용)
    *
    * @returns {object} hit item information
    */
@@ -913,10 +910,8 @@ const modules = {
       return (data.xp - cx) ** 2 + (data.yp - cy) ** 2;
     };
 
-    // dataIndex 미지정 시 클릭 좌표에 가장 가까운 라벨 인덱스를 결정한다.
-    // 기본은 "모든 시리즈가 null 인 라벨" 을 건너뛰지만, disableNullLabelSnap=true
-    // 이면 all-null 라벨도 후보로 인정해 click/dblclick 콜백이 그 위치를 그대로
-    // 받을 수 있게 한다.
+    // dataIndex 미지정 시 클릭 좌표에 가장 가까운 valid 라벨 인덱스 결정.
+    // disableNullLabelSnap=true 이면 all-null 라벨도 후보로 인정.
     let resolvedDataIndex = dataIndex;
     if (resolvedDataIndex === undefined && !useApproximate) {
       const refSeriesID = seriesIDs.find((sId) => {
@@ -1081,9 +1076,7 @@ const modules = {
       }
     }
 
-    // disableNullLabelSnap=true 이고 어떤 시리즈도 hit/fallback 후보가 되지 못한 경우
-    // (= 모든 시리즈가 해당 라벨에서 null), 라벨/인덱스만 채워 반환한다.
-    // sId 는 빈 문자열, value 는 ?? 0 으로 0 이 반환된다.
+    // all-null 라벨인 경우 label/dataIndex 만 채워 반환 (sId='', value=0).
     if (
       disableNullLabelSnap
       && hitSeriesID === ''

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -875,10 +875,20 @@ const modules = {
    * @param {boolean} useApproximate  if it's true. it'll look for closed item on mouse position
    * @param {number} dataIndex        selected data index
    * @param {boolean}  useSelectLabelOrItem   used to display select label/item at tooltip location
+   * @param {boolean}  disableNullLabelSnap   true 이면 모든 시리즈가 null 인 라벨도
+   *                                          후보로 인정한다 (click/dblclick 경로용).
+   *                                          이 경우 hit/fallback 모두 비면 해당 라벨의
+   *                                          label/dataIndex 만 채워서 반환한다 (sId='').
    *
    * @returns {object} hit item information
    */
-  getHitItemByPosition(offset, useApproximate = false, dataIndex, useSelectLabelOrItem = false) {
+  getHitItemByPosition(
+    offset,
+    useApproximate = false,
+    dataIndex,
+    useSelectLabelOrItem = false,
+    disableNullLabelSnap = false,
+  ) {
     const seriesIDs = Object.keys(this.seriesList);
     const isHorizontal = !!this.options.horizontal;
 
@@ -903,8 +913,10 @@ const modules = {
       return (data.xp - cx) ** 2 + (data.yp - cy) ** 2;
     };
 
-    // dataIndex 미지정 시 클릭 좌표에 가장 가까운 valid 라벨 인덱스를 결정한다.
-    // 모든 시리즈가 null 인 라벨은 제외한다.
+    // dataIndex 미지정 시 클릭 좌표에 가장 가까운 라벨 인덱스를 결정한다.
+    // 기본은 "모든 시리즈가 null 인 라벨" 을 건너뛰지만, disableNullLabelSnap=true
+    // 이면 all-null 라벨도 후보로 인정해 click/dblclick 콜백이 그 위치를 그대로
+    // 받을 수 있게 한다.
     let resolvedDataIndex = dataIndex;
     if (resolvedDataIndex === undefined && !useApproximate) {
       const refSeriesID = seriesIDs.find((sId) => {
@@ -917,7 +929,7 @@ const modules = {
         let nearestDistance = Infinity;
         let nearestIndex = -1;
         for (let i = 0; i < refData.length; i++) {
-          const hasValidData = seriesIDs.some((sId) => {
+          const hasValidData = disableNullLabelSnap || seriesIDs.some((sId) => {
             const s = this.seriesList[sId];
             return s?.show && s.data?.[i]?.o !== null && s.data?.[i]?.o !== undefined;
           });
@@ -1066,6 +1078,29 @@ const modules = {
             }
           }
         }
+      }
+    }
+
+    // disableNullLabelSnap=true 이고 어떤 시리즈도 hit/fallback 후보가 되지 못한 경우
+    // (= 모든 시리즈가 해당 라벨에서 null), 라벨/인덱스만 채워 반환한다.
+    // sId 는 빈 문자열, value 는 ?? 0 으로 0 이 반환된다.
+    if (
+      disableNullLabelSnap
+      && hitSeriesID === ''
+      && fallbackSeriesID === ''
+      && resolvedDataIndex !== undefined
+      && resolvedDataIndex >= 0
+    ) {
+      const refSeriesID = seriesIDs.find((sId) => {
+        const s = this.seriesList[sId];
+        return s?.show && s?.data?.length > 0;
+      });
+      const refPoint = refSeriesID
+        ? this.seriesList[refSeriesID].data?.[resolvedDataIndex]
+        : null;
+      if (refPoint) {
+        fallbackLabel = isHorizontal ? refPoint.y : refPoint.x;
+        fallbackDataIndex = resolvedDataIndex;
       }
     }
 

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -903,17 +903,39 @@ const modules = {
       return (data.xp - cx) ** 2 + (data.yp - cy) ** 2;
     };
 
-    // dataIndex 미지정 시 공통 라벨 인덱스를 먼저 계산해 모든 시리즈가 같은 라벨로 조회.
-    // (line binary-search 경로가 각 시리즈별로 null 을 걸러내고 이웃 포인트를 반환하는 걸 방지)
+    // dataIndex 미지정 시 클릭에 가장 가까운 라벨 인덱스를 직접 계산해 모든 시리즈에 전달.
+    // findClosestDataIndex 는 "모든 시리즈가 null 인 라벨" 을 건너뛰기 때문에
+    // 해당 라벨 클릭 시 이웃 라벨의 값이 잘못 선택되는 문제가 있어 여기선 쓰지 않는다.
     let resolvedDataIndex = dataIndex;
-    if (
-      resolvedDataIndex === undefined &&
-      !useApproximate &&
-      typeof this.findClosestDataIndex === 'function'
-    ) {
-      const closestIndex = this.findClosestDataIndex(offset, seriesIDs);
-      if (closestIndex !== -1) {
-        resolvedDataIndex = closestIndex;
+    if (resolvedDataIndex === undefined && !useApproximate) {
+      const refSeriesID = seriesIDs.find((sId) => {
+        const s = this.seriesList[sId];
+        return s?.show && s?.data?.length > 0;
+      });
+      if (refSeriesID) {
+        const refData = this.seriesList[refSeriesID].data;
+        const clickPos = isHorizontal ? offset[1] : offset[0];
+        let nearestDistance = Infinity;
+        let nearestIndex = -1;
+        for (let i = 0; i < refData.length; i++) {
+          const p = refData[i];
+          if (p) {
+            let labelPos;
+            if (isHorizontal) {
+              labelPos = p.h ? p.yp + p.h / 2 : p.yp;
+            } else {
+              labelPos = p.w ? p.xp + p.w / 2 : p.xp;
+            }
+            if (labelPos !== null && labelPos !== undefined) {
+              const d = Math.abs(clickPos - labelPos);
+              if (d < nearestDistance) {
+                nearestDistance = d;
+                nearestIndex = i;
+              }
+            }
+          }
+        }
+        if (nearestIndex !== -1) resolvedDataIndex = nearestIndex;
       }
     }
 

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -885,26 +885,7 @@ const modules = {
     const seriesIDs = Object.keys(this.seriesList);
     const isHorizontal = !!this.options.horizontal;
 
-    // w/h 가 있으면 박스까지 거리(내부면 0), 아니면 포인트까지 거리.
-    // bar.xp/yp 는 bottom-left 모서리라 단순 유클리드 거리로 재면
-    // 바 상단 빈 영역에서 line 포인트가 이기는 문제가 생긴다.
-    const calcFallbackDistance = (data) => {
-      const [cx, cy] = offset;
-      if (data.w !== null && data.w !== undefined && data.h !== null && data.h !== undefined) {
-        const sx = data.xp;
-        const sy = data.yp;
-        const ex = sx + data.w;
-        const ey = sy + data.h;
-        const xMin = Math.min(sx, ex);
-        const xMax = Math.max(sx, ex);
-        const yMin = Math.min(sy, ey);
-        const yMax = Math.max(sy, ey);
-        const dx = Math.max(0, xMin - cx, cx - xMax);
-        const dy = Math.max(0, yMin - cy, cy - yMax);
-        return dx * dx + dy * dy;
-      }
-      return (data.xp - cx) ** 2 + (data.yp - cy) ** 2;
-    };
+    const [cx, cy] = offset;
 
     // dataIndex 미지정 시 클릭 좌표에 가장 가까운 valid 라벨 인덱스 결정.
     // disableNullLabelSnap=true 이면 all-null 라벨도 후보로 인정.
@@ -1016,7 +997,7 @@ const modules = {
                 data.yp !== null &&
                 data.yp !== undefined;
               if (hasMeaningfulValue && hasCoords) {
-                const distance = calcFallbackDistance(data);
+                const distance = Util.calcBoxDistance(data, cx, cy);
                 if (fallbackSeriesID === '' || distance < fallbackDistance) {
                   fallbackDistance = distance;
                   fallbackType = series.type;

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -250,8 +250,8 @@ const modules = {
           const point = g.data[j];
           // point.x(ms)를 초 단위로 내림하여 슬롯 기준 시간(fromTime/toTime)과 비교 가능하게 맞춤
           const pointTimeInSeconds = Math.floor(point.x / MS_PER_SECOND) * MS_PER_SECOND;
-          const isInTimeRange = pointTimeInSeconds >= dataset.fromTime
-            && pointTimeInSeconds <= dataset.toTime;
+          const isInTimeRange =
+            pointTimeInSeconds >= dataset.fromTime && pointTimeInSeconds <= dataset.toTime;
           if (isInTimeRange && Number.isFinite(point.y)) {
             if (point.y > tempMinMax.maxY) tempMinMax.maxY = point.y;
             if (point.y < tempMinMax.minY) tempMinMax.minY = point.y;
@@ -882,6 +882,41 @@ const modules = {
     const seriesIDs = Object.keys(this.seriesList);
     const isHorizontal = !!this.options.horizontal;
 
+    // w/h 가 있으면 박스까지 거리(내부면 0), 아니면 포인트까지 거리.
+    // bar.xp/yp 는 bottom-left 모서리라 단순 유클리드 거리로 재면
+    // 바 상단 빈 영역에서 line 포인트가 이기는 문제가 생긴다.
+    const calcFallbackDistance = (data) => {
+      const [cx, cy] = offset;
+      if (data.w !== null && data.w !== undefined && data.h !== null && data.h !== undefined) {
+        const sx = data.xp;
+        const sy = data.yp;
+        const ex = sx + data.w;
+        const ey = sy + data.h;
+        const xMin = Math.min(sx, ex);
+        const xMax = Math.max(sx, ex);
+        const yMin = Math.min(sy, ey);
+        const yMax = Math.max(sy, ey);
+        const dx = Math.max(0, xMin - cx, cx - xMax);
+        const dy = Math.max(0, yMin - cy, cy - yMax);
+        return dx * dx + dy * dy;
+      }
+      return (data.xp - cx) ** 2 + (data.yp - cy) ** 2;
+    };
+
+    // dataIndex 미지정 시 공통 라벨 인덱스를 먼저 계산해 모든 시리즈가 같은 라벨로 조회.
+    // (line binary-search 경로가 각 시리즈별로 null 을 걸러내고 이웃 포인트를 반환하는 걸 방지)
+    let resolvedDataIndex = dataIndex;
+    if (
+      resolvedDataIndex === undefined &&
+      !useApproximate &&
+      typeof this.findClosestDataIndex === 'function'
+    ) {
+      const closestIndex = this.findClosestDataIndex(offset, seriesIDs);
+      if (closestIndex !== -1) {
+        resolvedDataIndex = closestIndex;
+      }
+    }
+
     // hit 기반 결과 (최우선)
     let hitType = null;
     let hitLabel = null;
@@ -892,13 +927,14 @@ const modules = {
     let hitDistance = Infinity;
     let hasDirectHit = false;
 
-    // fallback: hit이 전혀 없을 때 사용할 "데이터 있는 첫 시리즈" 정보
+    // hit 없을 때 쓸 fallback — 값이 있는 시리즈 중 클릭 좌표에 가장 가까운 것.
     let fallbackType = null;
     let fallbackLabel = null;
     let fallbackValuePos = null;
     let fallbackValue = null;
     let fallbackSeriesID = '';
     let fallbackDataIndex = null;
+    let fallbackDistance = Infinity;
 
     let acc = 0;
     let useStack = false;
@@ -909,7 +945,13 @@ const modules = {
       const findFn = useApproximate ? series.findApproximateData : series.findGraphData;
 
       if (findFn) {
-        const item = findFn.call(series, offset, isHorizontal, dataIndex, useSelectLabelOrItem);
+        const item = findFn.call(
+          series,
+          offset,
+          isHorizontal,
+          resolvedDataIndex,
+          useSelectLabelOrItem,
+        );
         const data = item.data;
         const index = item.index;
 
@@ -936,8 +978,27 @@ const modules = {
                 acc += data.y;
               }
 
-              // fallback 기록: 데이터가 있는 첫 시리즈를 저장
-              if (fallbackSeriesID === '') {
+              // fallback 후보: 값이 있는 시리즈 중 거리가 가장 가까운 쪽.
+              // 값이 null 인 시리즈는 제외.
+              const hasMeaningfulValue = g !== null && g !== undefined && !Number.isNaN(g);
+              const hasCoords =
+                data.xp !== null &&
+                data.xp !== undefined &&
+                data.yp !== null &&
+                data.yp !== undefined;
+              if (hasMeaningfulValue && hasCoords) {
+                const distance = calcFallbackDistance(data);
+                if (fallbackSeriesID === '' || distance < fallbackDistance) {
+                  fallbackDistance = distance;
+                  fallbackType = series.type;
+                  fallbackLabel = ldata;
+                  fallbackValuePos = lp;
+                  fallbackValue = g;
+                  fallbackSeriesID = seriesID;
+                  fallbackDataIndex = index;
+                }
+              } else if (hasMeaningfulValue && fallbackSeriesID === '') {
+                // 좌표 없는 예외 케이스 — 첫 후보로만 등록
                 fallbackType = series.type;
                 fallbackLabel = ldata;
                 fallbackValuePos = lp;
@@ -1137,13 +1198,12 @@ const modules = {
         y1: this.chartRect.y1 + this.labelOffset.top,
         y2: this.chartRect.y2 - this.labelOffset.bottom,
       };
-      const {
-        steps,
-        interval: labelValInterval,
-        graphMin,
-      } = this.axesSteps[targetAxisDirection][0];
-      const { width: labelWidth, height: labelHeight } =
-        this.axesRange[targetAxisDirection][0].size;
+      const { steps, interval: labelValInterval, graphMin } = this.axesSteps[
+        targetAxisDirection
+      ][0];
+      const { width: labelWidth, height: labelHeight } = this.axesRange[
+        targetAxisDirection
+      ][0].size;
       const axes = isXAxis ? this.axesX : this.axesY;
       const axisStartPoint = aPos[axes[0].units.rectStart];
       const axisEndPoint = aPos[axes[0].units.rectEnd];

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -373,6 +373,33 @@ describe('model.store getHitItemByPosition', () => {
       expect(result.dataIndex).not.toBe(null);
     });
 
+    it('disableNullLabelSnap=true 면 모든 시리즈가 null 인 라벨도 그대로 반환한다', () => {
+      // index 1 에서 두 시리즈 모두 null. 클릭 좌표는 xp=50 → index 1 이 가장 가깝다.
+      // 기본 동작이라면 index 1 을 건너뛰고 nearest valid 로 snap 하지만,
+      // disableNullLabelSnap=true 이면 index 1 그대로 반환 (sId='', value=0).
+      const points1 = [
+        { x: 'L0', y: 20, o: 20, xp: 10, yp: 180, index: 0 },
+        { x: 'L1', y: null, o: null, xp: 50, yp: null, index: 1 },
+        { x: 'L2', y: 80, o: 80, xp: 90, yp: 120, index: 2 },
+      ];
+      const points2 = [
+        { x: 'L0', y: 30, o: 30, xp: 10, yp: 170, index: 0 },
+        { x: 'L1', y: null, o: null, xp: 50, yp: null, index: 1 },
+        { x: 'L2', y: 70, o: 70, xp: 90, yp: 130, index: 2 },
+      ];
+
+      const store = createStore({
+        series1: mockLineWithIndexedData({ points: points1 }),
+        series2: mockLineWithIndexedData({ points: points2 }),
+      });
+      const result = store.getHitItemByPosition([50, 250], false, undefined, false, true);
+
+      expect(result.sId).toBe('');
+      expect(result.value).toBe(0);
+      expect(result.label).toBe('L1');
+      expect(result.dataIndex).toBe(1);
+    });
+
     it('차트 전체 데이터가 null 이면 empty 를 반환한다', () => {
       // 모든 라벨에서 모든 시리즈가 null → hasValidData 항상 false → resolvedDataIndex 미정 → empty.
       const points1 = [

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -346,9 +346,10 @@ describe('model.store getHitItemByPosition', () => {
       expect(result.dataIndex).toBe(1);
     });
 
-    it('두 시리즈 모두 null 인 라벨 클릭 시 이웃 라벨의 값이 잘못 선택되지 않는다', () => {
-      // index 1 에서 두 시리즈 모두 null. 로컬 nearest 는 필터 없이 index 1 을 리턴 →
-      // 두 시리즈 모두 값 가드에 걸려 제외 → sId='' (미선택).
+    it('두 시리즈 모두 null 인 라벨 클릭 시 nearest valid 라벨(이웃)을 반환한다 (hover/dblclick 일관성)', () => {
+      // index 1 에서 두 시리즈 모두 null, 이웃 라벨 (0, 2) 에는 값 존재.
+      // hasValidData 필터로 index 1 을 건너뛰고 nearest valid(index 0 또는 2)를 resolvedDataIndex 로 사용.
+      // hover/dblclick 이 findClosestDataIndex 로 이웃 라벨을 반환하는 것과 동일한 동작.
       const points1 = [
         { x: 'L0', y: 20, o: 20, xp: 10, yp: 180, index: 0 },
         { x: 'L1', y: null, o: null, xp: 50, yp: null, index: 1 },
@@ -358,6 +359,29 @@ describe('model.store getHitItemByPosition', () => {
         { x: 'L0', y: 30, o: 30, xp: 10, yp: 170, index: 0 },
         { x: 'L1', y: null, o: null, xp: 50, yp: null, index: 1 },
         { x: 'L2', y: 70, o: 70, xp: 90, yp: 130, index: 2 },
+      ];
+
+      const store = createStore({
+        series1: mockLineWithIndexedData({ points: points1 }),
+        series2: mockLineWithIndexedData({ points: points2 }),
+      });
+      // 클릭 xp=50 → index 0(xp=10, dist=40)과 index 2(xp=90, dist=40) 동거리 → index 0 선택.
+      // index 0 에서 series1(yp=180, dist²=6500)이 series2(yp=170, dist²=8000)보다 가까움.
+      const result = store.getHitItemByPosition([50, 250]);
+
+      expect(result.sId).not.toBe('');
+      expect(result.dataIndex).not.toBe(null);
+    });
+
+    it('차트 전체 데이터가 null 이면 empty 를 반환한다', () => {
+      // 모든 라벨에서 모든 시리즈가 null → hasValidData 항상 false → resolvedDataIndex 미정 → empty.
+      const points1 = [
+        { x: 'L0', y: null, o: null, xp: 10, yp: null, index: 0 },
+        { x: 'L1', y: null, o: null, xp: 50, yp: null, index: 1 },
+      ];
+      const points2 = [
+        { x: 'L0', y: null, o: null, xp: 10, yp: null, index: 0 },
+        { x: 'L1', y: null, o: null, xp: 50, yp: null, index: 1 },
       ];
 
       const store = createStore({

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -98,10 +98,11 @@ describe('model.store getHitItemByPosition', () => {
   });
 
   describe('hit 없음 + directHit 없음', () => {
-    it('bar/line 모두 hit=false면 데이터 있는 첫 시리즈로 fallback 한다', () => {
+    it('값이 있는 hit=false 시리즈는 거리 기반 fallback 으로 선택된다', () => {
+      // 클릭에 더 가까운 s1이 fallback 으로 잡히는지 확인.
       const s1 = mockSeries({
         type: 'bar',
-        data: { x: 0, y: 10, xp: 10, yp: 20, o: 10, index: 0 },
+        data: { x: 0, y: 10, xp: 990, yp: 990, o: 10, index: 0 },
         hit: false,
         directHit: false,
       });
@@ -154,6 +155,133 @@ describe('model.store getHitItemByPosition', () => {
 
       expect(result.dataIndex).toBe(3);
       expect(result.maxIndex).toBeUndefined();
+    });
+  });
+
+  describe('fallback 등록 조건 — null 값 제외', () => {
+    it('값(data.o)이 null인 첫 시리즈는 fallback 후보가 아니다', () => {
+      // 같은 라벨에서 A는 값 없고 B만 값 있음. 어느 시리즈도 hit=false 인 빈 영역 클릭.
+      // 기대: fallback 은 값이 존재하는 B.
+      const noValueSeries = mockSeries({
+        type: 'line',
+        data: { x: '2026-01-01', y: null, o: null, xp: 100, yp: null, index: 2 },
+        hit: false,
+      });
+      const valueSeries = mockSeries({
+        type: 'line',
+        data: { x: '2026-01-01', y: 50, o: 50, xp: 100, yp: 80, index: 2 },
+        hit: false,
+      });
+
+      const store = createStore({ A: noValueSeries, B: valueSeries });
+      const result = store.getHitItemByPosition([100, 200]);
+
+      expect(result.sId).toBe('B');
+      expect(result.value).toBe(50);
+      expect(result.dataIndex).toBe(2);
+    });
+
+    it('두 시리즈 모두 값이 null이면 sId는 빈 문자열로 fallback도 없다', () => {
+      const a = mockSeries({
+        type: 'line',
+        data: { x: '2026-01-01', y: null, o: null, xp: 100, yp: null, index: 1 },
+        hit: false,
+      });
+      const b = mockSeries({
+        type: 'line',
+        data: { x: '2026-01-01', y: null, o: null, xp: 100, yp: null, index: 1 },
+        hit: false,
+      });
+
+      const store = createStore({ A: a, B: b });
+      const result = store.getHitItemByPosition([100, 200]);
+
+      expect(result.sId).toBe('');
+      expect(result.dataIndex).toBe(null);
+    });
+
+    it('값이 0인 시리즈도 fallback 후보에 포함된다 (0은 의미 있는 값)', () => {
+      const zeroSeries = mockSeries({
+        type: 'line',
+        data: { x: '2026-01-01', y: 0, o: 0, xp: 100, yp: 250, index: 0 },
+        hit: false,
+      });
+      const nullSeries = mockSeries({
+        type: 'line',
+        data: { x: '2026-01-01', y: null, o: null, xp: 100, yp: null, index: 0 },
+        hit: false,
+      });
+
+      // nullSeries 가 먼저이지만 값이 없으니 fallback 은 zeroSeries.
+      const store = createStore({ null1: nullSeries, zero1: zeroSeries });
+      const result = store.getHitItemByPosition([100, 200]);
+
+      expect(result.sId).toBe('zero1');
+      expect(result.value).toBe(0);
+    });
+  });
+
+  describe('fallback 거리 기반 선택', () => {
+    it('두 시리즈 모두 값이 있고 hit=false일 때, 클릭 좌표에 더 가까운 시리즈가 선택된다', () => {
+      const farSeries = mockSeries({
+        type: 'line',
+        data: { x: 'L1', y: 10, o: 10, xp: 50, yp: 100, index: 1 },
+        hit: false,
+      });
+      const nearSeries = mockSeries({
+        type: 'line',
+        data: { x: 'L1', y: 50, o: 50, xp: 50, yp: 200, index: 1 },
+        hit: false,
+      });
+
+      // 클릭 (50, 210) — near(거리 10) vs far(거리 110). 정의 순서상 far 가 먼저지만
+      // 거리 기반이라 near 가 선택되어야 한다.
+      const store = createStore({ far: farSeries, near: nearSeries });
+      const result = store.getHitItemByPosition([50, 210]);
+
+      expect(result.sId).toBe('near');
+      expect(result.value).toBe(50);
+    });
+
+    it('bar+line combo: bar 위쪽 빈 영역 클릭 시, 박스 거리 기준으로 bar가 선택된다', () => {
+      // line 포인트 yp=200, bar 박스 xp=40, yp=300, w=20, h=-200 → 박스 y [100, 300].
+      // 클릭 (50, 50) — 바 상단 위쪽 빈 영역. 어느 쪽도 hit 아님.
+      // 단순 (xp,yp) 거리로 재면 line 이 이김 (line 22500, bar 62600).
+      // 박스 거리로 재면 bar 가 이김 (bar 2500, line 22500).
+      const lineSeries = mockSeries({
+        type: 'line',
+        data: { x: 'L1', y: 30, o: 30, xp: 50, yp: 200, w: null, h: null, index: 1 },
+        hit: false,
+      });
+      const barSeries = mockSeries({
+        type: 'bar',
+        data: { x: 'L1', y: 50, o: 50, xp: 40, yp: 300, w: 20, h: -200, index: 1 },
+        hit: false,
+      });
+
+      const store = createStore({ series1: lineSeries, series2: barSeries });
+      const result = store.getHitItemByPosition([50, 50]);
+
+      expect(result.sId).toBe('series2');
+      expect(result.type).toBe('bar');
+    });
+
+    it('null인 시리즈는 더 가까워도 fallback에서 제외된다 (값 가드 우선)', () => {
+      const nullSeries = mockSeries({
+        type: 'line',
+        data: { x: 'L1', y: null, o: null, xp: 50, yp: 205, index: 1 },
+        hit: false,
+      });
+      const valueSeries = mockSeries({
+        type: 'line',
+        data: { x: 'L1', y: 50, o: 50, xp: 50, yp: 100, index: 1 },
+        hit: false,
+      });
+
+      const store = createStore({ nullOne: nullSeries, valueOne: valueSeries });
+      const result = store.getHitItemByPosition([50, 210]);
+
+      expect(result.sId).toBe('valueOne');
     });
   });
 });

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -26,6 +26,40 @@ const mockSeries = ({ type, data, hit = false, directHit = false, stackIndex = n
   }),
 });
 
+/**
+ * dataIndex 인자에 반응하는 findGraphData mock.
+ * 인덱스별 데이터 포인트 배열을 받아, dataIndex 가 주어지면 그 인덱스 포인트를,
+ * 주어지지 않으면 "가장 가까운 non-null 포인트" (line binary-search 경로 근사) 를 반환한다.
+ * show/data 속성을 포함해 로컬 nearest label 계산에 참여할 수 있다.
+ */
+const mockLineWithIndexedData = ({ points, hitIndex = null, directHitIndex = null }) => ({
+  type: 'line',
+  show: true,
+  data: points,
+  stackIndex: null,
+  findGraphData: (offset, isHorizontal, dataIndex) => {
+    if (typeof dataIndex === 'number') {
+      const data = points[dataIndex] ?? null;
+      return {
+        data,
+        hit: data && dataIndex === hitIndex,
+        directHit: data && dataIndex === directHitIndex,
+        index: dataIndex,
+      };
+    }
+    const firstNonNullIdx = points.findIndex((p) => p && p.o !== null);
+    if (firstNonNullIdx === -1) {
+      return { data: null, hit: false, directHit: false, index: 0 };
+    }
+    return {
+      data: points[firstNonNullIdx],
+      hit: firstNonNullIdx === hitIndex,
+      directHit: firstNonNullIdx === directHitIndex,
+      index: firstNonNullIdx,
+    };
+  },
+});
+
 describe('model.store getHitItemByPosition', () => {
   describe('directHit 우선순위', () => {
     it('bar 박스 내부 클릭(directHit=true)은 좌표가 더 가까운 line(hit=true)보다 우선 선택된다', () => {
@@ -282,6 +316,58 @@ describe('model.store getHitItemByPosition', () => {
       const result = store.getHitItemByPosition([50, 210]);
 
       expect(result.sId).toBe('valueOne');
+    });
+  });
+
+  describe('dataIndex 미지정 시 로컬 nearest 라벨 계산', () => {
+    it('클릭 라벨에서 값이 null인 시리즈는 이웃 라벨의 값으로 잘못 선택되지 않는다', () => {
+      // series1 의 index 1 만 null, series2 는 index 1 에 값 있음.
+      // 클릭 좌표가 index 1 근처. 로컬 nearest 가 index 1 을 리턴 →
+      // series1 은 null 로 제외 → series2 선택.
+      const series1Points = [
+        { x: 'L0', y: 20, o: 20, xp: 10, yp: 180, index: 0 },
+        { x: 'L1', y: null, o: null, xp: 50, yp: null, index: 1 },
+        { x: 'L2', y: 80, o: 80, xp: 90, yp: 120, index: 2 },
+      ];
+      const series2Points = [
+        { x: 'L0', y: 10, o: 10, xp: 10, yp: 190, index: 0 },
+        { x: 'L1', y: 30, o: 30, xp: 50, yp: 170, index: 1 },
+        { x: 'L2', y: 50, o: 50, xp: 90, yp: 150, index: 2 },
+      ];
+
+      const store = createStore({
+        series1: mockLineWithIndexedData({ points: series1Points }),
+        series2: mockLineWithIndexedData({ points: series2Points }),
+      });
+      const result = store.getHitItemByPosition([50, 300]);
+
+      expect(result.sId).toBe('series2');
+      expect(result.value).toBe(30);
+      expect(result.dataIndex).toBe(1);
+    });
+
+    it('두 시리즈 모두 null 인 라벨 클릭 시 이웃 라벨의 값이 잘못 선택되지 않는다', () => {
+      // index 1 에서 두 시리즈 모두 null. 로컬 nearest 는 필터 없이 index 1 을 리턴 →
+      // 두 시리즈 모두 값 가드에 걸려 제외 → sId='' (미선택).
+      const points1 = [
+        { x: 'L0', y: 20, o: 20, xp: 10, yp: 180, index: 0 },
+        { x: 'L1', y: null, o: null, xp: 50, yp: null, index: 1 },
+        { x: 'L2', y: 80, o: 80, xp: 90, yp: 120, index: 2 },
+      ];
+      const points2 = [
+        { x: 'L0', y: 30, o: 30, xp: 10, yp: 170, index: 0 },
+        { x: 'L1', y: null, o: null, xp: 50, yp: null, index: 1 },
+        { x: 'L2', y: 70, o: 70, xp: 90, yp: 130, index: 2 },
+      ];
+
+      const store = createStore({
+        series1: mockLineWithIndexedData({ points: points1 }),
+        series2: mockLineWithIndexedData({ points: points2 }),
+      });
+      const result = store.getHitItemByPosition([50, 250]);
+
+      expect(result.sId).toBe('');
+      expect(result.dataIndex).toBe(null);
     });
   });
 });

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -2,6 +2,7 @@ import { cloneDeep, defaultsDeep, inRange, isEqual, isNil } from 'lodash-es';
 import dayjs from 'dayjs';
 import { numberWithComma } from '@/common/utils';
 import throttle from '@/common/utils.throttle';
+import Util from '../helpers/helpers.util';
 
 const modules = {
   /**
@@ -911,27 +912,7 @@ const modules = {
     const isHorizontal = !!this.options.horizontal;
     const ctx = this.tooltipCtx;
 
-    // w/h 가 있으면 박스까지 거리(내부면 0), 아니면 포인트까지 거리.
-    // bar.xp/yp 는 bottom-left 모서리라 단순 유클리드 거리로 재면
-    // 바 상단 빈 영역에서 line 포인트가 이기는 문제가 생긴다.
-    const calcFallbackDistance = (data) => {
-      const [cx, cy] = offset;
-      if (data.w !== null && data.w !== undefined && data.h !== null && data.h !== undefined) {
-        const sx = data.xp;
-        const sy = data.yp;
-        const ex = sx + data.w;
-        const ey = sy + data.h;
-        const xMin = Math.min(sx, ex);
-        const xMax = Math.max(sx, ex);
-        const yMin = Math.min(sy, ey);
-        const yMax = Math.max(sy, ey);
-        const dx = Math.max(0, xMin - cx, cx - xMax);
-        const dy = Math.max(0, yMin - cy, cy - yMax);
-        return dx * dx + dy * dy;
-      }
-      return (data.xp - cx) ** 2 + (data.yp - cy) ** 2;
-    };
-
+    const [cx, cy] = offset;
     let hitId = null;
     let maxs = '';
     let maxsw = 0;
@@ -1038,7 +1019,7 @@ const modules = {
               item.data.xp !== null &&
               item.data.yp !== null
             ) {
-              const fbDistance = calcFallbackDistance(item.data);
+              const fbDistance = Util.calcBoxDistance(item.data, cx, cy);
               if (fbDistance < fallbackDistance) {
                 fallbackDistance = fbDistance;
                 fallbackId = sId;

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -188,7 +188,7 @@ const modules = {
       }
 
       const setSelectedItemInfo = () => {
-        const hitInfo = this.findHitItem(offset);
+        const hitInfo = this.findHitItem(offset, true);
 
         // 실제 클릭된 아이템의 정보 추출 (hitId가 있으면 해당 아이템, 없으면 첫 번째 아이템)
         const hitItemId = hitInfo.hitId || Object.keys(hitInfo.items)[0];
@@ -204,7 +204,7 @@ const modules = {
       };
 
       const setSelectedLabelInfo = (targetAxis) => {
-        const hitInfo = this.findHitItem(offset);
+        const hitInfo = this.findHitItem(offset, true);
         const hitItemId = hitInfo.hitId || Object.keys(hitInfo.items)[0];
         const hitItem = hitInfo.items[hitItemId];
 
@@ -227,7 +227,7 @@ const modules = {
       };
 
       const setSelectedSeriesInfo = () => {
-        const hitInfo = this.findHitItem(offset);
+        const hitInfo = this.findHitItem(offset, true);
         const hitItemId = hitInfo.hitId || Object.keys(hitInfo.items)[0];
         const hitItem = hitInfo.items[hitItemId];
 
@@ -301,7 +301,7 @@ const modules = {
       const useSelectSeries = selectSeriesOpt?.use && selectSeriesOpt?.useClick;
 
       const setSelectedItemInfo = () => {
-        const hitInfo = this.getHitItemByPosition(offset, false);
+        const hitInfo = this.getHitItemByPosition(offset, false, undefined, false, true);
 
         ({
           label: args.label,
@@ -343,7 +343,7 @@ const modules = {
       };
 
       const setSelectedSeriesInfo = () => {
-        const hitInfo = this.findHitItem(offset);
+        const hitInfo = this.findHitItem(offset, true);
         const hitItemId = hitInfo.hitId || Object.keys(hitInfo.items)[0];
         const hitItem = hitInfo.items[hitItemId];
 

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -191,7 +191,7 @@ const modules = {
         const hitInfo = this.findHitItem(offset, true);
 
         // 실제 클릭된 아이템의 정보 추출 (hitId가 있으면 해당 아이템, 없으면 첫 번째 아이템)
-        const hitItemId = hitInfo.hitId || Object.keys(hitInfo.items)[0];
+        const hitItemId = hitInfo.hitId ?? Object.keys(hitInfo.items)[0];
         const hitItem = hitInfo.items[hitItemId];
 
         if (hitItem) {
@@ -205,7 +205,7 @@ const modules = {
 
       const setSelectedLabelInfo = (targetAxis) => {
         const hitInfo = this.findHitItem(offset, true);
-        const hitItemId = hitInfo.hitId || Object.keys(hitInfo.items)[0];
+        const hitItemId = hitInfo.hitId ?? Object.keys(hitInfo.items)[0];
         const hitItem = hitInfo.items[hitItemId];
 
         const { labelIndex: clickedLabelIndex } = this.getLabelInfoByPosition(offset, targetAxis);
@@ -228,7 +228,7 @@ const modules = {
 
       const setSelectedSeriesInfo = () => {
         const hitInfo = this.findHitItem(offset, true);
-        const hitItemId = hitInfo.hitId || Object.keys(hitInfo.items)[0];
+        const hitItemId = hitInfo.hitId ?? Object.keys(hitInfo.items)[0];
         const hitItem = hitInfo.items[hitItemId];
 
         if (hitItemId !== null) {
@@ -344,7 +344,7 @@ const modules = {
 
       const setSelectedSeriesInfo = () => {
         const hitInfo = this.findHitItem(offset, true);
-        const hitItemId = hitInfo.hitId || Object.keys(hitInfo.items)[0];
+        const hitItemId = hitInfo.hitId ?? Object.keys(hitInfo.items)[0];
         const hitItem = hitInfo.items[hitItemId];
 
         if (!isNil(hitItemId)) {

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1055,10 +1055,7 @@ const modules = {
     }
     const maxHighlight = maxg !== null ? [maxSID, maxg] : null;
 
-    // disableNullLabelSnap=true 인데 어떤 시리즈도 items 후보가 되지 못한 경우
-    // (= targetDataIndex 의 모든 시리즈 값이 null), click/dblclick 콜백이
-    // 그 라벨의 label/dataIndex 를 받을 수 있도록 synthetic items[''] 를 만든다.
-    // sId 빈 문자열 / value undefined 는 사용자 요청 사양.
+    // all-null 라벨인 경우 synthetic items[''] 로 label/index 만 채워 전달.
     if (disableNullLabelSnap
         && Object.keys(items).length === 0
         && targetDataIndex !== -1) {
@@ -1139,11 +1136,8 @@ const modules = {
     let closestDistance = Infinity;
     let closestIndex = -1;
 
-    // 각 라벨에서 가장 가까운 것 찾기
+    // 각 라벨에서 가장 가까운 것 찾기 (disableNullLabelSnap=true 면 all-null 라벨도 후보)
     for (let i = 0; i < referenceData.length; i++) {
-      // 이 라벨에 유효한 데이터가 있는 시리즈가 하나 이상 있는지 확인.
-      // disableNullLabelSnap=true 면 all-null 라벨도 후보로 인정해
-      // click/dblclick 콜백이 그 위치를 그대로 받을 수 있게 한다.
       const hasValidData = disableNullLabelSnap || sIds.some((sId) => {
         const series = this.seriesList[sId];
         return series?.show && series.data?.[i]?.o !== null && series.data?.[i]?.o !== undefined;

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1030,6 +1030,8 @@ const modules = {
             }
 
             // fallback 후보: hit 여부와 무관하게 거리가 가장 가까운 시리즈.
+            // 참고: 이 블록은 outer `if (gdata !== null && gdata !== undefined)` 안에 있어서
+            // 값이 null 인 시리즈는 items 수집 단계에서 이미 걸러진 상태. 별도 null 값 가드 불필요.
             if (
               item.data.xp !== undefined &&
               item.data.yp !== undefined &&

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -905,7 +905,7 @@ const modules = {
    *   maxHighlight: [string, number] | null,
    * }} hit item information
    */
-  findHitItem(offset) {
+  findHitItem(offset, disableNullLabelSnap = false) {
     const sIds = Object.keys(this.seriesList);
     const items = {};
     const isHorizontal = !!this.options.horizontal;
@@ -946,7 +946,7 @@ const modules = {
     let fallbackDistance = Infinity;
 
     // 1. 먼저 공통으로 사용할 데이터 인덱스 결정
-    const targetDataIndex = this.findClosestDataIndex(offset, sIds);
+    const targetDataIndex = this.findClosestDataIndex(offset, sIds, disableNullLabelSnap);
 
     if (targetDataIndex === -1 && !this.isNotUseIndicator()) {
       return { items, hitId, maxTip: [maxs, maxv], maxHighlight: null };
@@ -1055,6 +1055,33 @@ const modules = {
     }
     const maxHighlight = maxg !== null ? [maxSID, maxg] : null;
 
+    // disableNullLabelSnap=true 인데 어떤 시리즈도 items 후보가 되지 못한 경우
+    // (= targetDataIndex 의 모든 시리즈 값이 null), click/dblclick 콜백이
+    // 그 라벨의 label/dataIndex 를 받을 수 있도록 synthetic items[''] 를 만든다.
+    // sId 빈 문자열 / value undefined 는 사용자 요청 사양.
+    if (disableNullLabelSnap
+        && Object.keys(items).length === 0
+        && targetDataIndex !== -1) {
+      const refSeriesID = sIds.find((sId) => {
+        const s = this.seriesList[sId];
+        return s?.show && s?.data?.length > 0;
+      });
+      const refPoint = refSeriesID
+        ? this.seriesList[refSeriesID].data?.[targetDataIndex]
+        : null;
+      if (refPoint) {
+        items[''] = {
+          id: '',
+          name: '',
+          label: isHorizontal ? refPoint.y : refPoint.x,
+          index: targetDataIndex,
+          axis: { x: 0, y: 0 },
+          data: { o: undefined, x: refPoint.x, y: refPoint.y },
+        };
+        hitId = '';
+      }
+    }
+
     return { items, hitId, maxTip: [maxs, maxv], maxHighlight };
   },
 
@@ -1064,7 +1091,7 @@ const modules = {
    * @param {array} sIds series IDs
    * @returns {number} closest data index
    */
-  findClosestDataIndex(offset, sIds) {
+  findClosestDataIndex(offset, sIds, disableNullLabelSnap = false) {
     const [xp, yp] = offset;
     const isHorizontal = !!this.options.horizontal;
     const mousePos = isHorizontal ? yp : xp;
@@ -1114,8 +1141,10 @@ const modules = {
 
     // 각 라벨에서 가장 가까운 것 찾기
     for (let i = 0; i < referenceData.length; i++) {
-      // 이 라벨에 유효한 데이터가 있는 시리즈가 하나 이상 있는지 확인
-      const hasValidData = sIds.some((sId) => {
+      // 이 라벨에 유효한 데이터가 있는 시리즈가 하나 이상 있는지 확인.
+      // disableNullLabelSnap=true 면 all-null 라벨도 후보로 인정해
+      // click/dblclick 콜백이 그 위치를 그대로 받을 수 있게 한다.
+      const hasValidData = disableNullLabelSnap || sIds.some((sId) => {
         const series = this.seriesList[sId];
         return series?.show && series.data?.[i]?.o !== null && series.data?.[i]?.o !== undefined;
       });

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -911,6 +911,27 @@ const modules = {
     const isHorizontal = !!this.options.horizontal;
     const ctx = this.tooltipCtx;
 
+    // w/h 가 있으면 박스까지 거리(내부면 0), 아니면 포인트까지 거리.
+    // bar.xp/yp 는 bottom-left 모서리라 단순 유클리드 거리로 재면
+    // 바 상단 빈 영역에서 line 포인트가 이기는 문제가 생긴다.
+    const calcFallbackDistance = (data) => {
+      const [cx, cy] = offset;
+      if (data.w !== null && data.w !== undefined && data.h !== null && data.h !== undefined) {
+        const sx = data.xp;
+        const sy = data.yp;
+        const ex = sx + data.w;
+        const ey = sy + data.h;
+        const xMin = Math.min(sx, ex);
+        const xMax = Math.max(sx, ex);
+        const yMin = Math.min(sy, ey);
+        const yMax = Math.max(sy, ey);
+        const dx = Math.max(0, xMin - cx, cx - xMax);
+        const dy = Math.max(0, yMin - cy, cy - yMax);
+        return dx * dx + dy * dy;
+      }
+      return (data.xp - cx) ** 2 + (data.yp - cy) ** 2;
+    };
+
     let hitId = null;
     let maxs = '';
     let maxsw = 0;
@@ -918,9 +939,11 @@ const modules = {
     let maxg = null;
     let maxSID = null;
     let minDistance = Infinity;
-    // directHit(bar 박스 내부 클릭/hover) 시리즈가 발견되었는지 추적.
-    // 한 번이라도 directHit가 있으면 line의 근접 포인트 히트는 hitId 후보에서 배제된다.
+    // directHit 가 하나라도 있으면 일반 hit 는 hitId 후보에서 배제.
     let hasDirectHit = false;
+    // hit 이 없을 때 거리 기반으로 선택할 fallback (기존 "첫 시리즈 고정" 대체).
+    let fallbackId = null;
+    let fallbackDistance = Infinity;
 
     // 1. 먼저 공통으로 사용할 데이터 인덱스 결정
     const targetDataIndex = this.findClosestDataIndex(offset, sIds);
@@ -990,24 +1013,33 @@ const modules = {
               maxSID = sId;
             }
 
-            // 마우스 위치와의 거리 계산하여 가장 가까운 시리즈 선택.
-            // directHit(bar 박스 내부)가 하나라도 있으면 그중에서만 선택하고,
-            // 라인의 근접 포인트 히트(item.hit=true, directHit=false)는 hitId 후보에서 배제한다.
-            // bar + line combo 차트에서 작은 bar 클릭 시 큰 값의 line이 잡히던 버그 방지.
+            // hit 기반 선택: directHit 최우선, 그 외 일반 hit 는 directHit 없을 때만.
             if (item.hit && item.data.xp !== undefined && item.data.yp !== undefined) {
               const distance = (item.data.xp - offset[0]) ** 2 + (item.data.yp - offset[1]) ** 2;
 
               if (item.directHit) {
-                // directHit는 최우선. 여러 directHit 중에서는 가장 가까운 것 선택.
                 if (!hasDirectHit || distance < minDistance) {
                   minDistance = distance;
                   hitId = sId;
                 }
                 hasDirectHit = true;
               } else if (!hasDirectHit && distance < minDistance) {
-                // directHit가 없을 때만 일반 hit 거리 비교
                 minDistance = distance;
                 hitId = sId;
+              }
+            }
+
+            // fallback 후보: hit 여부와 무관하게 거리가 가장 가까운 시리즈.
+            if (
+              item.data.xp !== undefined &&
+              item.data.yp !== undefined &&
+              item.data.xp !== null &&
+              item.data.yp !== null
+            ) {
+              const fbDistance = calcFallbackDistance(item.data);
+              if (fbDistance < fallbackDistance) {
+                fallbackDistance = fbDistance;
+                fallbackId = sId;
               }
             }
           }
@@ -1015,7 +1047,10 @@ const modules = {
       }
     }
 
-    hitId = hitId === null ? Object.keys(items)[0] : hitId;
+    // hit 없으면 거리 기반 fallback, 그것도 없으면 items 첫 키(방어적 fallback).
+    if (hitId === null) {
+      hitId = fallbackId !== null ? fallbackId : Object.keys(items)[0];
+    }
     const maxHighlight = maxg !== null ? [maxSID, maxg] : null;
 
     return { items, hitId, maxTip: [maxs, maxv], maxHighlight };

--- a/src/components/chart/plugins/plugins.interaction.spec.js
+++ b/src/components/chart/plugins/plugins.interaction.spec.js
@@ -124,10 +124,11 @@ describe('plugins.interaction findHitItem', () => {
   });
 
   describe('hit 없을 때 fallback', () => {
-    it('모든 시리즈가 hit=false면 items의 첫 번째 키로 fallback 한다', () => {
+    it('모든 시리즈가 hit=false면 거리가 가장 가까운 시리즈로 fallback 한다', () => {
+      // 클릭 (1000, 1000) 에 s1 이 훨씬 가까운 좌표.
       const chart = createChart({
         s1: mockSeries({
-          data: { x: 0, y: 10, xp: 10, yp: 20, o: 10 },
+          data: { x: 0, y: 10, xp: 990, yp: 990, o: 10 },
           hit: false,
         }),
         s2: mockSeries({


### PR DESCRIPTION
## 배경
다중 시리즈 차트에서 빈 영역을 클릭했을 때 첫 시리즈가 고정으로 선택되는 문제를 수정했습니다.
`getHitItemByPosition` 과 `findHitItem` 두 경로에 동일한 증상이 있어 같이 수정했습니다.

## 문제
- 두 시리즈가 같은 라벨에 모두 값이 있고 어느 포인트도 hit 임계치 밖인 중간 영역을 클릭하면 거리와 무관하게 첫 시리즈가 선택됨
- series1이 null인 라벨의 빈 영역을 클릭하면 series2가 아닌 series1이 선택됨
- 두 시리즈 모두 null인 라벨을 클릭하면 이웃 라벨의 값이 잘못 선택됨
- bar + line combo에서 bar 상단 위쪽 빈 영역 클릭 시 무조건 line이 선택됨

## 원인
**getHitItemByPosition**
- fallback 등록이 라벨만 체크하고 값은 무시하고 있었습니다.
- fallback 선택이 첫 시리즈로 고정되어 있었습니다.
- 거리 비교가 단순 유클리드라 bar 박스 모서리까지의 거리가 왜곡되고 있었습니다.
- 공통 dataIndex 계산에 쓰던 `findClosestDataIndex` 가 null-only 라벨을 후보에서 제외시키고 있었습니다.

**findHitItem**
- `hitId === null ? Object.keys(items)[0] : hitId` 로 첫 시리즈로 고정되어 있었습니다.
- 동일하게 거리 비교가 포인트 기준 단순 유클리드로 구현되어 있었습니다.

## 기대 동작
hit detection의 선택 우선순위를 두 경로 모두에서 일관되게 통일
1. **directHit** — 여러 개면 거리 가까운 쪽
2. **hit** — 여러 개면 거리 가까운 쪽
3. **fallback** — 값이 있는 시리즈 중 거리가 가까운 쪽
4. 모두 제외되면 미선택 (`sId: ''`)

## 테스트
- `npm run test`
- docs 수동 검증
  - **Combo Chart → Area & Line**
    - `series1` 만 null인 라벨 클릭 → `series2` 선택
    - 두 시리즈 모두 null인 라벨 클릭 → 미선택
    - 두 시리즈 모두 값 있는 라벨의 중간 영역 클릭 → 거리상 가까운 쪽 선택
  - **Line Chart → Fill (with null)** — 위와 동일한 항목 테스트
  - **Line Chart → Select Series** — 두 라인 사이 single/double 클릭 시 `selected.seriesId`가 거리상 가까운 쪽으로 리턴되는지 확인

related #2205