### PR TITLE
fix: fill(with null) 차트에서 null 시리즈가 잘못 선택되는 onClick 버그

### DIFF
--- a/src/components/chart/element/element.bar.spec.js
+++ b/src/components/chart/element/element.bar.spec.js
@@ -102,4 +102,36 @@ describe('Bar Element', () => {
       expect(item.directHit).toBeFalsy();
     });
   });
+
+  describe('null 데이터 안전 fall-through (회귀 가드)', () => {
+    // bar 박스 비교는 null 좌표에서 NaN 으로 false fall-through.
+    const nullBar = { xp: null, yp: null, w: null, h: null, o: null, index: 0 };
+    const createBarWithNullData = () =>
+      createBar({
+        data: [nullBar],
+        show: true,
+        color: '#000',
+        visibleStartIndex: 0,
+        filteredCount: 1,
+      });
+
+    it('isPointInBar 는 null 박스 좌표에서 false 를 반환한다', () => {
+      const bar = createBar();
+      expect(bar.isPointInBar([40, 10], { xp: null, yp: null, w: null, h: null })).toBe(false);
+    });
+
+    it('dataIndex 분기(useIndicatorOnLabel=true) + null 데이터 → hit=false', () => {
+      const bar = createBarWithNullData();
+      const item = bar.findGraphData([40, 10], false, 0, true);
+      expect(item.hit).toBe(false);
+      expect(item.directHit).toBeFalsy();
+    });
+
+    it('binarySearchBar 경로(useIndicatorOnLabel=false) + null 데이터 → hit=false', () => {
+      const bar = createBarWithNullData();
+      const item = bar.findGraphData([40, 10], false, undefined, false);
+      expect(item.hit).toBe(false);
+      expect(item.directHit).toBeFalsy();
+    });
+  });
 });

--- a/src/components/chart/element/element.heatmap.spec.js
+++ b/src/components/chart/element/element.heatmap.spec.js
@@ -68,4 +68,25 @@ describe('HeatMap Element', () => {
       expect(hm.getFilteredLabel(labels, 10, 10, 20)).toEqual([]);
     });
   });
+
+  describe('findGraphData null 데이터 안전 fall-through (회귀 가드)', () => {
+    // 셀 박스 비교 `x <= xp && xp <= x+w` 는 null 좌표에서 NaN 비교로 false fall-through.
+    it('null 좌표 셀은 hit=false 로 fall-through 한다', () => {
+      const hm = createHeatMap({
+        data: [{ xp: null, yp: null, w: null, h: null, value: null }],
+      });
+      const item = hm.findGraphData([40, 10]);
+      expect(item.hit).toBe(false);
+      expect(item.data).toBe(null);
+    });
+
+    it('정상 셀 내부 클릭은 hit=true (회귀 가드)', () => {
+      const hm = createHeatMap({
+        data: [{ xp: 30, yp: 0, w: 20, h: 20, value: 5, dataColor: '#abc' }],
+      });
+      const item = hm.findGraphData([40, 10]);
+      expect(item.hit).toBe(true);
+      expect(item.index).toBe(0);
+    });
+  });
 });

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -385,15 +385,20 @@ class Line {
         item.index = dataIndex;
         if (item.data) {
           const point = gdata[dataIndex];
-          const yDist = Math.abs(yp - point.yp);
-          const directHitThreshold = 15; // 직접 히트 임계값
+          // null 좌표는 산술에서 0 으로 강제 변환되므로 hit 판정 대상에서 제외.
+          const hasValidPoint = point.o !== null && point.o !== undefined
+            && point.yp !== null && point.yp !== undefined;
+          if (hasValidPoint) {
+            const yDist = Math.abs(yp - point.yp);
+            const directHitThreshold = 15; // 직접 히트 임계값
 
-          if (yDist <= directHitThreshold) {
-            item.hit = true;
-          }
-          if (isLinePointDirectHit(point)) {
-            item.hit = true;
-            item.directHit = true;
+            if (yDist <= directHitThreshold) {
+              item.hit = true;
+            }
+            if (isLinePointDirectHit(point)) {
+              item.hit = true;
+              item.directHit = true;
+            }
           }
         }
       } else if (

--- a/src/components/chart/element/element.line.spec.js
+++ b/src/components/chart/element/element.line.spec.js
@@ -118,4 +118,63 @@ describe('Chart Interpolation', () => {
       expect(item.directHit).toBeFalsy();
     });
   });
