### PR TITLE
fix: 표시 가능한 label개수를 넘을 경우 range, interval 조합이 complete함에도 무시되는 현상 수정

### DIFF
--- a/docs/views/scatterChart/example/TimeAxis.vue
+++ b/docs/views/scatterChart/example/TimeAxis.vue
@@ -139,11 +139,17 @@ export default {
       },
     });
 
-    const rangeDateTimes = ref([threeHoursAgo.format('YYYY-MM-DD HH:mm:ss'), now.format('YYYY-MM-DD HH:mm:ss')]);
-    const intervalValue = ref(10);
-    const intervalUnit = ref('minute');
+    const todayStart = now.startOf('day');
+    const todayEnd = todayStart.add(23, 'hour');
+    const rangeDateTimes = ref([
+      todayStart.format('YYYY-MM-DD HH:mm:ss'),
+      todayEnd.format('YYYY-MM-DD HH:mm:ss'),
+    ]);
+
+    const intervalValue = ref(1);
+    const intervalUnit = ref('hour');
     const useInterval = ref(true);
-    const useRange = ref(false);
+    const useRange = ref(true);
 
     const chartOptions = computed(() => ({
       type: 'scatter',

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -120,12 +120,17 @@ class TimeScale extends Scale {
     const step = range.maxSteps;
 
     if (this.interval) {
+      let userInterval;
       if (typeof this.interval === 'string') {
-        return TIME_INTERVALS[this.interval].size;
+        userInterval = TIME_INTERVALS[this.interval].size;
       } else if (typeof this.interval === 'object') {
-        return this.interval.time * TIME_INTERVALS[this.interval.unit].size;
+        userInterval = this.interval.time * TIME_INTERVALS[this.interval.unit].size;
       } else if (typeof this.interval === 'number') {
-        return this.interval;
+        userInterval = this.interval;
+      }
+
+      if (userInterval > 0 && Number.isFinite(userInterval)) {
+        return userInterval;
       }
     }
     return Math.ceil((max - min) / step);

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -182,26 +182,30 @@ class TimeScale extends Scale {
     /**
      * 1) userRange + userInterval
      * 호환되면 그대로 사용
+     * 단, maxSteps를 넘을경우 interval을 증가시켜서 맞춤
      * 호환되지 않으면 userRange only 로직으로 fallback
      */
     if (hasUserRange && isValidInterval) {
-      const interval = resolvedInterval;
       const graphRange = graphMax - graphMin;
-      const rawSteps = graphRange / interval;
+      const rawSteps = graphRange / resolvedInterval;
       const isCompatible =
         Math.abs(rawSteps - Math.round(rawSteps)) < EPS;
 
-      if ((isCompatible && rawSteps <= maxSteps) || this.fixedSteps) {
-        const steps = Math.round(rawSteps);
-        return {
-          steps,
-          interval,
-          graphMin,
-          graphMax,
-        };
+      if (this.fixedSteps || isCompatible) {
+        let interval = resolvedInterval;
+        let steps = Math.round(rawSteps);
+
+        if (!this.fixedSteps) {
+          while (steps > maxSteps) {
+            interval += resolvedInterval;
+            steps = Math.ceil(graphRange / interval);
+          }
+        }
+
+        return { steps, interval, graphMin, graphMax };
       }
     }
-  
+
     /**
      * 2) userInterval only
      * Object(time, unit) interval에만 해당


### PR DESCRIPTION
### 개요 
- time Axis 에서 range 와 interval 옵션을 받을 경우, range가 최우선 보장되고 interval은 선택적으로 보장되게 수정하였으나, 
- 표시가능한 라벨 개수를 넘을 경우, interval이 무시되는 현상 발생 


### 변경 점 
- 표시가능한 라벨 개수를 넘을 경우, interval += interval 로직으로 표시할 라벨 개수를 줄여나가도록 함 


### Before
- interval: 1시간임에도 불구하고 1시간 간격이 아님 
- <img width="578" height="558" alt="image" src="https://github.com/user-attachments/assets/ebedab45-d896-4c00-ac5c-457dd33e04d0" />



### After
- interval을 늘리고 label 개수를 줄임
- <img width="620" height="542" alt="image" src="https://github.com/user-attachments/assets/38f2c5fa-ffcf-4ec3-a5c0-acd357cc46ab" />



### 테스트 가이드 
http://localhost:9999/EVUI/scatterChart#time-axis
차트의 사이즈 와 옵션을 변경하여 확인부탁드립니다.