### PR TITLE
[#2252] fix: Chart > Horizontal Bar > showValue > align: out 표시되지 않는 현상

### DIFF
--- a/docs/views/barChart/example/ShowValue.vue
+++ b/docs/views/barChart/example/ShowValue.vue
@@ -1,0 +1,167 @@
+<template>
+  <div class="case">
+    <resizable-wrapper>
+      <ev-chart :data="chartData" :options="chartOptions" />
+    </resizable-wrapper>
+  </div>
+  <div class="description">
+    <div class="row">
+      <div class="row-item">
+        <span class="item-title">Horizontal</span>
+        <ev-toggle v-model="isHorizontal" class="component" />
+      </div>
+      <div class="row-item">
+        <span class="item-title">Include Negative</span>
+        <ev-toggle v-model="useNegative" class="component" />
+      </div>
+    </div>
+    <div class="row">
+      <div class="row-item">
+        <span class="item-title">align</span>
+        <ev-select v-model="align" :items="alignItems" class="component" />
+      </div>
+      <div class="row-item">
+        <span class="item-title">fontSize</span>
+        <ev-input-number v-model="fontSize" :min="8" :max="30" class="component" />
+      </div>
+      <div class="row-item">
+        <span class="item-title">thickness</span>
+        <ev-input-number
+          v-model="thickness"
+          :min="0.1"
+          :max="1"
+          :step="0.1"
+          class="component"
+        />
+      </div>
+    </div>
+    <div class="row hint">
+      <span>
+        series1: [1500, 200, 30, 5, 0] &nbsp;/&nbsp;
+        series2 (negative on): [-800, -150, -20, -3, 0]
+      </span>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed } from 'vue';
+
+export default {
+  setup() {
+    const isHorizontal = ref(false);
+    const useNegative = ref(false);
+    const align = ref('out');
+    const fontSize = ref(12);
+    const thickness = ref(0.8);
+
+    const alignItems = [
+      { name: 'start', value: 'start' },
+      { name: 'center', value: 'center' },
+      { name: 'out', value: 'out' },
+      { name: 'end', value: 'end' },
+    ];
+
+    const numFormatter = (value) => {
+      const abs = Math.abs(value);
+      const sign = value < 0 ? '-' : '';
+      if (abs >= 1000) return `${sign}${(abs / 1000).toFixed(1)}K`;
+      return `${sign}${abs}`;
+    };
+
+    const showValueOption = computed(() => ({
+      use: true,
+      fontSize: fontSize.value,
+      align: align.value,
+    }));
+
+    const labels = ['Large', 'Medium', 'Small', 'Tiny', 'Zero'];
+
+    const chartData = computed(() => ({
+      series: {
+        series1: {
+          name: 'Series #1',
+          showValue: showValueOption.value,
+        },
+        series2: {
+          name: 'Series #2',
+          showValue: showValueOption.value,
+        },
+      },
+      labels,
+      data: {
+        series1: [1500, 200, 30, 5, 0],
+        series2: useNegative.value ? [-800, -150, -20, -3, 0] : [800, 150, 20, 3, 0],
+      },
+    }));
+
+    const stepAxes = computed(() => [
+      {
+        type: 'step',
+        showGrid: true,
+      },
+    ]);
+
+    const linearAxes = computed(() => [
+      {
+        type: 'linear',
+        startToZero: !useNegative.value,
+        autoScaleRatio: 0.2,
+        showGrid: true,
+      },
+    ]);
+
+    const chartOptions = computed(() => ({
+      type: 'bar',
+      thickness: thickness.value,
+      horizontal: isHorizontal.value,
+      axesX: isHorizontal.value ? linearAxes.value : stepAxes.value,
+      axesY: isHorizontal.value ? stepAxes.value : linearAxes.value,
+    }));
+
+    return {
+      isHorizontal,
+      useNegative,
+      align,
+      fontSize,
+      thickness,
+      alignItems,
+      chartData,
+      chartOptions,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.row {
+  display: flex;
+  flex-direction: row;
+  margin-top: 15px;
+  gap: 10px;
+
+  .row-item {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+
+    .item-title {
+      line-height: 33px;
+      margin-right: 3px;
+      min-width: 110px;
+      text-align: right;
+      white-space: nowrap;
+    }
+
+    .component {
+      max-width: 200px;
+    }
+  }
+
+  &.hint {
+    font-size: 12px;
+    color: #888;
+    margin-top: 8px;
+  }
+}
+</style>

--- a/docs/views/barChart/example/ShowValue.vue
+++ b/docs/views/barChart/example/ShowValue.vue
@@ -22,7 +22,7 @@
       </div>
       <div class="row-item">
         <span class="item-title">fontSize</span>
-        <ev-input-number v-model="fontSize" :min="8" :max="30" class="component" />
+        <ev-input-number v-model="fontSize" :min="8" :max="40" class="component" />
       </div>
       <div class="row-item">
         <span class="item-title">thickness</span>

--- a/docs/views/barChart/props.js
+++ b/docs/views/barChart/props.js
@@ -36,6 +36,8 @@ import UnSelectedOpacity from './example/UnSelectedOpacity';
 import UnSelectedOpacityRaw from './example/UnSelectedOpacity?raw';
 import AxesScaleChangeRaw from './example/AxesScaleChange?raw';
 import AxesScaleChange from './example/AxesScaleChange';
+import ShowValue from './example/ShowValue';
+import ShowValueRaw from './example/ShowValue?raw';
 
 export default {
   mdText,
@@ -137,6 +139,12 @@ export default {
         '차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 확인할 수 있습니다.',
       component: AxesScaleChange,
       parsedData: parse(AxesScaleChangeRaw).descriptor,
+    },
+    ShowValue: {
+      description:
+        'showValue 옵션의 align(start/center/out/end)과 horizontal 조합을 인터랙티브하게 테스트할 수 있습니다.',
+      component: ShowValue,
+      parsedData: parse(ShowValueRaw).descriptor,
     },
   },
 };

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -567,11 +567,21 @@ class Bar {
               ctx.fillText(formattedTxt, xPos, centerYOnBar);
             }
           }
-        } else if (fitsInVerticalBar) {
-          const yPos = isNegativeValue
-            ? barY + barHeight + LABEL_MARGIN + textHeight / 2
-            : barY + barHeight - LABEL_MARGIN - textHeight / 2;
-          ctx.fillText(formattedTxt, centerXOnBar, yPos);
+        } else {
+          const minYOnChart = this.chartRect.y1 + this.labelOffset.top;
+          const maxYOnChart = this.chartRect.y2 - this.labelOffset.bottom;
+
+          if (isNegativeValue) {
+            const yPos = barY + barHeight + LABEL_MARGIN + textHeight / 2;
+            if (yPos + textHeight / 2 <= maxYOnChart) {
+              ctx.fillText(formattedTxt, centerXOnBar, yPos);
+            }
+          } else {
+            const yPos = barY + barHeight - LABEL_MARGIN - textHeight / 2;
+            if (yPos - textHeight / 2 >= minYOnChart) {
+              ctx.fillText(formattedTxt, centerXOnBar, yPos);
+            }
+          }
         }
 
         break;

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -558,12 +558,12 @@ class Bar {
 
           if (isNegativeValue) {
             const xPos = barX - LABEL_MARGIN + barWidth - textWidth;
-            if (xPos > minXOnChart && textHeight + LABEL_MARGIN * 2 < absBarHeight) {
+            if (xPos > minXOnChart && textHeight < absBarHeight) {
               ctx.fillText(formattedTxt, xPos, centerYOnBar);
             }
           } else {
             const xPos = barX + LABEL_MARGIN + barWidth;
-            if (xPos + textWidth < maxXOnChart && textHeight + LABEL_MARGIN * 2 < absBarHeight) {
+            if (xPos + textWidth < maxXOnChart && textHeight < absBarHeight) {
               ctx.fillText(formattedTxt, xPos, centerYOnBar);
             }
           }

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -558,17 +558,19 @@ class Bar {
 
           if (isNegativeValue) {
             const xPos = barX - LABEL_MARGIN + barWidth - textWidth;
-            if (xPos > minXOnChart && textHeight < absBarHeight) {
+            if (xPos > minXOnChart) {
               ctx.fillText(formattedTxt, xPos, centerYOnBar);
             }
           } else {
             const xPos = barX + LABEL_MARGIN + barWidth;
-            if (xPos + textWidth < maxXOnChart && textHeight < absBarHeight) {
+            if (xPos + textWidth < maxXOnChart) {
               ctx.fillText(formattedTxt, xPos, centerYOnBar);
             }
           }
         } else if (fitsInVerticalBar) {
-          const yPos = isNegativeValue ? barY + barHeight + LABEL_MARGIN : barY + barHeight - LABEL_MARGIN;
+          const yPos = isNegativeValue
+            ? barY + barHeight + LABEL_MARGIN + textHeight / 2
+            : barY + barHeight - LABEL_MARGIN - textHeight / 2;
           ctx.fillText(formattedTxt, centerXOnBar, yPos);
         }
 

--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -109,7 +109,7 @@ class Bar {
     const bPad = isHorizontal ? (bArea - h) / 2 : (bArea - w) / 2;
     const barSeriesX = this.isExistGrp ? 1 : showIndex + 1;
 
-    this.size.cat = cArea;
+    this.size.bar = cArea;
     this.size.bar = bArea;
     this.size.cPad = cPad;
     this.size.bPad = bPad;
@@ -556,30 +556,34 @@ class Bar {
           const minXOnChart = this.chartRect.x1 + this.labelOffset.left;
           const maxXOnChart = this.chartRect.x2 - this.labelOffset.right;
 
-          if (isNegativeValue) {
-            const xPos = barX - LABEL_MARGIN + barWidth - textWidth;
-            if (xPos > minXOnChart) {
-              ctx.fillText(formattedTxt, xPos, centerYOnBar);
-            }
-          } else {
-            const xPos = barX + LABEL_MARGIN + barWidth;
-            if (xPos + textWidth < maxXOnChart) {
-              ctx.fillText(formattedTxt, xPos, centerYOnBar);
+          if (textHeight < this.size.bar) {
+            if (isNegativeValue) {
+              const xPos = barX - LABEL_MARGIN + barWidth - textWidth;
+              if (xPos > minXOnChart) {
+                ctx.fillText(formattedTxt, xPos, centerYOnBar);
+              }
+            } else {
+              const xPos = barX + LABEL_MARGIN + barWidth;
+              if (xPos + textWidth < maxXOnChart) {
+                ctx.fillText(formattedTxt, xPos, centerYOnBar);
+              }
             }
           }
         } else {
           const minYOnChart = this.chartRect.y1 + this.labelOffset.top;
           const maxYOnChart = this.chartRect.y2 - this.labelOffset.bottom;
 
-          if (isNegativeValue) {
-            const yPos = barY + barHeight + LABEL_MARGIN + textHeight / 2;
-            if (yPos + textHeight / 2 <= maxYOnChart) {
-              ctx.fillText(formattedTxt, centerXOnBar, yPos);
-            }
-          } else {
-            const yPos = barY + barHeight - LABEL_MARGIN - textHeight / 2;
-            if (yPos - textHeight / 2 >= minYOnChart) {
-              ctx.fillText(formattedTxt, centerXOnBar, yPos);
+          if (textWidth <= this.size.bar) {
+            if (isNegativeValue) {
+              const yPos = barY + barHeight + LABEL_MARGIN + textHeight / 2;
+              if (yPos + textHeight / 2 <= maxYOnChart) {
+                ctx.fillText(formattedTxt, centerXOnBar, yPos);
+              }
+            } else {
+              const yPos = barY + barHeight - LABEL_MARGIN - textHeight / 2;
+              if (yPos - textHeight / 2 >= minYOnChart) {
+                ctx.fillText(formattedTxt, centerXOnBar, yPos);
+              }
             }
           }
         }


### PR DESCRIPTION
### 이슈 내용 
Bar Chart > Horizontal : true > showValue: align:out 일 때  value가 표시되지 않는 현상 발생 

### 수정 내용 
1. Out일 때 바 크기와 무관하게 텍스트를 표시하고, 차트 경계 이탈 시에만 숨기도록 수정
3. Horizontal:false +  Out 조합일 때 막대 사이와의 간격이 없는 부분 수정 

### 이미지 
- Before
   - <img width="95" height="75" alt="image" src="https://github.com/user-attachments/assets/4560ee33-d697-4ed1-911d-b3c6b8f24535" />
- After
   - <img width="115" height="76" alt="image" src="https://github.com/user-attachments/assets/08cebff4-def2-49b5-b8ce-516a34eb1caa" />
 
 - Before
    - <img width="740" height="491" alt="image" src="https://github.com/user-attachments/assets/279864bc-c573-44e6-abf1-e2adcf8a4c01" />

 - After
    - <img width="576" height="273" alt="image" src="https://github.com/user-attachments/assets/5004e046-194f-44a2-91a1-9d85e85a321b" />
   - <img width="775" height="214" alt="image" src="https://github.com/user-attachments/assets/a55539ed-87cb-4558-9e34-a8c0080b6581" />
   - <img width="557" height="307" alt="image" src="https://github.com/user-attachments/assets/9a4686e8-bc76-42aa-8397-1ce4b305df5b" />



### 테스트 가이드 
- http://localhost:9999/EVUI/barChart#show-value