+
+  describe('findGraphData — null 데이터 위 dataIndex 호출 (onClick 경로)', () => {
+    // FillWithNull.vue 데이터 모사. onClick 은 useSelectLabelOrItem=false 로 호출.
+    const makeSeries1 = () => {
+      const line = new Line('series1', { interpolation: 'none' }, 0);
+      line.show = true;
+      line.pointSize = 3;
+      line.data = [
+        { x: '01/01', y: 20, o: 20, xp: 0, yp: 160 },
+        { x: '01/02', y: 45, o: 45, xp: 20, yp: 110 },
+        { x: '01/03', y: null, o: null, xp: 40, yp: null },
+        { x: '01/04', y: null, o: null, xp: 60, yp: null },
+        { x: '01/05', y: 80, o: 80, xp: 80, yp: 40 },
+        { x: '01/06', y: 55, o: 55, xp: 100, yp: 90 },
+        { x: '01/07', y: null, o: null, xp: 120, yp: null },
+        { x: '01/08', y: 50, o: 50, xp: 140, yp: 100 },
+      ];
+      return line;
+    };
+
+    const makeSeries2 = () => {
+      const line = new Line('series2', { interpolation: 'none' }, 0);
+      line.show = true;
+      line.pointSize = 3;
+      line.data = [
+        { x: '01/01', y: 55, o: 55, xp: 0, yp: 90 },
+        { x: '01/02', y: 30, o: 30, xp: 20, yp: 140 },
+        { x: '01/03', y: 40, o: 40, xp: 40, yp: 120 },
+        { x: '01/04', y: null, o: null, xp: 60, yp: null },
+        { x: '01/05', y: 45, o: 45, xp: 80, yp: 110 },
+        { x: '01/06', y: 25, o: 25, xp: 100, yp: 150 },
+        { x: '01/07', y: 65, o: 65, xp: 120, yp: 70 },
+        { x: '01/08', y: 40, o: 40, xp: 140, yp: 120 },
+      ];
+      return line;
+    };
+
+    it('series1 dataIndex=2 (o=null, yp=null) 위쪽 클릭 → hit=false, directHit=false', () => {
+      const line = makeSeries1();
+      const item = line.findGraphData([40, 10], false, 2, false);
+      expect(item.hit).toBeFalsy();
+      expect(item.directHit).toBeFalsy();
+    });
+
+    it('series1 dataIndex=2 → 반환된 data.o 는 null 을 그대로 보존한다', () => {
+      const line = makeSeries1();
+      const item = line.findGraphData([40, 10], false, 2, false);
+      expect(item.data?.o).toBe(null);
+      expect(item.data?.yp).toBe(null);
+    });
+
+    it('series2 dataIndex=2 (o=40, yp=120) 위쪽(클릭 yp=10) → hit=false 이지만 data.o=40', () => {
+      const line = makeSeries2();
+      const item = line.findGraphData([40, 10], false, 2, false);
+      expect(item.hit).toBeFalsy();
+      expect(item.data?.o).toBe(40);
+      expect(item.data?.yp).toBe(120);
+    });
+  });
 });

--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -177,13 +177,15 @@ const modules = {
         value = lastTip.value;
         label = lastTip.label;
       } else if (lastTip.pos !== null) {
-        const item =
-          type === 'bar' ? this.getItemByLabelIndex(lastTip.pos) : this.getItemByLabel(lastTip.pos);
-
-        value = item.useStack ? item.acc : item.value;
-        label = item.label;
-        lastTip.value = value;
-        lastTip.label = label;
+        // line/scatter 는 getItemByLabel 이 미정의(dead code) — typeof 가드.
+        const fnName = type === 'bar' ? 'getItemByLabelIndex' : 'getItemByLabel';
+        if (typeof this[fnName] === 'function') {
+          const item = this[fnName](lastTip.pos);
+          value = item.useStack ? item.acc : item.value;
+          label = item.label;
+          lastTip.value = value;
+          lastTip.label = label;
+        }
       }
     }
 

