### PR TITLE
fix: Chart > RealTimeScatter > realTimeScatter.use 토글(true→false→true) 시 같은 좌표에 점이 중복 누적되어 두꺼워지는 현상

### DIFF
--- a/docs/views/scatterChart/example/RealTimeScatter.vue
+++ b/docs/views/scatterChart/example/RealTimeScatter.vue
@@ -201,11 +201,19 @@ export default {
 
     watch(
       () => isRealTime.value,
-      () => {
-        if (isRealTime.value) {
+      (next, prev) => {
+        if (next) {
+          chartOptions.realTimeScatter.use = true;
           timeoutId = setTimeout(tick, 3000);
         } else {
           clearTimeout(timeoutId);
+          if (prev) {
+            chartData.value = {
+              series,
+              data: generateSnapshot(realTimeScatterRange.value * 1000),
+            };
+          }
+          chartOptions.realTimeScatter.use = false;
         }
       },
       { immediate: true },
@@ -228,6 +236,31 @@ export default {
           series2: [],
         },
       };
+    };
+
+    let snapshotCache = null;
+    const generateSnapshot = (rangeMs) => {
+      dataReset();
+
+      if (snapshotCache) {
+        return snapshotCache;
+      }
+
+      const now = Date.now();
+      const floor = (n) => Math.floor(n / 1000) * 1000;
+      const snapshot1 = [];
+      const snapshot2 = [];
+
+      for (let i = 0; i < 5000; i++) {
+        const tx = floor(now + getRandomInt(-rangeMs, 0));
+        const ty = floor(getRandomInt(3000, 57000));
+        const type = getRandomInt(0, 1);
+        const point = { x: tx, y: ty / 1000 };
+        if (type === 1) snapshot1.push(point);
+        else snapshot2.push(point);
+      }
+      snapshotCache = { series1: snapshot1, series2: snapshot2 };
+      return snapshotCache;
     };
 
     onUnmounted(() => {

--- a/docs/views/scatterChart/example/RealTimeScatter.vue
+++ b/docs/views/scatterChart/example/RealTimeScatter.vue
@@ -201,19 +201,11 @@ export default {
 
     watch(
       () => isRealTime.value,
-      (next, prev) => {
-        if (next) {
-          chartOptions.realTimeScatter.use = true;
+      () => {
+        if (isRealTime.value) {
           timeoutId = setTimeout(tick, 3000);
         } else {
           clearTimeout(timeoutId);
-          if (prev) {
-            chartData.value = {
-              series,
-              data: generateSnapshot(realTimeScatterRange.value * 1000),
-            };
-          }
-          chartOptions.realTimeScatter.use = false;
         }
       },
       { immediate: true },
@@ -236,31 +228,6 @@ export default {
           series2: [],
         },
       };
-    };
-
-    let snapshotCache = null;
-    const generateSnapshot = (rangeMs) => {
-      dataReset();
-
-      if (snapshotCache) {
-        return snapshotCache;
-      }
-
-      const now = Date.now();
-      const floor = (n) => Math.floor(n / 1000) * 1000;
-      const snapshot1 = [];
-      const snapshot2 = [];
-
-      for (let i = 0; i < 5000; i++) {
-        const tx = floor(now + getRandomInt(-rangeMs, 0));
-        const ty = floor(getRandomInt(3000, 57000));
-        const type = getRandomInt(0, 1);
-        const point = { x: tx, y: ty / 1000 };
-        if (type === 1) snapshot1.push(point);
-        else snapshot2.push(point);
-      }
-      snapshotCache = { series1: snapshot1, series2: snapshot2 };
-      return snapshotCache;
     };
 
     onUnmounted(() => {

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -1,5 +1,5 @@
 import { mobileCheck, truthyNumber } from '@/common/utils';
-import { calcExtraWidthLabel } from './helpers/helpers.util';
+import Util, { calcExtraWidthLabel } from './helpers/helpers.util';
 import Model from './model';
 import TimeScale from './scale/scale.time';
 import LinearScale from './scale/scale.linear';
@@ -240,7 +240,12 @@ class EvChart {
             extraFormattedLabels = [calcExtraWidthLabel(widestNumeric)];
           }
         }
-        const maxWidth = axis?.getLabelWidthHasMaxLength?.(notFormattedLabels, this.chartRect, extraFormattedLabels) ?? 0;
+        const maxWidth =
+          axis?.getLabelWidthHasMaxLength?.(
+            notFormattedLabels,
+            this.chartRect,
+            extraFormattedLabels,
+          ) ?? 0;
 
         return {
           ...value,
@@ -366,14 +371,14 @@ class EvChart {
             const dataItems = seriesDatas[i]?.data || [];
             for (let j = 0; j < dataItems.length; j++) {
               const item = dataItems[j];
-              duple.set(`${item.x}${item.y}`, series.sId);
+              duple.set(Util.coordinateKey(item.x, item.y), series.sId);
             }
           }
         } else {
           const seriesDatas = this.data.data[chartTypeSet[jx]] ?? [];
           for (let i = 0; i < seriesDatas.length; i++) {
             const item = seriesDatas[i];
-            duple.set(`${item.x}${item.y}`, series.sId);
+            duple.set(Util.coordinateKey(item.x, item.y), series.sId);
           }
         }
       }

--- a/src/components/chart/element/element.scatter.js
+++ b/src/components/chart/element/element.scatter.js
@@ -140,8 +140,7 @@ class Scatter {
     const { ctx, axesSteps, duple, legendHitInfo, coordinateDedupe } = param;
     const minmaxY = axesSteps.y[this.yAxisIndex];
 
-    // 비-realtime 경로는 data 레이어 dedupe(addSeriesDSforScatter)가 없어
-    // 시리즈 내부 (x,y) overdraw로 인한 두께 흔들림을 여기서 막는다.
+    // 비-realtime 경로는 push 시점 dedupe가 없어(realtime의 createRealTimeScatterDataSet 같은 데이터 적재 단계가 없음) 시리즈 내부 (x,y) overdraw로 인한 두께 흔들림을 여기서 막는다.
     const drawnKeys = new Set();
     const isDedupeOn = coordinateDedupe !== false;
 

--- a/src/components/chart/element/element.scatter.js
+++ b/src/components/chart/element/element.scatter.js
@@ -148,7 +148,7 @@ class Scatter {
     for (let i = 0; i < this.data.length; i++) {
       const item = this.data[i];
       const idx = i;
-      const key = `${item.x}${item.y}`;
+      const key = Util.coordinateKey(item.x, item.y);
       let shouldDraw;
       if (legendHitInfo) {
         shouldDraw = legendHitInfo.sId === this.sId;
@@ -203,7 +203,7 @@ class Scatter {
         if (legendHitInfo) {
           shouldDraw = legendHitInfo.sId === this.sId;
         } else if (isDedupeOnRT) {
-          shouldDraw = duple.get(`${item.x}${item.y}`) === this.sId;
+          shouldDraw = duple.get(Util.coordinateKey(item.x, item.y)) === this.sId;
         } else {
           shouldDraw = true;
         }

--- a/src/components/chart/element/element.scatter.js
+++ b/src/components/chart/element/element.scatter.js
@@ -140,7 +140,8 @@ class Scatter {
     const { ctx, axesSteps, duple, legendHitInfo, coordinateDedupe } = param;
     const minmaxY = axesSteps.y[this.yAxisIndex];
 
-    // 비-realtime 경로는 push 시점 dedupe가 없어(realtime의 createRealTimeScatterDataSet 같은 데이터 적재 단계가 없음) 시리즈 내부 (x,y) overdraw로 인한 두께 흔들림을 여기서 막는다.
+    // 비-realtime 경로는 push 시점 dedupe가 없어 시리즈 내부 (x,y) overdraw로 두께가 흔들린다.
+    // realtime은 createRealTimeScatterDataSet 적재 단계에서 dedupe 처리.
     const drawnKeys = new Set();
     const isDedupeOn = coordinateDedupe !== false;
 
@@ -172,7 +173,7 @@ class Scatter {
           ctx.fillStyle = this.getCachedColor(pointFillColor, fillOpacity);
 
           Canvas.drawPoint(ctx, this.pointStyle, this.pointSize, item.xp, item.yp);
-          drawnKeys.add(key);
+          if (isDedupeOn && !legendHitInfo) drawnKeys.add(key);
         }
       }
     }

--- a/src/components/chart/element/element.scatter.js
+++ b/src/components/chart/element/element.scatter.js
@@ -140,18 +140,22 @@ class Scatter {
     const { ctx, axesSteps, duple, legendHitInfo, coordinateDedupe } = param;
     const minmaxY = axesSteps.y[this.yAxisIndex];
 
+    // 시리즈 내부의 동일 (x,y) overdraw로 인한 두께 흔들림을 막기 위해 그린 좌표를 추적한다.
+    const drawnKeys = new Set();
+    const isDedupeOn = coordinateDedupe !== false;
+
     // Adjusted because Real Time Scatter is drawn from the back.
     for (let i = 0; i < this.data.length; i++) {
       const item = this.data[i];
       const idx = i;
-      const isDedupeOn = coordinateDedupe !== false;
+      const key = `${item.x}${item.y}`;
       let shouldDraw;
       if (legendHitInfo) {
         shouldDraw = legendHitInfo.sId === this.sId;
       } else if (isDedupeOn) {
-        shouldDraw = duple.get(`${item.x}${item.y}`) === this.sId;
+        shouldDraw = duple.get(key) === this.sId && !drawnKeys.has(key);
       } else {
-        shouldDraw = true;
+        shouldDraw = !drawnKeys.has(key);
       }
 
       if (shouldDraw) {
@@ -168,6 +172,7 @@ class Scatter {
           ctx.fillStyle = this.getCachedColor(pointFillColor, fillOpacity);
 
           Canvas.drawPoint(ctx, this.pointStyle, this.pointSize, item.xp, item.yp);
+          drawnKeys.add(key);
         }
       }
     }
@@ -187,19 +192,24 @@ class Scatter {
     const pointSize = typeof this.pointSize === 'number' ? this.pointSize : this.pointSize.value;
     let totalCount = 0;
 
+    // 시리즈 내부의 동일 (x,y) overdraw로 인한 두께 흔들림을 막기 위해 그린 좌표를 추적한다.
+    // totalCount는 findGraphData의 global index 계산에 필요하므로 dedupe와 별개로 모든 점을 셈한다.
+    const drawnKeys = new Set();
+    const isDedupeOnRT = coordinateDedupe !== false;
+
     for (let i = 0; i < this.data[this.sId]?.dataGroup?.length; i++) {
       for (let j = 0; j < this.data[this.sId]?.dataGroup[i]?.data.length; j++) {
         const item = this.data[this.sId]?.dataGroup[i]?.data[j];
         totalCount++;
 
-        const isDedupeOnRT = coordinateDedupe !== false;
+        const key = `${item.x}${item.y}`;
         let shouldDraw;
         if (legendHitInfo) {
           shouldDraw = legendHitInfo.sId === this.sId;
         } else if (isDedupeOnRT) {
-          shouldDraw = duple.get(`${item.x}${item.y}`) === this.sId;
+          shouldDraw = duple.get(key) === this.sId && !drawnKeys.has(key);
         } else {
-          shouldDraw = true;
+          shouldDraw = !drawnKeys.has(key);
         }
 
         if (shouldDraw) {
@@ -217,6 +227,7 @@ class Scatter {
             ctx.fillStyle = this.getCachedColor(baseFillColor, fillOpacity);
 
             Canvas.drawPoint(ctx, pointStyle, pointSize, item.xp, item.yp);
+            drawnKeys.add(key);
           }
         }
       }

--- a/src/components/chart/element/element.scatter.js
+++ b/src/components/chart/element/element.scatter.js
@@ -140,7 +140,8 @@ class Scatter {
     const { ctx, axesSteps, duple, legendHitInfo, coordinateDedupe } = param;
     const minmaxY = axesSteps.y[this.yAxisIndex];
 
-    // 시리즈 내부의 동일 (x,y) overdraw로 인한 두께 흔들림을 막기 위해 그린 좌표를 추적한다.
+    // 비-realtime 경로는 data 레이어 dedupe(addSeriesDSforScatter)가 없어
+    // 시리즈 내부 (x,y) overdraw로 인한 두께 흔들림을 여기서 막는다.
     const drawnKeys = new Set();
     const isDedupeOn = coordinateDedupe !== false;
 
@@ -155,7 +156,7 @@ class Scatter {
       } else if (isDedupeOn) {
         shouldDraw = duple.get(key) === this.sId && !drawnKeys.has(key);
       } else {
-        shouldDraw = !drawnKeys.has(key);
+        shouldDraw = true;
       }
 
       if (shouldDraw) {
@@ -192,9 +193,6 @@ class Scatter {
     const pointSize = typeof this.pointSize === 'number' ? this.pointSize : this.pointSize.value;
     let totalCount = 0;
 
-    // 시리즈 내부의 동일 (x,y) overdraw로 인한 두께 흔들림을 막기 위해 그린 좌표를 추적한다.
-    // totalCount는 findGraphData의 global index 계산에 필요하므로 dedupe와 별개로 모든 점을 셈한다.
-    const drawnKeys = new Set();
     const isDedupeOnRT = coordinateDedupe !== false;
 
     for (let i = 0; i < this.data[this.sId]?.dataGroup?.length; i++) {
@@ -202,14 +200,13 @@ class Scatter {
         const item = this.data[this.sId]?.dataGroup[i]?.data[j];
         totalCount++;
 
-        const key = `${item.x}${item.y}`;
         let shouldDraw;
         if (legendHitInfo) {
           shouldDraw = legendHitInfo.sId === this.sId;
         } else if (isDedupeOnRT) {
-          shouldDraw = duple.get(key) === this.sId && !drawnKeys.has(key);
+          shouldDraw = duple.get(`${item.x}${item.y}`) === this.sId;
         } else {
-          shouldDraw = !drawnKeys.has(key);
+          shouldDraw = true;
         }
 
         if (shouldDraw) {
@@ -227,7 +224,6 @@ class Scatter {
             ctx.fillStyle = this.getCachedColor(baseFillColor, fillOpacity);
 
             Canvas.drawPoint(ctx, pointStyle, pointSize, item.xp, item.yp);
-            drawnKeys.add(key);
           }
         }
       }

--- a/src/components/chart/element/element.scatter.spec.js
+++ b/src/components/chart/element/element.scatter.spec.js
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Scatter from './element.scatter';
+import Canvas from '../helpers/helpers.canvas';
+
+/**
+ * Scatter draw 메서드를 격리해서 테스트하기 위해 chartRect/axesSteps 등을 모두 입력하는
+ * 대신, calcItem 을 항등 매핑으로 바꿔 item.x/y 가 그대로 xp/yp 로 들어가게 한다.
+ * drawPoint 호출 횟수로 실제 그려진 점 수를 검증한다.
+ */
+const createDrawParam = () => ({
+  ctx: {},
+  axesSteps: { x: [{ graphMin: 0, graphMax: 1000 }], y: [{ graphMin: 0, graphMax: 1000 }] },
+  duple: new Map(),
+  legendHitInfo: null,
+  coordinateDedupe: true,
+  selectInfo: null,
+  unSelectedOpacity: 0.3,
+});
+
+const createScatter = ({ realTimeScatter = false } = {}) => {
+  const scatter = new Scatter('s1', { color: '#000000', pointFill: '#000000' }, 0, realTimeScatter);
+  scatter.show = true;
+  scatter.calcItem = (item) => {
+    item.xp = item.x;
+    item.yp = item.y;
+  };
+  return scatter;
+};
+
+describe('Scatter Element', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('defaultScatterDraw 시리즈 내부 (x,y) dedupe', () => {
+    it('같은 (x,y) 데이터가 N개 있어도 한 번만 그린다', () => {
+      const scatter = createScatter();
+      scatter.data = [
+        { x: 10, y: 20 },
+        { x: 10, y: 20 },
+        { x: 10, y: 20 },
+        { x: 30, y: 40 },
+      ];
+      const param = createDrawParam();
+      // dedupe 가 켜져 있으면 chart.core.js 가 duple 을 채워서 넘기므로 모킹한다.
+      param.duple.set('1020', 's1');
+      param.duple.set('3040', 's1');
+
+      const spy = vi.spyOn(Canvas, 'drawPoint').mockImplementation(() => {});
+      scatter.draw(param);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('coordinateDedupe=false 일 때는 모든 중복 좌표를 그대로 그린다 (#2011 opt-out 보존)', () => {
+      const scatter = createScatter();
+      scatter.data = [
+        { x: 10, y: 20 },
+        { x: 10, y: 20 },
+        { x: 10, y: 20 },
+      ];
+      const param = createDrawParam();
+      param.coordinateDedupe = false;
+
+      const spy = vi.spyOn(Canvas, 'drawPoint').mockImplementation(() => {});
+      scatter.draw(param);
+
+      expect(spy).toHaveBeenCalledTimes(3);
+    });
+
+    it('다른 좌표는 정상적으로 모두 그린다', () => {
+      const scatter = createScatter();
+      scatter.data = [
+        { x: 1, y: 1 },
+        { x: 2, y: 2 },
+        { x: 3, y: 3 },
+      ];
+      const param = createDrawParam();
+      param.duple.set('11', 's1');
+      param.duple.set('22', 's1');
+      param.duple.set('33', 's1');
+
+      const spy = vi.spyOn(Canvas, 'drawPoint').mockImplementation(() => {});
+      scatter.draw(param);
+
+      expect(spy).toHaveBeenCalledTimes(3);
+    });
+
+    it('duple 이 다른 시리즈를 owner 로 지정한 좌표는 그리지 않는다 (시리즈 간 dedupe)', () => {
+      const scatter = createScatter();
+      scatter.data = [
+        { x: 10, y: 20 },
+        { x: 30, y: 40 },
+      ];
+      const param = createDrawParam();
+      param.duple.set('1020', 'otherSeries');
+      param.duple.set('3040', 's1');
+
+      const spy = vi.spyOn(Canvas, 'drawPoint').mockImplementation(() => {});
+      scatter.draw(param);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('realTimeScatterDraw', () => {
+    it('dataGroup 의 모든 점을 그리며 totalCount 에 전수를 기록한다', () => {
+      const scatter = createScatter({ realTimeScatter: true });
+      scatter.data = {
+        s1: {
+          dataGroup: [
+            {
+              data: [
+                { x: 1, y: 1 },
+                { x: 1, y: 2 },
+              ],
+            },
+            { data: [{ x: 2, y: 1 }] },
+          ],
+        },
+      };
+      const param = createDrawParam();
+      param.duple.set('11', 's1');
+      param.duple.set('12', 's1');
+      param.duple.set('21', 's1');
+
+      const spy = vi.spyOn(Canvas, 'drawPoint').mockImplementation(() => {});
+      scatter.draw(param);
+
+      expect(spy).toHaveBeenCalledTimes(3);
+      expect(scatter._rtTotalCount).toBe(3);
+    });
+
+    it('coordinateDedupe=false 일 때 모든 점을 그린다', () => {
+      const scatter = createScatter({ realTimeScatter: true });
+      scatter.data = {
+        s1: {
+          dataGroup: [
+            {
+              data: [
+                { x: 1, y: 1 },
+                { x: 2, y: 2 },
+              ],
+            },
+          ],
+        },
+      };
+      const param = createDrawParam();
+      param.coordinateDedupe = false;
+
+      const spy = vi.spyOn(Canvas, 'drawPoint').mockImplementation(() => {});
+      scatter.draw(param);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/components/chart/element/element.scatter.spec.js
+++ b/src/components/chart/element/element.scatter.spec.js
@@ -43,8 +43,8 @@ describe('Scatter Element', () => {
       ];
       const param = createDrawParam();
       // dedupe 가 켜져 있으면 chart.core.js 가 duple 을 채워서 넘기므로 모킹한다.
-      param.duple.set('1020', 's1');
-      param.duple.set('3040', 's1');
+      param.duple.set('10|20', 's1');
+      param.duple.set('30|40', 's1');
 
       const spy = vi.spyOn(Canvas, 'drawPoint').mockImplementation(() => {});
       scatter.draw(param);
@@ -76,9 +76,9 @@ describe('Scatter Element', () => {
         { x: 3, y: 3 },
       ];
       const param = createDrawParam();
-      param.duple.set('11', 's1');
-      param.duple.set('22', 's1');
-      param.duple.set('33', 's1');
+      param.duple.set('1|1', 's1');
+      param.duple.set('2|2', 's1');
+      param.duple.set('3|3', 's1');
 
       const spy = vi.spyOn(Canvas, 'drawPoint').mockImplementation(() => {});
       scatter.draw(param);
@@ -93,8 +93,8 @@ describe('Scatter Element', () => {
         { x: 30, y: 40 },
       ];
       const param = createDrawParam();
-      param.duple.set('1020', 'otherSeries');
-      param.duple.set('3040', 's1');
+      param.duple.set('10|20', 'otherSeries');
+      param.duple.set('30|40', 's1');
 
       const spy = vi.spyOn(Canvas, 'drawPoint').mockImplementation(() => {});
       scatter.draw(param);
@@ -120,9 +120,9 @@ describe('Scatter Element', () => {
         },
       };
       const param = createDrawParam();
-      param.duple.set('11', 's1');
-      param.duple.set('12', 's1');
-      param.duple.set('21', 's1');
+      param.duple.set('1|1', 's1');
+      param.duple.set('1|2', 's1');
+      param.duple.set('2|1', 's1');
 
       const spy = vi.spyOn(Canvas, 'drawPoint').mockImplementation(() => {});
       scatter.draw(param);

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -130,6 +130,18 @@ export default {
   },
 
   /**
+   * scatter dedupe/duple Map의 좌표 키 포맷.
+   * 구분자 없는 단순 concat 은 (12, 34) 와 (123, 4) 가 같은 키가 되는 충돌이 있어
+   * '|' 로 분리한다. set/get 양쪽에서 반드시 이 함수를 통해 키를 생성해야 일치한다.
+   * @param {string|number} x
+   * @param {string|number} y
+   * @returns {string}
+   */
+  coordinateKey(x, y) {
+    return `${x}|${y}`;
+  },
+
+  /**
    * Create string for canvas font style
    * @param {object} style    style object by user
    *

--- a/src/components/chart/helpers/helpers.util.spec.js
+++ b/src/components/chart/helpers/helpers.util.spec.js
@@ -127,6 +127,20 @@ describe('helpers.util', () => {
     });
   });
 
+  describe('coordinateKey', () => {
+    it('should join x and y with the | separator', () => {
+      expect(Util.coordinateKey(10, 20)).toBe('10|20');
+    });
+
+    it('should disambiguate (12, 34) and (123, 4)', () => {
+      expect(Util.coordinateKey(12, 34)).not.toBe(Util.coordinateKey(123, 4));
+    });
+
+    it('should handle string labels safely', () => {
+      expect(Util.coordinateKey('2026-05-13', 100)).toBe('2026-05-13|100');
+    });
+  });
+
   describe('getLabelStyle', () => {
     it('should create font style string with defaults', () => {
       const style = Util.getLabelStyle({});

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -227,15 +227,19 @@ const modules = {
             if (index < 0) index = length + index;
 
             const group = dataGroup[index];
-            group.data.push({
-              x: item.x,
-              y: item.y,
-              o: item.value ?? item.y,
-              color: item.color,
-            });
+            const isExactDuplicate = group.data.some((d) => d.x === item.x && d.y === item.y);
 
-            group.max = Math.max(group.max, item.y);
-            group.min = Math.min(group.min, item.y);
+            if (!isExactDuplicate) {
+              group.data.push({
+                x: item.x,
+                y: item.y,
+                o: item.value ?? item.y,
+                color: item.color,
+              });
+
+              group.max = Math.max(group.max, item.y);
+              group.min = Math.min(group.min, item.y);
+            }
           }
         }
       }
@@ -910,10 +914,12 @@ const modules = {
         let nearestDistance = Infinity;
         let nearestIndex = -1;
         for (let i = 0; i < refData.length; i++) {
-          const hasValidData = disableNullLabelSnap || seriesIDs.some((sId) => {
-            const s = this.seriesList[sId];
-            return s?.show && s.data?.[i]?.o !== null && s.data?.[i]?.o !== undefined;
-          });
+          const hasValidData =
+            disableNullLabelSnap ||
+            seriesIDs.some((sId) => {
+              const s = this.seriesList[sId];
+              return s?.show && s.data?.[i]?.o !== null && s.data?.[i]?.o !== undefined;
+            });
 
           const p = refData[i];
           if (hasValidData && p) {
@@ -1064,19 +1070,17 @@ const modules = {
 
     // all-null 라벨인 경우 label/dataIndex 만 채워 반환 (sId='', value=0).
     if (
-      disableNullLabelSnap
-      && hitSeriesID === ''
-      && fallbackSeriesID === ''
-      && resolvedDataIndex !== undefined
-      && resolvedDataIndex >= 0
+      disableNullLabelSnap &&
+      hitSeriesID === '' &&
+      fallbackSeriesID === '' &&
+      resolvedDataIndex !== undefined &&
+      resolvedDataIndex >= 0
     ) {
       const refSeriesID = seriesIDs.find((sId) => {
         const s = this.seriesList[sId];
         return s?.show && s?.data?.length > 0;
       });
-      const refPoint = refSeriesID
-        ? this.seriesList[refSeriesID].data?.[resolvedDataIndex]
-        : null;
+      const refPoint = refSeriesID ? this.seriesList[refSeriesID].data?.[resolvedDataIndex] : null;
       if (refPoint) {
         fallbackLabel = isHorizontal ? refPoint.y : refPoint.x;
         fallbackDataIndex = resolvedDataIndex;
@@ -1239,12 +1243,13 @@ const modules = {
         y1: this.chartRect.y1 + this.labelOffset.top,
         y2: this.chartRect.y2 - this.labelOffset.bottom,
       };
-      const { steps, interval: labelValInterval, graphMin } = this.axesSteps[
-        targetAxisDirection
-      ][0];
-      const { width: labelWidth, height: labelHeight } = this.axesRange[
-        targetAxisDirection
-      ][0].size;
+      const {
+        steps,
+        interval: labelValInterval,
+        graphMin,
+      } = this.axesSteps[targetAxisDirection][0];
+      const { width: labelWidth, height: labelHeight } =
+        this.axesRange[targetAxisDirection][0].size;
       const axes = isXAxis ? this.axesX : this.axesY;
       const axisStartPoint = aPos[axes[0].units.rectStart];
       const axisEndPoint = aPos[axes[0].units.rectEnd];
@@ -1310,20 +1315,28 @@ const modules = {
             if (!isHorizontal) {
               if (
                 smm.minX !== null &&
-                (minmax.x[axisX].min === null || (smm.minX !== null && smm.minX < minmax.x[axisX].min))
+                (minmax.x[axisX].min === null ||
+                  (smm.minX !== null && smm.minX < minmax.x[axisX].min))
               ) {
                 minmax.x[axisX].min = smm.minX;
               }
-              if (minmax.y[axisY].min === null || (smm.minY !== null && smm.minY < minmax.y[axisY].min)) {
+              if (
+                minmax.y[axisY].min === null ||
+                (smm.minY !== null && smm.minY < minmax.y[axisY].min)
+              ) {
                 minmax.y[axisY].min = smm.minY;
               }
             } else {
-              if (minmax.x[axisX].min === null || (smm.minX !== null && smm.minX < minmax.x[axisX].min)) {
+              if (
+                minmax.x[axisX].min === null ||
+                (smm.minX !== null && smm.minX < minmax.x[axisX].min)
+              ) {
                 minmax.x[axisX].min = smm.minX;
               }
               if (
                 smm.minY !== null &&
-                (minmax.y[axisY].min === null || (smm.minY !== null && smm.minY < minmax.y[axisY].min))
+                (minmax.y[axisY].min === null ||
+                  (smm.minY !== null && smm.minY < minmax.y[axisY].min))
               ) {
                 minmax.y[axisY].min = smm.minY;
               }

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -146,6 +146,17 @@ const modules = {
       // 5) nextToTime 결정: 새 데이터가 있으면 lastTime, 없으면 이전 유지
       const nextToTime = lastTime || prevToTime;
 
+      const resetDataGroup = (group) => {
+        group.data.length = 0;
+        if (group.dataKeys) {
+          group.dataKeys.clear();
+        } else {
+          group.dataKeys = new Set();
+        }
+        group.max = 0;
+        group.min = Infinity;
+      };
+
       // 6) endIndex/startIndex 초기화 (최초 1회) + length 변경 시 재구성
       if (dataset.endIndex == null || lengthChanged) {
         dataset.startIndex = 0;
@@ -154,20 +165,8 @@ const modules = {
         // dataGroup 크기 맞추고 모두 reset
         dataGroup.length = length;
         for (let i = 0; i < length; i++) {
-          dataGroup[i] = dataGroup[i] || {
-            data: [],
-            dataKeys: new Set(),
-            max: 0,
-            min: Infinity,
-          };
-          dataGroup[i].data.length = 0;
-          if (dataGroup[i].dataKeys) {
-            dataGroup[i].dataKeys.clear();
-          } else {
-            dataGroup[i].dataKeys = new Set();
-          }
-          dataGroup[i].max = 0;
-          dataGroup[i].min = Infinity;
+          dataGroup[i] = dataGroup[i] || { data: [], dataKeys: new Set(), max: 0, min: Infinity };
+          resetDataGroup(dataGroup[i]);
         }
 
         // toTime/fromTime도 새 기준으로 맞춤
@@ -187,17 +186,6 @@ const modules = {
       if (lastTime && (dataset.toTime - lastTime) / 1000 > length && key === '') {
         return;
       }
-
-      const resetDataGroup = (group) => {
-        group.data.length = 0;
-        if (group.dataKeys) {
-          group.dataKeys.clear();
-        } else {
-          group.dataKeys = new Set();
-        }
-        group.max = 0;
-        group.min = Infinity;
-      };
 
       // 9) dataGroup 슬롯 확보
       for (let i = 0; i < length; i++) {
@@ -235,6 +223,9 @@ const modules = {
       }
 
       // 11) 데이터 push (윈도우 안에 들어오는 것만)
+      // coordinateDedupe=false 는 #2011 에서 "모든 중복 좌표 표시" opt-out 으로 도입됐다.
+      // data 레이어에서 dedupe 가 강제되면 draw 레이어의 opt-out 도 무력화되므로 옵션을 존중한다.
+      const isDedupeOn = this.options.coordinateDedupe !== false;
       for (let i = 0; i < storeLength; i++) {
         const item = data[i];
         if (item) {
@@ -246,9 +237,12 @@ const modules = {
 
             const group = dataGroup[index];
             const dedupeKey = `${item.x}${item.y}`;
+            const isDuplicate = isDedupeOn && group.dataKeys.has(dedupeKey);
 
-            if (!group.dataKeys.has(dedupeKey)) {
-              group.dataKeys.add(dedupeKey);
+            if (!isDuplicate) {
+              if (isDedupeOn) {
+                group.dataKeys.add(dedupeKey);
+              }
               group.data.push({
                 x: item.x,
                 y: item.y,

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -236,7 +236,7 @@ const modules = {
             if (index < 0) index = length + index;
 
             const group = dataGroup[index];
-            const dedupeKey = `${item.x}${item.y}`;
+            const dedupeKey = Util.coordinateKey(item.x, item.y);
             const isDuplicate = isDedupeOn && group.dataKeys.has(dedupeKey);
 
             if (!isDuplicate) {

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -154,8 +154,18 @@ const modules = {
         // dataGroup 크기 맞추고 모두 reset
         dataGroup.length = length;
         for (let i = 0; i < length; i++) {
-          dataGroup[i] = dataGroup[i] || { data: [], max: 0, min: Infinity };
+          dataGroup[i] = dataGroup[i] || {
+            data: [],
+            dataKeys: new Set(),
+            max: 0,
+            min: Infinity,
+          };
           dataGroup[i].data.length = 0;
+          if (dataGroup[i].dataKeys) {
+            dataGroup[i].dataKeys.clear();
+          } else {
+            dataGroup[i].dataKeys = new Set();
+          }
           dataGroup[i].max = 0;
           dataGroup[i].min = Infinity;
         }
@@ -180,6 +190,11 @@ const modules = {
 
       const resetDataGroup = (group) => {
         group.data.length = 0;
+        if (group.dataKeys) {
+          group.dataKeys.clear();
+        } else {
+          group.dataKeys = new Set();
+        }
         group.max = 0;
         group.min = Infinity;
       };
@@ -187,11 +202,14 @@ const modules = {
       // 9) dataGroup 슬롯 확보
       for (let i = 0; i < length; i++) {
         if (!dataGroup[i]) {
-          dataGroup[i] = { data: [], max: 0, min: Infinity };
+          dataGroup[i] = { data: [], dataKeys: new Set(), max: 0, min: Infinity };
         } else if (!dataGroup[i].data) {
           dataGroup[i].data = [];
+          dataGroup[i].dataKeys = new Set();
           dataGroup[i].max = 0;
           dataGroup[i].min = Infinity;
+        } else if (!dataGroup[i].dataKeys) {
+          dataGroup[i].dataKeys = new Set();
         }
       }
 
@@ -227,9 +245,10 @@ const modules = {
             if (index < 0) index = length + index;
 
             const group = dataGroup[index];
-            const isExactDuplicate = group.data.some((d) => d.x === item.x && d.y === item.y);
+            const dedupeKey = `${item.x}${item.y}`;
 
-            if (!isExactDuplicate) {
+            if (!group.dataKeys.has(dedupeKey)) {
+              group.dataKeys.add(dedupeKey);
               group.data.push({
                 x: item.x,
                 y: item.y,

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -674,7 +674,7 @@ describe('model.store createRealTimeScatterDataSet (x,y) dedupe', () => {
     const groups = store.dataSet.series1.dataGroup;
     const slotWithData = groups.find((g) => g.data.length > 0);
     expect(slotWithData.dataKeys).toBeInstanceOf(Set);
-    expect(slotWithData.dataKeys.has(`${t}10`)).toBe(true);
+    expect(slotWithData.dataKeys.has(`${t}|10`)).toBe(true);
   });
 
   it('윈도우 밖으로 밀려난 슬롯이 reset 되면 dataKeys 도 비워져 같은 좌표를 재 push 할 수 있다', () => {
@@ -695,7 +695,7 @@ describe('model.store createRealTimeScatterDataSet (x,y) dedupe', () => {
     const t1 = t0 + 10 * SECOND;
     store.createRealTimeScatterDataSet({ series1: [{ x: t1, y: 10 }] });
     const slotsAfterReset = store.dataSet.series1.dataGroup;
-    const containsKey = slotsAfterReset.some((g) => g.dataKeys?.has(`${t1}10`));
+    const containsKey = slotsAfterReset.some((g) => g.dataKeys?.has(`${t1}|10`));
     expect(containsKey).toBe(true);
   });
 

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -613,13 +613,13 @@ describe('model.store getItem (selectLabel indicator 용)', () => {
 describe('model.store createRealTimeScatterDataSet (x,y) dedupe', () => {
   const SECOND = 1000;
 
-  const buildRealTimeStore = (range = 5) => {
+  const buildRealTimeStore = (range = 5, options = {}) => {
     const store = Object.create(modules);
     Object.assign(store, {
       isInit: false,
       updateSeries: false,
       dataSet: {},
-      options: { realTimeScatter: { range } },
+      options: { realTimeScatter: { range }, ...options },
       seriesInfo: { charts: { scatter: ['series1'] } },
       seriesList: {
         series1: {},
@@ -697,5 +697,23 @@ describe('model.store createRealTimeScatterDataSet (x,y) dedupe', () => {
     const slotsAfterReset = store.dataSet.series1.dataGroup;
     const containsKey = slotsAfterReset.some((g) => g.dataKeys?.has(`${t1}10`));
     expect(containsKey).toBe(true);
+  });
+
+  it('coordinateDedupe=false 일 때 동일 (x,y) 가 N개여도 모두 push 된다 (#2011 opt-out 보존)', () => {
+    const store = buildRealTimeStore(5, { coordinateDedupe: false });
+    const t = Math.floor(Date.now() / SECOND) * SECOND;
+
+    store.createRealTimeScatterDataSet({
+      series1: [
+        { x: t, y: 10 },
+        { x: t, y: 10 },
+        { x: t, y: 10 },
+        { x: t, y: 20 },
+      ],
+    });
+
+    const groups = store.dataSet.series1.dataGroup;
+    const totalPoints = groups.reduce((acc, g) => acc + g.data.length, 0);
+    expect(totalPoints).toBe(4);
   });
 });

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -605,3 +605,97 @@ describe('model.store getItem (selectLabel indicator 용)', () => {
     expect(result[0].dataIndex).toBe(2);
   });
 });
+
+/**
+ * createRealTimeScatterDataSet 의 시리즈 내부 (x,y) dedupe 회귀 테스트.
+ * 같은 dataGroup 슬롯에 동일 (x,y) 가 두 번 들어오면 한 번만 push 되어야 한다.
+ */
+describe('model.store createRealTimeScatterDataSet (x,y) dedupe', () => {
+  const SECOND = 1000;
+
+  const buildRealTimeStore = (range = 5) => {
+    const store = Object.create(modules);
+    Object.assign(store, {
+      isInit: false,
+      updateSeries: false,
+      dataSet: {},
+      options: { realTimeScatter: { range } },
+      seriesInfo: { charts: { scatter: ['series1'] } },
+      seriesList: {
+        series1: {},
+      },
+    });
+    return store;
+  };
+
+  it('한 배치에 동일 (x,y) 가 N개 있어도 dataGroup 에는 한 번만 push 된다', () => {
+    const store = buildRealTimeStore();
+    const t = Math.floor(Date.now() / SECOND) * SECOND;
+
+    store.createRealTimeScatterDataSet({
+      series1: [
+        { x: t, y: 10 },
+        { x: t, y: 10 },
+        { x: t, y: 10 },
+        { x: t, y: 20 },
+      ],
+    });
+
+    const groups = store.dataSet.series1.dataGroup;
+    const totalPoints = groups.reduce((acc, g) => acc + g.data.length, 0);
+    expect(totalPoints).toBe(2);
+  });
+
+  it('서로 다른 (x,y) 는 모두 push 된다', () => {
+    const store = buildRealTimeStore();
+    const t = Math.floor(Date.now() / SECOND) * SECOND;
+
+    store.createRealTimeScatterDataSet({
+      series1: [
+        { x: t, y: 10 },
+        { x: t, y: 20 },
+        { x: t, y: 30 },
+      ],
+    });
+
+    const groups = store.dataSet.series1.dataGroup;
+    const totalPoints = groups.reduce((acc, g) => acc + g.data.length, 0);
+    expect(totalPoints).toBe(3);
+  });
+
+  it('dataKeys Set 이 슬롯마다 생성되고 push 된 좌표를 보관한다', () => {
+    const store = buildRealTimeStore();
+    const t = Math.floor(Date.now() / SECOND) * SECOND;
+
+    store.createRealTimeScatterDataSet({
+      series1: [{ x: t, y: 10 }],
+    });
+
+    const groups = store.dataSet.series1.dataGroup;
+    const slotWithData = groups.find((g) => g.data.length > 0);
+    expect(slotWithData.dataKeys).toBeInstanceOf(Set);
+    expect(slotWithData.dataKeys.has(`${t}10`)).toBe(true);
+  });
+
+  it('윈도우 밖으로 밀려난 슬롯이 reset 되면 dataKeys 도 비워져 같은 좌표를 재 push 할 수 있다', () => {
+    const store = buildRealTimeStore(3);
+    const t0 = Math.floor(Date.now() / SECOND) * SECOND;
+
+    // 1차 batch: (t0, 10) push
+    store.createRealTimeScatterDataSet({ series1: [{ x: t0, y: 10 }] });
+    const firstTotal = store.dataSet.series1.dataGroup.reduce((acc, g) => acc + g.data.length, 0);
+    expect(firstTotal).toBe(1);
+
+    // 2차 batch: 같은 (x,y) 재 push → 이미 슬롯에 있으니 무시
+    store.createRealTimeScatterDataSet({ series1: [{ x: t0, y: 10 }] });
+    const secondTotal = store.dataSet.series1.dataGroup.reduce((acc, g) => acc + g.data.length, 0);
+    expect(secondTotal).toBe(1);
+
+    // 3차 batch: 시간이 length 초 이상 지나 모든 슬롯 reset → 같은 (x,y) 재 push 가능
+    const t1 = t0 + 10 * SECOND;
+    store.createRealTimeScatterDataSet({ series1: [{ x: t1, y: 10 }] });
+    const slotsAfterReset = store.dataSet.series1.dataGroup;
+    const containsKey = slotsAfterReset.some((g) => g.dataKeys?.has(`${t1}10`));
+    expect(containsKey).toBe(true);
+  });
+});


### PR DESCRIPTION
# 작업 배경
- `realTimeScatter` 사용 중 데이터 자동 업데이트를 OFF/ON 토글하면 일부 점들의 굵기가 미세하게 흔들려 보이는 현상이 있음.
- 중복 좌표 처리에 문제가 있음. 
  
# 변경 사항 요약
- 토글이나 데이터 갱신을 반복해도 점 굵기가 일관되게 유지
- 중복 좌표 처리 좀 더 개선

## 동작 변경 요약
| 옵션 | 변경 전 | 변경 후 |
|---|---|---|
| `coordinateDedupe: true` (default) | 시리즈 간 dedupe 만 | **시리즈 간 + 시리즈 내부 dedupe** |
| `coordinateDedupe: false` (opt-out, #2011) | 모든 중복 좌표 표시 | **동일 (변경 없음)** |

# 기존 동작
https://github.com/user-attachments/assets/bb91cb89-ef40-4fc3-afd2-091e47649d43
- 같은 데이터를 기준으로 realTimeScatter 기능을 On/Off를 반복할 경우 scatter 점이 굵게 표시되는 현상이 보임.

# 기대 동작
https://github.com/user-attachments/assets/67520486-23db-4dcb-b4cb-95b554f77791

# TODO
- RealTimeScatter.vue 원복