### PR TITLE
fix: step: 1일때 nice scale 적용되지 않음

### DIFF
--- a/src/components/chart/scale/scale.linear.js
+++ b/src/components/chart/scale/scale.linear.js
@@ -167,7 +167,7 @@ class LinearScale extends Scale {
       const pow = 10 ** exp;
       for (const fraction of NICE_FRACTIONS) {
         const interval = fraction * pow;
-        if (interval >= minInterval && interval < range) {
+        if (interval >= minInterval) {
           // floating-point 오차 보정을 위해 epsilon 적용
           const EPS = interval * 1e-10;
           const niceMin = Math.floor((min + EPS) / interval) * interval;


### PR DESCRIPTION
## 이슈
nice scale 계산 로직에서 interval < range 조건으로 step이 1개일때 range를 벗어나지 못해 nice scale이 아닌 부동소수점을 가진 라벨로 보임

## 변경 내용
 nice scale일때는 interval이 range를 넘어설 수 있으므로 조건 삭제
 
 
 ## 이전 동작
<img width="1064" height="233" alt="image" src="https://github.com/user-attachments/assets/4683c49c-5ea3-4e86-ae8f-56d968c0e7cf" />

 
 ## 이후 동작
<img width="1114" height="211" alt="image" src="https://github.com/user-attachments/assets/7b572207-f7f7-4794-8647-38f97c90fe23" />

## 테스트 방법
차트 높이를 최대한 줄였을떄 y축 max 값 라벨 확인