--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -168,10 +168,15 @@ const modules = {
     let value = isHorizontal ? series.minMax.maxX : series.minMax.maxY;
     let label;
     if (tipType === 'sel') {
-      if (hitInfo && hitInfo.value !== null) {
-        value = hitInfo.useStack ? hitInfo.acc : hitInfo.value;
+      if (hitInfo && hitInfo.label !== null) {
+        // value=null 라벨 클릭에서도 label 자체는 hitInfo 우선. value 만 별도 fallback.
         label = hitInfo.label;
-        lastTip.value = value;
+        if (hitInfo.value !== null) {
+          value = hitInfo.useStack ? hitInfo.acc : hitInfo.value;
+          lastTip.value = value;
+        } else if (lastTip.value !== null) {
+          value = lastTip.value;
+        }
         lastTip.label = label;
       } else if (lastTip.value !== null) {
         value = lastTip.value;

--- a/src/components/chart/element/element.tip.spec.js
+++ b/src/components/chart/element/element.tip.spec.js
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import modules from './element.tip';
+
+const createCtx = ({ lastTip = { pos: null, value: null, label: null } } = {}) =>
+  Object.assign(Object.create(modules), {
+    options: { horizontal: false },
+    chartRect: { x1: 0, x2: 100, y1: 0, y2: 100, chartWidth: 100, chartHeight: 100 },
+    labelOffset: { left: 0, right: 0, top: 0, bottom: 0 },
+    axesSteps: { x: [{ graphMin: 0, graphMax: 10 }], y: [{ graphMin: 0, graphMax: 100 }] },
+    lastTip,
+    scrollbar: { x: {}, y: {} },
+  });
+
+const buildSeries = (overrides = {}) => ({
+  type: 'line',
+  size: { comboOffset: 0 },
+  xAxisIndex: 0,
+  yAxisIndex: 0,
+  minMax: { maxDomain: 5, maxDomainIndex: 0, maxX: 10, maxY: 100 },
+  ...overrides,
+});
+
+describe('element.tip calculateTipInfo — sel 분기 label 우선 동작', () => {
+  it('hitInfo.value 가 valid → label/value 모두 hitInfo, lastTip 갱신', () => {
+    const ctx = createCtx();
+    const result = ctx.calculateTipInfo(buildSeries(), 'sel', {
+      label: 5, value: 50, useStack: false, dataIndex: 0,
+    });
+
+    expect(result.label).toBe(5);
+    expect(result.value).toBe(50);
+    expect(ctx.lastTip.label).toBe(5);
+    expect(ctx.lastTip.value).toBe(50);
+  });
+
+  it('hitInfo.value=null + hitInfo.label valid + lastTip 비어있음 → label=hitInfo, value=default(maxY)', () => {
+    const ctx = createCtx();
+    const result = ctx.calculateTipInfo(buildSeries(), 'sel', {
+      label: 3, value: null, dataIndex: 3,
+    });
+
+    expect(result.label).toBe(3);
+    expect(result.value).toBe(100); // series.minMax.maxY
+  });
+
+  it('(회귀 가드) hitInfo.value=null + hitInfo.label valid + lastTip.label 다른 값 → label=hitInfo, value=lastTip', () => {
+    // 직전 클릭이 데이터 있는 라벨(idx=1, value=80)이고 현재 클릭이 null 라벨(idx=3).
+    // 잘못된 fallback 으로 돌아가면 label=1 로 떨어진다 → RED.
+    const ctx = createCtx({ lastTip: { pos: 1, value: 80, label: 1 } });
+    const result = ctx.calculateTipInfo(buildSeries(), 'sel', {
+      label: 3, value: null, dataIndex: 3,
+    });
+
+    expect(result.label).toBe(3);
+    expect(result.value).toBe(80);
+  });
+
+  it('hitInfo.label=null + lastTip.label valid → lastTip 으로 fallback', () => {
+    const ctx = createCtx({ lastTip: { pos: 2, value: 30, label: 2 } });
+    const result = ctx.calculateTipInfo(buildSeries(), 'sel', {
+      label: null, value: null,
+    });
+
+    expect(result.label).toBe(2);
+    expect(result.value).toBe(30);
+  });
+
+  it('hitInfo.label=null + lastTip 도 모두 null → label=undefined, value=default', () => {
+    const ctx = createCtx();
+    const result = ctx.calculateTipInfo(buildSeries(), 'sel', {
+      label: null, value: null,
+    });
+
+    expect(result.label).toBeUndefined();
+    expect(result.value).toBe(100);
+  });
+
+  it('bar 타입 + hitInfo → label/value 가 hitInfo 그대로 반영', () => {
+    const ctx = createCtx();
+    const series = buildSeries({
+      type: 'bar',
+      size: { w: 10, h: 0, cat: 20, cPad: 0, bar: 10, ix: 0, bPad: 0 },
+    });
+    const result = ctx.calculateTipInfo(series, 'sel', {
+      label: 'A', value: 50, useStack: false, dataIndex: 2,
+    });
+
+    expect(result.label).toBe('A');
+    expect(result.value).toBe(50);
+  });
+});

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -832,12 +832,21 @@ const modules = {
           return null;
         }
 
-        return this.getHitItemByPosition(
+        const hitInfo = this.getHitItemByPosition(
           [dataInfo?.xp ?? 0, dataInfo?.yp ?? 0],
           useApproximate,
           idx,
           true,
         );
+
+        // 모두 null 라벨에서 sId='' 반환 → element.tip indicator 그리기 skip 회피.
+        if (hitInfo && !hitInfo.sId) {
+          hitInfo.sId = firShowSeriesID;
+          hitInfo.label = this.data?.labels?.[idx] ?? hitInfo.label;
+          hitInfo.dataIndex = idx;
+        }
+
+        return hitInfo;
       });
     }
 
@@ -1080,7 +1089,7 @@ const modules = {
       type: hasHit ? hitType : fallbackType,
       label: hasHit ? hitLabel : fallbackLabel,
       pos: hasHit ? hitValuePos : fallbackValuePos,
-      value: (hasHit ? hitValue : fallbackValue) ?? 0,
+      value: hasHit ? hitValue : fallbackValue,
       sId: hasHit ? hitSeriesID : fallbackSeriesID,
       acc,
       useStack,

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -495,6 +495,56 @@ describe('model.store getHitItemByPosition', () => {
       expect(result.dataIndex).toBe(0);
     });
   });
+
+  describe('area 차트 — null 시리즈는 후보에서 제외', () => {
+    // area 차트(line + fill) 의 null 데이터 처리. hit detection 흐름은 동일하지만,
+    // isExistGrp + linear interpolation 시 element.line.draw 가 null 데이터의 yp 를
+    // baseline 으로 채우는 케이스가 있다. 그래도 o=null 이면 후보에서 제외되어야 한다.
+
+    it('o=null 시리즈는 yp 가 baseline 으로 채워져도 fallback 후보에서 제외된다', () => {
+      // isExistGrp + linear interpolation 모방: yp=100 (baseline) 으로 set 되었지만 o=null.
+      // hasMeaningfulValue 체크(g = data.o || data.y)가 모두 null 이라 후보 미등록.
+      const nullSeries = mockSeries({
+        type: 'line',
+        isExistGrp: true,
+        interpolation: 'linear',
+        data: { x: 'L0', y: null, o: null, xp: 50, yp: 100, index: 0 },
+        hit: false,
+      });
+      const valueSeries = mockSeries({
+        type: 'line',
+        data: { x: 'L0', y: 50, o: 50, xp: 50, yp: 80, index: 0 },
+        hit: false,
+      });
+
+      const store = createStore({ nullOne: nullSeries, valueOne: valueSeries });
+      const result = store.getHitItemByPosition([50, 100]);
+
+      expect(result.sId).toBe('valueOne');
+      expect(result.value).toBe(50);
+    });
+
+    it('o=null 시리즈가 클릭 좌표에 더 가까워도(yp 직격) 값 있는 시리즈가 선택된다', () => {
+      // 클릭 (50, 100). nullOne.yp=100 정확히 직격(거리 0), valueOne.yp=80 (거리 20).
+      // 거리만 보면 nullOne 이 이기지만 hasMeaningfulValue=false 라 후보 미등록.
+      const nullSeries = mockSeries({
+        type: 'line',
+        data: { x: 'L0', y: null, o: null, xp: 50, yp: 100, index: 0 },
+        hit: false,
+      });
+      const valueSeries = mockSeries({
+        type: 'line',
+        data: { x: 'L0', y: 50, o: 50, xp: 50, yp: 80, index: 0 },
+        hit: false,
+      });
+
+      const store = createStore({ nullOne: nullSeries, valueOne: valueSeries });
+      const result = store.getHitItemByPosition([50, 100]);
+
+      expect(result.sId).toBe('valueOne');
+      expect(result.value).toBe(50);
+    });
+  });
 });
 
 describe('model.store getItem (selectLabel indicator 용)', () => {

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -395,7 +395,7 @@ describe('model.store getHitItemByPosition', () => {
       const result = store.getHitItemByPosition([50, 250], false, undefined, false, true);
 
       expect(result.sId).toBe('');
-      expect(result.value).toBe(0);
+      expect(result.value).toBeNull();
       expect(result.label).toBe('L1');
       expect(result.dataIndex).toBe(1);
     });
@@ -420,5 +420,138 @@ describe('model.store getHitItemByPosition', () => {
       expect(result.sId).toBe('');
       expect(result.dataIndex).toBe(null);
     });
+  });
+
+  describe('Fill(with null) 8라벨 × 2시리즈 — onClick 경로 회귀', () => {
+    // FillWithNull.vue 데이터 모사. onClick 경로 인자로 호출.
+    const buildSeries1Points = () => [
+      { x: '01/01', y: 20, o: 20, xp: 0, yp: 160, index: 0 },
+      { x: '01/02', y: 45, o: 45, xp: 20, yp: 110, index: 1 },
+      { x: '01/03', y: null, o: null, xp: 40, yp: null, index: 2 },
+      { x: '01/04', y: null, o: null, xp: 60, yp: null, index: 3 },
+      { x: '01/05', y: 80, o: 80, xp: 80, yp: 40, index: 4 },
+      { x: '01/06', y: 55, o: 55, xp: 100, yp: 90, index: 5 },
+      { x: '01/07', y: null, o: null, xp: 120, yp: null, index: 6 },
+      { x: '01/08', y: 50, o: 50, xp: 140, yp: 100, index: 7 },
+    ];
+    const buildSeries2Points = () => [
+      { x: '01/01', y: 55, o: 55, xp: 0, yp: 90, index: 0 },
+      { x: '01/02', y: 30, o: 30, xp: 20, yp: 140, index: 1 },
+      { x: '01/03', y: 40, o: 40, xp: 40, yp: 120, index: 2 },
+      { x: '01/04', y: null, o: null, xp: 60, yp: null, index: 3 },
+      { x: '01/05', y: 45, o: 45, xp: 80, yp: 110, index: 4 },
+      { x: '01/06', y: 25, o: 25, xp: 100, yp: 150, index: 5 },
+      { x: '01/07', y: 65, o: 65, xp: 120, yp: 70, index: 6 },
+      { x: '01/08', y: 40, o: 40, xp: 140, yp: 120, index: 7 },
+    ];
+
+    const createFillStore = () =>
+      createStore({
+        series1: mockLineWithIndexedData({ points: buildSeries1Points() }),
+        series2: mockLineWithIndexedData({ points: buildSeries2Points() }),
+      });
+
+    it('01/03 (series1 만 null) 위쪽 빈 영역 클릭 → series2 선택, value=40', () => {
+      const store = createFillStore();
+      const result = store.getHitItemByPosition([40, 10], false, undefined, false, true);
+
+      expect(result.sId).toBe('series2');
+      expect(result.value).toBe(40);
+      expect(result.dataIndex).toBe(2);
+    });
+
+    it('01/04 (둘 다 null) 위쪽 빈 영역 클릭 → sId="", label="01/04", dataIndex=3', () => {
+      const store = createFillStore();
+      const result = store.getHitItemByPosition([60, 10], false, undefined, false, true);
+
+      expect(result.sId).toBe('');
+      expect(result.label).toBe('01/04');
+      expect(result.dataIndex).toBe(3);
+    });
+
+    it('01/04 (둘 다 null) 클릭 시 value 는 null 로 emit 된다', () => {
+      // 0 강제 변환 시 "값이 0" 과 "값이 없음" 구분 불가.
+      const store = createFillStore();
+      const result = store.getHitItemByPosition([60, 10], false, undefined, false, true);
+
+      expect(result.value).toBeNull();
+    });
+
+    it('01/07 (series1 만 null) 위쪽 빈 영역 클릭 → series2 선택, value=65', () => {
+      const store = createFillStore();
+      const result = store.getHitItemByPosition([120, 10], false, undefined, false, true);
+
+      expect(result.sId).toBe('series2');
+      expect(result.value).toBe(65);
+      expect(result.dataIndex).toBe(6);
+    });
+
+    it('01/01 (둘 다 값) 위쪽 빈 영역 클릭 → 클릭 좌표에 가까운 쪽이 선택된다', () => {
+      const store = createFillStore();
+      const result = store.getHitItemByPosition([0, 85], false, undefined, false, true);
+
+      expect(result.sId).toBe('series2');
+      expect(result.value).toBe(55);
+      expect(result.dataIndex).toBe(0);
+    });
+  });
+});
+
+describe('model.store getItem (selectLabel indicator 용)', () => {
+  // selectLabel 시 chart.core.drawTip → getItem 결과가 element.tip 에 전달된다.
+  // 모두 null 라벨에서 sId='' 이면 indicator 그리기가 skip 되므로 sId 를 보정해야 한다.
+
+  const buildSeries = (points) => ({
+    type: 'line',
+    show: true,
+    data: points,
+    stackIndex: null,
+    findGraphData: (offset, isHorizontal, dataIndex) => {
+      if (typeof dataIndex === 'number') {
+        const data = points[dataIndex] ?? null;
+        return { data, hit: false, directHit: false, index: dataIndex };
+      }
+      return { data: null, hit: false, directHit: false, index: 0 };
+    },
+  });
+
+  const buildFillStore = () => {
+    const points1 = [
+      { x: '01/01', y: 20, o: 20, xp: 0, yp: 160, index: 0 },
+      { x: '01/02', y: 45, o: 45, xp: 20, yp: 110, index: 1 },
+      { x: '01/03', y: null, o: null, xp: 40, yp: null, index: 2 },
+      { x: '01/04', y: null, o: null, xp: 60, yp: null, index: 3 },
+    ];
+    const points2 = [
+      { x: '01/01', y: 55, o: 55, xp: 0, yp: 90, index: 0 },
+      { x: '01/02', y: 30, o: 30, xp: 20, yp: 140, index: 1 },
+      { x: '01/03', y: 40, o: 40, xp: 40, yp: 120, index: 2 },
+      { x: '01/04', y: null, o: null, xp: 60, yp: null, index: 3 },
+    ];
+    const store = createStore({
+      series1: buildSeries(points1),
+      series2: buildSeries(points2),
+    });
+    store.data = { labels: ['01/01', '01/02', '01/03', '01/04'] };
+    return store;
+  };
+
+  it('모두 null 인 라벨(01/04) selectLabel → 첫 visible series 의 sId/label/dataIndex 가 보정된다', () => {
+    const store = buildFillStore();
+    const result = store.getItem({ dataIndex: [3] });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).not.toBeNull();
+    expect(result[0].sId).toBe('series1');
+    expect(result[0].label).toBe('01/04');
+    expect(result[0].dataIndex).toBe(3);
+  });
+
+  it('일부 null 라벨(01/03) selectLabel → hit detection fallback 으로 series2 가 선택된다', () => {
+    const store = buildFillStore();
+    const result = store.getItem({ dataIndex: [2] });
+
+    expect(result[0].sId).toBe('series2');
+    expect(result[0].dataIndex).toBe(2);
   });
 });

