### PR TITLE
fix: apply willReadFrequently option to all canvas contexts

### DIFF
--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -97,6 +97,7 @@ const chartData =
 | title            | Object          | ([상세](#title))                               | 차트 상단에 위치할 차트 제목 표시 여부 및 속성                  |                                 |
 | legend           | Object          | ([상세](#legend))                              | 차트의 범례 표시 여부 및 속성                                   |                                 |
 | doughnutHoleSize | number          | 0                                              | 내부 hole 사이즈                                                | 0 ~ 1                           |
+| doughnutHoleColor | Hex, RGB, RGBA Code(String) | null                              | 도넛 내부 hole 색상. 명시하지 않으면 차트 부모 요소의 `background-color`를 자동 탐색하며, `documentElement`/`body`의 class/style/data-theme 변경을 감시해 테마 토글 시 자동으로 hole 색을 갱신한다. 부모가 반투명/CSS 변수/그라데이션이거나 자동 감지로 안 잡히는 케이스에서는 명시 권장 (예: `computed(() => theme.value === 'dark' ? '#1e1e1e' : '#ffffff')`) | '#1e1e1e'                     |
 | pieStroke        | Object          | { show: true, color: '#FFFFFF', lineWidth: 2 } | 차트의 테두리선 표시 여부 및 색상, 두께를 설정하는 옵션         |                                 |
 | tooltip          | Object          | ([상세](#tooltip))                             | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성                |                                 |
 | eventBehavior    | Object          | ([상세](#eventbehavior))                       | 이벤트별 동작 설정 | | 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -141,6 +141,8 @@ class EvChart {
 
     this.createEventFunctions?.();
     this.isInit = true;
+
+    this.setupDoughnutHoleThemeObserver?.();
   }
 
   _updateSeriesCount() {
@@ -1077,9 +1079,6 @@ class EvChart {
 
     this.initDefaultSelectInfo();
 
-    // update 시점에 doughnutHoleColor 옵션이 바뀌었거나 DOM 컨텍스트가 달라졌을 수 있다.
-    this.invalidateDoughnutHoleColorCache?.();
-
     let renderHitInfo = updateInfo?.hitInfo;
     if (!renderHitInfo?.legend && this.legendHover?.sId) {
       renderHitInfo = { ...(renderHitInfo || {}), legend: this.legendHover };
@@ -1180,7 +1179,6 @@ class EvChart {
 
     this.initScale();
     this.chartRect = this.getChartRect();
-    this.invalidateDoughnutHoleColorCache?.();
     this.drawChart();
     if (this.dragInfoBackup) {
       this.drawSelectionArea?.(this.dragInfoBackup);
@@ -1394,6 +1392,8 @@ class EvChart {
     if (!this.isInit) {
       return;
     }
+
+    this.teardownDoughnutHoleThemeObserver?.();
 
     const target = this.target;
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -57,10 +57,10 @@ class EvChart {
 
     this.displayCanvas = document.createElement('canvas');
     this.displayCanvas.setAttribute('style', 'display: block;');
-    this.displayCtx = this.displayCanvas.getContext('2d');
+    this.displayCtx = this.displayCanvas.getContext('2d', { willReadFrequently: true });
     this.bufferCanvas = document.createElement('canvas');
     this.bufferCanvas.setAttribute('style', 'display: block;');
-    this.bufferCtx = this.bufferCanvas.getContext('2d');
+    this.bufferCtx = this.bufferCanvas.getContext('2d', { willReadFrequently: true });
 
     this.pixelRatio = window.devicePixelRatio || 1;
     this.oldPixelRatio = this.pixelRatio;
@@ -71,7 +71,7 @@ class EvChart {
       this.overlayCanvas = document.createElement('canvas');
       this.overlayCanvas.setAttribute('style', 'display: block; z-index: 2;');
       this.overlayCanvas.setAttribute('class', 'overlay-canvas');
-      this.overlayCtx = this.overlayCanvas.getContext('2d');
+      this.overlayCtx = this.overlayCanvas.getContext('2d', { willReadFrequently: true });
 
       this.chartDOM.appendChild(this.overlayCanvas);
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -55,12 +55,13 @@ class EvChart {
     this.wrapperDOM.appendChild(this.chartDOM);
     this.target.appendChild(this.wrapperDOM);
 
+    const isPie = options.type === 'pie';
     this.displayCanvas = document.createElement('canvas');
     this.displayCanvas.setAttribute('style', 'display: block;');
-    this.displayCtx = this.displayCanvas.getContext('2d', { willReadFrequently: true });
+    this.displayCtx = this.displayCanvas.getContext('2d', { willReadFrequently: isPie });
     this.bufferCanvas = document.createElement('canvas');
     this.bufferCanvas.setAttribute('style', 'display: block;');
-    this.bufferCtx = this.bufferCanvas.getContext('2d', { willReadFrequently: true });
+    this.bufferCtx = this.bufferCanvas.getContext('2d', { willReadFrequently: isPie });
 
     this.pixelRatio = window.devicePixelRatio || 1;
     this.oldPixelRatio = this.pixelRatio;
@@ -71,7 +72,7 @@ class EvChart {
       this.overlayCanvas = document.createElement('canvas');
       this.overlayCanvas.setAttribute('style', 'display: block; z-index: 2;');
       this.overlayCanvas.setAttribute('class', 'overlay-canvas');
-      this.overlayCtx = this.overlayCanvas.getContext('2d', { willReadFrequently: true });
+      this.overlayCtx = this.overlayCanvas.getContext('2d', { willReadFrequently: isPie });
 
       this.chartDOM.appendChild(this.overlayCanvas);
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -55,13 +55,12 @@ class EvChart {
     this.wrapperDOM.appendChild(this.chartDOM);
     this.target.appendChild(this.wrapperDOM);
 
-    const isPie = options.type === 'pie';
     this.displayCanvas = document.createElement('canvas');
     this.displayCanvas.setAttribute('style', 'display: block;');
-    this.displayCtx = this.displayCanvas.getContext('2d', { willReadFrequently: isPie });
+    this.displayCtx = this.displayCanvas.getContext('2d');
     this.bufferCanvas = document.createElement('canvas');
     this.bufferCanvas.setAttribute('style', 'display: block;');
-    this.bufferCtx = this.bufferCanvas.getContext('2d', { willReadFrequently: isPie });
+    this.bufferCtx = this.bufferCanvas.getContext('2d');
 
     this.pixelRatio = window.devicePixelRatio || 1;
     this.oldPixelRatio = this.pixelRatio;
@@ -72,7 +71,7 @@ class EvChart {
       this.overlayCanvas = document.createElement('canvas');
       this.overlayCanvas.setAttribute('style', 'display: block; z-index: 2;');
       this.overlayCanvas.setAttribute('class', 'overlay-canvas');
-      this.overlayCtx = this.overlayCanvas.getContext('2d', { willReadFrequently: isPie });
+      this.overlayCtx = this.overlayCanvas.getContext('2d');
 
       this.chartDOM.appendChild(this.overlayCanvas);
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -1077,6 +1077,9 @@ class EvChart {
 
     this.initDefaultSelectInfo();
 
+    // update 시점에 doughnutHoleColor 옵션이 바뀌었거나 DOM 컨텍스트가 달라졌을 수 있다.
+    this.invalidateDoughnutHoleColorCache?.();
+
     let renderHitInfo = updateInfo?.hitInfo;
     if (!renderHitInfo?.legend && this.legendHover?.sId) {
       renderHitInfo = { ...(renderHitInfo || {}), legend: this.legendHover };
@@ -1177,6 +1180,7 @@ class EvChart {
 
     this.initScale();
     this.chartRect = this.getChartRect();
+    this.invalidateDoughnutHoleColorCache?.();
     this.drawChart();
     if (this.dragInfoBackup) {
       this.drawSelectionArea?.(this.dragInfoBackup);

--- a/src/components/chart/plugins/plugins.pie.js
+++ b/src/components/chart/plugins/plugins.pie.js
@@ -256,30 +256,6 @@ const modules = {
   },
 
   /**
-   * doughnutHoleColor 캐시를 무효화한다.
-   * 옵션 변경/리사이즈/리렌더 등으로 부모 DOM의 background-color 컨텍스트가
-   * 달라졌을 수 있을 때 호출한다.
-   */
-  invalidateDoughnutHoleColorCache() {
-    this.cachedDoughnutHoleColor = null;
-  },
-
-  /**
-   * 캐시된 doughnutHoleColor를 반환하거나, 없으면 한 번 계산해 캐시한다.
-   * tooltip hover 중 hole이 자주 다시 그려지므로(plugins.tooltip.js의 highlight 경로)
-   * 매 호출마다 getComputedStyle로 DOM을 거슬러 올라가지 않도록 한다.
-   */
-  getDoughnutHoleColor() {
-    if (this.cachedDoughnutHoleColor) {
-      return this.cachedDoughnutHoleColor;
-    }
-
-    const rootElement = this.chartDOM || this.wrapperDOM || this.target;
-    this.cachedDoughnutHoleColor = resolveDoughnutHoleColor(this.options, rootElement);
-    return this.cachedDoughnutHoleColor;
-  },
-
-  /**
    * Draw doughnut hole
    * @param ctx
    */
@@ -320,7 +296,9 @@ const modules = {
       ? ceilToDevicePixel(radius + erasePadding, pixelRatio)
       : radius;
 
-    const doughnutHoleColor = this.getDoughnutHoleColor();
+    const rootElement = this.chartDOM || this.wrapperDOM || this.target;
+    const doughnutHoleColor = resolveDoughnutHoleColor(pieOption, rootElement);
+    this.lastDoughnutHoleColor = doughnutHoleColor;
 
     ctx.save();
 
@@ -347,6 +325,75 @@ const modules = {
 
     // adjustedRadius는 렌더링 보정값이므로 hit-test 등에 사용되는 내부 논리값은 기존 radius를 유지한다.
     this.pieDataSet[this.pieDataSet.length - 1].ir = radius;
+  },
+
+  /**
+   * 다크↔라이트 테마 토글 등 상위 DOM의 background-color가 바뀌었을 때
+   * hole 색이 자동으로 갱신되도록 documentElement / body 의 attribute 변화를 감시한다.
+   *
+   * - doughnutHoleColor 옵션이 명시되어 있으면 사용자가 직접 색을 통제하는 것으로 보고
+   *   옵저버를 등록하지 않는다 (옵션을 reactive로 바인딩한 경우 Vue가 update를 트리거하므로 불필요).
+   * - doughnutHoleSize가 0이면 hole 자체를 그리지 않으므로 등록하지 않는다.
+   */
+  setupDoughnutHoleThemeObserver() {
+    if (typeof window === 'undefined' || typeof MutationObserver === 'undefined') {
+      return;
+    }
+    if (!(this.options?.doughnutHoleSize > 0)) {
+      return;
+    }
+    if (this.options?.doughnutHoleColor) {
+      return;
+    }
+    if (this.doughnutHoleThemeObserver) {
+      return;
+    }
+
+    // 테마 클래스가 html/body가 아니라 그 하위 wrapper div에 붙는 앱도 흔하므로
+    // documentElement subtree 전체의 attribute 변화를 감시한다.
+    // 다양한 무관 mutation에 대해 매번 DOM walk를 돌지 않도록 rAF로 coalesce 한다.
+    this.doughnutHoleThemeObserver = new MutationObserver(() => {
+      if (this.doughnutHoleThemeRafId != null) {
+        return;
+      }
+
+      this.doughnutHoleThemeRafId = requestAnimationFrame(() => {
+        this.doughnutHoleThemeRafId = null;
+
+        if (!this.isInit) {
+          return;
+        }
+
+        const rootElement = this.chartDOM || this.wrapperDOM || this.target;
+        if (!rootElement) {
+          return;
+        }
+
+        const nextColor = resolveDoughnutHoleColor(this.options, rootElement);
+        if (nextColor !== this.lastDoughnutHoleColor) {
+          this.render();
+        }
+      });
+    });
+
+    if (document.documentElement) {
+      this.doughnutHoleThemeObserver.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['class', 'style', 'data-theme'],
+        subtree: true,
+      });
+    }
+  },
+
+  teardownDoughnutHoleThemeObserver() {
+    if (this.doughnutHoleThemeObserver) {
+      this.doughnutHoleThemeObserver.disconnect();
+      this.doughnutHoleThemeObserver = null;
+    }
+    if (this.doughnutHoleThemeRafId != null) {
+      cancelAnimationFrame(this.doughnutHoleThemeRafId);
+      this.doughnutHoleThemeRafId = null;
+    }
   },
 };
 

--- a/src/components/chart/plugins/plugins.pie.js
+++ b/src/components/chart/plugins/plugins.pie.js
@@ -24,7 +24,7 @@ const isTransparentColor = (color) => {
 };
 
 const resolveDoughnutHoleColor = (pieOption, rootElement) => {
-  const optionColor = pieOption?.doughnutHoleColor || pieOption?.backgroundColor;
+  const optionColor = pieOption?.doughnutHoleColor;
 
   if (!isTransparentColor(optionColor)) {
     return optionColor;
@@ -298,12 +298,11 @@ const modules = {
 
     const rootElement = this.chartDOM || this.wrapperDOM || this.target;
     const doughnutHoleColor = resolveDoughnutHoleColor(pieOption, rootElement);
-    this.lastDoughnutHoleColor = doughnutHoleColor;
+    this._lastDoughnutHoleColor = doughnutHoleColor;
 
     ctx.save();
 
-    // 일부 GPU 가속 환경에서 destination-out 합성 경계가 깨지는 케이스가 있어,
-    // hole을 투명하게 지우지 않고 실제 배경색으로 덮는다.
+    // 일부 GPU 가속 환경에서 destination-out의 가장자리가 깨져 source-over로 칠한다.
     ctx.globalCompositeOperation = 'source-over';
     ctx.beginPath();
     ctx.fillStyle = doughnutHoleColor;
@@ -345,20 +344,20 @@ const modules = {
     if (this.options?.doughnutHoleColor) {
       return;
     }
-    if (this.doughnutHoleThemeObserver) {
+    if (this._doughnutHoleThemeObserver) {
       return;
     }
 
     // 테마 클래스가 html/body가 아니라 그 하위 wrapper div에 붙는 앱도 흔하므로
     // documentElement subtree 전체의 attribute 변화를 감시한다.
     // 다양한 무관 mutation에 대해 매번 DOM walk를 돌지 않도록 rAF로 coalesce 한다.
-    this.doughnutHoleThemeObserver = new MutationObserver(() => {
-      if (this.doughnutHoleThemeRafId != null) {
+    this._doughnutHoleThemeObserver = new MutationObserver(() => {
+      if (this._doughnutHoleThemeRafId != null) {
         return;
       }
 
-      this.doughnutHoleThemeRafId = requestAnimationFrame(() => {
-        this.doughnutHoleThemeRafId = null;
+      this._doughnutHoleThemeRafId = requestAnimationFrame(() => {
+        this._doughnutHoleThemeRafId = null;
 
         if (!this.isInit) {
           return;
@@ -370,14 +369,14 @@ const modules = {
         }
 
         const nextColor = resolveDoughnutHoleColor(this.options, rootElement);
-        if (nextColor !== this.lastDoughnutHoleColor) {
+        if (nextColor !== this._lastDoughnutHoleColor) {
           this.render();
         }
       });
     });
 
     if (document.documentElement) {
-      this.doughnutHoleThemeObserver.observe(document.documentElement, {
+      this._doughnutHoleThemeObserver.observe(document.documentElement, {
         attributes: true,
         attributeFilter: ['class', 'style', 'data-theme'],
         subtree: true,
@@ -386,13 +385,13 @@ const modules = {
   },
 
   teardownDoughnutHoleThemeObserver() {
-    if (this.doughnutHoleThemeObserver) {
-      this.doughnutHoleThemeObserver.disconnect();
-      this.doughnutHoleThemeObserver = null;
+    if (this._doughnutHoleThemeObserver) {
+      this._doughnutHoleThemeObserver.disconnect();
+      this._doughnutHoleThemeObserver = null;
     }
-    if (this.doughnutHoleThemeRafId != null) {
-      cancelAnimationFrame(this.doughnutHoleThemeRafId);
-      this.doughnutHoleThemeRafId = null;
+    if (this._doughnutHoleThemeRafId != null) {
+      cancelAnimationFrame(this._doughnutHoleThemeRafId);
+      this._doughnutHoleThemeRafId = null;
     }
   },
 };

--- a/src/components/chart/plugins/plugins.pie.js
+++ b/src/components/chart/plugins/plugins.pie.js
@@ -216,43 +216,108 @@ const modules = {
     const pieOption = this.options;
     const { width, height } = this.chartRect;
     const padding = this.options.padding;
-
+  
     const centerX = width / 2;
     const centerY = height / 2;
-
+  
     const chartWidth = centerX - (padding.left + padding.right);
     const chartHeight = centerY - (padding.bottom + padding.top);
+  
     if (
       (typeof chartWidth === 'number' && chartWidth < 0) ||
       (typeof chartHeight === 'number' && chartHeight < 0)
     ) {
       return;
     }
-
+  
     const radius = Math.min(chartWidth, chartHeight) * pieOption.doughnutHoleSize;
-
+  
+    const pixelRatio = this.pixelRatio || window.devicePixelRatio || 1;
+    const isFractionalPixelRatio = !Number.isInteger(pixelRatio);
+  
+    const alignToDevicePixel = (value) => Math.round(value * pixelRatio) / pixelRatio;
+    const ceilToDevicePixel = (value) => Math.ceil(value * pixelRatio) / pixelRatio;
+  
+    const adjustedCenterX = isFractionalPixelRatio ? alignToDevicePixel(centerX) : centerX;
+    const adjustedCenterY = isFractionalPixelRatio ? alignToDevicePixel(centerY) : centerY;
+  
+    // fractional scale 환경에서 원 경계 잔여 픽셀이 남는 케이스를 줄이기 위해
+    // hole 영역만 1 device pixel 정도 더 크게 덮는다.
+    const erasePadding = isFractionalPixelRatio ? 1 / pixelRatio : 0;
+    const adjustedRadius = isFractionalPixelRatio
+      ? ceilToDevicePixel(radius + erasePadding)
+      : radius;
+  
+    const isTransparentColor = (color) => {
+      if (!color) {
+        return true;
+      }
+  
+      const normalizedColor = color.trim().toLowerCase();
+  
+      if (normalizedColor === 'transparent') {
+        return true;
+      }
+  
+      const colorMatch = normalizedColor.match(
+        /rgba?\(\s*[\d.]+%?\s*(?:,|\s)\s*[\d.]+%?\s*(?:,|\s)\s*[\d.]+%?\s*(?:,|\/)\s*([\d.]+%?)\s*\)/,
+      );
+  
+      if (!colorMatch) {
+        return false;
+      }
+  
+      return Number.parseFloat(colorMatch[1]) === 0;
+    };
+  
+    const getDoughnutHoleColor = () => {
+      const optionColor = pieOption?.doughnutHoleColor || pieOption?.backgroundColor;
+  
+      if (!isTransparentColor(optionColor)) {
+        return optionColor;
+      }
+  
+      let element = this.chartDOM || this.wrapperDOM || this.target;
+  
+      while (element && element !== document.documentElement) {
+        const backgroundColor = getComputedStyle(element)?.backgroundColor;
+  
+        if (!isTransparentColor(backgroundColor)) {
+          return backgroundColor;
+        }
+  
+        element = element.parentElement;
+      }
+  
+      return '#fff';
+    };
+  
+    const doughnutHoleColor = getDoughnutHoleColor();
+  
     ctx.save();
-    ctx.globalCompositeOperation = 'destination-out';
+  
+    // 일부 GPU 가속 환경에서 destination-out 합성 경계가 깨지는 케이스가 있어,
+    // hole을 투명하게 지우지 않고 실제 배경색으로 덮는다.
+    ctx.globalCompositeOperation = 'source-over';
     ctx.beginPath();
-    ctx.fillStyle = '#fff';
-    ctx.fillOpacity = 0;
-    ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI);
-    ctx.fill();
-    ctx.strokeStyle = '#fff';
-    ctx.stroke();
+    ctx.fillStyle = doughnutHoleColor;
+    ctx.arc(adjustedCenterX, adjustedCenterY, adjustedRadius, 0, Math.PI * 2);
     ctx.closePath();
+    ctx.fill();
+  
     ctx.restore();
-
-    // inner stroke
+  
+    // inner stroke는 시각 보정용 adjustedRadius가 아니라 원래 논리 radius 기준으로 유지한다.
     if (pieOption?.pieStroke?.use) {
       ctx.beginPath();
       ctx.strokeStyle = pieOption.pieStroke.color;
       ctx.lineWidth = pieOption.pieStroke.lineWidth;
-      ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
-      ctx.stroke();
+      ctx.arc(adjustedCenterX, adjustedCenterY, radius, 0, Math.PI * 2);
       ctx.closePath();
+      ctx.stroke();
     }
-
+  
+    // adjustedRadius는 렌더링 보정값이므로 hit-test 등에 사용되는 내부 논리값은 기존 radius를 유지한다.
     this.pieDataSet[this.pieDataSet.length - 1].ir = radius;
   },
 };

--- a/src/components/chart/plugins/plugins.pie.js
+++ b/src/components/chart/plugins/plugins.pie.js
@@ -1,3 +1,50 @@
+const alignToDevicePixel = (value, pixelRatio) => Math.round(value * pixelRatio) / pixelRatio;
+const ceilToDevicePixel = (value, pixelRatio) => Math.ceil(value * pixelRatio) / pixelRatio;
+
+const isTransparentColor = (color) => {
+  if (!color) {
+    return true;
+  }
+
+  const normalizedColor = color.trim().toLowerCase();
+
+  if (normalizedColor === 'transparent') {
+    return true;
+  }
+
+  const colorMatch = normalizedColor.match(
+    /rgba?\(\s*[\d.]+%?\s*(?:,|\s)\s*[\d.]+%?\s*(?:,|\s)\s*[\d.]+%?\s*(?:,|\/)\s*([\d.]+%?)\s*\)/,
+  );
+
+  if (!colorMatch) {
+    return false;
+  }
+
+  return Number.parseFloat(colorMatch[1]) === 0;
+};
+
+const resolveDoughnutHoleColor = (pieOption, rootElement) => {
+  const optionColor = pieOption?.doughnutHoleColor || pieOption?.backgroundColor;
+
+  if (!isTransparentColor(optionColor)) {
+    return optionColor;
+  }
+
+  let element = rootElement;
+
+  while (element) {
+    const backgroundColor = getComputedStyle(element)?.backgroundColor;
+
+    if (!isTransparentColor(backgroundColor)) {
+      return backgroundColor;
+    }
+
+    element = element.parentElement;
+  }
+
+  return '#fff';
+};
+
 const modules = {
   pieDataSet: [],
   /**
@@ -209,6 +256,30 @@ const modules = {
   },
 
   /**
+   * doughnutHoleColor 캐시를 무효화한다.
+   * 옵션 변경/리사이즈/리렌더 등으로 부모 DOM의 background-color 컨텍스트가
+   * 달라졌을 수 있을 때 호출한다.
+   */
+  invalidateDoughnutHoleColorCache() {
+    this.cachedDoughnutHoleColor = null;
+  },
+
+  /**
+   * 캐시된 doughnutHoleColor를 반환하거나, 없으면 한 번 계산해 캐시한다.
+   * tooltip hover 중 hole이 자주 다시 그려지므로(plugins.tooltip.js의 highlight 경로)
+   * 매 호출마다 getComputedStyle로 DOM을 거슬러 올라가지 않도록 한다.
+   */
+  getDoughnutHoleColor() {
+    if (this.cachedDoughnutHoleColor) {
+      return this.cachedDoughnutHoleColor;
+    }
+
+    const rootElement = this.chartDOM || this.wrapperDOM || this.target;
+    this.cachedDoughnutHoleColor = resolveDoughnutHoleColor(this.options, rootElement);
+    return this.cachedDoughnutHoleColor;
+  },
+
+  /**
    * Draw doughnut hole
    * @param ctx
    */
@@ -216,86 +287,43 @@ const modules = {
     const pieOption = this.options;
     const { width, height } = this.chartRect;
     const padding = this.options.padding;
-  
+
     const centerX = width / 2;
     const centerY = height / 2;
-  
+
     const chartWidth = centerX - (padding.left + padding.right);
     const chartHeight = centerY - (padding.bottom + padding.top);
-  
+
     if (
       (typeof chartWidth === 'number' && chartWidth < 0) ||
       (typeof chartHeight === 'number' && chartHeight < 0)
     ) {
       return;
     }
-  
+
     const radius = Math.min(chartWidth, chartHeight) * pieOption.doughnutHoleSize;
-  
+
     const pixelRatio = this.pixelRatio || window.devicePixelRatio || 1;
     const isFractionalPixelRatio = !Number.isInteger(pixelRatio);
-  
-    const alignToDevicePixel = (value) => Math.round(value * pixelRatio) / pixelRatio;
-    const ceilToDevicePixel = (value) => Math.ceil(value * pixelRatio) / pixelRatio;
-  
-    const adjustedCenterX = isFractionalPixelRatio ? alignToDevicePixel(centerX) : centerX;
-    const adjustedCenterY = isFractionalPixelRatio ? alignToDevicePixel(centerY) : centerY;
-  
+
+    const adjustedCenterX = isFractionalPixelRatio
+      ? alignToDevicePixel(centerX, pixelRatio)
+      : centerX;
+    const adjustedCenterY = isFractionalPixelRatio
+      ? alignToDevicePixel(centerY, pixelRatio)
+      : centerY;
+
     // fractional scale 환경에서 원 경계 잔여 픽셀이 남는 케이스를 줄이기 위해
     // hole 영역만 1 device pixel 정도 더 크게 덮는다.
     const erasePadding = isFractionalPixelRatio ? 1 / pixelRatio : 0;
     const adjustedRadius = isFractionalPixelRatio
-      ? ceilToDevicePixel(radius + erasePadding)
+      ? ceilToDevicePixel(radius + erasePadding, pixelRatio)
       : radius;
-  
-    const isTransparentColor = (color) => {
-      if (!color) {
-        return true;
-      }
-  
-      const normalizedColor = color.trim().toLowerCase();
-  
-      if (normalizedColor === 'transparent') {
-        return true;
-      }
-  
-      const colorMatch = normalizedColor.match(
-        /rgba?\(\s*[\d.]+%?\s*(?:,|\s)\s*[\d.]+%?\s*(?:,|\s)\s*[\d.]+%?\s*(?:,|\/)\s*([\d.]+%?)\s*\)/,
-      );
-  
-      if (!colorMatch) {
-        return false;
-      }
-  
-      return Number.parseFloat(colorMatch[1]) === 0;
-    };
-  
-    const getDoughnutHoleColor = () => {
-      const optionColor = pieOption?.doughnutHoleColor || pieOption?.backgroundColor;
-  
-      if (!isTransparentColor(optionColor)) {
-        return optionColor;
-      }
-  
-      let element = this.chartDOM || this.wrapperDOM || this.target;
-  
-      while (element && element !== document.documentElement) {
-        const backgroundColor = getComputedStyle(element)?.backgroundColor;
-  
-        if (!isTransparentColor(backgroundColor)) {
-          return backgroundColor;
-        }
-  
-        element = element.parentElement;
-      }
-  
-      return '#fff';
-    };
-  
-    const doughnutHoleColor = getDoughnutHoleColor();
-  
+
+    const doughnutHoleColor = this.getDoughnutHoleColor();
+
     ctx.save();
-  
+
     // 일부 GPU 가속 환경에서 destination-out 합성 경계가 깨지는 케이스가 있어,
     // hole을 투명하게 지우지 않고 실제 배경색으로 덮는다.
     ctx.globalCompositeOperation = 'source-over';
@@ -304,9 +332,9 @@ const modules = {
     ctx.arc(adjustedCenterX, adjustedCenterY, adjustedRadius, 0, Math.PI * 2);
     ctx.closePath();
     ctx.fill();
-  
+
     ctx.restore();
-  
+
     // inner stroke는 시각 보정용 adjustedRadius가 아니라 원래 논리 radius 기준으로 유지한다.
     if (pieOption?.pieStroke?.use) {
       ctx.beginPath();
@@ -316,7 +344,7 @@ const modules = {
       ctx.closePath();
       ctx.stroke();
     }
-  
+
     // adjustedRadius는 렌더링 보정값이므로 hit-test 등에 사용되는 내부 논리값은 기존 radius를 유지한다.
     this.pieDataSet[this.pieDataSet.length - 1].ir = radius;
   },

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -67,6 +67,7 @@ const DEFAULT_OPTIONS = {
   unSelectedOpacity: 0.3,
   useSelect: false,
   doughnutHoleSize: 0,
+  doughnutHoleColor: null,
   pieStroke: {
     use: true,
     lineWidth: 2,


### PR DESCRIPTION
## 문제
GPU 가속 환경에서 125% 배율(fractional scale) 사용 시
파이/도넛 차트 내부가 자글자글하게 깨져 보이는 현상 발생

## 원인
기존 도넛 홀은 destination-out 합성 모드로 중앙 영역을 투명하게 지우는 방식이었습니다.

일부 GPU 가속 Canvas 환경에서는 fractional scale과 함께 사용될 때 destination-out의 alpha composite 경계가 불안정하게 처리되어, 도넛 홀 테두리에 잔여 픽셀이 남는 것으로 판단했습니다.

기존에 검토했던 willReadFrequently: true 옵션은 GPU 렌더링 경로를 우회할 수는 있으나, 현재 차트 구조에서는 canvas readback이 없어 불필요하고 성능 저하 가능성이 있어 제외했습니다.

## 수정
- willReadFrequently: true 옵션 제거 ( 기존 수정 방향 )
- drawDoughnutHole()에서 destination-out 합성 방식 제거
- 도넛 hole 영역을 차트 배경색으로 덮는 방식으로 변경
- doughnutHoleColor 옵션이 있으면 우선 사용하고, 없으면 chart DOM의 실제 backgroundColor를 탐색하여 사용
- fractional scale 환경에서 center/radius를 pixelRatio 기준으로 보정
- 동작에 영향 없는 ctx.fillOpacity = 0 제거
- 내부 hit-test 등에 사용되는 ir 값은 기존 radius 유지

이슈 올리신 담당자 분 께, 로컬 공유해서 안 깨지는 것 확인 받았습니다!

<img width="132" height="116" alt="image" src="https://github.com/user-attachments/assets/c02c02a7-3304-416b-9b25-75a25884a237" />

Closes #2228