### PR TITLE
fix: realTimeScatter > 데이터가 없을 경우, Y축에 0~1 범위가 아닌 0~1.1 범위가 표시되는 현상 수정

### DIFF
--- a/docs/views/textField/example/Default.vue
+++ b/docs/views/textField/example/Default.vue
@@ -70,6 +70,20 @@
   </div>
 
   <div class="case">
+    <p class="case-title">v-model.trim</p>
+    <ev-text-field
+      v-model.trim="modelValue8"
+      placeholder="Please enter the content"
+      type="text"
+    />
+    <div class="description">
+      <span class="badge yellow"> v-model.trim </span>
+      <span class="badge"> Text Field Value </span>
+      [{{ modelValue8 }}]
+    </div>
+  </div>
+
+  <div class="case">
     <p class="case-title">Error Message</p>
     <ev-text-field
       v-model="modelValue7"
@@ -93,6 +107,7 @@ export default {
     const modelValue5 = ref();
     const modelValue6 = ref();
     const modelValue7 = ref('1234가나다');
+    const modelValue8 = ref();
     const errMsg = ref();
     const checkValid = () => {
       const regexp = /^[0-9]*$/;
@@ -111,6 +126,7 @@ export default {
       modelValue5,
       modelValue6,
       modelValue7,
+      modelValue8,
       checkValid,
       errMsg,
     };

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -270,7 +270,7 @@ const modules = {
 
     if (!Number.isFinite(minMaxValues.minY)) {
       minMaxValues.minY = 0;
-      minMaxValues.maxY = 1;
+      minMaxValues.maxY = 0;
     }
 
     this.seriesInfo.charts.scatter.forEach((seriesID) => {

--- a/src/components/textField/TextField.vue
+++ b/src/components/textField/TextField.vue
@@ -140,6 +140,10 @@ export default {
       type: String,
       default: 'off',
     },
+    modelModifiers: {
+      type: Object,
+      default: () => ({}),
+    },
   },
   emits: ['update:modelValue', 'focus', 'blur', 'input', 'change', 'search'],
   setup(props, { emit }) {
@@ -193,6 +197,13 @@ export default {
       emit('focus', e);
     };
     const blurInput = (e) => {
+      if (props.modelModifiers.trim && typeof e.target.value === 'string') {
+        const trimmed = e.target.value.trim();
+        if (trimmed !== e.target.value) {
+          mv.value = trimmed;
+          e.target.value = trimmed;
+        }
+      }
       emit('blur', e);
     };
 


### PR DESCRIPTION
### 개요 
- autoScaleRatio: 0.1  이 설정되어있는 real time scatter에서 
- 데이터가 없을 경우, 0~1로 축이 설정될것을 기대하지만
- 0~1.1 로 설정되는 현상 발생 
- 1.1 을 대상으로 niceScale 로직까지 타서 의미가 없지만 의미 있는듯한 숫자가 최상단에 위치하게됨

### 원인
- model.store에서 미리 maxY로 1을 지정                                       
- calculateScaleRange에서 maxValue = 1 → autoScaleRatio 적용 → 1 * 1.1 = 1.1 → 0~1.1 문제 발생             
- <img width="703" height="483" alt="image" src="https://github.com/user-attachments/assets/7acd44c8-8bb3-40a0-86d4-d1e30fe8aeaa" />

### 변경                                            
- (maxY = 0): maxValue = 0, minValue = 0 → autoScaleRatio 적용해도 0 * 1.1 = 0 → 이후 maxValue === minValue 보정으로 0~1이 됨
- <img width="656" height="459" alt="image" src="https://github.com/user-attachments/assets/cd066011-3aec-4d83-9693-b274234c5f1e" />