--- a/src/components/chart/plugins/plugins.interaction.spec.js
+++ b/src/components/chart/plugins/plugins.interaction.spec.js
@@ -182,6 +182,106 @@ describe('plugins.interaction findHitItem', () => {
       expect(result.hitId).toBe('bar1');
     });
   });
+
+  describe('Fill(with null) 8라벨 × 2시리즈 — onDblClick(findHitItem) 회귀', () => {
+    // mock 은 element.line null 가드 적용 후의 결과(null 포인트 → hit=false) 모방.
+
+    it('01/03 (series1 만 null) → hitId=series2, items 에 series2 만', () => {
+      const series1 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/03', y: null, o: null, xp: 40, yp: null, index: 2 },
+        hit: false,
+        directHit: false,
+      });
+      const series2 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/03', y: 40, o: 40, xp: 40, yp: 120, index: 2 },
+        hit: false,
+        directHit: false,
+      });
+
+      const chart = createChart({ series1, series2 });
+      chart.findClosestDataIndex = () => 2;
+
+      const result = chart.findHitItem([40, 10], true);
+
+      expect(result.hitId).toBe('series2');
+      expect(Object.keys(result.items)).toEqual(['series2']);
+    });
+
+    it('01/04 (둘 다 null) → hitId="", items[""] synthetic (label/dataIndex 보존)', () => {
+      const series1 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/04', y: null, o: null, xp: 60, yp: null, index: 3 },
+        hit: false,
+      });
+      const series2 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/04', y: null, o: null, xp: 60, yp: null, index: 3 },
+        hit: false,
+      });
+
+      // synthetic items[''] 는 series.data?.[targetDataIndex] 의 x/y 를 참조하므로
+      // mock 시리즈에 series.data 배열을 명시 주입.
+      series1.data = [
+        { x: '01/01', y: 20, o: 20 },
+        { x: '01/02', y: 45, o: 45 },
+        { x: '01/03', y: null, o: null },
+        { x: '01/04', y: null, o: null },
+      ];
+
+      const chart = createChart({ series1, series2 });
+      chart.findClosestDataIndex = () => 3;
+
+      const result = chart.findHitItem([60, 10], true);
+
+      expect(result.hitId).toBe('');
+      expect(result.items[''].label).toBe('01/04');
+      expect(result.items[''].index).toBe(3);
+    });
+
+    it('01/07 (series1 만 null) → hitId=series2', () => {
+      const series1 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/07', y: null, o: null, xp: 120, yp: null, index: 6 },
+        hit: false,
+      });
+      const series2 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/07', y: 65, o: 65, xp: 120, yp: 70, index: 6 },
+        hit: false,
+      });
+
+      const chart = createChart({ series1, series2 });
+      chart.findClosestDataIndex = () => 6;
+
+      const result = chart.findHitItem([120, 10], true);
+
+      expect(result.hitId).toBe('series2');
+      expect(Object.keys(result.items)).toEqual(['series2']);
+    });
+
+    it('01/01 (둘 다 값) → 거리 가까운 시리즈가 hitId', () => {
+      // 클릭 (0, 85). series1.yp=160(거리 75), series2.yp=90(거리 5) → series2.
+      const series1 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/01', y: 20, o: 20, xp: 0, yp: 160, index: 0 },
+        hit: false,
+      });
+      const series2 = mockSeries({
+        interpolation: 'none',
+        data: { x: '01/01', y: 55, o: 55, xp: 0, yp: 90, index: 0 },
+        hit: false,
+      });
+
+      const chart = createChart({ series1, series2 });
+      chart.findClosestDataIndex = () => 0;
+
+      const result = chart.findHitItem([0, 85], true);
+
+      expect(result.hitId).toBe('series2');
+    });
+  });
 });
 
 describe('plugins.interaction findClosestDataIndex', () => {


### PR DESCRIPTION
## 기존 동작
1. line / area 차트에서 일부 시리즈만 값이 null인 x축 라벨의 위쪽 빈 영역을 클릭하면, click event parameter의 seriesId가 null인 시리즈로 잘못 채워지고 value가 0으로 emit 되고있었습니다.

https://github.com/user-attachments/assets/1c8f428a-393c-4cca-85eb-d66a5a71d145

2. 데이터가 모두 null인 라벨 클릭하면 click event parameter의 value가 0으로 emit 되고있었습니다.

https://github.com/user-attachments/assets/2fbb2938-3322-4ae3-97a6-0947b27e748d

## 기대 동작
1. line / area 차트에서 일부 시리즈만 값이 null인 x축 라벨의 위쪽 빈 영역을 클릭하면, click event parameter의 seriesId가 null인 시리즈로 잘못 채워지고 value가 0으로 emit 되고있었습니다.

https://github.com/user-attachments/assets/3ac13c19-952c-4588-9271-a86742b9d4ce

2. 데이터가 모두 null인 라벨 클릭하면 click event parameter의 value가 0으로 emit 되고있었습니다.

https://github.com/user-attachments/assets/8f4e0938-1d39-48a1-9931-98d808d2ab85


## 테스트 방법
1. npm run test
2. 예제: docs/views/lineChart/example/FillWithNull.vue
    또는 null이 있는 다양한 차트에서 테스트 해주세요.

related #2248 