### PR TITLE
fix: Chart > BrushChart > 브러쉬 영역 드래그하여 늘릴 때 마우스가 전체 브러쉬 영역 벗어나면 오히려 줄어드는 현상

### DIFF
--- a/src/components/chartBrush/chartBrush.core.js
+++ b/src/components/chartBrush/chartBrush.core.js
@@ -185,8 +185,18 @@ export default class EvChartBrush {
     }
 
     const maxBrushCanvasWidth = brushCanvasWidth * pixelRatio;
+    const isButtonMode =
+      mode === BRUSH_UPDATE_MODE.BUTTON.INCREASE || mode === BRUSH_UPDATE_MODE.BUTTON.DECREASE;
 
-    if (this.brushRectX < 0) {
+    if (isButtonMode) {
+      if (this.brushRectX < 0) {
+        this.brushRectWidth += this.brushRectX;
+        this.brushRectX = 0;
+      }
+      if (this.brushRectX + this.brushRectWidth > maxBrushCanvasWidth) {
+        this.brushRectWidth = maxBrushCanvasWidth - this.brushRectX;
+      }
+    } else if (this.brushRectX < 0) {
       this.brushRectX = 0;
     } else if (this.brushRectX + this.brushRectWidth > maxBrushCanvasWidth) {
       this.brushRectX = maxBrushCanvasWidth - this.brushRectWidth;


### PR DESCRIPTION
### 문제 화면

https://github.com/user-attachments/assets/3b99e8f6-98e3-4dcd-b1ed-8a70ba218666

- 브러쉬 영역 드래그하여 늘릴 때 마우스가 전체 브러쉬 영역 벗어나면 오히려 줄어드는 현상이 있음

### 문제 원인
- setBrushXAndWidth 마지막에 있는 공통 클램프 로직이 모든 조작 모드에 동일하게 적용된 게 원인 (드래그 이동, 드래그 크기 조정)
- 이 로직은 width를 유지하고 x를 옮기는 방식이라서, 브러쉬 전체를 잡고 끄는 GRAB 모드엔 맞지만, 우측 버튼으로 엣지를 늘리는 BUTTON 모드엔 해당 이슈와 같은 버그를 유발할 수 있음

### 수정 내용
조작 모드를 구분해서 클램프 방식을 바꿨습니다.

- BUTTON 모드(엣지 리사이즈): 반대편 엣지를 고정한 채 width를 잘라냄
- GRAB 모드(전체 이동): 기존처럼 width 유지하고 x를 시프트

### 개선 화면

https://github.com/user-attachments/assets/1ed67ce2-5a6d-4d20-8ffc-e24ebc53bede

