### PR TITLE
fix: maxtip이 정상적인 위치에 그려지지 않는 현상 수정

### DIFF
--- a/src/components/chart/element/element.bar.js
+++ b/src/components/chart/element/element.bar.js
@@ -109,7 +109,7 @@ class Bar {
     const bPad = isHorizontal ? (bArea - h) / 2 : (bArea - w) / 2;
     const barSeriesX = this.isExistGrp ? 1 : showIndex + 1;
 
-    this.size.bar = cArea;
+    this.size.cat = cArea;
     this.size.bar = bArea;
     this.size.cPad = cPad;
     this.size.bPad = bPad;


### PR DESCRIPTION
### 개요
- <img width="703" height="350" alt="image" src="https://github.com/user-attachments/assets/e312a75c-5c23-47b0-8e3d-7537d3785ed3" />

- 오탈자 수정 

### 결과 
1. maxTip 정상 표시 
   - <img width="822" height="556" alt="maxtip issue" src="https://github.com/user-attachments/assets/bf84408f-03fd-48e0-89da-54ce41f0e793" />
2. 관련 이슈 정상 동작 확인
   - <img width="822" height="556" alt="showValue" src="https://github.com/user-attachments/assets/a3a16b8f-d40e-4b48-9b14-107f6688b153" />

