### PR TITLE
fix: scale time 축 categoryMode일때 라벨 겹침 현상

### DIFF
--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -189,7 +189,7 @@ class TimeCategoryScale extends Scale {
     // 첫번째 라벨이 축 시작점보다 오른쪽에 있을 경우, count를 1로 설정
     // 추후 개선 필요: 근본적 문제는 라벨이 2개인 경우 oriSteps가 1로 와야하는데 2로 옴. horizontal일 때 예외처리 필요.
     const isStartPointRightOfRectStart = startPoint > Math.ceil(aPos[this.units.rectStart]);
-    if (this.type === 'x' && isStartPointRightOfRectStart && count === oriSteps) {
+    if (this.type === 'x' && isStartPointRightOfRectStart && count === oriSteps && oriSteps <= 2) {
       count = 1;
     }
 

--- a/src/components/chart/scale/scale.time.category.js
+++ b/src/components/chart/scale/scale.time.category.js
@@ -184,14 +184,7 @@ class TimeCategoryScale extends Scale {
     let ix;
 
     // 2개 이하일 경우, 첫번째와 마지막 라벨만 표시
-    let count = steps <= 2 ? oriSteps : Math.round(oriSteps / steps);
-
-    // 첫번째 라벨이 축 시작점보다 오른쪽에 있을 경우, count를 1로 설정
-    // 추후 개선 필요: 근본적 문제는 라벨이 2개인 경우 oriSteps가 1로 와야하는데 2로 옴. horizontal일 때 예외처리 필요.
-    const isStartPointRightOfRectStart = startPoint > Math.ceil(aPos[this.units.rectStart]);
-    if (this.type === 'x' && isStartPointRightOfRectStart && count === oriSteps && oriSteps <= 2) {
-      count = 1;
-    }
+    const count = steps <= 2 ? Math.max(1, oriSteps - 1) : Math.round(oriSteps / steps);
 
     const maxIndex = count === oriSteps ? oriSteps : oriSteps - 1;
 
@@ -273,11 +266,7 @@ class TimeCategoryScale extends Scale {
           ctx.closePath();
         }
 
-        if (
-          ix < oriSteps &&
-          this.showGrid &&
-          (isStartPointRightOfRectStart || (!isStartPointRightOfRectStart && ix !== 0))
-        ) {
+        if (ix < oriSteps && this.showGrid) {
           ctx.beginPath();
           ctx.strokeStyle = this.gridLineColor;
           ctx.moveTo(linePosition, offsetPoint);
@@ -298,11 +287,7 @@ class TimeCategoryScale extends Scale {
           ctx.closePath();
         }
 
-        if (
-          ix < oriSteps &&
-          this.showGrid &&
-          (isStartPointRightOfRectStart || (!isStartPointRightOfRectStart && ix !== 0))
-        ) {
+        if (ix < oriSteps && this.showGrid) {
           ctx.beginPath();
           ctx.strokeStyle = this.gridLineColor;
           ctx.moveTo(offsetPoint, linePosition);

--- a/src/components/chart/scale/scale.time.category.spec.js
+++ b/src/components/chart/scale/scale.time.category.spec.js
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import dayjs from 'dayjs';
+import { describe, it, expect, vi } from 'vitest';
+import { AXIS_UNITS } from '../helpers/helpers.constant';
 import TimeCategoryScale from './scale.time.category';
+
+const HOUR = 3600_000;
 
 const createScale = (overrides = {}) => {
   const scale = Object.create(TimeCategoryScale.prototype);
@@ -9,6 +13,66 @@ const createScale = (overrides = {}) => {
   return scale;
 };
 
+const createCtxMock = () => ({
+  font: '',
+  textAlign: '',
+  textBaseline: '',
+  fillStyle: '',
+  strokeStyle: '',
+  lineWidth: 1,
+  beginPath: vi.fn(),
+  stroke: vi.fn(),
+  closePath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  fillText: vi.fn(),
+  measureText: vi.fn(() => ({ width: 0 })),
+});
+
+/**
+ * draw() 호출에 필요한 최소한의 scale 인스턴스를 생성한다.
+ * stepInfo는 calculateSteps()의 실제 반환값 또는 수동으로 구성한 값을 전달한다.
+ */
+const createDrawableScale = (overrides = {}) => {
+  const ctx = createCtxMock();
+  const scale = Object.create(TimeCategoryScale.prototype);
+
+  scale.type = 'x';
+  scale.position = 'bottom';
+  scale.categoryMode = true;
+  scale.interval = 'hour';
+  scale.timeFormat = 'HH:mm';
+  scale.formatter = null;
+  scale.labelStyle = {
+    color: '#000000',
+    alignToGridLine: false,
+    fontSize: 11,
+    fontStyle: 'normal',
+    fontWeight: 'normal',
+    fontFamily: 'Arial',
+    fitWidth: false,
+    fitDir: 'right',
+    fixWidth: undefined,
+  };
+  scale.axisLineWidth = 1;
+  scale.axisLineColor = '#cccccc';
+  scale.gridLineColor = '#eeeeee';
+  scale.showGrid = false;
+  scale.showAxisTick = false;
+  scale.options = {};
+  scale.labels = [];
+  scale.units = AXIS_UNITS.x;
+  scale.drawAxisTitle = vi.fn();
+  scale.ctx = ctx;
+
+  Object.assign(scale, overrides);
+  return scale;
+};
+
+const chartRect = { x1: 0, x2: 600, y1: 0, y2: 300 };
+const labelOffset = { left: 0, right: 0, top: 0, bottom: 0 };
+
+// ─────────────────────────────────────────────────
 describe('TimeCategoryScale', () => {
   describe('getInterval', () => {
     it('사용자 지정 interval이 숫자이면 그대로 반환한다', () => {
@@ -39,6 +103,131 @@ describe('TimeCategoryScale', () => {
       const scale = createScale();
       const result = scale.getInterval({ maxValue: 100, minValue: 0, maxSteps: 3 });
       expect(result).toBe(34);
+    });
+  });
+
+  // ─────────────────────────────────────────────────
+  describe('calculateSteps', () => {
+    it('데이터 2개 → oriSteps=2, steps=2를 반환한다', () => {
+      const t0 = dayjs('2026-01-01 00:00:00').valueOf();
+      const t1 = dayjs('2026-01-01 01:00:00').valueOf();
+      const scale = createScale({ interval: 'hour' });
+
+      const result = scale.calculateSteps({
+        minValue: t0,
+        maxValue: t1,
+        maxSteps: 10,
+      });
+
+      expect(result.oriSteps).toBe(2);
+      expect(result.steps).toBe(2);
+    });
+
+    it('데이터 5개 → oriSteps=5, steps=5를 반환한다', () => {
+      const t0 = dayjs('2026-01-01 00:00:00').valueOf();
+      const t4 = dayjs('2026-01-01 04:00:00').valueOf();
+      const scale = createScale({ interval: 'hour' });
+
+      const result = scale.calculateSteps({
+        minValue: t0,
+        maxValue: t4,
+        maxSteps: 10,
+      });
+
+      expect(result.oriSteps).toBe(5);
+      expect(result.steps).toBe(5);
+    });
+
+    it('maxSteps보다 데이터가 많으면 steps가 maxSteps 이하로 줄어든다', () => {
+      const t0 = dayjs('2026-01-01 00:00:00').valueOf();
+      const t9 = dayjs('2026-01-01 09:00:00').valueOf();
+      const scale = createScale({ interval: 'hour' });
+
+      const result = scale.calculateSteps({
+        minValue: t0,
+        maxValue: t9,
+        maxSteps: 3,
+      });
+
+      expect(result.oriSteps).toBe(10);
+      expect(result.steps).toBeLessThanOrEqual(3);
+    });
+
+    it('graphMin/graphMax를 올바르게 반환한다', () => {
+      const t0 = dayjs('2026-01-01 00:00:00').valueOf();
+      const t1 = dayjs('2026-01-01 01:00:00').valueOf();
+      const scale = createScale({ interval: 'hour' });
+
+      const result = scale.calculateSteps({
+        minValue: t0,
+        maxValue: t1,
+        maxSteps: 10,
+      });
+
+      expect(result.graphMin).toBe(t0);
+      expect(result.graphMax).toBe(t1);
+    });
+  });
+
+  // ─────────────────────────────────────────────────
+  describe('draw - steps <= 2 라벨 렌더링', () => {
+    const t0 = dayjs('2026-01-01 00:00:00').valueOf();
+
+    const getDrawnLabels = (scale, stepInfo) => {
+      scale.draw(chartRect, labelOffset, stepInfo, null, null);
+      return scale.ctx.fillText.mock.calls.map(([text]) => text);
+    };
+
+    it('데이터 2개일 때 첫번째·마지막 라벨이 모두 그려진다', () => {
+      const t1 = t0 + HOUR;
+      const scale = createDrawableScale({
+        labels: [dayjs(t0), dayjs(t1)],
+        timeFormat: 'HH:mm',
+      });
+      const stepInfo = { steps: 2, oriSteps: 2, rawInterval: HOUR, graphMin: t0, graphMax: t1 };
+
+      const labels = getDrawnLabels(scale, stepInfo);
+
+      expect(labels).toHaveLength(2);
+      expect(labels[0]).toBe(dayjs(t0).format('HH:mm'));
+      expect(labels[1]).toBe(dayjs(t1).format('HH:mm'));
+    });
+
+    it('oriSteps > steps=2로 압축될 때 첫·마지막 라벨만 그려진다', () => {
+      const t9 = t0 + 9 * HOUR;
+      const labels = Array.from({ length: 10 }, (_, i) => dayjs(t0 + i * HOUR));
+      const scale = createDrawableScale({ labels, timeFormat: 'HH:mm' });
+      const stepInfo = { steps: 2, oriSteps: 10, rawInterval: HOUR, graphMin: t0, graphMax: t9 };
+
+      const drawn = getDrawnLabels(scale, stepInfo);
+
+      expect(drawn).toHaveLength(2);
+      expect(drawn[0]).toBe(dayjs(t0).format('HH:mm'));
+      expect(drawn[1]).toBe(dayjs(t9).format('HH:mm'));
+    });
+
+    it('alignToGridLine: true일 때 데이터 2개 모두 그려진다', () => {
+      const t1 = t0 + HOUR;
+      const scale = createDrawableScale({
+        labels: [dayjs(t0), dayjs(t1)],
+        timeFormat: 'HH:mm',
+        labelStyle: {
+          color: '#000000',
+          alignToGridLine: true,
+          fontSize: 11,
+          fontStyle: 'normal',
+          fontWeight: 'normal',
+          fontFamily: 'Arial',
+          fitWidth: false,
+          fitDir: 'right',
+          fixWidth: undefined,
+        },
+      });
+      const stepInfo = { steps: 2, oriSteps: 2, rawInterval: HOUR, graphMin: t0, graphMax: t1 };
+
+      const drawn = getDrawnLabels(scale, stepInfo);
+
+      expect(drawn.length).toBeGreaterThanOrEqual(2);
     });
   });
 });


### PR DESCRIPTION
[이슈]
1. scale time 축 categoryMode: true일때 라벨 겹침 현상
2. 라벨이 2개일때 마지막 라벨이 표시되지 않는 현상
- #2002 임시로 처리했던 로직에서 oristeps가 2개 이상일 경우에 count:1로 변경되면서 라벨 겹침 현상 발생

[수정 내용]
count 게산 로직 변경
- oristeps 2이하일때 Math.max(1, oristeps-1)로 하여 최소 개수를 1로 변경

[이전 동작]
<img width="619" height="549" alt="image" src="https://github.com/user-attachments/assets/1b09d8a6-e6f3-4844-acdb-bcf8636b7d4f" />

[이후 동작]
<img width="1440" height="1024" alt="Apr-20-2026 14-56-20" src="https://github.com/user-attachments/assets/3db3e194-18ae-4424-81f6-90774073fcd3" />

[테스트 방법]
1. bar chart > Time 예제에서 넓이를 줄였을때 라벨 겹침 현상이 발생되는지 확인해주세요.
2. 축의 타입이 time이고 categoryMode: true일때 라벨이 2개이면 마지막 라벨이 표시되는지 확인해주세요.
   - bar chart > Time 예제 onMounted의 for문 조건을 2로 변경
   - combo chart > Line&Bar 예제 onMounted의 for문 조건을 2로 변경
   
   ```
   onMounted(() => {
      for (let ix = 0; ix < 2; ix++) {
        addRandomChartData();
      }
    });
    ```