### PR TITLE
fix: Bar Chart showValue 값이 Bar 영역을 벗어나거나 잘림

### DIFF
--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -509,10 +509,13 @@ class Bar {
 
     switch (align) {
       case 'start': {
-        if (isHorizontal && textWidth < drawableBarWidth) {
-          const xPos = isNegativeValue ? minXPos - textWidth : minXPos;
-          ctx.fillText(formattedTxt, xPos, centerYOnBar);
-        } else if (!isHorizontal && textHeight < drawableBarHeight) {
+        if (isHorizontal) {
+          if (textWidth < drawableBarWidth && textHeight < Math.abs(barHeight)) {
+            const xPos = isNegativeValue ? minXPos - textWidth : minXPos;
+            ctx.fillText(formattedTxt, xPos, centerYOnBar);
+          }
+        } else if (textWidth <= Math.abs(barWidth) && textHeight / 2 < drawableBarHeight
+          && Math.abs(barWidth) >= fontSize) {
           const yPos = isNegativeValue ? barY + GAP : barY - GAP;
           ctx.fillText(formattedTxt, centerXOnBar, yPos);
         }
@@ -521,9 +524,12 @@ class Bar {
       }
 
       case 'center': {
-        if (isHorizontal && textWidth < drawableBarWidth) {
-          ctx.fillText(formattedTxt, centerXOnBar, centerYOnBar);
-        } else if (!isHorizontal && textHeight < drawableBarHeight) {
+        if (isHorizontal) {
+          if (textWidth < drawableBarWidth && textHeight < Math.abs(barHeight)) {
+            ctx.fillText(formattedTxt, centerXOnBar, centerYOnBar);
+          }
+        } else if (textWidth <= Math.abs(barWidth) && textHeight < drawableBarHeight
+          && Math.abs(barWidth) >= fontSize) {
           ctx.fillText(formattedTxt, centerXOnBar, barY + barHeight / 2);
         }
 
@@ -553,7 +559,7 @@ class Bar {
               ctx.fillText(formattedTxt, xPos, centerYOnBar);
             }
           }
-        } else {
+        } else if (textWidth <= Math.abs(barWidth) && Math.abs(barWidth) >= fontSize) {
           const yPos = isNegativeValue ? barY + barHeight + GAP : barY + barHeight - GAP;
           ctx.fillText(formattedTxt, centerXOnBar, yPos);
         }
@@ -563,18 +569,21 @@ class Bar {
 
       default:
       case 'end': {
-        if (isHorizontal && textWidth < drawableBarWidth) {
-          const xPos = isNegativeValue ? barX + barWidth + GAP : barX + barWidth - textWidth - GAP;
-          ctx.fillText(formattedTxt, xPos, centerYOnBar);
+        if (isHorizontal) {
+          if (textWidth < drawableBarWidth && textHeight < Math.abs(barHeight)) {
+            const xPos = isNegativeValue ? barX + barWidth + GAP : barX + barWidth - textWidth - GAP;
+            ctx.fillText(formattedTxt, xPos, centerYOnBar);
+          }
         } else if (!isHorizontal) {
           if (isNegativeValue) {
             const yPos = barY + barHeight - GAP;
-            if (yPos > minYPos) {
+            if (yPos > minYPos && textWidth <= Math.abs(barWidth)
+              && textHeight / 2 < drawableBarHeight && Math.abs(barWidth) >= fontSize) {
               ctx.fillText(formattedTxt, centerXOnBar, yPos);
             }
-          } else if (textHeight < drawableBarHeight) {
-            const yPos = barY + barHeight + GAP;
-            ctx.fillText(formattedTxt, centerXOnBar, yPos);
+          } else if (textWidth <= Math.abs(barWidth) && textHeight / 2 < drawableBarHeight
+            && Math.abs(barWidth) >= fontSize) {
+            ctx.fillText(formattedTxt, centerXOnBar, barY + barHeight + GAP);
           }
         }
 

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -498,25 +498,32 @@ class Bar {
     const textHeight = fontSize; // fontSize와 textHeight는 같을 수 없지만, 정확히 구할 필요 없음
 
     const GAP = 10;
+    const LABEL_MARGIN = 4;
     const minXPos = isNegativeValue ? barX - GAP : barX + GAP;
     const minYPos = isNegativeValue ? barY + GAP : barY - GAP;
 
     const centerXOnBar = barX + barWidth / 2;
     const centerYOnBar = isHighlight ? barY + barHeight / 2 : barY - barHeight / 2;
 
-    const drawableBarWidth = Math.abs(barWidth) - GAP;
-    const drawableBarHeight = Math.abs(barHeight) - GAP;
+    const absBarWidth = Math.abs(barWidth);
+    const absBarHeight = Math.abs(barHeight);
+    // long dim(텍스트 배치 방향)에만 GAP 적용, thin dim(중앙 정렬 방향)은 GAP 불필요
+    const drawableBarWidth = absBarWidth - GAP;
+    const drawableBarHeight = absBarHeight - GAP;
+    // 비수평 bar의 너비(thin dim)는 중앙 정렬이므로 경계값(==)도 허용
+    const fitsInVerticalBar = textWidth <= absBarWidth && absBarWidth >= textHeight;
 
     switch (align) {
       case 'start': {
         if (isHorizontal) {
-          if (textWidth < drawableBarWidth && textHeight < Math.abs(barHeight)) {
+          if (textWidth < drawableBarWidth && textHeight < absBarHeight) {
             const xPos = isNegativeValue ? minXPos - textWidth : minXPos;
             ctx.fillText(formattedTxt, xPos, centerYOnBar);
           }
-        } else if (textWidth <= Math.abs(barWidth) && textHeight / 2 < drawableBarHeight
-          && Math.abs(barWidth) >= fontSize) {
-          const yPos = isNegativeValue ? barY + GAP : barY - GAP;
+        } else if (fitsInVerticalBar && textHeight + LABEL_MARGIN <= absBarHeight) {
+          const yPos = isNegativeValue
+            ? barY + textHeight / 2 + LABEL_MARGIN
+            : barY - textHeight / 2 - LABEL_MARGIN;
           ctx.fillText(formattedTxt, centerXOnBar, yPos);
         }
 
@@ -525,11 +532,10 @@ class Bar {
 
       case 'center': {
         if (isHorizontal) {
-          if (textWidth < drawableBarWidth && textHeight < Math.abs(barHeight)) {
+          if (textWidth < drawableBarWidth && textHeight < absBarHeight) {
             ctx.fillText(formattedTxt, centerXOnBar, centerYOnBar);
           }
-        } else if (textWidth <= Math.abs(barWidth) && textHeight < drawableBarHeight
-          && Math.abs(barWidth) >= fontSize) {
+        } else if (fitsInVerticalBar && textHeight < drawableBarHeight) {
           ctx.fillText(formattedTxt, centerXOnBar, barY + barHeight / 2);
         }
 
@@ -559,7 +565,7 @@ class Bar {
               ctx.fillText(formattedTxt, xPos, centerYOnBar);
             }
           }
-        } else if (textWidth <= Math.abs(barWidth) && Math.abs(barWidth) >= fontSize) {
+        } else if (fitsInVerticalBar) {
           const yPos = isNegativeValue ? barY + barHeight + GAP : barY + barHeight - GAP;
           ctx.fillText(formattedTxt, centerXOnBar, yPos);
         }
@@ -570,21 +576,17 @@ class Bar {
       default:
       case 'end': {
         if (isHorizontal) {
-          if (textWidth < drawableBarWidth && textHeight < Math.abs(barHeight)) {
+          if (textWidth < drawableBarWidth && textHeight < absBarHeight) {
             const xPos = isNegativeValue ? barX + barWidth + GAP : barX + barWidth - textWidth - GAP;
             ctx.fillText(formattedTxt, xPos, centerYOnBar);
           }
-        } else if (!isHorizontal) {
-          if (isNegativeValue) {
-            const yPos = barY + barHeight - GAP;
-            if (yPos > minYPos && textWidth <= Math.abs(barWidth)
-              && textHeight / 2 < drawableBarHeight && Math.abs(barWidth) >= fontSize) {
-              ctx.fillText(formattedTxt, centerXOnBar, yPos);
-            }
-          } else if (textWidth <= Math.abs(barWidth) && textHeight / 2 < drawableBarHeight
-            && Math.abs(barWidth) >= fontSize) {
-            ctx.fillText(formattedTxt, centerXOnBar, barY + barHeight + GAP);
+        } else if (isNegativeValue) {
+          const yPos = barY + barHeight - textHeight / 2 - LABEL_MARGIN;
+          if (yPos > minYPos && fitsInVerticalBar && textHeight + LABEL_MARGIN <= absBarHeight) {
+            ctx.fillText(formattedTxt, centerXOnBar, yPos);
           }
+        } else if (fitsInVerticalBar && textHeight + LABEL_MARGIN <= absBarHeight) {
+          ctx.fillText(formattedTxt, centerXOnBar, barY + barHeight + textHeight / 2 + LABEL_MARGIN);
         }
 
         break;

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -497,19 +497,21 @@ class Bar {
     const textWidth = Math.round(ctx.measureText(formattedTxt).width);
     const textHeight = fontSize; // fontSize와 textHeight는 같을 수 없지만, 정확히 구할 필요 없음
 
-    const GAP = 10;
-    const LABEL_MARGIN = 4;
-    const minXPos = isNegativeValue ? barX - GAP : barX + GAP;
-    const minYPos = isNegativeValue ? barY + GAP : barY - GAP;
+    const LABEL_MARGIN = isHorizontal && align !== 'end' ? 10 : 4; // text 끝과 bar 경계 사이의 최소 여백
+    const minXPos = isNegativeValue ? barX - LABEL_MARGIN : barX + LABEL_MARGIN;
+    const minYPos = isNegativeValue ? barY + LABEL_MARGIN : barY - LABEL_MARGIN;
 
     const centerXOnBar = barX + barWidth / 2;
-    const centerYOnBar = isHighlight ? barY + barHeight / 2 : barY - barHeight / 2;
+    const barCenterY = isHighlight ? barY + barHeight / 2 : barY - barHeight / 2;
+    // 수평바: textBaseline='middle'은 em 박스 중앙 기준이므로 실제 글자의 시각적 중앙과
+    // 차이가 발생함 (fontSize에 비례). 고정 비율로 보정
+    const centerYOnBar = isHorizontal ? barCenterY + fontSize * 0.1 : barCenterY;
 
     const absBarWidth = Math.abs(barWidth);
     const absBarHeight = Math.abs(barHeight);
     // long dim(텍스트 배치 방향)에만 GAP 적용, thin dim(중앙 정렬 방향)은 GAP 불필요
-    const drawableBarWidth = absBarWidth - GAP;
-    const drawableBarHeight = absBarHeight - GAP;
+    const drawableBarWidth = absBarWidth - LABEL_MARGIN;
+    const drawableBarHeight = absBarHeight - LABEL_MARGIN;
     // 비수평 bar의 너비(thin dim)는 중앙 정렬이므로 경계값(==)도 허용
     const fitsInVerticalBar = textWidth <= absBarWidth && absBarWidth >= textHeight;
 
@@ -555,18 +557,18 @@ class Bar {
           const maxXOnChart = this.chartRect.x2 - this.labelOffset.right;
 
           if (isNegativeValue) {
-            const xPos = barX - GAP + barWidth - textWidth;
-            if (xPos > minXOnChart) {
+            const xPos = barX - LABEL_MARGIN + barWidth - textWidth;
+            if (xPos > minXOnChart && textHeight + LABEL_MARGIN * 2 < absBarHeight) {
               ctx.fillText(formattedTxt, xPos, centerYOnBar);
             }
           } else {
-            const xPos = barX + GAP + barWidth;
-            if (xPos + textWidth < maxXOnChart) {
+            const xPos = barX + LABEL_MARGIN + barWidth;
+            if (xPos + textWidth < maxXOnChart && textHeight + LABEL_MARGIN * 2 < absBarHeight) {
               ctx.fillText(formattedTxt, xPos, centerYOnBar);
             }
           }
         } else if (fitsInVerticalBar) {
-          const yPos = isNegativeValue ? barY + barHeight + GAP : barY + barHeight - GAP;
+          const yPos = isNegativeValue ? barY + barHeight + LABEL_MARGIN : barY + barHeight - LABEL_MARGIN;
           ctx.fillText(formattedTxt, centerXOnBar, yPos);
         }
 
@@ -577,7 +579,7 @@ class Bar {
       case 'end': {
         if (isHorizontal) {
           if (textWidth < drawableBarWidth && textHeight < absBarHeight) {
-            const xPos = isNegativeValue ? barX + barWidth + GAP : barX + barWidth - textWidth - GAP;
+            const xPos = isNegativeValue ? barX + barWidth + LABEL_MARGIN : barX + barWidth - textWidth - LABEL_MARGIN;
             ctx.fillText(formattedTxt, xPos, centerYOnBar);
           }
         } else if (isNegativeValue) {


### PR DESCRIPTION
## 이슈
수직 Bar 차트에서 showValue 사용 시:
value text가 좁은 bar 너비를 초과하여 바깥으로 벗어남

원인: 수직 방향에서 bar의 높이만 검증하고, 너비에 대한 검증이 누락되어 있었음

## 변경 내용
element.bar.js — drawValueLabels
- 수직: textWidth <= barWidth 및 barWidth >= fontSize 조건 추가 (모든 align)
- 수평: textHeight < barHeight 조건 추가 (기존 누락)
- text가 bar에 들어가지 않으면 렌더링하지 않도록 변경
## 이전 동작

<img width="1115" height="539" alt="image" src="https://github.com/user-attachments/assets/6be00a82-4509-490d-8bff-8ecf1dd2506a" />
<img width="910" height="259" alt="image" src="https://github.com/user-attachments/assets/478d8cd1-a4ee-4792-9975-6e20c8b7b319" />



## 이후 동작
<img width="1147" height="480" alt="image" src="https://github.com/user-attachments/assets/0f8f7c7d-678f-4c27-a3dc-6127e63d18c8" />

<img width="1125" height="282" alt="image" src="https://github.com/user-attachments/assets/07ac3685-536e-483d-8d9e-6494051b9502" />


## 테스트 가이드
차트 너비를 줄여 bar가 좁아질 때 text가 벗어나지 않고 숨겨지는지 확인
Horizontal일때 차트 높이를 줄여가며 text가 벗어나지 않고 숨겨지는지 확인