### PR TITLE
fix: fill(with null) 차트에서 null 시리즈가 잘못 선택되는 onClick 버그

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evui",
-  "version": "3.4.158",
+  "version": "3.4.159",
   "description": "A EXEM Library project",
   "author": "exem <dev_client@ex-em.com>",
   "license": "MIT",

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -352,15 +352,20 @@ class Line {
         item.index = dataIndex;
         if (item.data) {
           const point = gdata[dataIndex];
-          const yDist = Math.abs(yp - point.yp);
-          const directHitThreshold = 15; // 직접 히트 임계값
+          // null 좌표는 산술에서 0 으로 강제 변환되므로 hit 판정 대상에서 제외.
+          const hasValidPoint = point.o !== null && point.o !== undefined
+            && point.yp !== null && point.yp !== undefined;
+          if (hasValidPoint) {
+            const yDist = Math.abs(yp - point.yp);
+            const directHitThreshold = 15; // 직접 히트 임계값
 
-          if (yDist <= directHitThreshold) {
-            item.hit = true;
-          }
-          if (isLinePointDirectHit(point)) {
-            item.hit = true;
-            item.directHit = true;
+            if (yDist <= directHitThreshold) {
+              item.hit = true;
+            }
+            if (isLinePointDirectHit(point)) {
+              item.hit = true;
+              item.directHit = true;
+            }
           }
         }
       } else if (typeof this.beforeFindItemIndex === 'number' && this.beforeFindItemIndex !== -1 && this.show && useSelectLabelOrItem) {

--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -165,10 +165,15 @@ const modules = {
     let value = isHorizontal ? series.minMax.maxX : series.minMax.maxY;
     let label;
     if (tipType === 'sel') {
-      if (hitInfo && hitInfo.value !== null) {
-        value = hitInfo.useStack ? hitInfo.acc : hitInfo.value;
+      if (hitInfo && hitInfo.label !== null) {
+        // value=null 라벨 클릭에서도 label 자체는 hitInfo 우선. value 만 별도 fallback.
         label = hitInfo.label;
-        lastTip.value = value;
+        if (hitInfo.value !== null) {
+          value = hitInfo.useStack ? hitInfo.acc : hitInfo.value;
+          lastTip.value = value;
+        } else if (lastTip.value !== null) {
+          value = lastTip.value;
+        }
         lastTip.label = label;
       } else if (lastTip.value !== null) {
         value = lastTip.value;

--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -174,13 +174,15 @@ const modules = {
         value = lastTip.value;
         label = lastTip.label;
       } else if (lastTip.pos !== null) {
-        const item = type === 'bar'
-          ? this.getItemByLabelIndex(lastTip.pos) : this.getItemByLabel(lastTip.pos);
-
-        value = item.useStack ? item.acc : item.value;
-        label = item.label;
-        lastTip.value = value;
-        lastTip.label = label;
+        // line/scatter 는 getItemByLabel 이 미정의(dead code) — typeof 가드.
+        const fnName = type === 'bar' ? 'getItemByLabelIndex' : 'getItemByLabel';
+        if (typeof this[fnName] === 'function') {
+          const item = this[fnName](lastTip.pos);
+          value = item.useStack ? item.acc : item.value;
+          label = item.label;
+          lastTip.value = value;
+          lastTip.label = label;
+        }
       }
     }
 

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -832,12 +832,21 @@ const modules = {
           return null;
         }
 
-        return this.getHitItemByPosition(
+        const hitInfo = this.getHitItemByPosition(
           [dataInfo?.xp ?? 0, dataInfo?.yp ?? 0],
           useApproximate,
           idx,
           true,
         );
+
+        // 모두 null 라벨에서 sId='' 반환 → element.tip indicator 그리기 skip 회피.
+        if (hitInfo && !hitInfo.sId) {
+          hitInfo.sId = firShowSeriesID;
+          hitInfo.label = this.data?.labels?.[idx] ?? hitInfo.label;
+          hitInfo.dataIndex = idx;
+        }
+
+        return hitInfo;
       });
     }
 
@@ -1077,7 +1086,7 @@ const modules = {
       type: hasHit ? hitType : fallbackType,
       label: hasHit ? hitLabel : fallbackLabel,
       pos: hasHit ? hitValuePos : fallbackValuePos,
-      value: (hasHit ? hitValue : fallbackValue) ?? 0,
+      value: hasHit ? hitValue : fallbackValue,
       sId: hasHit ? hitSeriesID : fallbackSeriesID,
       acc,
       useStack,

--- a/tests/unit/element.bar.spec.js
+++ b/tests/unit/element.bar.spec.js
@@ -1,0 +1,136 @@
+import Bar from '@/components/chart/element/element.bar';
+
+const createBar = (overrides = {}) => {
+  const bar = Object.create(Bar.prototype);
+  Object.assign(bar, overrides);
+  return bar;
+};
+
+describe('Bar Element', () => {
+  describe('calculateBarSize', () => {
+    it('px 문자열을 파싱하여 크기를 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize('30px', 50)).toBe(30);
+    });
+
+    it('px 값이 bArea보다 크면 bArea를 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize('100px', 50)).toBe(50);
+    });
+
+    it('0~1 사이 숫자는 비율로 계산한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize(0.5, 100)).toBe(50);
+    });
+
+    it('비율 0은 0을 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize(0, 100)).toBe(0);
+    });
+
+    it('비율 1은 전체 영역을 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize(1, 100)).toBe(100);
+    });
+
+    it('유효하지 않은 값은 bArea를 반환한다', () => {
+      const bar = createBar();
+      expect(bar.calculateBarSize('auto', 80)).toBe(80);
+      expect(bar.calculateBarSize(null, 80)).toBe(80);
+      expect(bar.calculateBarSize(2, 80)).toBe(80);
+    });
+  });
+
+  describe('isPointInBar', () => {
+    it('바 영역 내 점은 true를 반환한다', () => {
+      const bar = createBar();
+      const barData = { xp: 10, yp: 50, w: 20, h: -30 };
+      // bar: x 10~30, y 20~50
+      expect(bar.isPointInBar([15, 40], barData)).toBe(true);
+    });
+
+    it('바 영역 밖 점은 false를 반환한다', () => {
+      const bar = createBar();
+      const barData = { xp: 10, yp: 50, w: 20, h: -30 };
+      expect(bar.isPointInBar([5, 40], barData)).toBe(false);
+      expect(bar.isPointInBar([35, 40], barData)).toBe(false);
+    });
+  });
+
+  describe('findGraphData directHit 플래그', () => {
+    // bar: x 10~30, y 20~50
+    const barData = { xp: 10, yp: 50, w: 20, h: -30, index: 0 };
+
+    const createBarWithData = () =>
+      createBar({
+        data: [barData],
+        show: true,
+        color: '#000',
+        visibleStartIndex: 0,
+        filteredCount: 1,
+      });
+
+    it('bar 박스 내부 클릭은 hit=true, directHit=true를 반환한다', () => {
+      const bar = createBarWithData();
+      const item = bar.findGraphData([15, 40], false, 0, true);
+      expect(item.hit).toBe(true);
+      expect(item.directHit).toBe(true);
+    });
+
+    it('bar 박스 밖 클릭은 hit=false, directHit=false를 반환한다', () => {
+      const bar = createBarWithData();
+      const item = bar.findGraphData([5, 40], false, 0, true);
+      expect(item.hit).toBe(false);
+      expect(item.directHit).toBe(false);
+    });
+
+    it('binarySearchBar 경로(findGraphRange)에서도 directHit를 세팅한다', () => {
+      // useIndicatorOnLabel=false로 두면 findGraphRange → binarySearchBar 경로 진입
+      const bar = createBarWithData();
+      const item = bar.findGraphData([15, 40], false, undefined, false);
+      expect(item.hit).toBe(true);
+      expect(item.directHit).toBe(true);
+    });
+
+    it('binarySearchBar에서 x범위 밖 클릭은 directHit가 세팅되지 않는다', () => {
+      // binarySearchBar는 inRange 조건을 만족해야 item이 세팅됨.
+      // 범위 밖이면 초기값 { hit: false } 유지 (directHit 없음 = falsy).
+      const bar = createBarWithData();
+      const item = bar.findGraphData([50, 40], false, undefined, false);
+      expect(item.hit).toBe(false);
+      expect(item.directHit).toBeFalsy();
+    });
+  });
+
+  describe('null 데이터 안전 fall-through (회귀 가드)', () => {
+    // bar 박스 비교는 null 좌표에서 NaN 으로 false fall-through.
+    const nullBar = { xp: null, yp: null, w: null, h: null, o: null, index: 0 };
+    const createBarWithNullData = () =>
+      createBar({
+        data: [nullBar],
+        show: true,
+        color: '#000',
+        visibleStartIndex: 0,
+        filteredCount: 1,
+      });
+
+    it('isPointInBar 는 null 박스 좌표에서 false 를 반환한다', () => {
+      const bar = createBar();
+      expect(bar.isPointInBar([40, 10], { xp: null, yp: null, w: null, h: null })).toBe(false);
+    });
+
+    it('dataIndex 분기(useIndicatorOnLabel=true) + null 데이터 → hit=false', () => {
+      const bar = createBarWithNullData();
+      const item = bar.findGraphData([40, 10], false, 0, true);
+      expect(item.hit).toBe(false);
+      expect(item.directHit).toBeFalsy();
+    });
+
+    it('binarySearchBar 경로(useIndicatorOnLabel=false) + null 데이터 → hit=false', () => {
+      const bar = createBarWithNullData();
+      const item = bar.findGraphData([40, 10], false, undefined, false);
+      expect(item.hit).toBe(false);
+      expect(item.directHit).toBeFalsy();
+    });
+  });
+});

