### PR TITLE
fix: Chart > 마지막 시리즈 데이터가 없을 경우 축의 min, max가 0, 1로 잡힘

### DIFF
--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -1300,20 +1300,20 @@ const modules = {
             if (!isHorizontal) {
               if (
                 smm.minX !== null &&
-                (minmax.x[axisX].min === null || smm.minX < minmax.x[axisX].min)
+                (minmax.x[axisX].min === null || (smm.minX !== null && smm.minX < minmax.x[axisX].min))
               ) {
                 minmax.x[axisX].min = smm.minX;
               }
-              if (minmax.y[axisY].min === null || smm.minY < minmax.y[axisY].min) {
+              if (minmax.y[axisY].min === null || (smm.minY !== null && smm.minY < minmax.y[axisY].min)) {
                 minmax.y[axisY].min = smm.minY;
               }
             } else {
-              if (minmax.x[axisX].min === null || smm.minX < minmax.x[axisX].min) {
+              if (minmax.x[axisX].min === null || (smm.minX !== null && smm.minX < minmax.x[axisX].min)) {
                 minmax.x[axisX].min = smm.minX;
               }
               if (
                 smm.minY !== null &&
-                (minmax.y[axisY].min === null || smm.minY < minmax.y[axisY].min)
+                (minmax.y[axisY].min === null || (smm.minY !== null && smm.minY < minmax.y[axisY].min))
               ) {
                 minmax.y[axisY].min = smm.minY;
               }


### PR DESCRIPTION
### 이슈
- Chart에서 마지막 시리즈 데이터가 없을 경우 축의 min, max 값이 0, 1로 설정되는 문제 발생
  - 마지막 시리즈가 빈 배열일 때, min/max 계산 로직에서 min 값이 null로 설정됨
  - min 값이 null인 경우, scale.linear.js에서 기본값(min: 0, max: 1)으로 range를 고정
  
### 변경 내용
- getStoreMinMax 로직 수정
  - min 값 비교 시 null이 아닌 경우에만 비교하도록 조건 추가
  - 잘못된 min 계산으로 인해 기본 range로 설정되는 문제 방지

### 이전 동작
<img width="1811" height="625" alt="image" src="https://github.com/user-attachments/assets/f3d3862f-8467-43ec-b2a6-b9eee07f6be8" />


### 이후 동작
<img width="872" height="339" alt="image" src="https://github.com/user-attachments/assets/8fc25f0b-8b65-43a6-a803-97be4893fdb6" />

### 테스트 방법
scatter widget 에서 마지막 시리즈의 데이터를 빈배열로 변경했을 때 y축이 정상적으로 보여지는지 확인해주세요.