### PR TITLE
fix: scale time 축 라벨 표시 개수 감소

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -232,7 +232,7 @@ class EvChart {
         // 라벨의 소수점이 변경될때 너비 팽창을 사전에 반영한다.
         let extraFormattedLabels = [];
         const axesStepsX = this.axesSteps?.x[index];
-        if (axis?.type !== 'step' && axesStepsX != null) {
+        if (axis?.type === 'linear' && axesStepsX != null) {
           const { graphMin, graphMax } = axesStepsX;
           if (typeof graphMin === 'number' && typeof graphMax === 'number') {
             const widestNumeric = Math.abs(graphMin) >= Math.abs(graphMax) ? graphMin : graphMax;


### PR DESCRIPTION
[이슈]
#2219 라벨 겹침 현상 해결되면서 축이 time일때도 로직이 적용되어 기존 라벨 개수보다 적게 표시됨

[수정 내용]
너비 팽창 사전 반영을 축의 타입이 linear일때만 반영

[이전 동작]
<img width="652" height="477" alt="image" src="https://github.com/user-attachments/assets/abfd9fc6-5bff-49d9-a86a-5de8ebb2e389" />

[이후 동작]
<img width="493" height="486" alt="image" src="https://github.com/user-attachments/assets/3b0fddbe-683f-4eac-8b45-acec915ec5c4" />

[테스트 방법]
x축의 type이 time인 차트일때 이전보다 라벨 표시가 증가되었는지 확인해주세요.