--- a/tests/unit/element.heatmap.spec.js
+++ b/tests/unit/element.heatmap.spec.js
@@ -1,0 +1,91 @@
+import HeatMap from '@/components/chart/element/element.heatmap';
+
+const createHeatMap = (overrides = {}) => {
+  const hm = Object.create(HeatMap.prototype);
+  Object.assign(hm, overrides);
+  return hm;
+};
+
+describe('HeatMap Element', () => {
+  describe('getAdjustedBounds', () => {
+    it('기본 범위를 조정한다', () => {
+      const hm = createHeatMap();
+      const result = hm.getAdjustedBounds({
+        xp: 10,
+        yp: 20,
+        width: 30,
+        height: 40,
+      });
+      expect(result.xsp).toBe(10);
+      expect(result.xep).toBe(40);
+      expect(result.ysp).toBe(20);
+      expect(result.yep).toBe(60);
+    });
+
+    it('음수 width/height는 0으로 조정된다', () => {
+      const hm = createHeatMap();
+      const result = hm.getAdjustedBounds({
+        xp: 10,
+        yp: 20,
+        width: -5,
+        height: -10,
+      });
+      expect(result.xep).toBeGreaterThanOrEqual(result.xsp);
+      expect(result.yep).toBeGreaterThanOrEqual(result.ysp);
+    });
+
+    it('소수점 값의 부동소수점 오차를 보정한다', () => {
+      const hm = createHeatMap();
+      const result = hm.getAdjustedBounds({
+        xp: 10.123,
+        yp: 20.456,
+        width: 5.789,
+        height: 3.012,
+      });
+      // xsp는 floor, xep는 ceil 처리
+      expect(result.xsp).toBeLessThanOrEqual(10.123);
+      expect(result.xep).toBeGreaterThanOrEqual(10.123 + 5.789);
+    });
+  });
+
+  describe('getFilteredLabel', () => {
+    it('count가 일치하면 labels을 그대로 반환한다', () => {
+      const hm = createHeatMap();
+      const labels = [1, 2, 3, 4, 5];
+      expect(hm.getFilteredLabel(labels, 5, 1, 5)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('count가 다르면 min/max 범위로 필터링한다', () => {
+      const hm = createHeatMap();
+      const labels = [1, 2, 3, 4, 5];
+      expect(hm.getFilteredLabel(labels, 10, 2, 4)).toEqual([2, 3, 4]);
+    });
+
+    it('범위에 맞는 레이블이 없으면 빈 배열을 반환한다', () => {
+      const hm = createHeatMap();
+      const labels = [1, 2, 3];
+      expect(hm.getFilteredLabel(labels, 10, 10, 20)).toEqual([]);
+    });
+  });
+
+  describe('findGraphData null 데이터 안전 fall-through (회귀 가드)', () => {
+    // 셀 박스 비교 `x <= xp && xp <= x+w` 는 null 좌표에서 NaN 비교로 false fall-through.
+    it('null 좌표 셀은 hit=false 로 fall-through 한다', () => {
+      const hm = createHeatMap({
+        data: [{ xp: null, yp: null, w: null, h: null, value: null }],
+      });
+      const item = hm.findGraphData([40, 10]);
+      expect(item.hit).toBe(false);
+      expect(item.data).toBe(null);
+    });
+
+    it('정상 셀 내부 클릭은 hit=true (회귀 가드)', () => {
+      const hm = createHeatMap({
+        data: [{ xp: 30, yp: 0, w: 20, h: 20, value: 5, dataColor: '#abc' }],
+      });
+      const item = hm.findGraphData([40, 10]);
+      expect(item.hit).toBe(true);
+      expect(item.index).toBe(0);
+    });
+  });
+});

--- a/tests/unit/element.line.spec.js
+++ b/tests/unit/element.line.spec.js
@@ -1,0 +1,88 @@
+import Line from '@/components/chart/element/element.line';
+
+describe('Line Element findGraphData', () => {
+  describe('null 데이터 위 dataIndex 호출 (onClick 경로)', () => {
+    // FillWithNull.vue 데이터 모사. onClick 은 useSelectLabelOrItem=false 로 호출.
+    const makeSeries1 = () => {
+      const line = new Line('series1', { interpolation: 'none' }, 0);
+      line.show = true;
+      line.pointSize = 3;
+      line.data = [
+        { x: '01/01', y: 20, o: 20, xp: 0, yp: 160 },
+        { x: '01/02', y: 45, o: 45, xp: 20, yp: 110 },
+        { x: '01/03', y: null, o: null, xp: 40, yp: null },
+        { x: '01/04', y: null, o: null, xp: 60, yp: null },
+        { x: '01/05', y: 80, o: 80, xp: 80, yp: 40 },
+        { x: '01/06', y: 55, o: 55, xp: 100, yp: 90 },
+        { x: '01/07', y: null, o: null, xp: 120, yp: null },
+        { x: '01/08', y: 50, o: 50, xp: 140, yp: 100 },
+      ];
+      return line;
+    };
+
+    const makeSeries2 = () => {
+      const line = new Line('series2', { interpolation: 'none' }, 0);
+      line.show = true;
+      line.pointSize = 3;
+      line.data = [
+        { x: '01/01', y: 55, o: 55, xp: 0, yp: 90 },
+        { x: '01/02', y: 30, o: 30, xp: 20, yp: 140 },
+        { x: '01/03', y: 40, o: 40, xp: 40, yp: 120 },
+        { x: '01/04', y: null, o: null, xp: 60, yp: null },
+        { x: '01/05', y: 45, o: 45, xp: 80, yp: 110 },
+        { x: '01/06', y: 25, o: 25, xp: 100, yp: 150 },
+        { x: '01/07', y: 65, o: 65, xp: 120, yp: 70 },
+        { x: '01/08', y: 40, o: 40, xp: 140, yp: 120 },
+      ];
+      return line;
+    };
+
+    it('series1 dataIndex=2 (o=null, yp=null) 위쪽 클릭 → hit=false, directHit=false', () => {
+      const line = makeSeries1();
+      const item = line.findGraphData([40, 10], false, 2, false);
+      expect(item.hit).toBeFalsy();
+      expect(item.directHit).toBeFalsy();
+    });
+
+    it('series1 dataIndex=2 → 반환된 data.o 는 null 을 그대로 보존한다', () => {
+      const line = makeSeries1();
+      const item = line.findGraphData([40, 10], false, 2, false);
+      expect(item.data?.o).toBe(null);
+      expect(item.data?.yp).toBe(null);
+    });
+
+    it('series2 dataIndex=2 (o=40, yp=120) 위쪽(클릭 yp=10) → hit=false 이지만 data.o=40', () => {
+      const line = makeSeries2();
+      const item = line.findGraphData([40, 10], false, 2, false);
+      expect(item.hit).toBeFalsy();
+      expect(item.data?.o).toBe(40);
+      expect(item.data?.yp).toBe(120);
+    });
+
+    it('o=0 인 데이터(0은 의미 있는 값) 위 dataIndex 호출 → hit 판정에 정상 진입', () => {
+      // 가드가 truthy 체크(if (point.o))로 바뀌면 0 데이터가 깨짐 — 회귀 가드.
+      const line = new Line('zeroSeries', { interpolation: 'none' }, 0);
+      line.show = true;
+      line.pointSize = 3;
+      line.data = [
+        { x: 'L0', y: 0, o: 0, xp: 50, yp: 100 },
+      ];
+      const item = line.findGraphData([50, 100], false, 0, false);
+      expect(item.hit).toBe(true);
+      expect(item.directHit).toBe(true);
+      expect(item.data?.o).toBe(0);
+    });
+
+    it('yp=0 인 데이터(차트 상단 baseline) 위 클릭 → hit 판정에 정상 진입', () => {
+      const line = new Line('topSeries', { interpolation: 'none' }, 0);
+      line.show = true;
+      line.pointSize = 3;
+      line.data = [
+        { x: 'L0', y: 100, o: 100, xp: 50, yp: 0 },
+      ];
+      const item = line.findGraphData([50, 5], false, 0, false);
+      expect(item.hit).toBe(true);
+      expect(item.data?.yp).toBe(0);
+    });
+  });
+});

--- a/tests/unit/element.tip.spec.js
+++ b/tests/unit/element.tip.spec.js
@@ -1,0 +1,90 @@
+import modules from '@/components/chart/element/element.tip';
+
+const createCtx = ({ lastTip = { pos: null, value: null, label: null } } = {}) =>
+  Object.assign(Object.create(modules), {
+    options: { horizontal: false },
+    chartRect: { x1: 0, x2: 100, y1: 0, y2: 100, chartWidth: 100, chartHeight: 100 },
+    labelOffset: { left: 0, right: 0, top: 0, bottom: 0 },
+    axesSteps: { x: [{ graphMin: 0, graphMax: 10 }], y: [{ graphMin: 0, graphMax: 100 }] },
+    lastTip,
+    scrollbar: { x: {}, y: {} },
+  });
+
+const buildSeries = (overrides = {}) => ({
+  type: 'line',
+  size: { comboOffset: 0 },
+  xAxisIndex: 0,
+  yAxisIndex: 0,
+  minMax: { maxDomain: 5, maxDomainIndex: 0, maxX: 10, maxY: 100 },
+  ...overrides,
+});
+
+describe('element.tip calculateTipInfo — sel 분기 label 우선 동작', () => {
+  it('hitInfo.value 가 valid → label/value 모두 hitInfo, lastTip 갱신', () => {
+    const ctx = createCtx();
+    const result = ctx.calculateTipInfo(buildSeries(), 'sel', {
+      label: 5, value: 50, useStack: false, dataIndex: 0,
+    });
+
+    expect(result.label).toBe(5);
+    expect(result.value).toBe(50);
+    expect(ctx.lastTip.label).toBe(5);
+    expect(ctx.lastTip.value).toBe(50);
+  });
+
+  it('hitInfo.value=null + hitInfo.label valid + lastTip 비어있음 → label=hitInfo, value=default(maxY)', () => {
+    const ctx = createCtx();
+    const result = ctx.calculateTipInfo(buildSeries(), 'sel', {
+      label: 3, value: null, dataIndex: 3,
+    });
+
+    expect(result.label).toBe(3);
+    expect(result.value).toBe(100); // series.minMax.maxY
+  });
+
+  it('(회귀 가드) hitInfo.value=null + hitInfo.label valid + lastTip.label 다른 값 → label=hitInfo, value=lastTip', () => {
+    // 직전 클릭이 데이터 있는 라벨(idx=1, value=80)이고 현재 클릭이 null 라벨(idx=3).
+    // 잘못된 fallback 으로 돌아가면 label=1 로 떨어진다 → RED.
+    const ctx = createCtx({ lastTip: { pos: 1, value: 80, label: 1 } });
+    const result = ctx.calculateTipInfo(buildSeries(), 'sel', {
+      label: 3, value: null, dataIndex: 3,
+    });
+
+    expect(result.label).toBe(3);
+    expect(result.value).toBe(80);
+  });
+
+  it('hitInfo.label=null + lastTip.label valid → lastTip 으로 fallback', () => {
+    const ctx = createCtx({ lastTip: { pos: 2, value: 30, label: 2 } });
+    const result = ctx.calculateTipInfo(buildSeries(), 'sel', {
+      label: null, value: null,
+    });
+
+    expect(result.label).toBe(2);
+    expect(result.value).toBe(30);
+  });
+
+  it('hitInfo.label=null + lastTip 도 모두 null → label=undefined, value=default', () => {
+    const ctx = createCtx();
+    const result = ctx.calculateTipInfo(buildSeries(), 'sel', {
+      label: null, value: null,
+    });
+
+    expect(result.label).toBeUndefined();
+    expect(result.value).toBe(100);
+  });
+
+  it('bar 타입 + hitInfo → label/value 가 hitInfo 그대로 반영', () => {
+    const ctx = createCtx();
+    const series = buildSeries({
+      type: 'bar',
+      size: { w: 10, h: 0, cat: 20, cPad: 0, bar: 10, ix: 0, bPad: 0 },
+    });
+    const result = ctx.calculateTipInfo(series, 'sel', {
+      label: 'A', value: 50, useStack: false, dataIndex: 2,
+    });
+
+    expect(result.label).toBe('A');
+    expect(result.value).toBe(50);
+  });
+});

--- a/tests/unit/model.store.spec.js
+++ b/tests/unit/model.store.spec.js
@@ -205,7 +205,7 @@ describe('model.store getHitItemByPosition', () => {
       const result = store.getHitItemByPosition([50, 250], false, undefined, false, true);
 
       expect(result.sId).toBe('');
-      expect(result.value).toBe(0);
+      expect(result.value).toBeNull();
       expect(result.label).toBe('L1');
       expect(result.dataIndex).toBe(1);
     });
@@ -354,5 +354,138 @@ describe('model.store getHitItemByPosition', () => {
 
       expect(result.sId).toBe('s1');
     });
+  });
+
+  describe('Fill(with null) 8라벨 × 2시리즈 — onClick 경로 회귀', () => {
+    // FillWithNull.vue 데이터 모사. onClick 경로 인자로 호출.
+    const buildSeries1Points = () => [
+      { x: '01/01', y: 20, o: 20, xp: 0, yp: 160, index: 0 },
+      { x: '01/02', y: 45, o: 45, xp: 20, yp: 110, index: 1 },
+      { x: '01/03', y: null, o: null, xp: 40, yp: null, index: 2 },
+      { x: '01/04', y: null, o: null, xp: 60, yp: null, index: 3 },
+      { x: '01/05', y: 80, o: 80, xp: 80, yp: 40, index: 4 },
+      { x: '01/06', y: 55, o: 55, xp: 100, yp: 90, index: 5 },
+      { x: '01/07', y: null, o: null, xp: 120, yp: null, index: 6 },
+      { x: '01/08', y: 50, o: 50, xp: 140, yp: 100, index: 7 },
+    ];
+    const buildSeries2Points = () => [
+      { x: '01/01', y: 55, o: 55, xp: 0, yp: 90, index: 0 },
+      { x: '01/02', y: 30, o: 30, xp: 20, yp: 140, index: 1 },
+      { x: '01/03', y: 40, o: 40, xp: 40, yp: 120, index: 2 },
+      { x: '01/04', y: null, o: null, xp: 60, yp: null, index: 3 },
+      { x: '01/05', y: 45, o: 45, xp: 80, yp: 110, index: 4 },
+      { x: '01/06', y: 25, o: 25, xp: 100, yp: 150, index: 5 },
+      { x: '01/07', y: 65, o: 65, xp: 120, yp: 70, index: 6 },
+      { x: '01/08', y: 40, o: 40, xp: 140, yp: 120, index: 7 },
+    ];
+
+    const createFillStore = () =>
+      createStore({
+        series1: mockLineWithIndexedData({ points: buildSeries1Points() }),
+        series2: mockLineWithIndexedData({ points: buildSeries2Points() }),
+      });
+
+    it('01/03 (series1 만 null) 위쪽 빈 영역 클릭 → series2 선택, value=40', () => {
+      const store = createFillStore();
+      const result = store.getHitItemByPosition([40, 10], false, undefined, false, true);
+
+      expect(result.sId).toBe('series2');
+      expect(result.value).toBe(40);
+      expect(result.dataIndex).toBe(2);
+    });
+
+    it('01/04 (둘 다 null) 위쪽 빈 영역 클릭 → sId="", label="01/04", dataIndex=3', () => {
+      const store = createFillStore();
+      const result = store.getHitItemByPosition([60, 10], false, undefined, false, true);
+
+      expect(result.sId).toBe('');
+      expect(result.label).toBe('01/04');
+      expect(result.dataIndex).toBe(3);
+    });
+
+    it('01/04 (둘 다 null) 클릭 시 value 는 null 로 emit 된다', () => {
+      // 0 강제 변환 시 "값이 0" 과 "값이 없음" 구분 불가.
+      const store = createFillStore();
+      const result = store.getHitItemByPosition([60, 10], false, undefined, false, true);
+
+      expect(result.value).toBeNull();
+    });
+
+    it('01/07 (series1 만 null) 위쪽 빈 영역 클릭 → series2 선택, value=65', () => {
+      const store = createFillStore();
+      const result = store.getHitItemByPosition([120, 10], false, undefined, false, true);
+
+      expect(result.sId).toBe('series2');
+      expect(result.value).toBe(65);
+      expect(result.dataIndex).toBe(6);
+    });
+
+    it('01/01 (둘 다 값) 위쪽 빈 영역 클릭 → 클릭 좌표에 가까운 쪽이 선택된다', () => {
+      const store = createFillStore();
+      const result = store.getHitItemByPosition([0, 85], false, undefined, false, true);
+
+      expect(result.sId).toBe('series2');
+      expect(result.value).toBe(55);
+      expect(result.dataIndex).toBe(0);
+    });
+  });
+});
+
+describe('model.store getItem (selectLabel indicator 용)', () => {
+  // selectLabel 시 chart.core.drawTip → getItem 결과가 element.tip 에 전달된다.
+  // 모두 null 라벨에서 sId='' 이면 indicator 그리기가 skip 되므로 sId 를 보정해야 한다.
+
+  const buildSeries = (points) => ({
+    type: 'line',
+    show: true,
+    data: points,
+    stackIndex: null,
+    findGraphData: (offset, isHorizontal, dataIndex) => {
+      if (typeof dataIndex === 'number') {
+        const data = points[dataIndex] ?? null;
+        return { data, hit: false, directHit: false, index: dataIndex };
+      }
+      return { data: null, hit: false, directHit: false, index: 0 };
+    },
+  });
+
+  const buildFillStore = () => {
+    const points1 = [
+      { x: '01/01', y: 20, o: 20, xp: 0, yp: 160, index: 0 },
+      { x: '01/02', y: 45, o: 45, xp: 20, yp: 110, index: 1 },
+      { x: '01/03', y: null, o: null, xp: 40, yp: null, index: 2 },
+      { x: '01/04', y: null, o: null, xp: 60, yp: null, index: 3 },
+    ];
+    const points2 = [
+      { x: '01/01', y: 55, o: 55, xp: 0, yp: 90, index: 0 },
+      { x: '01/02', y: 30, o: 30, xp: 20, yp: 140, index: 1 },
+      { x: '01/03', y: 40, o: 40, xp: 40, yp: 120, index: 2 },
+      { x: '01/04', y: null, o: null, xp: 60, yp: null, index: 3 },
+    ];
+    const store = createStore({
+      series1: buildSeries(points1),
+      series2: buildSeries(points2),
+    });
+    store.data = { labels: ['01/01', '01/02', '01/03', '01/04'] };
+    return store;
+  };
+
+  it('모두 null 인 라벨(01/04) selectLabel → 첫 visible series 의 sId/label/dataIndex 가 보정된다', () => {
+    const store = buildFillStore();
+    const result = store.getItem({ dataIndex: [3] });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).not.toBeNull();
+    expect(result[0].sId).toBe('series1');
+    expect(result[0].label).toBe('01/04');
+    expect(result[0].dataIndex).toBe(3);
+  });
+
+  it('일부 null 라벨(01/03) selectLabel → hit detection fallback 으로 series2 가 선택된다', () => {
+    const store = buildFillStore();
+    const result = store.getItem({ dataIndex: [2] });
+
+    expect(result[0].sId).toBe('series2');
+    expect(result[0].dataIndex).toBe(2);
   });
 });

