### PR TITLE
fix(chart): apply willReadFrequently option to canvas context

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -57,10 +57,10 @@ class EvChart {
 
     this.displayCanvas = document.createElement('canvas');
     this.displayCanvas.setAttribute('style', 'display: block;');
-    this.displayCtx = this.displayCanvas.getContext('2d');
+    this.displayCtx = this.displayCanvas.getContext('2d', { willReadFrequently: true });
     this.bufferCanvas = document.createElement('canvas');
     this.bufferCanvas.setAttribute('style', 'display: block;');
-    this.bufferCtx = this.bufferCanvas.getContext('2d');
+    this.bufferCtx = this.bufferCanvas.getContext('2d', { willReadFrequently: true });
 
     this.pixelRatio = window.devicePixelRatio || 1;
     this.oldPixelRatio = this.pixelRatio;


### PR DESCRIPTION
Closes #2227

## Summary

On Chrome with a fractional display scale (125%) and GPU acceleration enabled, pie and doughnut charts render with visible flickering inside the chart. Passing `willReadFrequently: true` to `getContext('2d')` on the display and buffer canvases nudges Chrome toward the software renderer for these contexts, which stabilises the output. This matches the issue's proposed fix and the general guidance for 2D canvases that are read frequently via `getImageData` (which `EvChart` does during rendering).

## Change

`src/components/chart/chart.core.js`:

```js
this.displayCtx = this.displayCanvas.getContext('2d', { willReadFrequently: true });
...
this.bufferCtx = this.bufferCanvas.getContext('2d', { willReadFrequently: true });
```

The other canvas contexts (`chartBrush`, `plugins.tooltip`, `chartZoom`, the internal `textMeasureCtx`, and the optional `overlayCtx`) are not adjusted, because the reported flicker is specific to the display + buffer canvases used by the main chart render loop. If a maintainer wants the same treatment on the tooltip/overlay/zoom canvases, happy to follow up in a separate PR.

## Testing

- `npm run lint` passes
- `npm run build:lib` builds cleanly (815 modules transformed)
- Visual fix can't be verified without a 125%-scale Windows/Chrome setup, so relying on the screenshots in #2227 for the behavior confirmation.
