### PR TITLE
fix: v-model.trim 사용 시 내부/외부 값 동기화 안되는 현상 수정

### DIFF
--- a/docs/views/textField/example/Default.vue
+++ b/docs/views/textField/example/Default.vue
@@ -70,6 +70,20 @@
   </div>
 
   <div class="case">
+    <p class="case-title">v-model.trim</p>
+    <ev-text-field
+      v-model.trim="modelValue8"
+      placeholder="Please enter the content"
+      type="text"
+    />
+    <div class="description">
+      <span class="badge yellow"> v-model.trim </span>
+      <span class="badge"> Text Field Value </span>
+      [{{ modelValue8 }}]
+    </div>
+  </div>
+
+  <div class="case">
     <p class="case-title">Error Message</p>
     <ev-text-field
       v-model="modelValue7"
@@ -93,6 +107,7 @@ export default {
     const modelValue5 = ref();
     const modelValue6 = ref();
     const modelValue7 = ref('1234가나다');
+    const modelValue8 = ref();
     const errMsg = ref();
     const checkValid = () => {
       const regexp = /^[0-9]*$/;
@@ -111,6 +126,7 @@ export default {
       modelValue5,
       modelValue6,
       modelValue7,
+      modelValue8,
       checkValid,
       errMsg,
     };

--- a/src/components/textField/TextField.vue
+++ b/src/components/textField/TextField.vue
@@ -140,6 +140,10 @@ export default {
       type: String,
       default: 'off',
     },
+    modelModifiers: {
+      type: Object,
+      default: () => ({}),
+    },
   },
   emits: ['update:modelValue', 'focus', 'blur', 'input', 'change', 'search'],
   setup(props, { emit }) {
@@ -193,6 +197,13 @@ export default {
       emit('focus', e);
     };
     const blurInput = (e) => {
+      if (props.modelModifiers.trim && typeof e.target.value === 'string') {
+        const trimmed = e.target.value.trim();
+        if (trimmed !== e.target.value) {
+          mv.value = trimmed;
+          e.target.value = trimmed;
+        }
+      }
       emit('blur', e);
     };
 


### PR DESCRIPTION
## Summary
- `ev-text-field`에서 `v-model.trim` 사용 시 내부 DOM과 외부 modelValue가 동기화되지 않는 현상 수정
- `modelModifiers` prop을 추가하여 blur 시 trim된 값으로 DOM과 modelValue를 동기화

## Test plan
- [x] `<ev-text-field v-model.trim="val">` 사용 시 앞뒤 공백 입력 후 blur → 공백 제거 확인
- [x] 타이핑 중 공백 자유롭게 입력 가능 확인
- [x] textarea 타입에서도 동일 동작 확인
- [x] 기존 기능(clearable, maxLength, password toggle) 정상 동작 확인

Closes #2214

🤖 Generated with [Claude Code](https://claude.com/claude-code)