### PR TITLE
fix: Chart > Dense 데이터에서 hover snap이 불안정하게 동작하는 문제

### DIFF
--- a/docs/views/lineChart/example/Default.vue
+++ b/docs/views/lineChart/example/Default.vue
@@ -1,8 +1,12 @@
 <template>
   <div class="case">
-    <resizable-wrapper>
+    <div
+      v-for="chartIndex in chartCount"
+      :key="chartIndex"
+      class="chart-item"
+    >
       <ev-chart :data="chartData" :options="chartOptions" />
-    </resizable-wrapper>
+    </div>
   </div>
   <div class="description">
     <span class="toggle-label">데이터 자동 업데이트</span>
@@ -16,6 +20,8 @@ import dayjs from 'dayjs';
 
 export default {
   setup() {
+    const chartCount = 16;
+    const minutePointsInDay = 24 * 60;
     const chartData = reactive({
       series: {
         series1: { name: '정수', point: false },
@@ -49,14 +55,14 @@ export default {
         show: true,
       },
       legend: {
-        show: true,
+        show: false,
         position: 'right',
       },
       axesX: [
         {
           type: 'time',
           timeFormat: 'DD HH:mm',
-          interval: 'hour',
+          interval: { time: 10, unit: 'minute' },
           formatter: (value, data) => {
             if (data?.prev) {
               const curr = dayjs(value).format('yy-MM-DD');
@@ -88,14 +94,14 @@ export default {
 
     const isLive = ref(false);
     const liveInterval = ref();
-    let timeValue = dayjs().format('YYYY-MM-DD HH:mm:ss');
+    let timeValue = dayjs().subtract(24, 'hour').format('YYYY-MM-DD HH:mm:ss');
 
     const addRandomChartData = () => {
       if (isLive.value) {
         chartData.labels.shift();
       }
 
-      timeValue = dayjs(timeValue).add(1, 'hour');
+      timeValue = dayjs(timeValue).add(1, 'minute');
       chartData.labels.push(dayjs(timeValue));
 
       Object.values(chartData.data).forEach((seriesData, sIndex) => {
@@ -120,7 +126,7 @@ export default {
     };
 
     onMounted(() => {
-      for (let ix = 0; ix < 60; ix++) {
+      for (let ix = 0; ix < minutePointsInDay; ix++) {
         addRandomChartData();
       }
     });
@@ -141,6 +147,7 @@ export default {
     return {
       chartData,
       chartOptions,
+      chartCount,
       isLive,
     };
   },
@@ -148,6 +155,16 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.case {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.chart-item {
+  min-height: 220px;
+}
+
 .toggle-label {
   vertical-align: top;
   margin-right: 7px;

--- a/docs/views/lineChart/example/Default.vue
+++ b/docs/views/lineChart/example/Default.vue
@@ -1,12 +1,8 @@
 <template>
   <div class="case">
-    <div
-      v-for="chartIndex in chartCount"
-      :key="chartIndex"
-      class="chart-item"
-    >
+    <resizable-wrapper>
       <ev-chart :data="chartData" :options="chartOptions" />
-    </div>
+    </resizable-wrapper>
   </div>
   <div class="description">
     <span class="toggle-label">데이터 자동 업데이트</span>
@@ -20,8 +16,6 @@ import dayjs from 'dayjs';
 
 export default {
   setup() {
-    const chartCount = 16;
-    const minutePointsInDay = 24 * 60;
     const chartData = reactive({
       series: {
         series1: { name: '정수', point: false },
@@ -55,14 +49,14 @@ export default {
         show: true,
       },
       legend: {
-        show: false,
+        show: true,
         position: 'right',
       },
       axesX: [
         {
           type: 'time',
           timeFormat: 'DD HH:mm',
-          interval: { time: 10, unit: 'minute' },
+          interval: 'hour',
           formatter: (value, data) => {
             if (data?.prev) {
               const curr = dayjs(value).format('yy-MM-DD');
@@ -94,14 +88,14 @@ export default {
 
     const isLive = ref(false);
     const liveInterval = ref();
-    let timeValue = dayjs().subtract(24, 'hour').format('YYYY-MM-DD HH:mm:ss');
+    let timeValue = dayjs().format('YYYY-MM-DD HH:mm:ss');
 
     const addRandomChartData = () => {
       if (isLive.value) {
         chartData.labels.shift();
       }
 
-      timeValue = dayjs(timeValue).add(1, 'minute');
+      timeValue = dayjs(timeValue).add(1, 'hour');
       chartData.labels.push(dayjs(timeValue));
 
       Object.values(chartData.data).forEach((seriesData, sIndex) => {
@@ -126,7 +120,7 @@ export default {
     };
 
     onMounted(() => {
-      for (let ix = 0; ix < minutePointsInDay; ix++) {
+      for (let ix = 0; ix < 60; ix++) {
         addRandomChartData();
       }
     });
@@ -147,7 +141,6 @@ export default {
     return {
       chartData,
       chartOptions,
-      chartCount,
       isLive,
     };
   },
@@ -155,16 +148,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.case {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.chart-item {
-  min-height: 220px;
-}
-
 .toggle-label {
   vertical-align: top;
   margin-right: 7px;

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -1170,6 +1170,7 @@ const modules = {
         selectLabel?.useApproximateValue,
         dataIndex,
         true,
+        true,
       );
       labelIndex = hitInfo.dataIndex ?? -1;
     }

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1166,7 +1166,7 @@ const modules = {
           const passingValue = series.passingValue;
           const interpolation = series.interpolation;
           const hasPassingValueInData = series.hasPassingValueInData;
-    
+
           return (
             interpolation === 'linear' ||
             (interpolation === 'none' && !!passingValue && hasPassingValueInData)

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1161,7 +1161,7 @@ const modules = {
     if (closestDistance >= snapThreshold) {
       const useLinearInterpolation = sIds.some((sId) => {
         const series = this.seriesList[sId];
-    
+
         if (series?.show) {
           const passingValue = series.passingValue;
           const interpolation = series.interpolation;
@@ -1172,13 +1172,12 @@ const modules = {
             (interpolation === 'none' && !!passingValue && hasPassingValueInData)
           );
         }
-    
+
         return false;
       });
-    
       return useLinearInterpolation ? closestIndex : -1;
     }
-    
+
     return closestIndex;
   },
 

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1150,27 +1150,32 @@ const modules = {
       return -1;
     }
     
-    const useLinearInterpolation = sIds.some((sId) => {
-      const series = this.seriesList[sId];
-    
-      if (series?.show) {
-        const passingValue = series.passingValue;
-        const interpolation = series.interpolation;
-        const hasPassingValueInData = series.hasPassingValueInData;
-    
-        return (
-          interpolation === 'linear' ||
-          (interpolation === 'none' && !!passingValue && hasPassingValueInData)
-        );
-      }
-    
-      return false;
-    });
-    
-    // 데이터가 매우 촘촘할 때 avgInterval이 1px 이하로 작아질 수 있으므로 최소 snap 범위를 보정
-    const snapThreshold = Math.max(avgInterval, 6);
+    // 최소 hover snap 반경 (px)
+    // - 데이터 밀도가 높을 때 avgInterval이 1px 이하로 감소하는 문제 보정
+    // - 마우스 포인터의 실제 조작 정밀도(≈1px 이하)보다 충분히 넓은 범위를 확보하여 안정적인 hover 보장
+    // - 주요 차트 라이브러리 기준: tooltip.snap 기본값 10px (touch 25px)
+    // → 6px은 과도하게 넓지 않으면서도 안정적인 선택이 가능한 절충값
+    const MIN_SNAP_THRESHOLD_PX = 6;
+    const snapThreshold = Math.max(avgInterval, MIN_SNAP_THRESHOLD_PX);
     
     if (closestDistance >= snapThreshold) {
+      const useLinearInterpolation = sIds.some((sId) => {
+        const series = this.seriesList[sId];
+    
+        if (series?.show) {
+          const passingValue = series.passingValue;
+          const interpolation = series.interpolation;
+          const hasPassingValueInData = series.hasPassingValueInData;
+    
+          return (
+            interpolation === 'linear' ||
+            (interpolation === 'none' && !!passingValue && hasPassingValueInData)
+          );
+        }
+    
+        return false;
+      });
+    
       return useLinearInterpolation ? closestIndex : -1;
     }
     

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1145,27 +1145,35 @@ const modules = {
         }
       }
     }
-
-    if (closestDistance >= avgInterval) {
-      const useLinearInterpolation = sIds.some((sId) => {
-        const series = this.seriesList[sId];
-
-        if (series?.show) {
-          const passingValue = series.passingValue;
-          const interpolation = series.interpolation;
-          const hasPassingValueInData = series.hasPassingValueInData;
-
-          return (
-            interpolation === 'linear' ||
-            (interpolation === 'none' && !!passingValue && hasPassingValueInData)
-          );
-        }
-
-        return false;
-      });
+    
+    if (closestIndex === -1) {
+      return -1;
+    }
+    
+    const useLinearInterpolation = sIds.some((sId) => {
+      const series = this.seriesList[sId];
+    
+      if (series?.show) {
+        const passingValue = series.passingValue;
+        const interpolation = series.interpolation;
+        const hasPassingValueInData = series.hasPassingValueInData;
+    
+        return (
+          interpolation === 'linear' ||
+          (interpolation === 'none' && !!passingValue && hasPassingValueInData)
+        );
+      }
+    
+      return false;
+    });
+    
+    // 데이터가 매우 촘촘할 때 avgInterval이 1px 이하로 작아질 수 있으므로 최소 snap 범위를 보정
+    const snapThreshold = Math.max(avgInterval, 6);
+    
+    if (closestDistance >= snapThreshold) {
       return useLinearInterpolation ? closestIndex : -1;
     }
-
+    
     return closestIndex;
   },
 

--- a/src/components/chart/plugins/plugins.interaction.spec.js
+++ b/src/components/chart/plugins/plugins.interaction.spec.js
@@ -17,6 +17,12 @@ const createChart = (seriesList, opts = {}) =>
     isNotUseIndicator: () => false,
   });
 
+const createChartForClosestIndex = (seriesList, opts = {}) =>
+  Object.assign(Object.create(modules), {
+    seriesList,
+    options: { horizontal: false, ...opts },
+  });
+
 /**
  * findGraphData가 고정된 item을 리턴하는 mock 시리즈.
  */
@@ -41,6 +47,20 @@ const mockSeries = ({
     directHit,
     index: data?.index ?? 0,
   }),
+});
+
+const createClosestSeries = ({
+  data,
+  show = true,
+  interpolation = 'none',
+  passingValue = null,
+  hasPassingValueInData = false,
+}) => ({
+  show,
+  data,
+  interpolation,
+  passingValue,
+  hasPassingValueInData,
 });
 
 describe('plugins.interaction findHitItem', () => {
@@ -161,5 +181,72 @@ describe('plugins.interaction findHitItem', () => {
       expect(Object.keys(result.items).sort()).toEqual(['bar1', 'line1']);
       expect(result.hitId).toBe('bar1');
     });
+  });
+});
+
+describe('plugins.interaction findClosestDataIndex', () => {
+  it('avgInterval < 6 이고 closestDistance < 6 이면 closestIndex를 반환한다', () => {
+    const chart = createChartForClosestIndex({
+      s1: createClosestSeries({
+        data: [
+          { xp: 10, yp: 100, o: 1 },
+          { xp: 14, yp: 100, o: 2 },
+          { xp: 18, yp: 100, o: 3 },
+        ],
+      }),
+    });
+
+    const result = chart.findClosestDataIndex([16, 0], ['s1']);
+    expect(result).toBe(1);
+  });
+
+  it('avgInterval > 6 이고 closestDistance < avgInterval 이면 closestIndex를 반환한다', () => {
+    const chart = createChartForClosestIndex({
+      s1: createClosestSeries({
+        data: [
+          { xp: 10, yp: 100, o: 1 },
+          { xp: 30, yp: 100, o: 2 },
+          { xp: 50, yp: 100, o: 3 },
+        ],
+      }),
+    });
+
+    const result = chart.findClosestDataIndex([37, 0], ['s1']);
+    expect(result).toBe(1);
+  });
+
+  it('closestDistance가 snapThreshold보다 크고 선형보간이 꺼져 있으면 -1을 반환한다', () => {
+    const chart = createChartForClosestIndex({
+      s1: createClosestSeries({
+        interpolation: 'none',
+        data: [
+          { xp: 10, yp: 100, o: 1 },
+          { xp: 20, yp: 100, o: 2 },
+        ],
+      }),
+    });
+
+    const result = chart.findClosestDataIndex([100, 0], ['s1']);
+    expect(result).toBe(-1);
+  });
+
+  it('모든 데이터가 null이고 disableNullLabelSnap=false면 -1을 반환한다', () => {
+    const chart = createChartForClosestIndex({
+      s1: createClosestSeries({
+        data: [
+          { xp: 10, yp: null, o: null },
+          { xp: 20, yp: null, o: null },
+        ],
+      }),
+      s2: createClosestSeries({
+        data: [
+          { xp: 10, yp: null, o: null },
+          { xp: 20, yp: null, o: null },
+        ],
+      }),
+    });
+
+    const result = chart.findClosestDataIndex([12, 0], ['s1', 's2'], false);
+    expect(result).toBe(-1);
   });
 });


### PR DESCRIPTION
### 개요 
- 동일한 크기의 차트를 여러 개 배치했을 때, 일부 차트는 hover 시 정상적으로 index 반환
- 일부 차트는 동일 조건에서도 -1 반환
- 특히 고밀도 데이터 (예: 24시간 / 1분 간격)에서 빈번하게 발생

### 재현 조건
- 차트 width 360px 이하 
- 데이터 개수 : 1분 간격 24시간 (약 1440개)
- 마우스를 올려도 툴팁이 발생하지 않음 

### 원인 분석 
- `avgInterval` 은 데이터간의 평균 픽셀 간격 
- 데이터가 많아질수록 값이 급격히 작아짐 
- 마우스 좌표 오차는 일반적으로 0.1~0.5px
- threshold가 0.167px이면, 거의 대부분 경우 조건 실패

### 변경 내용 
- 최소 snap threshold 도입 
   - 데이터 간격(avgInterval)이 1px 이하로 작아지는 경우에도 일관된 hover 동작 보장
   - 사용자 기준에서 자연스러운 hover 범위 유지
   
 ### 근거 (차트 라이브러리 사례) 
1. Highcharts
   -  tooltip.snap (픽셀 단위 threshold 제공)
2. Chart.js
   - nearest element를 픽셀 거리 기반으로 선택
3. ECharts
   - 내부적으로 mouse proximity 기반 hit test
4. 공통점
   - hover 판정은 데이터 간격이 아니라 픽셀 거리 기반
   
### Before
   - <img width="1896" height="638" alt="260424_before" src="https://github.com/user-attachments/assets/453989c7-5b4d-4fd9-9396-1754fa0292a5" />
### After
   - <img width="1896" height="638" alt="완벽히 모르겠음" src="https://github.com/user-attachments/assets/263bb598-5cac-4d65-a431-ce16f70e801d" />


### 테스트 가이드 
- 툴팁이 정상적으로 보이는지 확인해주세요 
- 특히, 데이터 간격이 어느 정도 거리가 있는 차트일때, 이전처럼 가장 가까운 데이터 포인트에 붙는지 확인해주세요

### TODO
- 테스트 코드 제거