### PR TITLE
[#2260] fix: Chart > Tooltip > htmlFormatter 사용중일 때, 툴팁 내부 스크롤바가 없음에도 불구하고 마우스 휠 이벤트 막힘

### DIFF
--- a/docs/views/lineChart/example/CustomTooltip.vue
+++ b/docs/views/lineChart/example/CustomTooltip.vue
@@ -25,7 +25,7 @@ export default {
       ),
       labels: [],
       data: Object.fromEntries(
-        Array.from({ length: 100 }, (_, i) => {
+        Array.from({ length: 3 }, (_, i) => {
           const seriesId = `series${i + 1}`;
           return [seriesId, []];
         }),

--- a/docs/views/lineChart/example/CustomTooltip.vue
+++ b/docs/views/lineChart/example/CustomTooltip.vue
@@ -18,7 +18,7 @@ export default {
   setup() {
     const chartData = reactive({
       series: Object.fromEntries(
-        Array.from({ length: 100 }, (_, i) => {
+        Array.from({ length: 3 }, (_, i) => {
           const seriesId = `series${i + 1}`;
           return [seriesId, { name: `series#${i + 1}`, point: false }];
         }),

--- a/docs/views/lineChart/example/Tooltip.vue
+++ b/docs/views/lineChart/example/Tooltip.vue
@@ -180,7 +180,7 @@ export default {
     const topPadding = ref(0);
     const bottomPadding = ref(8);
     const showHeader = ref(true);
-    const showTooltip = ref(false);
+    const showTooltip = ref(true);
 
     const chartData = reactive({
       series: {

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -518,13 +518,11 @@ const modules = {
       const isScrollingUp = e.deltaY < 0;
       const isScrollingDown = e.deltaY > 0;
 
-      if ((isAtTop && isScrollingUp) || (isAtBottom && isScrollingDown)) {
-        this.hideTooltipDOM();
-        return;
-      }
-
       e.preventDefault();
-      scrollTarget.scrollTop += e.deltaY;
+
+      if (!(isAtTop && isScrollingUp) && !(isAtBottom && isScrollingDown)) {
+        scrollTarget.scrollTop += e.deltaY;
+      }
     };
 
     if (this.options?.tooltip?.useScrollbar) {

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -514,7 +514,7 @@ const modules = {
 
       const { scrollTop, scrollHeight, clientHeight } = scrollTarget;
       const isAtTop = scrollTop <= 0;
-      const isAtBottom = scrollTop + clientHeight >= scrollHeight;
+      const isAtBottom = Math.ceil(scrollTop) + clientHeight >= scrollHeight;
       const isScrollingUp = e.deltaY < 0;
       const isScrollingDown = e.deltaY > 0;
 

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -502,21 +502,29 @@ const modules = {
 
     this.onWheel = (e) => {
       const isTooltipVisible = this.tooltipDOM?.style?.display === 'block';
-      const customTooltip = this.tooltipDOM?.querySelector(this.options.tooltip.htmlScrollTarget);
+      if (!isTooltipVisible) return;
 
-      if (
-        isTooltipVisible ||
-        (customTooltip && customTooltip.scrollHeight > customTooltip.clientHeight)
-      ) {
-        e.preventDefault();
-
-        if (isTooltipVisible) {
-          this.tooltipBodyDOM.scrollTop += e.deltaY;
-        }
-        if (customTooltip) {
-          customTooltip.scrollTop += e.deltaY;
-        }
+      const scrollTarget =
+        this.tooltipDOM?.querySelector(this.options.tooltip.htmlScrollTarget) ||
+        this.tooltipBodyDOM;
+      if (!scrollTarget || scrollTarget.scrollHeight <= scrollTarget.clientHeight) {
+        this.hideTooltipDOM();
+        return;
       }
+
+      const { scrollTop, scrollHeight, clientHeight } = scrollTarget;
+      const isAtTop = scrollTop <= 0;
+      const isAtBottom = scrollTop + clientHeight >= scrollHeight;
+      const isScrollingUp = e.deltaY < 0;
+      const isScrollingDown = e.deltaY > 0;
+
+      if ((isAtTop && isScrollingUp) || (isAtBottom && isScrollingDown)) {
+        this.hideTooltipDOM();
+        return;
+      }
+
+      e.preventDefault();
+      scrollTarget.scrollTop += e.deltaY;
     };
 
     if (this.options?.tooltip?.useScrollbar) {

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -570,7 +570,7 @@ const module = {
       if (isTooltipVisible && tooltipBodyDOM) {
         const { scrollTop, scrollHeight, clientHeight } = tooltipBodyDOM;
         const isAtTop = scrollTop <= 0;
-        const isAtBottom = scrollTop + clientHeight >= scrollHeight;
+        const isAtBottom = Math.ceil(scrollTop) + clientHeight >= scrollHeight;
 
         const isScrollingUp = e.deltaY < 0;
         const isScrollingDown = e.deltaY > 0;


### PR DESCRIPTION
### 배경 
- chart > tooltip > formatter > html 옵션을 사용중일 때, 마우스 휠 이벤트가 viewport로 전파되지 않는 현상 발생 

### 수정 내용 
- tooltip 내부에 스크롤 가능한 콘텐츠가 없거나, 내부 스크롤이 끝에 도달한 경우, preventDefault()를 호출하지 않아 viewport 스크롤이 정상 동작하도록 변경
**- 스펙 변경
   - 툴팁 내부에 스크롤이 생겼을 때, 스크롤 천장 혹은 바닥에 닿은 상태에서 추가적인 휠 이벤트가 발생할 경우 이벤트를 부모로 전가한다. 
   -> 전가하지 않는다**

### Before
- LineChart Docs > Tooltip, Custom Tooltip 예제에서 차트 툴팁이 보이는 상태에서 마우스 휠 이벤트 동작을 할 경우 viewport가 이동되지 않음 
- <img width="1132" height="840" alt="tooltip_wheel-evnet-after-44" src="https://github.com/user-attachments/assets/d55f3c98-74a8-48c5-87e7-363f3872b895" />


### After
<img width="1132" height="840" alt="tooltip_wheel-evnet-after-44" src="https://github.com/user-attachments/assets/1457bcd5-9860-4008-8bef-ef56be1105db" />