--- a/tests/unit/plugins.interaction.spec.js
+++ b/tests/unit/plugins.interaction.spec.js
@@ -1,0 +1,351 @@
+import modules from '@/components/chart/plugins/plugins.interaction';
+
+/**
+ * findHitItem 테스트를 위한 가짜 차트 컨텍스트.
+ * plugins.interaction의 메서드들은 차트 인스턴스의 this에 바인딩되어 사용되므로,
+ * 필요한 속성과 최소한의 의존 메서드를 주입한 컨텍스트를 만들어 직접 호출한다.
+ */
+const createChart = (seriesList, opts = {}) =>
+  Object.assign(Object.create(modules), {
+    seriesList,
+    options: { horizontal: false, ...opts },
+    tooltipCtx: null,
+    getFormattedTooltipLabel: ({ seriesName }) => seriesName,
+    getFormattedTooltipValue: ({ value }) => String(value),
+    findClosestDataIndex: () => 0,
+    isNotUseIndicator: () => false,
+  });
+
+const createChartForClosestIndex = (seriesList, opts = {}) =>
+  Object.assign(Object.create(modules), {
+    seriesList,
+    options: { horizontal: false, ...opts },
+  });
+
+/**
+ * findGraphData가 고정된 item을 리턴하는 mock 시리즈.
+ */
+const mockSeries = ({
+  show = true,
+  data,
+  hit = false,
+  directHit = false,
+  interpolation = 'linear',
+  isExistGrp = false,
+}) => ({
+  show,
+  id: 'mock-id',
+  name: 'mock-name',
+  xAxisIndex: 0,
+  yAxisIndex: 0,
+  interpolation,
+  isExistGrp,
+  findGraphData: () => ({
+    data,
+    hit,
+    directHit,
+    index: data?.index ?? 0,
+  }),
+});
+
+const createClosestSeries = ({
+  data,
+  show = true,
+  interpolation = 'none',
+  passingValue = null,
+  hasPassingValueInData = false,
+}) => ({
+  show,
+  data,
+  interpolation,
+  passingValue,
+  hasPassingValueInData,
+});
+
+describe('plugins.interaction findHitItem', () => {
+  describe('directHit 우선순위', () => {
+    it('bar directHit는 더 가까운 line 포인트보다 우선 선택된다', () => {
+      // bar: directHit=true, 좌표는 클릭 지점에서 멀리 있음 (박스 꼭짓점 기준)
+      // line: hit=true (directHit 아님), 좌표는 클릭 지점에 매우 가까움 (포인트)
+      // 기존엔 거리만 봐서 line이 이겼으나, directHit 도입 후 bar가 이겨야 한다.
+      const chart = createChart({
+        bar1: mockSeries({
+          data: { x: 0, y: 10, xp: 10, yp: 90, o: 10 },
+          hit: true,
+          directHit: true,
+        }),
+        line1: mockSeries({
+          data: { x: 0, y: 100, xp: 51, yp: 101, o: 100 },
+          hit: true,
+          directHit: false,
+        }),
+      });
+
+      const result = chart.findHitItem([50, 100]);
+      expect(result.hitId).toBe('bar1');
+    });
+
+    it('여러 bar에 directHit가 겹치면 클릭 좌표에 가장 가까운 bar가 선택된다', () => {
+      const chart = createChart({
+        far: mockSeries({
+          data: { x: 0, y: 10, xp: 10, yp: 20, o: 10 },
+          hit: true,
+          directHit: true,
+        }),
+        near: mockSeries({
+          data: { x: 0, y: 20, xp: 48, yp: 52, o: 20 },
+          hit: true,
+          directHit: true,
+        }),
+      });
+
+      const result = chart.findHitItem([50, 50]);
+      expect(result.hitId).toBe('near');
+    });
+
+    it('같은 좌표에서 line 포인트 directHit는 bar 박스 directHit를 거리로 이긴다', () => {
+      // combo 차트에서 line 포인트가 bar 박스 내부에 있어 둘 다 directHit인 경우.
+      // line 포인트 중심이 클릭 좌표에 더 가까우므로 line이 선택되어야 한다.
+      const chart = createChart({
+        bar: mockSeries({
+          data: { x: 0, y: 10, xp: 30, yp: 20, o: 10 },
+          hit: true,
+          directHit: true,
+        }),
+        line: mockSeries({
+          data: { x: 0, y: 50, xp: 50, yp: 50, o: 50 },
+          hit: true,
+          directHit: true,
+        }),
+      });
+
+      const result = chart.findHitItem([50, 50]);
+      expect(result.hitId).toBe('line');
+    });
+  });
+
+  describe('일반 line 차트 회귀 방지', () => {
+    it('directHit가 없으면 거리 기반으로 가장 가까운 hit 시리즈가 선택된다', () => {
+      const chart = createChart({
+        far: mockSeries({
+          data: { x: 0, y: 10, xp: 10, yp: 10, o: 10 },
+          hit: true,
+        }),
+        near: mockSeries({
+          data: { x: 0, y: 20, xp: 49, yp: 51, o: 20 },
+          hit: true,
+        }),
+      });
+
+      const result = chart.findHitItem([50, 50]);
+      expect(result.hitId).toBe('near');
+    });
+  });
+
+  describe('hit 없을 때 fallback', () => {
+    it('모든 시리즈가 hit=false면 거리가 가장 가까운 시리즈로 fallback 한다', () => {
+      // 클릭 (1000, 1000) 에 s1 이 훨씬 가까운 좌표.
+      const chart = createChart({
+        s1: mockSeries({
+          data: { x: 0, y: 10, xp: 990, yp: 990, o: 10 },
+          hit: false,
+        }),
+        s2: mockSeries({
+          data: { x: 0, y: 20, xp: 30, yp: 40, o: 20 },
+          hit: false,
+        }),
+      });
+
+      const result = chart.findHitItem([1000, 1000]);
+      expect(result.hitId).toBe('s1');
+    });
+  });
+
+  describe('items 수집', () => {
+    it('hit 여부와 무관하게 유효한 data를 가진 모든 시리즈가 items에 포함된다 (tooltip용)', () => {
+      const chart = createChart({
+        bar1: mockSeries({
+          data: { x: 0, y: 10, xp: 10, yp: 20, o: 10 },
+          hit: true,
+          directHit: true,
+        }),
+        line1: mockSeries({
+          data: { x: 0, y: 100, xp: 30, yp: 40, o: 100 },
+          hit: true,
+          directHit: false,
+        }),
+      });
+
+      const result = chart.findHitItem([10, 20]);
+      expect(Object.keys(result.items).sort()).toEqual(['bar1', 'line1']);
+      expect(result.hitId).toBe('bar1');
+    });
+  });
+
+  describe('Fill(with null) 8라벨 × 2시리즈 — onDblClick(findHitItem) 회귀', () => {
+    // mock 은 element.line null 가드 적용 후의 결과(null 포인트 → hit=false) 모방.
+
+    it('01/03 (series1 만 null) → hitId=series2, items 에 series2 만', () => {
+      const series1 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/03', y: null, o: null, xp: 40, yp: null, index: 2 },
+        hit: false,
+        directHit: false,
+      });
+      const series2 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/03', y: 40, o: 40, xp: 40, yp: 120, index: 2 },
+        hit: false,
+        directHit: false,
+      });
+
+      const chart = createChart({ series1, series2 });
+      chart.findClosestDataIndex = () => 2;
+
+      const result = chart.findHitItem([40, 10], true);
+
+      expect(result.hitId).toBe('series2');
+      expect(Object.keys(result.items)).toEqual(['series2']);
+    });
+
+    it('01/04 (둘 다 null) → hitId="", items[""] synthetic (label/dataIndex 보존)', () => {
+      const series1 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/04', y: null, o: null, xp: 60, yp: null, index: 3 },
+        hit: false,
+      });
+      const series2 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/04', y: null, o: null, xp: 60, yp: null, index: 3 },
+        hit: false,
+      });
+
+      // synthetic items[''] 는 series.data?.[targetDataIndex] 의 x/y 를 참조하므로
+      // mock 시리즈에 series.data 배열을 명시 주입.
+      series1.data = [
+        { x: '01/01', y: 20, o: 20 },
+        { x: '01/02', y: 45, o: 45 },
+        { x: '01/03', y: null, o: null },
+        { x: '01/04', y: null, o: null },
+      ];
+
+      const chart = createChart({ series1, series2 });
+      chart.findClosestDataIndex = () => 3;
+
+      const result = chart.findHitItem([60, 10], true);
+
+      expect(result.hitId).toBe('');
+      expect(result.items[''].label).toBe('01/04');
+      expect(result.items[''].index).toBe(3);
+    });
+
+    it('01/07 (series1 만 null) → hitId=series2', () => {
+      const series1 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/07', y: null, o: null, xp: 120, yp: null, index: 6 },
+        hit: false,
+      });
+      const series2 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/07', y: 65, o: 65, xp: 120, yp: 70, index: 6 },
+        hit: false,
+      });
+
+      const chart = createChart({ series1, series2 });
+      chart.findClosestDataIndex = () => 6;
+
+      const result = chart.findHitItem([120, 10], true);
+
+      expect(result.hitId).toBe('series2');
+      expect(Object.keys(result.items)).toEqual(['series2']);
+    });
+
+    it('01/01 (둘 다 값) → 거리 가까운 시리즈가 hitId', () => {
+      // 클릭 (0, 85). series1.yp=160(거리 75), series2.yp=90(거리 5) → series2.
+      const series1 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/01', y: 20, o: 20, xp: 0, yp: 160, index: 0 },
+        hit: false,
+      });
+      const series2 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/01', y: 55, o: 55, xp: 0, yp: 90, index: 0 },
+        hit: false,
+      });
+
+      const chart = createChart({ series1, series2 });
+      chart.findClosestDataIndex = () => 0;
+
+      const result = chart.findHitItem([0, 85], true);
+
+      expect(result.hitId).toBe('series2');
+    });
+  });
+});
+
+describe('plugins.interaction findClosestDataIndex', () => {
+  it('avgInterval < 6 이고 closestDistance < 6 이면 closestIndex를 반환한다', () => {
+    const chart = createChartForClosestIndex({
+      s1: createClosestSeries({
+        data: [
+          { xp: 10, yp: 100, o: 1 },
+          { xp: 14, yp: 100, o: 2 },
+          { xp: 18, yp: 100, o: 3 },
+        ],
+      }),
+    });
+
+    const result = chart.findClosestDataIndex([16, 0], ['s1']);
+    expect(result).toBe(1);
+  });
+
+  it('avgInterval > 6 이고 closestDistance < avgInterval 이면 closestIndex를 반환한다', () => {
+    const chart = createChartForClosestIndex({
+      s1: createClosestSeries({
+        data: [
+          { xp: 10, yp: 100, o: 1 },
+          { xp: 30, yp: 100, o: 2 },
+          { xp: 50, yp: 100, o: 3 },
+        ],
+      }),
+    });
+
+    const result = chart.findClosestDataIndex([37, 0], ['s1']);
+    expect(result).toBe(1);
+  });
+
+  it('closestDistance가 snapThreshold보다 크고 선형보간이 꺼져 있으면 -1을 반환한다', () => {
+    const chart = createChartForClosestIndex({
+      s1: createClosestSeries({
+        interpolation: 'none',
+        data: [
+          { xp: 10, yp: 100, o: 1 },
+          { xp: 20, yp: 100, o: 2 },
+        ],
+      }),
+    });
+
+    const result = chart.findClosestDataIndex([100, 0], ['s1']);
+    expect(result).toBe(-1);
+  });
+
+  it('모든 데이터가 null이고 disableNullLabelSnap=false면 -1을 반환한다', () => {
+    const chart = createChartForClosestIndex({
+      s1: createClosestSeries({
+        data: [
+          { xp: 10, yp: null, o: null },
+          { xp: 20, yp: null, o: null },
+        ],
+      }),
+      s2: createClosestSeries({
+        data: [
+          { xp: 10, yp: null, o: null },
+          { xp: 20, yp: null, o: null },
+        ],
+      }),
+    });
+
+    const result = chart.findClosestDataIndex([12, 0], ['s1', 's2'], false);
+    expect(result).toBe(-1);
+  });
+});


