### PR TITLE
feat: willReadFrequently 옵션을 pie type에만 적용

### DIFF
--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -55,12 +55,13 @@ class EvChart {
     this.wrapperDOM.appendChild(this.chartDOM);
     this.target.appendChild(this.wrapperDOM);
 
+    const isPie = options.type === 'pie';
     this.displayCanvas = document.createElement('canvas');
     this.displayCanvas.setAttribute('style', 'display: block;');
-    this.displayCtx = this.displayCanvas.getContext('2d');
+    this.displayCtx = this.displayCanvas.getContext('2d', { willReadFrequently: isPie });
     this.bufferCanvas = document.createElement('canvas');
     this.bufferCanvas.setAttribute('style', 'display: block;');
-    this.bufferCtx = this.bufferCanvas.getContext('2d');
+    this.bufferCtx = this.bufferCanvas.getContext('2d', { willReadFrequently: isPie });
 
     this.pixelRatio = window.devicePixelRatio || 1;
     this.oldPixelRatio = this.pixelRatio;
@@ -71,7 +72,7 @@ class EvChart {
       this.overlayCanvas = document.createElement('canvas');
       this.overlayCanvas.setAttribute('style', 'display: block; z-index: 2;');
       this.overlayCanvas.setAttribute('class', 'overlay-canvas');
-      this.overlayCtx = this.overlayCanvas.getContext('2d');
+      this.overlayCtx = this.overlayCanvas.getContext('2d', { willReadFrequently: isPie });
 
       this.chartDOM.appendChild(this.overlayCanvas);
 


### PR DESCRIPTION
## 문제

GPU 가속 환경에서 125% 배율(fractional scale) 사용 시  
파이/도넛 차트의 도넛 홀 내부 테두리가 자글자글하게 깨져 보이는 현상이 발생했습니다.

특정 Lenovo PC에서 재현되었으며, Chrome GPU 가속을 비활성화하면 정상적으로 렌더링되는 것으로 확인되었습니다.

## 원인

도넛 차트의 hole 영역은 `destination-out` 합성 모드를 사용해 중앙 영역을 지우는 방식으로 처리되고 있습니다.

일부 GPU 가속 Canvas 환경에서는 fractional scale과 함께 사용될 때  
해당 합성 경계가 불안정하게 처리되어 도넛 홀 내부 테두리에 잔여 픽셀이 남는 것으로 판단했습니다.

## 수정

기존에는 `willReadFrequently` 옵션을 전체 차트 canvas context에 적용하는 방향을 검토했으나,  
전체 차트 타입에 적용할 경우 불필요한 렌더링 성능 저하가 발생할 수 있어 적용 범위를 제한했습니다.

- `options.type === 'pie'` 여부를 기준으로 `isPie` 값 추가
- 파이 차트인 경우에만 canvas context 생성 시 `willReadFrequently: true` 적용
  - `displayCtx`
  - `bufferCtx`
  - `overlayCtx`
- 파이 차트가 아닌 경우에는 기존과 동일하게 `willReadFrequently: false`로 동작

```js
const isPie = options.type === 'pie';

this.displayCtx = this.displayCanvas.getContext('2d', { willReadFrequently: isPie });
this.bufferCtx = this.bufferCanvas.getContext('2d', { willReadFrequently: isPie });
this.overlayCtx = this.overlayCanvas.getContext('2d', { willReadFrequently: isPie });