### PR TITLE
[#2243] 차트 > 표시 가능한 라벨 개수 계산 로직 완화

### DIFF
--- a/docs/views/lineChart/example/Default.vue
+++ b/docs/views/lineChart/example/Default.vue
@@ -56,7 +56,7 @@ export default {
         {
           type: 'time',
           timeFormat: 'DD HH:mm',
-          interval: { time: 12, unit: 'hour' },
+          interval: { time: 1, unit: 'hour' },
           formatter: (value, data) => {
             if (data?.prev) {
               const curr = dayjs(value).format('yy-MM-DD');

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -43,17 +43,17 @@ class Scale {
 
     if (type === 'x') {
       chartSize = chartRect.chartWidth;
-      bufferedTickSize = Math.floor(tickSize * 1.1);
+      bufferedTickSize = Math.floor(tickSize * 1.2);
       axisOffset = [labelOffset.left, labelOffset.right];
     } else {
       chartSize = chartRect.chartHeight;
       axisOffset = [labelOffset.top, labelOffset.bottom];
-      bufferedTickSize = tickSize + Math.floor(chartSize * 0.1);
+      bufferedTickSize = Math.floor(tickSize * 1.5);
     }
 
     const drawRange = chartSize - (axisOffset[0] + axisOffset[1]);
     const minSteps = 1;
-    const maxSteps = Math.max(Math.floor(drawRange / bufferedTickSize) - 1, 1);
+    const maxSteps = Math.max(Math.floor(drawRange / bufferedTickSize), 1);
 
     return {
       min: minSteps,

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -48,7 +48,7 @@ class Scale {
     } else {
       chartSize = chartRect.chartHeight;
       axisOffset = [labelOffset.top, labelOffset.bottom];
-      bufferedTickSize = Math.floor(tickSize * 1.5);
+      bufferedTickSize = tickSize + Math.floor(chartSize * 0.1);
     }
 
     const drawRange = chartSize - (axisOffset[0] + axisOffset[1]);

--- a/src/components/chart/scale/scale.spec.js
+++ b/src/components/chart/scale/scale.spec.js
@@ -72,9 +72,9 @@ describe('Scale', () => {
           { top: 20, bottom: 20 },
           14,
         );
-        // drawRange=360, bufferedTickSize=floor(14*1.5)=21
-        // maxSteps=floor(360/21)=17
-        expect(result.max).toBe(17);
+        // drawRange=360, bufferedTickSize=14+floor(400*0.1)=14+40=54
+        // maxSteps=floor(360/54)=6
+        expect(result.max).toBe(6);
       });
 
       it('좁은 캔버스에서도 maxSteps가 최소 1을 반환한다', () => {
@@ -85,12 +85,12 @@ describe('Scale', () => {
           { top: 10, bottom: 10 },
           30,
         );
-        // drawRange=30, bufferedTickSize=floor(30*1.5)=45
-        // floor(30/45)=0 → Math.max(0,1)=1
+        // drawRange=30, bufferedTickSize=30+floor(50*0.1)=30+5=35
+        // floor(30/35)=0 → Math.max(0,1)=1
         expect(result.max).toBe(1);
       });
 
-      it('버퍼 배율 1.5가 적용된다', () => {
+      it('차트 높이에 비례하여 버퍼가 증가한다', () => {
         const scale = createScale();
         const result = scale.calculateLabelRange(
           'y',
@@ -98,28 +98,9 @@ describe('Scale', () => {
           { top: 0, bottom: 0 },
           20,
         );
-        // drawRange=300, bufferedTickSize=floor(20*1.5)=30
-        // maxSteps=floor(300/30)=10
-        expect(result.max).toBe(10);
-      });
-
-      it('차트 높이가 달라져도 동일한 tickSize면 bufferedTickSize가 동일하다', () => {
-        const scale = createScale();
-        const result300 = scale.calculateLabelRange(
-          'y',
-          { chartHeight: 300 },
-          { top: 0, bottom: 0 },
-          14,
-        );
-        const result600 = scale.calculateLabelRange(
-          'y',
-          { chartHeight: 600 },
-          { top: 0, bottom: 0 },
-          14,
-        );
-        // bufferedTickSize = floor(14*1.5) = 21 (차트 높이와 무관)
-        // 300: floor(300/21)=14, 600: floor(600/21)=28
-        expect(result600.max).toBe(result300.max * 2);
+        // drawRange=300, bufferedTickSize=20+floor(300*0.1)=20+30=50
+        // maxSteps=floor(300/50)=6
+        expect(result.max).toBe(6);
       });
     });
   });

--- a/src/components/chart/scale/scale.spec.js
+++ b/src/components/chart/scale/scale.spec.js
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import Scale from './scale';
+
+const createScale = () => {
+  const scale = Object.create(Scale.prototype);
+  return scale;
+};
+
+describe('Scale', () => {
+  describe('calculateLabelRange', () => {
+    describe('x축', () => {
+      it('drawRange 내에 라벨이 여러 개 들어갈 수 있으면 maxSteps > 1을 반환한다', () => {
+        const scale = createScale();
+        const result = scale.calculateLabelRange(
+          'x',
+          { chartWidth: 500 },
+          { left: 50, right: 50 },
+          60,
+        );
+        // drawRange=400, bufferedTickSize=floor(60*1.2)=72
+        // maxSteps=floor(400/72)=5
+        expect(result.max).toBe(5);
+        expect(result.min).toBe(1);
+      });
+
+      it('좁은 캔버스에서도 maxSteps가 최소 1을 반환한다', () => {
+        const scale = createScale();
+        const result = scale.calculateLabelRange(
+          'x',
+          { chartWidth: 100 },
+          { left: 30, right: 30 },
+          60,
+        );
+        // drawRange=40, bufferedTickSize=72
+        // floor(40/72)=0 → Math.max(0,1)=1
+        expect(result.max).toBe(1);
+      });
+
+      it('tickSize가 작으면 더 많은 라벨이 표시된다', () => {
+        const scale = createScale();
+        const result = scale.calculateLabelRange(
+          'x',
+          { chartWidth: 400 },
+          { left: 50, right: 50 },
+          30,
+        );
+        // drawRange=300, bufferedTickSize=floor(30*1.2)=36
+        // maxSteps=floor(300/36)=8
+        expect(result.max).toBe(8);
+      });
+
+      it('버퍼 배율 1.2가 적용된다', () => {
+        const scale = createScale();
+        const result = scale.calculateLabelRange(
+          'x',
+          { chartWidth: 300 },
+          { left: 0, right: 0 },
+          100,
+        );
+        // drawRange=300, bufferedTickSize=floor(100*1.2)=120
+        // maxSteps=floor(300/120)=2
+        expect(result.max).toBe(2);
+      });
+    });
+
+    describe('y축', () => {
+      it('drawRange 내에 라벨이 여러 개 들어갈 수 있으면 maxSteps > 1을 반환한다', () => {
+        const scale = createScale();
+        const result = scale.calculateLabelRange(
+          'y',
+          { chartHeight: 400 },
+          { top: 20, bottom: 20 },
+          14,
+        );
+        // drawRange=360, bufferedTickSize=floor(14*1.5)=21
+        // maxSteps=floor(360/21)=17
+        expect(result.max).toBe(17);
+      });
+
+      it('좁은 캔버스에서도 maxSteps가 최소 1을 반환한다', () => {
+        const scale = createScale();
+        const result = scale.calculateLabelRange(
+          'y',
+          { chartHeight: 50 },
+          { top: 10, bottom: 10 },
+          30,
+        );
+        // drawRange=30, bufferedTickSize=floor(30*1.5)=45
+        // floor(30/45)=0 → Math.max(0,1)=1
+        expect(result.max).toBe(1);
+      });
+
+      it('버퍼 배율 1.5가 적용된다', () => {
+        const scale = createScale();
+        const result = scale.calculateLabelRange(
+          'y',
+          { chartHeight: 300 },
+          { top: 0, bottom: 0 },
+          20,
+        );
+        // drawRange=300, bufferedTickSize=floor(20*1.5)=30
+        // maxSteps=floor(300/30)=10
+        expect(result.max).toBe(10);
+      });
+
+      it('차트 높이가 달라져도 동일한 tickSize면 bufferedTickSize가 동일하다', () => {
+        const scale = createScale();
+        const result300 = scale.calculateLabelRange(
+          'y',
+          { chartHeight: 300 },
+          { top: 0, bottom: 0 },
+          14,
+        );
+        const result600 = scale.calculateLabelRange(
+          'y',
+          { chartHeight: 600 },
+          { top: 0, bottom: 0 },
+          14,
+        );
+        // bufferedTickSize = floor(14*1.5) = 21 (차트 높이와 무관)
+        // 300: floor(300/21)=14, 600: floor(600/21)=28
+        expect(result600.max).toBe(result300.max * 2);
+      });
+    });
+  });
+});

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -395,7 +395,7 @@ class TimeScale extends Scale {
     // 예상 tick 수에서 초기 multiplier를 추정하여 불필요한 반복을 줄인다
     // fixedSteps인 경우 interval 확장을 하지 않으므로 multiplier는 항상 1
     const estimatedTicks = Math.ceil((graphMax - graphMin) / baseMeta.ms);
-    let multiplier = !this.fixedSteps && estimatedTicks > maxSteps
+    let multiplier = (!this.fixedSteps && estimatedTicks > maxSteps)
       ? Math.max(1, Math.floor(estimatedTicks / maxSteps))
       : 1;
     let ticks;


### PR DESCRIPTION
### 변경 배경
- 기존 버퍼가 과도하게 잡혀 있어, 좁은 캔버스에서 라벨이 충분히 표시될 공간이 있음에도 불구하고 라벨 수가 불필요하게 줄어드는 문제가 있었습니다.

### 수정사항
- X축
   - <img width="661" height="166" alt="image" src="https://github.com/user-attachments/assets/674c24ea-8b25-4f68-935f-5d7110957f63" />

### Before / After
- <img width="443" height="362" alt="image" src="https://github.com/user-attachments/assets/fe7c7fcb-72fb-4812-b164-08a90f45ad57" />
- <img width="439" height="351" alt="image" src="https://github.com/user-attachments/assets/a3cbbf27-45ce-4fe0-8007-eeee1fb7fa21" />