### PR DESCRIPTION
## 기존 동작
1. line / area 차트에서 일부 시리즈만 값이 null인 x축 라벨의 위쪽 빈 영역을 클릭하면, click event parameter의 seriesId가 null인 시리즈로 잘못 채워지고 value가 0으로 emit 되고있었습니다.

https://github.com/user-attachments/assets/1c8f428a-393c-4cca-85eb-d66a5a71d145

2. 데이터가 모두 null인 라벨 클릭하면 click event parameter의 value가 0으로 emit 되고있었습니다.

https://github.com/user-attachments/assets/2fbb2938-3322-4ae3-97a6-0947b27e748d

## 기대 동작
1. line / area 차트에서 일부 시리즈만 값이 null인 x축 라벨의 위쪽 빈 영역을 클릭하면, click event parameter의 seriesId가 null인 시리즈로 잘못 채워지고 value가 0으로 emit 되고있었습니다.

https://github.com/user-attachments/assets/a0529ea5-ef45-4d2f-9e20-085905d3e511

2. 데이터가 모두 null인 라벨 클릭하면 click event parameter의 value가 0으로 emit 되고있었습니다.

https://github.com/user-attachments/assets/c2ff4d53-4be3-483d-a97e-352ac4e65afb

## 테스트 방법
1. `npm run test:unit `
2. 예제: docs/views/lineChart/example/FillWithNull.vue
    또는 null이 있는 다양한 차트에서 테스트 해주세요.