### PR TITLE
fix: Chart > Scatter > 범례 hover 했을때 드래그 영역 사라짐

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -1088,7 +1088,11 @@ class EvChart {
     if (isDragMove) {
       this.drawSelectionArea(this.dragInfo);
     } else if (this.dragInfoBackup) {
-      this.dragInfoBackup = null;
+      if (lightUpdate) {
+        this.drawSelectionArea(this.dragInfoBackup);
+      } else {
+        this.dragInfoBackup = null;
+      }
     }
   }
 


### PR DESCRIPTION
## 이슈
Chart > Scatter 에서 드래그 옵션이 keepDisplay: true 일때 범례 hover 하는 경우 드래그 영역 사라짐

## 변경 내용
범례가 hover일때는 lightUpdate: true 이므로 lightUpdate인 경우에는 dargBackupInfo가 있을때 드래그 영역을 그려줌

## 이전 동작
<img width="1148" height="788" alt="Apr-24-2026 10-59-39" src="https://github.com/user-attachments/assets/7ed7a320-8d5c-4bf2-bee0-a71b3339c75b" />

## 이후 동작
<img width="1148" height="788" alt="Apr-24-2026 11-29-49" src="https://github.com/user-attachments/assets/4f445195-b804-4fcb-a460-0bd29acdee2f" />

## 테스트 방법
scatter > Event 예제에서 확인 가능