### PR TITLE
fix: 브러쉬 차트 드래그 시 캔버스 영역 밖에서도 정상 동작하도록 개선

### DIFF
--- a/src/components/chartBrush/chartBrush.core.js
+++ b/src/components/chartBrush/chartBrush.core.js
@@ -184,6 +184,18 @@ export default class EvChartBrush {
         break;
     }
 
+    const maxBrushCanvasWidth = brushCanvasWidth * pixelRatio;
+
+    if (this.brushRectX < 0) {
+      this.brushRectX = 0;
+    } else if (this.brushRectX + this.brushRectWidth > maxBrushCanvasWidth) {
+      this.brushRectX = maxBrushCanvasWidth - this.brushRectWidth;
+    }
+
+    if (this.brushRectWidth > maxBrushCanvasWidth) {
+      this.brushRectWidth = maxBrushCanvasWidth;
+    }
+
     return {
       brushRectX: this.brushRectX,
       brushRectWidth: this.brushRectWidth,
@@ -238,25 +250,49 @@ export default class EvChartBrush {
     };
   }
 
+  getCanvasOffsetX(e) {
+    const rect = this.brushCanvas.getBoundingClientRect();
+
+    return e.clientX - rect.left;
+  }
+
   addEvent() {
     let mousePosition;
+
+    const onDocumentMouseMove = (e) => {
+      if (this.isDragMode) {
+        const offsetX = this.getCanvasOffsetX(e);
+        this.mouseDownAndMove({ offsetX });
+      }
+    };
+    this.onDocumentMouseMove = throttle(onDocumentMouseMove, 5);
+
+    this.onDocumentMouseUp = () => {
+      document.removeEventListener('mousemove', this.onDocumentMouseMove);
+      document.removeEventListener('mouseup', this.onDocumentMouseUp);
+      this.initEventState();
+    };
 
     this.onMouseDown = (e) => {
       e.preventDefault();
 
       if (mousePosition.isInsideButton) {
-        this.clickBrushInsideX = -1;
+        this.isDragMode = 'button';
       } else if (mousePosition.isInsideBrush) {
         this.clickBrushInsideX = e.offsetX;
+        this.isDragMode = 'grab';
       } else if (mousePosition.isOutsideBrush) {
         this.teleportBrush(e);
+      }
+
+      if (this.isDragMode) {
+        document.addEventListener('mousemove', this.onDocumentMouseMove);
+        document.addEventListener('mouseup', this.onDocumentMouseUp);
       }
     };
 
     const onMouseMove = (e) => {
-      if (this.clickBrushInsideX) {
-        this.mouseDownAndMove(e);
-      } else {
+      if (!this.isDragMode) {
         mousePosition = this.getMousePosition(e);
 
         this.changeCursor(mousePosition);
@@ -284,12 +320,6 @@ export default class EvChartBrush {
 
     this.onMouseUp = () => {
       this.initEventState();
-    };
-
-    this.onMouseLeave = () => {
-      if (this.clickBrushInsideX) {
-        this.initEventState();
-      }
     };
 
     const onWheelDebounce = () => {
@@ -330,6 +360,9 @@ export default class EvChartBrush {
     if (this.brushCanvas) {
       this.setEventListener('removeEventListener');
 
+      document.removeEventListener('mousemove', this.onDocumentMouseMove);
+      document.removeEventListener('mouseup', this.onDocumentMouseUp);
+
       this.brushCanvas = null;
     }
 
@@ -351,7 +384,6 @@ export default class EvChartBrush {
     this.brushCanvas[type]('mousemove', this.onMouseMove);
     this.brushCanvas[type]('mousedown', this.onMouseDown);
     this.brushCanvas[type]('mouseup', this.onMouseUp);
-    this.brushCanvas[type]('mouseleave', this.onMouseLeave);
 
     if (this.evChartBrushOptions.value.useWheelMove) {
       this.brushCanvas[type]('wheel', this.onWheel);
@@ -451,7 +483,7 @@ export default class EvChartBrush {
 
     if (e.offsetX > this.beforeMouseXPos) {
       // 오른쪽 이동
-      if (this.clickBrushInsideX > 0) {
+      if (this.isDragMode === 'grab') {
         if (this.clickBrushInsideX < e.offsetX - moveSensitive) {
           mode = BRUSH_UPDATE_MODE.GRAB.UP;
 
@@ -473,7 +505,7 @@ export default class EvChartBrush {
       }
     } else if (e.offsetX < this.beforeMouseXPos) {
       // 왼쪽 이동
-      if (this.clickBrushInsideX > 0) {
+      if (this.isDragMode === 'grab') {
         if (this.clickBrushInsideX > e.offsetX + moveSensitive) {
           mode = BRUSH_UPDATE_MODE.GRAB.DOWN;
 
@@ -643,6 +675,11 @@ export default class EvChartBrush {
    * @returns {undefined}
    */
   initEventState() {
+    if (this.isCleaningUp) {
+      return;
+    }
+    this.isCleaningUp = true;
+
     const promise = new Promise((resolve) => {
       this.updateBrushIdxUseXPos();
 
@@ -652,6 +689,7 @@ export default class EvChartBrush {
     promise.then((isUpdateBrushIdx) => {
       if (isUpdateBrushIdx) {
         this.clickBrushInsideX = null;
+        this.isDragMode = null;
         this.beforeMouseXPos = null;
         this.curBrushButtonType = null;
 
@@ -660,6 +698,7 @@ export default class EvChartBrush {
         this.brushIdx.isUseButton = false;
         this.brushIdx.isUseScroll = false;
       }
+      this.isCleaningUp = false;
     });
   }
 }


### PR DESCRIPTION
### 이슈 내용
- 브러쉬 차트에서 드래그 시 마우스가 캔버스 영역을 벗어나면 드래그가 중단되는 현상

### 변경 내용
- 드래그 중 마우스가 캔버스 밖으로 나가도 드래그가 유지되도록 이벤트 처리 범위 확장

### 이전 동작 
- 드래그 중 마우스가 캔버스 밖으로 벗어나면 드래그가 즉시 중단됨
- 빠르게 드래그 시 브러쉬가 캔버스 양쪽 끝을 벗어남

https://github.com/user-attachments/assets/466bed60-425b-4c74-9832-2c3daac10068

### 이후 동작
- 마우스가 캔버스 밖으로 나가도 드래그가 유지되며, 마우스를 놓으면 정상 종료됨
- 브러쉬가 양쪽 끝에서 경계를 넘지 않음
- 브러쉬 위치와 관계없이 드래그가 안정적으로 유지됨

https://github.com/user-attachments/assets/58c9a738-41a6-4359-be2e-347a115b2eac