### PR TITLE
feat: headless EvInput compound component 추가

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,6 +3,7 @@ module.exports = {
   env: {
     node: true,
     es2022: true,
+    'vue/setup-compiler-macros': true,
   },
   parserOptions: {
     ecmaVersion: 2022,
@@ -431,6 +432,15 @@ module.exports = {
   overrides: [
     {
       files: ['**/__tests__/*.{j,t}s?(x)', '**/tests/unit/**/*.spec.{j,t}s?(x)'],
+    },
+    {
+      files: ['src/components/input/*.vue'],
+      rules: {
+        'vue/multi-word-component-names': 'off',
+      },
+      globals: {
+        defineOptions: 'readonly',
+      },
     },
   ],
 };

--- a/docs/router/index.js
+++ b/docs/router/index.js
@@ -8,6 +8,7 @@ import selectProps from 'docs/views/select/props';
 import toggleProps from 'docs/views/toggle/props';
 import radioProps from 'docs/views/radio/props';
 import textFieldProps from 'docs/views/textField/props';
+import inputProps from 'docs/views/input/props';
 import inputNumberProps from 'docs/views/inputNumber/props';
 import sliderProps from 'docs/views/slider/props';
 import iconProps from 'docs/views/icon/props';
@@ -137,6 +138,15 @@ const routes = [
     name: 'TextField',
     component: PageView,
     props: textFieldProps,
+    meta: {
+      category: 'Form',
+    },
+  },
+  {
+    path: '/input',
+    name: 'Input',
+    component: PageView,
+    props: inputProps,
     meta: {
       category: 'Form',
     },

--- a/docs/views/input/api/input.md
+++ b/docs/views/input/api/input.md
@@ -1,0 +1,68 @@
+### Desc
+- Headless compound component 패턴의 input 컴포넌트
+- 동작과 접근성(WAI-ARIA)만 제공하며, 스타일은 포함하지 않음
+- 5개의 서브 컴포넌트를 조합하여 사용
+
+```
+<ev-input-root>
+  <ev-input-label>레이블</ev-input-label>
+  <ev-input v-model="value" />
+  <ev-input-description>설명</ev-input-description>
+  <ev-input-error-message>에러</ev-input-error-message>
+</ev-input-root>
+```
+- &lt;ev-input&gt;은 단독으로도 사용 가능
+
+```
+<ev-input v-model="value" type="email" name="email" />
+```
+
+### Components
+
+#### ev-input-root
+- context provider. 하위 컴포넌트에 상태(disabled, required, invalid)를 전파
+- ID를 자동 생성하여 label↔input, error↔input을 aria로 연결
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류 |
+|------|------|--------|------|------|
+| disabled | Boolean | false | 하위 input에 disabled 전파 | true, false |
+| required | Boolean | false | 하위 input에 required 전파 | true, false |
+| invalid | Boolean | false | 하위 input에 aria-invalid 전파 | true, false |
+
+#### ev-input
+- 핵심 input 요소. `inheritAttrs: false`로 모든 native HTML 속성을 내부 `<input>`에 직접 전달
+- Root 없이 단독 사용 가능
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류 |
+|------|------|--------|------|------|
+| v-model | String, Number | '' | 입력 값 바인딩 | |
+| v-model.trim | | | blur 시 앞뒤 공백 자동 제거 (Vue native modifier) | |
+| disabled | Boolean | undefined | 비활성화. undefined이면 Root의 값을 따름 | true, false |
+| required | Boolean | undefined | 필수 입력. undefined이면 Root의 값을 따름 | true, false |
+
+Native HTML 속성(type, name, placeholder, autocomplete, maxlength, data-* 등)은 내부 `<input>`에 직접 전달됩니다.
+
+#### ev-input-label
+- `<label>` 요소. Root 내에서 사용 시 input과 `for`/`id`가 자동 연결
+
+#### ev-input-description
+- 설명 텍스트. mount 시 input의 `aria-describedby`에 자동 등록
+
+#### ev-input-error-message
+- 에러 메시지. `role="alert"`, `aria-live="assertive"` 자동 설정
+- mount 시 input의 `aria-describedby`에 자동 등록
+
+### Event (ev-input)
+
+| 이름 | 파라미터 | 설명 |
+|------|----------|------|
+| focus | event | focus 이벤트 |
+| blur | event | blur 이벤트. v-model.trim 사용 시 이 시점에 trim 적용 |
+| input | (value, event) | input 이벤트 |
+| change | (value, event) | change 이벤트 |
+
+### Accessibility
+- Root 내에서 사용 시 label↔input, description↔input, error↔input이 aria 속성으로 자동 연결
+- `aria-invalid`, `aria-required`가 Root의 상태에 따라 자동 설정
+- ErrorMessage에 `role="alert"`, `aria-live="assertive"` 자동 적용
+- Description/ErrorMessage가 unmount되면 `aria-describedby`에서 자동 제거

--- a/docs/views/input/example/Accessibility.vue
+++ b/docs/views/input/example/Accessibility.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="case">
+    <p class="case-title">required + invalid 상태</p>
+    <ev-input-root :required="true" :invalid="!value1">
+      <ev-input-label>필수 입력</ev-input-label>
+      <ev-input v-model="value1" placeholder="필수 입력 항목입니다" />
+      <ev-input-error-message v-if="!value1">
+        필수 입력 항목입니다.
+      </ev-input-error-message>
+    </ev-input-root>
+    <div class="description">
+      <span class="badge yellow"> required </span>
+      <span class="badge yellow"> invalid </span>
+      <span class="badge">aria-required, aria-invalid 자동 설정</span>
+    </div>
+  </div>
+
+  <div class="case">
+    <p class="case-title">disabled 상태 전파</p>
+    <ev-input-root :disabled="isDisabled">
+      <ev-input-label>비활성 입력</ev-input-label>
+      <ev-input v-model="value2" placeholder="Root에서 disabled 전파" />
+      <ev-input-description>
+        Root의 disabled가 Input에 자동 전파됩니다.
+      </ev-input-description>
+    </ev-input-root>
+    <div class="description">
+      <button @click="isDisabled = !isDisabled">
+        {{ isDisabled ? 'Enable' : 'Disable' }}
+      </button>
+    </div>
+  </div>
+
+  <div class="case">
+    <p class="case-title">Native Attributes 전달</p>
+    <ev-input-root>
+      <ev-input-label>검색</ev-input-label>
+      <ev-input
+        v-model="value3"
+        type="search"
+        name="search"
+        autocomplete="off"
+        data-testid="search-input"
+        placeholder="native attrs가 input에 직접 전달됩니다"
+      />
+    </ev-input-root>
+    <div class="description">
+      <span class="badge yellow"> type, name, autocomplete, data-testid </span>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const value1 = ref('');
+    const value2 = ref('');
+    const value3 = ref('');
+    const isDisabled = ref(true);
+
+    return {
+      value1,
+      value2,
+      value3,
+      isDisabled,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.case [role="group"] {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 300px;
+}
+.case label {
+  font-size: 14px;
+  font-weight: 500;
+}
+.case input {
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  outline: none;
+}
+.case input:focus {
+  border-color: #409eff;
+}
+.case input:disabled {
+  background: #f5f5f5;
+  cursor: not-allowed;
+}
+.case [role="alert"] {
+  color: #f56c6c;
+  font-size: 12px;
+}
+.case .ev-input-description {
+  color: #909399;
+  font-size: 12px;
+}
+.case button {
+  padding: 4px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  cursor: pointer;
+}
+</style>

--- a/docs/views/input/example/Compound.vue
+++ b/docs/views/input/example/Compound.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="case">
+    <p class="case-title">Compound Component (Root + Label + Input)</p>
+    <ev-input-root>
+      <ev-input-label>사용자 이름</ev-input-label>
+      <ev-input v-model="value1" placeholder="이름을 입력하세요" />
+    </ev-input-root>
+    <div class="description">
+      <span class="badge"> Value </span>
+      {{ value1 }}
+    </div>
+  </div>
+
+  <div class="case">
+    <p class="case-title">Description 포함</p>
+    <ev-input-root>
+      <ev-input-label>이메일</ev-input-label>
+      <ev-input v-model="value2" type="email" placeholder="이메일을 입력하세요" />
+      <ev-input-description>업무용 이메일을 입력하세요.</ev-input-description>
+    </ev-input-root>
+  </div>
+
+  <div class="case">
+    <p class="case-title">Error Message 포함</p>
+    <ev-input-root :invalid="!!errorMsg">
+      <ev-input-label>전화번호</ev-input-label>
+      <ev-input
+        v-model="value3"
+        placeholder="숫자만 입력하세요"
+        @input="checkValid"
+      />
+      <ev-input-error-message v-if="errorMsg">
+        {{ errorMsg }}
+      </ev-input-error-message>
+    </ev-input-root>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const value1 = ref('');
+    const value2 = ref('');
+    const value3 = ref('abc');
+    const errorMsg = ref('');
+
+    const checkValid = (val) => {
+      const regexp = /^[0-9]*$/;
+      errorMsg.value = regexp.test(val) ? '' : '숫자만 입력 가능합니다.';
+    };
+    checkValid(value3.value);
+
+    return {
+      value1,
+      value2,
+      value3,
+      errorMsg,
+      checkValid,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.case [role="group"] {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 300px;
+}
+.case label {
+  font-size: 14px;
+  font-weight: 500;
+}
+.case input {
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  outline: none;
+}
+.case input:focus {
+  border-color: #409eff;
+}
+.case [role="alert"] {
+  color: #f56c6c;
+  font-size: 12px;
+}
+.case .ev-input-description {
+  color: #909399;
+  font-size: 12px;
+}
+</style>

--- a/docs/views/input/example/CustomLayout.vue
+++ b/docs/views/input/example/CustomLayout.vue
@@ -1,0 +1,159 @@
+<template>
+  <div class="case">
+    <p class="case-title">Prefix Icon</p>
+    <ev-input-root>
+      <ev-input-label>검색</ev-input-label>
+      <div class="input-wrapper">
+        <i class="ev-icon-search prefix" />
+        <ev-input v-model="value1" type="search" placeholder="검색어를 입력하세요" />
+      </div>
+    </ev-input-root>
+  </div>
+
+  <div class="case">
+    <p class="case-title">Suffix Icon (Clear)</p>
+    <ev-input-root>
+      <ev-input-label>이름</ev-input-label>
+      <div class="input-wrapper">
+        <ev-input v-model="value2" placeholder="이름을 입력하세요" />
+        <i
+          v-if="value2"
+          class="ev-icon-error suffix"
+          @click="value2 = ''"
+        />
+      </div>
+    </ev-input-root>
+    <div class="description">
+      <span class="badge"> Value </span>
+      {{ value2 }}
+    </div>
+  </div>
+
+  <div class="case">
+    <p class="case-title">Prefix + Suffix</p>
+    <ev-input-root>
+      <ev-input-label>금액</ev-input-label>
+      <div class="input-wrapper has-prefix has-suffix">
+        <span class="prefix text">₩</span>
+        <ev-input v-model="value3" type="text" placeholder="0" />
+        <span class="suffix text">원</span>
+      </div>
+    </ev-input-root>
+  </div>
+
+  <div class="case">
+    <p class="case-title">Prefix + Suffix + Error</p>
+    <ev-input-root :invalid="!!errorMsg">
+      <ev-input-label>이메일</ev-input-label>
+      <div class="input-wrapper has-prefix">
+        <i class="ev-icon-search prefix" />
+        <ev-input
+          v-model="value4"
+          type="email"
+          placeholder="example@email.com"
+          @input="validateEmail"
+        />
+      </div>
+      <ev-input-error-message v-if="errorMsg">
+        {{ errorMsg }}
+      </ev-input-error-message>
+    </ev-input-root>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const value1 = ref('');
+    const value2 = ref('');
+    const value3 = ref('');
+    const value4 = ref('abc');
+    const errorMsg = ref('');
+
+    const validateEmail = (val) => {
+      if (!val) {
+        errorMsg.value = '';
+        return;
+      }
+      const regexp = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      errorMsg.value = regexp.test(val) ? '' : '올바른 이메일 형식이 아닙니다.';
+    };
+    validateEmail(value4.value);
+
+    return {
+      value1,
+      value2,
+      value3,
+      value4,
+      errorMsg,
+      validateEmail,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.case [role="group"] {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 300px;
+}
+.case label {
+  font-size: 14px;
+  font-weight: 500;
+}
+.input-wrapper {
+  display: flex;
+  align-items: center;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  overflow: hidden;
+
+  &:focus-within {
+    border-color: #409eff;
+  }
+
+  input {
+    flex: 1;
+    padding: 8px 12px;
+    border: none;
+    font-size: 14px;
+    outline: none;
+    min-width: 0;
+  }
+
+  &.has-prefix input {
+    padding-left: 4px;
+  }
+  &.has-suffix input {
+    padding-right: 4px;
+  }
+}
+
+.prefix {
+  padding-left: 10px;
+  color: #909399;
+  &.text {
+    font-size: 14px;
+    white-space: nowrap;
+  }
+}
+.suffix {
+  padding-right: 10px;
+  color: #909399;
+  cursor: pointer;
+  &.text {
+    font-size: 14px;
+    cursor: default;
+    white-space: nowrap;
+  }
+}
+
+.case [role="alert"] {
+  color: #f56c6c;
+  font-size: 12px;
+}
+</style>

--- a/docs/views/input/example/Default.vue
+++ b/docs/views/input/example/Default.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="case">
+    <p class="case-title">기본 사용</p>
+    <ev-input v-model="value1" placeholder="내용을 입력하세요" />
+    <div class="description">
+      <span class="badge"> Value </span>
+      {{ value1 }}
+    </div>
+  </div>
+
+  <div class="case">
+    <p class="case-title">단독 사용 (Root 없이)</p>
+    <ev-input
+      v-model="value2"
+      type="email"
+      name="email"
+      placeholder="이메일을 입력하세요"
+    />
+    <div class="description">
+      <span class="badge yellow"> type="email" name="email" </span>
+      <span class="badge"> Value </span>
+      {{ value2 }}
+    </div>
+  </div>
+
+  <div class="case">
+    <p class="case-title">disabled / readonly</p>
+    <div style="display: flex; gap: 12px">
+      <ev-input v-model="value3" disabled />
+      <ev-input v-model="value4" readonly />
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const value1 = ref('');
+    const value2 = ref('');
+    const value3 = ref('Disabled');
+    const value4 = ref('Readonly');
+
+    return {
+      value1,
+      value2,
+      value3,
+      value4,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.case input {
+  width: 300px;
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  outline: none;
+}
+.case input:focus {
+  border-color: #409eff;
+}
+.case input:disabled {
+  background: #f5f5f5;
+  cursor: not-allowed;
+}
+</style>

--- a/docs/views/input/example/Trim.vue
+++ b/docs/views/input/example/Trim.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="case">
+    <p class="case-title">v-model.trim</p>
+    <ev-input-root>
+      <ev-input-label>Trim 적용</ev-input-label>
+      <ev-input v-model.trim="value1" placeholder="앞뒤 공백을 넣어보세요" />
+    </ev-input-root>
+    <div class="description">
+      <span class="badge yellow"> v-model.trim </span>
+      <span class="badge"> Value </span>
+      "{{ value1 }}"
+    </div>
+  </div>
+
+  <div class="case">
+    <p class="case-title">Trim 미적용 (비교)</p>
+    <ev-input-root>
+      <ev-input-label>Trim 없음</ev-input-label>
+      <ev-input v-model="value2" placeholder="앞뒤 공백을 넣어보세요" />
+    </ev-input-root>
+    <div class="description">
+      <span class="badge"> Value </span>
+      "{{ value2 }}"
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const value1 = ref('');
+    const value2 = ref('');
+
+    return {
+      value1,
+      value2,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.case [role="group"] {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 300px;
+}
+.case label {
+  font-size: 14px;
+  font-weight: 500;
+}
+.case input {
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  outline: none;
+}
+.case input:focus {
+  border-color: #409eff;
+}
+</style>

--- a/docs/views/input/props.js
+++ b/docs/views/input/props.js
@@ -1,0 +1,43 @@
+import { parse } from '@vue/compiler-sfc';
+import mdText from './api/input.md?raw';
+import Default from './example/Default';
+import DefaultRaw from './example/Default?raw';
+import Compound from './example/Compound';
+import CompoundRaw from './example/Compound?raw';
+import Trim from './example/Trim';
+import TrimRaw from './example/Trim?raw';
+import Accessibility from './example/Accessibility';
+import AccessibilityRaw from './example/Accessibility?raw';
+import CustomLayout from './example/CustomLayout';
+import CustomLayoutRaw from './example/CustomLayout?raw';
+
+export default {
+  mdText,
+  components: {
+    Default: {
+      description: '기본 input 사용 예시입니다.',
+      component: Default,
+      parsedData: parse(DefaultRaw).descriptor,
+    },
+    Compound: {
+      description: 'Root, Label, Description, ErrorMessage를 조합한 예시입니다.',
+      component: Compound,
+      parsedData: parse(CompoundRaw).descriptor,
+    },
+    Trim: {
+      description: 'v-model.trim modifier를 사용한 예시입니다.',
+      component: Trim,
+      parsedData: parse(TrimRaw).descriptor,
+    },
+    Accessibility: {
+      description: '접근성(required, invalid, disabled, native attrs) 예시입니다.',
+      component: Accessibility,
+      parsedData: parse(AccessibilityRaw).descriptor,
+    },
+    CustomLayout: {
+      description: 'Prefix/Suffix 아이콘, 텍스트 등 커스텀 레이아웃 예시입니다.',
+      component: CustomLayout,
+      parsedData: parse(CustomLayoutRaw).descriptor,
+    },
+  },
+};

--- a/src/components/input/Input.spec.js
+++ b/src/components/input/Input.spec.js
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import EvInput from './Input.vue';
+import EvInputRoot from './InputRoot.vue';
+import EvInputLabel from './InputLabel.vue';
+import EvInputDescription from './InputDescription.vue';
+import EvInputErrorMessage from './InputErrorMessage.vue';
+
+describe('EvInput', () => {
+  describe('단독 사용', () => {
+    it('기본 input이 렌더링된다', () => {
+      const wrapper = mount(EvInput);
+      expect(wrapper.find('input').exists()).toBe(true);
+    });
+
+    it('v-model이 동작한다', async () => {
+      const wrapper = mount(EvInput, {
+        props: { modelValue: '' },
+      });
+
+      await wrapper.find('input').setValue('hello');
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    });
+
+    it('native attrs가 input에 전달된다', () => {
+      const wrapper = mount(EvInput, {
+        attrs: {
+          name: 'email',
+          type: 'email',
+          'data-testid': 'my-input',
+          placeholder: '입력하세요',
+        },
+      });
+
+      const input = wrapper.find('input');
+      expect(input.attributes('name')).toBe('email');
+      expect(input.attributes('type')).toBe('email');
+      expect(input.attributes('data-testid')).toBe('my-input');
+      expect(input.attributes('placeholder')).toBe('입력하세요');
+    });
+
+    it('focus 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvInput);
+      await wrapper.find('input').trigger('focus');
+      expect(wrapper.emitted('focus')).toBeTruthy();
+    });
+
+    it('blur 이벤트가 발생한다', async () => {
+      const wrapper = mount(EvInput);
+      await wrapper.find('input').trigger('blur');
+      expect(wrapper.emitted('blur')).toBeTruthy();
+    });
+
+    it('context 없이 aria 속성이 생략된다', () => {
+      const wrapper = mount(EvInput);
+      const input = wrapper.find('input');
+      expect(input.attributes('aria-labelledby')).toBeUndefined();
+      expect(input.attributes('aria-describedby')).toBeUndefined();
+    });
+  });
+
+  describe('v-model.trim modifier', () => {
+    it('trim modifier가 있으면 blur 시 앞뒤 공백이 제거된다', async () => {
+      const wrapper = mount(EvInput, {
+        props: { modelModifiers: { trim: true }, modelValue: '' },
+      });
+
+      const input = wrapper.find('input');
+      await input.setValue('  hello  ');
+      await input.trigger('blur');
+
+      const emitted = wrapper.emitted('update:modelValue');
+      expect(emitted[emitted.length - 1][0]).toBe('hello');
+    });
+
+    it('trim modifier가 없으면 blur 시 공백이 유지된다', async () => {
+      const wrapper = mount(EvInput, {
+        props: { modelValue: '' },
+      });
+
+      const input = wrapper.find('input');
+      await input.setValue('  hello  ');
+      await input.trigger('blur');
+
+      const emitted = wrapper.emitted('update:modelValue');
+      expect(emitted[emitted.length - 1][0]).toBe('  hello  ');
+    });
+
+    it('trim modifier가 있어도 입력 중 DOM 값은 유지된다', async () => {
+      const wrapper = mount(EvInput, {
+        props: { modelModifiers: { trim: true }, modelValue: '' },
+      });
+
+      const input = wrapper.find('input');
+      input.element.value = 'test ';
+      await input.trigger('input');
+
+      expect(input.element.value).toBe('test ');
+    });
+  });
+
+  describe('Compound 사용', () => {
+    const CompoundInput = {
+      components: {
+        EvInputRoot,
+        EvInput,
+        EvInputLabel,
+        EvInputDescription,
+        EvInputErrorMessage,
+      },
+      template: `
+        <ev-input-root v-bind="rootProps">
+          <ev-input-label v-if="showLabel">이메일</ev-input-label>
+          <ev-input v-model="value" />
+          <ev-input-description v-if="showDescription">
+            설명 텍스트
+          </ev-input-description>
+          <ev-input-error-message v-if="showError">
+            에러 메시지
+          </ev-input-error-message>
+        </ev-input-root>
+      `,
+      props: {
+        rootProps: { type: Object, default: () => ({}) },
+        showLabel: { type: Boolean, default: true },
+        showDescription: { type: Boolean, default: false },
+        showError: { type: Boolean, default: false },
+      },
+      data() {
+        return { value: '' };
+      },
+    };
+
+    it('Label과 Input이 자동 연결된다', async () => {
+      const wrapper = mount(CompoundInput);
+      await nextTick();
+
+      const label = wrapper.find('label');
+      const input = wrapper.find('input');
+
+      expect(label.attributes('for')).toBe(input.attributes('id'));
+      expect(label.attributes('id')).toBeTruthy();
+    });
+
+    it('ErrorMessage가 aria-describedby로 연결된다', async () => {
+      const wrapper = mount(CompoundInput, {
+        props: { showError: true },
+      });
+      await nextTick();
+
+      const input = wrapper.find('input');
+      const error = wrapper.find('[role="alert"]');
+
+      expect(input.attributes('aria-describedby')).toContain(
+        error.attributes('id'),
+      );
+    });
+
+    it('Description과 ErrorMessage가 모두 aria-describedby에 포함된다',
+      async () => {
+        const wrapper = mount(CompoundInput, {
+          props: { showDescription: true, showError: true },
+        });
+        await nextTick();
+
+        const input = wrapper.find('input');
+        const describedby = input.attributes('aria-describedby');
+        expect(describedby).toBeTruthy();
+
+        const ids = describedby.split(' ');
+        expect(ids.length).toBe(2);
+      },
+    );
+
+    it('Root의 disabled가 Input에 전파된다', async () => {
+      const wrapper = mount(CompoundInput, {
+        props: { rootProps: { disabled: true } },
+      });
+      await nextTick();
+
+      expect(wrapper.find('input').element.disabled).toBe(true);
+    });
+
+    it('Root의 required가 Input에 전파된다', async () => {
+      const wrapper = mount(CompoundInput, {
+        props: { rootProps: { required: true } },
+      });
+      await nextTick();
+
+      const input = wrapper.find('input');
+      expect(input.element.required).toBe(true);
+      expect(input.attributes('aria-required')).toBe('true');
+    });
+
+    it('Root의 invalid가 aria-invalid로 설정된다', async () => {
+      const wrapper = mount(CompoundInput, {
+        props: { rootProps: { invalid: true } },
+      });
+      await nextTick();
+
+      expect(wrapper.find('input').attributes('aria-invalid')).toBe('true');
+    });
+
+    it('ErrorMessage가 role="alert"과 aria-live를 갖는다', async () => {
+      const wrapper = mount(CompoundInput, {
+        props: { showError: true },
+      });
+      await nextTick();
+
+      const error = wrapper.find('[role="alert"]');
+      expect(error.exists()).toBe(true);
+      expect(error.attributes('aria-live')).toBe('assertive');
+    });
+
+    it('Description unmount 시 aria-describedby에서 제거된다', async () => {
+      const wrapper = mount(CompoundInput, {
+        props: { showDescription: true },
+      });
+      await nextTick();
+
+      expect(wrapper.find('input').attributes('aria-describedby'))
+        .toBeTruthy();
+
+      await wrapper.setProps({ showDescription: false });
+      await nextTick();
+
+      const describedby = wrapper.find('input')
+        .attributes('aria-describedby');
+      expect(!describedby || describedby === '').toBe(true);
+    });
+  });
+});

--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -1,0 +1,98 @@
+<script setup>
+import { computed, useAttrs } from 'vue';
+import { useInputContext } from './context';
+
+defineOptions({ name: 'EvInput', inheritAttrs: false });
+
+const props = defineProps({
+  modelValue: {
+    type: [String, Number],
+    default: '',
+  },
+  modelModifiers: {
+    type: Object,
+    default: () => ({}),
+  },
+  disabled: {
+    type: Boolean,
+    default: undefined,
+  },
+  required: {
+    type: Boolean,
+    default: undefined,
+  },
+});
+
+const emit = defineEmits([
+  'update:modelValue',
+  'focus',
+  'blur',
+  'input',
+  'change',
+]);
+
+const ctx = useInputContext();
+const attrs = useAttrs();
+
+const isDisabled = computed(
+  () => props.disabled ?? ctx?.disabled.value ?? false,
+);
+const isRequired = computed(
+  () => props.required ?? ctx?.required.value ?? false,
+);
+const isInvalid = computed(() => ctx?.invalid.value ?? false);
+
+const inputAttrs = computed(() => {
+  const { class: _, style: __, ...rest } = attrs;
+  return rest;
+});
+
+const ariaDescribedby = computed(() => {
+  if (!ctx) return undefined;
+  const ids = [
+    ctx.errorMessageId.value,
+    ctx.descriptionId.value,
+  ].filter(Boolean);
+  return ids.length ? ids.join(' ') : undefined;
+});
+
+const emitValue = (val) => emit('update:modelValue', val);
+
+const handleFocus = (e) => emit('focus', e);
+
+const handleBlur = (e) => {
+  if (props.modelModifiers.trim) {
+    const trimmed = (e.target.value || '').trim();
+    if (trimmed !== e.target.value) {
+      e.target.value = trimmed;
+      emitValue(trimmed);
+    }
+  }
+  emit('blur', e);
+};
+
+const handleInput = (e) => {
+  emitValue(e.target.value);
+  emit('input', e.target.value, e);
+};
+
+const handleChange = (e) => emit('change', e.target.value, e);
+</script>
+
+<template>
+  <input
+    :id="ctx?.inputId.value"
+    v-bind="inputAttrs"
+    :value="modelValue"
+    :disabled="isDisabled"
+    :required="isRequired"
+    :aria-labelledby="ctx?.labelId.value"
+    :aria-describedby="ariaDescribedby"
+    :aria-invalid="isInvalid || undefined"
+    :aria-required="isRequired || undefined"
+    @focus="handleFocus"
+    @blur="handleBlur"
+    @input="handleInput"
+    @change="handleChange"
+  />
+</template>

--- a/src/components/input/InputDescription.vue
+++ b/src/components/input/InputDescription.vue
@@ -1,0 +1,30 @@
+<script setup>
+import { onMounted, onUnmounted } from 'vue';
+import { useInputContext } from './context';
+
+defineOptions({ name: 'EvInputDescription', inheritAttrs: false });
+
+const ctx = useInputContext();
+const id = ctx ? `${ctx.fieldId}-description` : undefined;
+
+onMounted(() => {
+  if (ctx) {
+    ctx.descriptionId.value = id;
+  }
+});
+
+onUnmounted(() => {
+  if (ctx) {
+    ctx.descriptionId.value = null;
+  }
+});
+</script>
+
+<template>
+  <div
+    v-bind="$attrs"
+    :id="id"
+  >
+    <slot />
+  </div>
+</template>

--- a/src/components/input/InputErrorMessage.vue
+++ b/src/components/input/InputErrorMessage.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { onMounted, onUnmounted } from 'vue';
+import { useInputContext } from './context';
+
+defineOptions({ name: 'EvInputErrorMessage', inheritAttrs: false });
+
+const ctx = useInputContext();
+const id = ctx ? `${ctx.fieldId}-error` : undefined;
+
+onMounted(() => {
+  if (ctx) {
+    ctx.errorMessageId.value = id;
+  }
+});
+
+onUnmounted(() => {
+  if (ctx) {
+    ctx.errorMessageId.value = null;
+  }
+});
+</script>
+
+<template>
+  <div
+    v-bind="$attrs"
+    :id="id"
+    role="alert"
+    aria-live="assertive"
+  >
+    <slot />
+  </div>
+</template>

--- a/src/components/input/InputLabel.vue
+++ b/src/components/input/InputLabel.vue
@@ -1,0 +1,17 @@
+<script setup>
+import { useInputContext } from './context';
+
+defineOptions({ name: 'EvInputLabel', inheritAttrs: false });
+
+const ctx = useInputContext();
+</script>
+
+<template>
+  <label
+    v-bind="$attrs"
+    :id="ctx?.labelId.value"
+    :for="ctx?.inputId.value"
+  >
+    <slot />
+  </label>
+</template>

--- a/src/components/input/InputRoot.vue
+++ b/src/components/input/InputRoot.vue
@@ -1,0 +1,28 @@
+<script setup>
+import { provideInputContext } from './context';
+
+defineOptions({ name: 'EvInputRoot' });
+
+const props = defineProps({
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  required: {
+    type: Boolean,
+    default: false,
+  },
+  invalid: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+provideInputContext(props);
+</script>
+
+<template>
+  <div role="group">
+    <slot />
+  </div>
+</template>

--- a/src/components/input/context.js
+++ b/src/components/input/context.js
@@ -1,0 +1,31 @@
+import { inject, provide, computed, ref } from 'vue';
+
+const INPUT_CONTEXT_KEY = Symbol('EvInputContext');
+
+let uid = 0;
+
+export function provideInputContext(props) {
+  const fieldId = `ev-input-${uid++}`;
+  const inputId = computed(() => `${fieldId}-input`);
+  const labelId = computed(() => `${fieldId}-label`);
+  const descriptionId = ref(null);
+  const errorMessageId = ref(null);
+
+  const context = {
+    fieldId,
+    inputId,
+    labelId,
+    descriptionId,
+    errorMessageId,
+    disabled: computed(() => props.disabled),
+    required: computed(() => props.required),
+    invalid: computed(() => props.invalid),
+  };
+
+  provide(INPUT_CONTEXT_KEY, context);
+  return context;
+}
+
+export function useInputContext() {
+  return inject(INPUT_CONTEXT_KEY, null);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,11 @@ import EvRadioGroup from '@/components/radioGroup/';
 import EvSelect from '@/components/select/';
 import EvToggle from '@/components/toggle/';
 import EvTextField from '@/components/textField/';
+import EvInputRoot from '@/components/input/InputRoot.vue';
+import EvInput from '@/components/input/Input.vue';
+import EvInputLabel from '@/components/input/InputLabel.vue';
+import EvInputDescription from '@/components/input/InputDescription.vue';
+import EvInputErrorMessage from '@/components/input/InputErrorMessage.vue';
 import EvInputNumber from '@/components/inputNumber/';
 import EvSlider from '@/components/slider/';
 import EvIcon from '@/components/icon/';
@@ -69,12 +74,23 @@ const components = [
   EvPagination,
 ];
 
+const inputComponents = {
+  EvInputRoot,
+  EvInput,
+  EvInputLabel,
+  EvInputDescription,
+  EvInputErrorMessage,
+};
+
 const install = (app) => {
   if (!app) {
     return;
   }
   components.forEach((component) => {
     app.use(component);
+  });
+  Object.entries(inputComponents).forEach(([name, component]) => {
+    app.component(name, component);
   });
 };
 
@@ -95,6 +111,11 @@ export {
   EvSelect,
   EvToggle,
   EvTextField,
+  EvInputRoot,
+  EvInput,
+  EvInputLabel,
+  EvInputDescription,
+  EvInputErrorMessage,
   EvInputNumber,
   EvSlider,
   EvIcon,


### PR DESCRIPTION
## Summary

- Radix Vue / Ark UI 패턴의 headless compound component로 새 `EvInput` 구현 (#2214)
- 5개 서브 컴포넌트: `EvInputRoot`, `EvInput`, `EvInputLabel`, `EvInputDescription`, `EvInputErrorMessage`
- `<script setup>`, `inheritAttrs: false`, WAI-ARIA 완전 지원, 스타일 없음 (headless)
- `v-model.trim` modifier 지원으로 Issue #2214 (model-DOM 불일치) 해결
- 기존 `EvTextField`는 변경 없이 유지

## 주요 특징

- **Compound Component** — provide/inject로 context 공유, ID 자동 생성, aria 자동 연결
- **Vue native 최대 호환** — native HTML attrs가 내부 `<input>`에 직접 전달
- **단독 사용 가능** — `<ev-input v-model="val" />` 만으로도 동작 (Root 없이)
- **접근성** — label↔input, description↔input, error↔input aria 자동 연결

## Test plan

- [x] 17개 유닛 테스트 통과 (단독, compound, trim, 접근성, native attrs)
- [x] 전체 711개 테스트 통과 (기존 테스트 영향 없음)
- [x] ESLint 통과
- [x] docs 빌드 성공
- [ ] docs 서버에서 `/input` 페이지 확인 (Default, Compound, Trim, Accessibility, CustomLayout 예시)

Closes #2214

🤖 Generated with [Claude Code](https://claude.com/claude-code)