### PR TITLE
fix: Select box Window 안에 있을 경우 dropbox flip 오작동

### DIFF
--- a/docs/views/select/api/select.md
+++ b/docs/views/select/api/select.md
@@ -41,6 +41,7 @@
 
 - <셀렉트> 클릭 시 <드랍다운 박스>가 나타나며, 목록 선택 시 <드랍다운 박스>가 닫혀야한다.
 - `teleport` 옵션 사용 시 <드랍박스>는 viewport 기준(position: fixed)으로 위치가 계산되며, ev-window 등 부모 컨테이너 경계에 잘리지 않는다.
+- `teleport` target 또는 그 ancestor에 `transform`/`filter`/`perspective`/`will-change` 등이 적용돼 있으면 `position: fixed`의 containing block이 해당 ancestor로 바뀌어 <드랍박스> 위치가 어긋날 수 있다. 기본값인 `"body"` 또는 body 직속 element를 권장한다.
 
 2) 멀티 셀렉트 사용 시
 

--- a/docs/views/select/api/select.md
+++ b/docs/views/select/api/select.md
@@ -37,8 +37,10 @@
   | searchPlaceholder | String | '' | <셀렉트> 필터링의 표기문구 |  |
   | noMatchingText | String | '' | <셀렉트> 필터링 결과가 없을 시 표기문구 |  |
   | checkable      | Boolean | false | <셀렉트> 체크박스 여부 |  |
+  | teleport | String | '' | <드랍박스>를 옮길 target CSS selector (예: `"body"`, `".my-class"`, `"#some-id"`). 빈 문자열이면 teleport 비활성. 매칭되는 element가 없거나 selector가 유효하지 않으면 `document.body`로 fallback하고 console.warn. | `"body"`, `".class"`, `"#id"` |
 
 - <셀렉트> 클릭 시 <드랍다운 박스>가 나타나며, 목록 선택 시 <드랍다운 박스>가 닫혀야한다.
+- `teleport` 옵션 사용 시 <드랍박스>는 viewport 기준(position: fixed)으로 위치가 계산되며, ev-window 등 부모 컨테이너 경계에 잘리지 않는다.
 
 2) 멀티 셀렉트 사용 시
 
@@ -55,6 +57,7 @@
   | searchPlaceholder | String | '' | <셀렉트> 필터링의 표기문구 |  |
   | noMatchingText | String | '' | <셀렉트> 필터링 결과가 없을 시 표기문구 |  |
   | checkable         | Boolean | false | <셀렉트> 체크박스 여부 |  |
+  | teleport | String | '' | <드랍박스>를 옮길 target CSS selector (예: `"body"`, `".my-class"`, `"#some-id"`). 빈 문자열이면 teleport 비활성. 매칭되는 element가 없거나 selector가 유효하지 않으면 `document.body`로 fallback하고 console.warn. | `"body"`, `".class"`, `"#id"` |
 
 - <셀렉트> 클릭 시 <드랍다운 박스>가 나타나며, 목록 선택 시 <드랍다운 박스>가 닫히지 말아야 한다.
 

--- a/docs/views/select/api/select.md
+++ b/docs/views/select/api/select.md
@@ -59,6 +59,7 @@
   | noMatchingText | String | '' | <셀렉트> 필터링 결과가 없을 시 표기문구 |  |
   | checkable         | Boolean | false | <셀렉트> 체크박스 여부 |  |
   | teleport | String | '' | <드랍박스>를 옮길 target CSS selector (예: `"body"`, `".my-class"`, `"#some-id"`). 빈 문자열이면 teleport 비활성. 매칭되는 element가 없거나 selector가 유효하지 않으면 `document.body`로 fallback하고 console.warn. | `"body"`, `".class"`, `"#id"` |
+  | tagMaxRows | Number | 0 | multiple 모드에서 tag wrapper가 노출할 최대 줄 수. `0`(기본)은 무제한, 양의 정수는 그 줄 수까지 표시하고 이상은 wrapper 내부 scroll. 항목이 많이 선택되어 wrapper가 폭발적으로 커질 때 teleport 모드에서 dropbox가 viewport 밖으로 밀려나는 문제와 non-teleport 모드에서 wrapper height 변화로 flip 방향이 점프하는 문제를 옵트인 방식으로 막는다. | `0`, `3` |
 
 - <셀렉트> 클릭 시 <드랍다운 박스>가 나타나며, 목록 선택 시 <드랍다운 박스>가 닫히지 말아야 한다.
 

--- a/docs/views/select/example/InWindow.vue
+++ b/docs/views/select/example/InWindow.vue
@@ -1,0 +1,158 @@
+<template>
+  <div class="case">
+    <p class="case-title">Dropbox flip (window 상단 근처) - 기본값</p>
+    <ev-window
+      v-model:visible="isVisible2"
+      title="Select near window top"
+      width="500px"
+      height="320px"
+    >
+      <div class="window-row">
+        <label>Top Select</label>
+        <ev-select v-model="selectVal2" :items="manyItems" placeholder="Please select value." />
+      </div>
+      <div class="filler" />
+      <div class="description">
+        window content 상단에 가까운 select. 위로 펼칠 공간이 부족하므로
+        <strong>아래쪽으로 펼쳐져야</strong> 한다.
+      </div>
+    </ev-window>
+    <div class="description">
+      <button class="btn" @click="clickButton2">click to open window!</button>
+    </div>
+  </div>
+
+  <div class="case">
+    <p class="case-title">Dropbox flip (window 하단 근처)</p>
+    <ev-window
+      v-model:visible="isVisible1"
+      title="Select near window bottom"
+      width="500px"
+      height="320px"
+    >
+      <div class="filler" />
+      <div class="window-row">
+        <label>Bottom Select</label>
+        <ev-select v-model="selectVal1" :items="manyItems" placeholder="Please select value." />
+      </div>
+      <div class="description">
+        window content 하단에 가까운 select. 옵션 레이어가 viewport에는 들어가도 window 컨테이너
+        하단을 넘기면 <strong>위쪽으로 펼쳐져야</strong> 한다.
+      </div>
+    </ev-window>
+    <div class="description">
+      <button class="btn" @click="clickButton1">click to open window!</button>
+    </div>
+  </div>
+
+  <div class="case">
+    <p class="case-title">Draggable / Resizable window + Footer + Select</p>
+    <ev-window
+      v-model:visible="isVisible3"
+      title="Window with footer (non-scrollable)"
+      width="500px"
+      height="320px"
+      draggable
+      resizable
+      maximizable
+    >
+      <div class="filler" />
+      <div class="window-row">
+        <label>Select</label>
+        <ev-select v-model="selectVal3" :items="manyItems" placeholder="Please select value." />
+      </div>
+      <div class="description">
+        window를 화면 하단까지 드래그해서 옮긴 후 select를 열어보세요. viewport 하단과 window 하단
+        모두에 의해 flip 이 결정되어야 한다.
+        <br />
+        <br />
+        <br />
+      </div>
+      <template #footer>
+        <div class="window-footer-buttons">
+          <ev-button @click="closeWindow3">닫기</ev-button>
+        </div>
+      </template>
+    </ev-window>
+    <div class="description">
+      <button class="btn" @click="clickButton3">click to open window!</button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const manyItems = ref(
+      Array.from({ length: 10 }, (_, i) => ({
+        name: `name${i}`,
+        value: `value${i}`,
+      })),
+    );
+
+    const isVisible1 = ref(false);
+    const isVisible2 = ref(false);
+    const isVisible3 = ref(false);
+
+    const clickButton1 = () => {
+      isVisible1.value = true;
+    };
+    const clickButton2 = () => {
+      isVisible2.value = true;
+    };
+    const clickButton3 = () => {
+      isVisible3.value = true;
+    };
+    const closeWindow3 = () => {
+      isVisible3.value = false;
+    };
+
+    const selectVal1 = ref('');
+    const selectVal2 = ref('');
+    const selectVal3 = ref('');
+
+    return {
+      manyItems,
+      isVisible1,
+      isVisible2,
+      isVisible3,
+      clickButton1,
+      clickButton2,
+      clickButton3,
+      closeWindow3,
+      selectVal1,
+      selectVal2,
+      selectVal3,
+    };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.window-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 8px 0;
+
+  label {
+    min-width: 100px;
+  }
+}
+.filler {
+  height: 140px;
+  background-color: #f5f5f5;
+  border: 1px dashed #ccc;
+
+  &.tall {
+    height: 600px;
+  }
+}
+.window-footer-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+</style>

--- a/docs/views/select/example/InWindow.vue
+++ b/docs/views/select/example/InWindow.vue
@@ -124,9 +124,11 @@
           <label>Default Multi</label>
           <ev-select
             v-model="multiDefaultVal"
+            :tag-max-rows="3"
             :items="manyItems"
             multiple
             checkable
+            filterable
             placeholder="Please select values."
           />
         </div>
@@ -134,9 +136,11 @@
           <label>Multi Teleport</label>
           <ev-select
             v-model="multiTeleportVal"
+            :tag-max-rows="3"
             :items="manyItems"
             multiple
             checkable
+            filterable
             placeholder="Please select values."
             teleport="body"
           />
@@ -144,9 +148,9 @@
       </div>
       <div class="filler" />
       <div class="description">
-        <strong>multiple + teleport</strong> 조합. dropbox를 열고 항목을 4~5개 이상 차례로
-        선택해서 tag가 두 번째 줄로 <strong>wrap</strong>되는 순간에도 dropbox가 그대로 유지되어
-        다중 선택 흐름이 끊기지 않는지 확인 (Default Multi 와 동일하게 유지되어야 함).
+        <strong>multiple + teleport</strong> 조합. dropbox를 열고 항목을 4~5개 이상 차례로 선택해서
+        tag가 두 번째 줄로 <strong>wrap</strong>되는 순간에도 dropbox가 그대로 유지되어 다중 선택
+        흐름이 끊기지 않는지 확인 (Default Multi 와 동일하게 유지되어야 함).
       </div>
     </ev-window>
     <div class="description">

--- a/docs/views/select/example/InWindow.vue
+++ b/docs/views/select/example/InWindow.vue
@@ -110,6 +110,39 @@
       <button class="btn" @click="clickButton3">click to open window!</button>
     </div>
   </div>
+
+  <div class="case">
+    <p class="case-title">Multiple + Teleport (회귀 가드: tag wrap 시 dropbox 유지)</p>
+    <ev-window
+      v-model:visible="isVisible4"
+      title="Multiple select inside window"
+      width="500px"
+      height="360px"
+    >
+      <div class="window-row">
+        <div class="window-cell">
+          <label>Multi+Teleport</label>
+          <ev-select
+            v-model="multiTeleportVal"
+            :items="manyItems"
+            multiple
+            checkable
+            placeholder="Please select values."
+            teleport="body"
+          />
+        </div>
+      </div>
+      <div class="filler" />
+      <div class="description">
+        <strong>multiple + teleport</strong> 조합. dropbox를 열고 항목을 4~5개 이상 차례로
+        선택해서 tag가 두 번째 줄로 <strong>wrap</strong>되는 순간에도 dropbox가 그대로 유지되어
+        다중 선택 흐름이 끊기지 않는지 확인.
+      </div>
+    </ev-window>
+    <div class="description">
+      <button class="btn" @click="clickButton4">click to open window!</button>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -127,6 +160,7 @@ export default {
     const isVisible1 = ref(false);
     const isVisible2 = ref(false);
     const isVisible3 = ref(false);
+    const isVisible4 = ref(false);
 
     const clickButton1 = () => {
       isVisible1.value = true;
@@ -136,6 +170,9 @@ export default {
     };
     const clickButton3 = () => {
       isVisible3.value = true;
+    };
+    const clickButton4 = () => {
+      isVisible4.value = true;
     };
     const closeWindow3 = () => {
       isVisible3.value = false;
@@ -147,15 +184,18 @@ export default {
     const selectVal1Teleport = ref('');
     const selectVal2Teleport = ref('');
     const selectVal3Teleport = ref('');
+    const multiTeleportVal = ref([]);
 
     return {
       manyItems,
       isVisible1,
       isVisible2,
       isVisible3,
+      isVisible4,
       clickButton1,
       clickButton2,
       clickButton3,
+      clickButton4,
       closeWindow3,
       selectVal1,
       selectVal2,
@@ -163,6 +203,7 @@ export default {
       selectVal1Teleport,
       selectVal2Teleport,
       selectVal3Teleport,
+      multiTeleportVal,
     };
   },
 };

--- a/docs/views/select/example/InWindow.vue
+++ b/docs/views/select/example/InWindow.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="case">
-    <p class="case-title">Dropbox flip (window 상단 근처) - 기본값</p>
+    <p class="case-title">Dropbox flip (window 상단 근처) - 기본값 + teleport 비교</p>
     <ev-window
       v-model:visible="isVisible2"
       title="Select near window top"
@@ -8,13 +8,24 @@
       height="320px"
     >
       <div class="window-row">
-        <label>Top Select</label>
-        <ev-select v-model="selectVal2" :items="manyItems" placeholder="Please select value." />
+        <div class="window-cell">
+          <label>Default</label>
+          <ev-select v-model="selectVal2" :items="manyItems" placeholder="Please select value." />
+        </div>
+        <div class="window-cell">
+          <label>Teleport</label>
+          <ev-select
+            v-model="selectVal2Teleport"
+            :items="manyItems"
+            placeholder="Please select value."
+            teleport="body"
+          />
+        </div>
       </div>
       <div class="filler" />
       <div class="description">
-        window content 상단에 가까운 select. 위로 펼칠 공간이 부족하므로
-        <strong>아래쪽으로 펼쳐져야</strong> 한다.
+        window content 상단에 가까운 select. 기본은 wrapper 내부에서 펼쳐지고,
+        <strong>teleport</strong>는 body로 옮겨져 펼쳐진다.
       </div>
     </ev-window>
     <div class="description">
@@ -23,7 +34,7 @@
   </div>
 
   <div class="case">
-    <p class="case-title">Dropbox flip (window 하단 근처)</p>
+    <p class="case-title">Dropbox flip (window 하단 근처) - 기본값 + teleport 비교</p>
     <ev-window
       v-model:visible="isVisible1"
       title="Select near window bottom"
@@ -32,12 +43,23 @@
     >
       <div class="filler" />
       <div class="window-row">
-        <label>Bottom Select</label>
-        <ev-select v-model="selectVal1" :items="manyItems" placeholder="Please select value." />
+        <div class="window-cell">
+          <label>Default</label>
+          <ev-select v-model="selectVal1" :items="manyItems" placeholder="Please select value." />
+        </div>
+        <div class="window-cell">
+          <label>Teleport</label>
+          <ev-select
+            v-model="selectVal1Teleport"
+            :items="manyItems"
+            placeholder="Please select value."
+            teleport="body"
+          />
+        </div>
       </div>
       <div class="description">
-        window content 하단에 가까운 select. 옵션 레이어가 viewport에는 들어가도 window 컨테이너
-        하단을 넘기면 <strong>위쪽으로 펼쳐져야</strong> 한다.
+        window content 하단에 가까운 select. 기본은 window 컨테이너 경계 기준으로 flip 되고,
+        <strong>teleport</strong>는 viewport 경계 기준으로 flip 되어 window 밖으로도 펼쳐진다.
       </div>
     </ev-window>
     <div class="description">
@@ -46,7 +68,7 @@
   </div>
 
   <div class="case">
-    <p class="case-title">Draggable / Resizable window + Footer + Select</p>
+    <p class="case-title">Draggable / Resizable window + Footer + 기본값 + teleport 비교</p>
     <ev-window
       v-model:visible="isVisible3"
       title="Window with footer (non-scrollable)"
@@ -58,13 +80,23 @@
     >
       <div class="filler" />
       <div class="window-row">
-        <label>Select</label>
-        <ev-select v-model="selectVal3" :items="manyItems" placeholder="Please select value." />
+        <div class="window-cell">
+          <label>Default</label>
+          <ev-select v-model="selectVal3" :items="manyItems" placeholder="Please select value." />
+        </div>
+        <div class="window-cell">
+          <label>Teleport</label>
+          <ev-select
+            v-model="selectVal3Teleport"
+            :items="manyItems"
+            placeholder="Please select value."
+            teleport="body"
+          />
+        </div>
       </div>
       <div class="description">
-        window를 화면 하단까지 드래그해서 옮긴 후 select를 열어보세요. viewport 하단과 window 하단
-        모두에 의해 flip 이 결정되어야 한다.
-        <br />
+        window를 화면 하단까지 드래그해서 옮긴 후 두 select를 각각 열어보세요. 기본은 window 경계에
+        맞춰 flip 되고, teleport는 viewport 기준으로 flip 된다.
         <br />
         <br />
       </div>
@@ -112,6 +144,9 @@ export default {
     const selectVal1 = ref('');
     const selectVal2 = ref('');
     const selectVal3 = ref('');
+    const selectVal1Teleport = ref('');
+    const selectVal2Teleport = ref('');
+    const selectVal3Teleport = ref('');
 
     return {
       manyItems,
@@ -125,6 +160,9 @@ export default {
       selectVal1,
       selectVal2,
       selectVal3,
+      selectVal1Teleport,
+      selectVal2Teleport,
+      selectVal3Teleport,
     };
   },
 };
@@ -134,21 +172,24 @@ export default {
 .window-row {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 16px;
   margin: 8px 0;
+}
+.window-cell {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
 
   label {
-    min-width: 100px;
+    min-width: 60px;
   }
 }
 .filler {
   height: 140px;
   background-color: #f5f5f5;
   border: 1px dashed #ccc;
-
-  &.tall {
-    height: 600px;
-  }
 }
 .window-footer-buttons {
   display: flex;

--- a/docs/views/select/example/InWindow.vue
+++ b/docs/views/select/example/InWindow.vue
@@ -121,7 +121,17 @@
     >
       <div class="window-row">
         <div class="window-cell">
-          <label>Multi+Teleport</label>
+          <label>Default Multi</label>
+          <ev-select
+            v-model="multiDefaultVal"
+            :items="manyItems"
+            multiple
+            checkable
+            placeholder="Please select values."
+          />
+        </div>
+        <div class="window-cell">
+          <label>Multi Teleport</label>
           <ev-select
             v-model="multiTeleportVal"
             :items="manyItems"
@@ -136,7 +146,7 @@
       <div class="description">
         <strong>multiple + teleport</strong> 조합. dropbox를 열고 항목을 4~5개 이상 차례로
         선택해서 tag가 두 번째 줄로 <strong>wrap</strong>되는 순간에도 dropbox가 그대로 유지되어
-        다중 선택 흐름이 끊기지 않는지 확인.
+        다중 선택 흐름이 끊기지 않는지 확인 (Default Multi 와 동일하게 유지되어야 함).
       </div>
     </ev-window>
     <div class="description">
@@ -184,6 +194,7 @@ export default {
     const selectVal1Teleport = ref('');
     const selectVal2Teleport = ref('');
     const selectVal3Teleport = ref('');
+    const multiDefaultVal = ref([]);
     const multiTeleportVal = ref([]);
 
     return {
@@ -203,6 +214,7 @@ export default {
       selectVal1Teleport,
       selectVal2Teleport,
       selectVal3Teleport,
+      multiDefaultVal,
       multiTeleportVal,
     };
   },

--- a/docs/views/select/props.js
+++ b/docs/views/select/props.js
@@ -4,6 +4,8 @@ import Default from './example/Default';
 import DefaultRaw from './example/Default?raw';
 import Multiple from './example/Multiple';
 import MultipleRaw from './example/Multiple?raw';
+import InWindow from './example/InWindow';
+import InWindowRaw from './example/InWindow?raw';
 
 export default {
   mdText,
@@ -17,6 +19,11 @@ export default {
       description: '다중 선택가능한 멀티 체크박스입니다.',
       component: Multiple,
       parsedData: parse(MultipleRaw).descriptor,
+    },
+    InWindow: {
+      description: 'ev-window 안에서 사용하는 경우의 예시입니다.',
+      component: InWindow,
+      parsedData: parse(InWindowRaw).descriptor,
     },
   },
 };

--- a/src/common/utils.teleport.js
+++ b/src/common/utils.teleport.js
@@ -1,0 +1,41 @@
+/**
+ * teleport selector 문자열로 실제 target element를 해석한다.
+ *
+ * - selector가 빈 문자열/null/undefined면 'body' 문자열을 그대로 반환한다.
+ *   (호출부에서 Teleport를 `:disabled`로 비활성화하는 케이스를 위한 placeholder)
+ * - selector가 매칭되는 element를 찾으면 그 element를 반환한다.
+ * - selector가 매칭되지 않거나 syntax error로 throw되면 document.body로 fallback하고
+ *   console.warn을 남긴다.
+ *
+ * @param {string} selector - "body", ".foo", "#bar" 같은 CSS selector
+ * @param {string} [componentName='Component'] - warn 메시지 prefix용 컴포넌트 식별자
+ * @returns {string | HTMLElement} 'body' 문자열 또는 실제 element
+ */
+const resolveTeleportTarget = (selector, componentName = 'Component') => {
+  if (!selector) {
+    return 'body';
+  }
+  try {
+    const found = document.querySelector(selector);
+    if (!found) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[${componentName}] teleport selector "${selector}" did not match any element. ` +
+          'Falling back to document.body.',
+      );
+      return document.body;
+    }
+    return found;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[${componentName}] teleport selector "${selector}" is invalid. ` +
+        'Falling back to document.body.',
+      e,
+    );
+    return document.body;
+  }
+};
+
+export { resolveTeleportTarget };
+export default resolveTeleportTarget;

--- a/src/common/utils.teleport.js
+++ b/src/common/utils.teleport.js
@@ -5,21 +5,34 @@
  *   (호출부에서 Teleport를 `:disabled`로 비활성화하는 케이스를 위한 placeholder)
  * - selector가 매칭되는 element를 찾으면 그 element를 반환한다.
  * - selector가 매칭되지 않거나 syntax error로 throw되면 document.body로 fallback하고
- *   console.warn을 남긴다.
+ *   console.warn을 남긴다. 같은 (componentName, selector) 조합은 1회만 warn하여
+ *   매 open마다 콘솔이 누적 오염되는 것을 막는다.
  *
  * @param {string} selector - "body", ".foo", "#bar" 같은 CSS selector
  * @param {string} [componentName='Component'] - warn 메시지 prefix용 컴포넌트 식별자
  * @returns {string | HTMLElement} 'body' 문자열 또는 실제 element
  */
+const warnedSelectors = new Set();
+
+const warnOnce = (key, ...args) => {
+  if (warnedSelectors.has(key)) {
+    return;
+  }
+  warnedSelectors.add(key);
+  // eslint-disable-next-line no-console
+  console.warn(...args);
+};
+
 const resolveTeleportTarget = (selector, componentName = 'Component') => {
   if (!selector) {
     return 'body';
   }
+  const warnKey = `${componentName}::${selector}`;
   try {
     const found = document.querySelector(selector);
     if (!found) {
-      // eslint-disable-next-line no-console
-      console.warn(
+      warnOnce(
+        warnKey,
         `[${componentName}] teleport selector "${selector}" did not match any element. ` +
           'Falling back to document.body.',
       );
@@ -27,8 +40,8 @@ const resolveTeleportTarget = (selector, componentName = 'Component') => {
     }
     return found;
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.warn(
+    warnOnce(
+      warnKey,
       `[${componentName}] teleport selector "${selector}" is invalid. ` +
         'Falling back to document.body.',
       e,
@@ -37,5 +50,10 @@ const resolveTeleportTarget = (selector, componentName = 'Component') => {
   }
 };
 
-export { resolveTeleportTarget };
+// test-only: 동일 selector 반복 호출을 검증하는 spec에서 캐시를 비울 수 있게 한다.
+const __resetTeleportWarnCache = () => {
+  warnedSelectors.clear();
+};
+
+export { resolveTeleportTarget, __resetTeleportWarnCache };
 export default resolveTeleportTarget;

--- a/src/common/utils.teleport.spec.js
+++ b/src/common/utils.teleport.spec.js
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { resolveTeleportTarget } from './utils.teleport';
+import { resolveTeleportTarget, __resetTeleportWarnCache } from './utils.teleport';
 
 describe('utils.teleport', () => {
   let warnSpy;
 
   beforeEach(() => {
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    __resetTeleportWarnCache();
   });
 
   afterEach(() => {
@@ -85,6 +86,28 @@ describe('utils.teleport', () => {
       resolveTeleportTarget('.missing', 'EvSelect');
       const msg = warnSpy.mock.calls[0][0];
       expect(msg).toContain('[EvSelect]');
+    });
+  });
+
+  describe('warn 캐시 (selector별 1회)', () => {
+    it('같은 mismatch selector를 반복 호출해도 console.warn은 1회만 출력된다', () => {
+      resolveTeleportTarget('.does-not-exist');
+      resolveTeleportTarget('.does-not-exist');
+      resolveTeleportTarget('.does-not-exist');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('서로 다른 mismatch selector는 각각 1회씩 warn한다', () => {
+      resolveTeleportTarget('.miss-a');
+      resolveTeleportTarget('.miss-b');
+      resolveTeleportTarget('.miss-a');
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('같은 selector라도 componentName이 다르면 각각 1회씩 warn한다', () => {
+      resolveTeleportTarget('.miss', 'EvSelect');
+      resolveTeleportTarget('.miss', 'EvDatePicker');
+      expect(warnSpy).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/common/utils.teleport.spec.js
+++ b/src/common/utils.teleport.spec.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolveTeleportTarget } from './utils.teleport';
+
+describe('utils.teleport', () => {
+  let warnSpy;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    document.body.innerHTML = '';
+  });
+
+  describe('empty / falsy selector', () => {
+    it("should return 'body' string when selector is empty string", () => {
+      expect(resolveTeleportTarget('')).toBe('body');
+    });
+
+    it("should return 'body' string when selector is undefined", () => {
+      expect(resolveTeleportTarget(undefined)).toBe('body');
+    });
+
+    it("should return 'body' string when selector is null", () => {
+      expect(resolveTeleportTarget(null)).toBe('body');
+    });
+
+    it('should not warn for empty selector (it is the disabled placeholder)', () => {
+      resolveTeleportTarget('');
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('matching selector', () => {
+    it('should return the body element when selector is "body"', () => {
+      const result = resolveTeleportTarget('body');
+      expect(result).toBe(document.body);
+    });
+
+    it('should return the matched element for class selector', () => {
+      const div = document.createElement('div');
+      div.className = 'teleport-target';
+      document.body.appendChild(div);
+
+      const result = resolveTeleportTarget('.teleport-target');
+      expect(result).toBe(div);
+    });
+
+    it('should return the matched element for id selector', () => {
+      const div = document.createElement('div');
+      div.id = 'teleport-root';
+      document.body.appendChild(div);
+
+      const result = resolveTeleportTarget('#teleport-root');
+      expect(result).toBe(div);
+    });
+
+    it('should not warn when selector matches an element', () => {
+      const div = document.createElement('div');
+      div.id = 'ok';
+      document.body.appendChild(div);
+
+      resolveTeleportTarget('#ok');
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('non-matching selector', () => {
+    it('should fall back to document.body when selector matches nothing', () => {
+      const result = resolveTeleportTarget('.does-not-exist');
+      expect(result).toBe(document.body);
+    });
+
+    it('should console.warn with selector string and default component name', () => {
+      resolveTeleportTarget('.does-not-exist');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const msg = warnSpy.mock.calls[0][0];
+      expect(msg).toContain('[Component]');
+      expect(msg).toContain('.does-not-exist');
+      expect(msg).toContain('Falling back to document.body');
+    });
+
+    it('should use the provided componentName in the warning prefix', () => {
+      resolveTeleportTarget('.missing', 'EvSelect');
+      const msg = warnSpy.mock.calls[0][0];
+      expect(msg).toContain('[EvSelect]');
+    });
+  });
+
+  describe('invalid selector (querySelector throws)', () => {
+    it('should fall back to document.body when selector is syntactically invalid', () => {
+      const result = resolveTeleportTarget('..bad', 'EvSelect');
+      expect(result).toBe(document.body);
+    });
+
+    it('should console.warn with the error object as a second argument', () => {
+      resolveTeleportTarget('..bad', 'EvSelect');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [msg, err] = warnSpy.mock.calls[0];
+      expect(msg).toContain('[EvSelect]');
+      expect(msg).toContain('..bad');
+      expect(msg).toContain('is invalid');
+      // jsdom throws DOMException (not a subclass of Error), real browsers may throw either.
+      expect(err).toBeTruthy();
+      expect(typeof err.message).toBe('string');
+    });
+  });
+});

--- a/src/components/select/Select.spec.js
+++ b/src/components/select/Select.spec.js
@@ -362,6 +362,98 @@ describe('EvSelect Component', () => {
     });
   });
 
+  describe('Teleport 모드 dropbox flip 동작', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+      document
+        .querySelectorAll('body > .ev-select-dropbox')
+        .forEach((el) => el.parentElement.removeChild(el));
+    });
+
+    const mockTeleportBounds = ({ selectWrapperRect, dropboxRect, docClientHeight = 1000 }) => {
+      vi.spyOn(document.documentElement, 'clientHeight', 'get').mockReturnValue(docClientHeight);
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function rect() {
+        if (this.classList?.contains('ev-select__wrapper')) return selectWrapperRect;
+        if (this.classList?.contains('ev-select-dropbox')) return dropboxRect;
+        return { top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0, x: 0, y: 0 };
+      });
+    };
+
+    it('teleport="body" + 화면 상단 select 는 viewport bottom 좌표로 dropDown 한다', async () => {
+      mockTeleportBounds({
+        selectWrapperRect: { top: 100, bottom: 130, left: 50, width: 200, height: 30, y: 100 },
+        dropboxRect: { height: 175 },
+        docClientHeight: 1000,
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, teleport: 'body' },
+        attachTo: document.body,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = document.querySelector('body > .ev-select-dropbox');
+      expect(dropboxEl).not.toBeNull();
+      // teleport 분기: dropDown 시 top = selectRect.bottom (viewport 절대 좌표, px)
+      expect(dropboxEl.style.top).toBe('130px');
+      expect(dropboxEl.style.left).toBe('50px');
+      wrapper.unmount();
+    });
+
+    it('teleport="body" + 화면 하단 select 는 viewport top 기준으로 위로 펼친다', async () => {
+      mockTeleportBounds({
+        selectWrapperRect: { top: 900, bottom: 930, left: 50, width: 200, height: 30, y: 900 },
+        dropboxRect: { height: 175 },
+        docClientHeight: 1000,
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, teleport: 'body' },
+        attachTo: document.body,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = document.querySelector('body > .ev-select-dropbox');
+      expect(dropboxEl).not.toBeNull();
+      // teleport 분기 dropTop: top = selectRect.top - dropboxHeight = 900 - 175 = 725
+      expect(dropboxEl.style.top).toBe('725px');
+      expect(dropboxEl.style.left).toBe('50px');
+      wrapper.unmount();
+    });
+
+    it('teleport="body" 활성 시 dropbox에 teleported 클래스가 적용되고 body 직속으로 옮겨진다', async () => {
+      mockTeleportBounds({
+        selectWrapperRect: { top: 100, bottom: 130, left: 50, width: 200, height: 30, y: 100 },
+        dropboxRect: { height: 175 },
+        docClientHeight: 1000,
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, teleport: 'body' },
+        attachTo: document.body,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = document.querySelector('body > .ev-select-dropbox');
+      expect(dropboxEl).not.toBeNull();
+      expect(dropboxEl.classList.contains('teleported')).toBe(true);
+      expect(dropboxEl.style.width).toBe('200px');
+      wrapper.unmount();
+    });
+  });
+
   describe('기본값', () => {
     it('컴포넌트 이름이 EvSelect이다', () => {
       expect(EvSelect.name).toBe('EvSelect');

--- a/src/components/select/Select.spec.js
+++ b/src/components/select/Select.spec.js
@@ -466,7 +466,37 @@ describe('EvSelect Component', () => {
       });
     };
 
-    it('teleport 모드에서 window scroll 시 dropbox 위치가 재계산된다', async () => {
+    it('teleport 모드에서 ancestor/viewport scroll 시 dropbox가 닫힌다', async () => {
+      const wrapperRectRef = {
+        current: { top: 100, bottom: 130, left: 50, width: 200, height: 30, y: 100 },
+      };
+      mockMutableTeleportBounds({
+        wrapperRectRef,
+        dropboxRect: { height: 175 },
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, teleport: 'body' },
+        attachTo: document.body,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      expect(document.querySelector('body > .ev-select-dropbox')).not.toBeNull();
+
+      // ancestor가 스크롤되면 dropbox는 위치 재계산이 아니라 닫혀야 한다 (native select UX)
+      window.dispatchEvent(new Event('scroll'));
+      await nextTick();
+      await nextTick();
+
+      expect(document.querySelector('body > .ev-select-dropbox')).toBeNull();
+      wrapper.unmount();
+    });
+
+    it('teleport 모드에서 dropbox 내부 scroll(필터 input, item list)은 닫지 않는다', async () => {
       const wrapperRectRef = {
         current: { top: 100, bottom: 130, left: 50, width: 200, height: 30, y: 100 },
       };
@@ -486,20 +516,19 @@ describe('EvSelect Component', () => {
       await nextTick();
 
       const dropboxEl = document.querySelector('body > .ev-select-dropbox');
-      expect(dropboxEl.style.top).toBe('130px');
+      expect(dropboxEl).not.toBeNull();
 
-      // 페이지가 위로 50px 스크롤된 상황: selectWrapperRect도 위로 이동
-      wrapperRectRef.current = { top: 50, bottom: 80, left: 50, width: 200, height: 30, y: 50 };
-      window.dispatchEvent(new Event('scroll'));
+      // dropbox 내부 element에서 발생한 scroll은 capture phase에서도 무시되어야 한다
+      const innerScrollTarget = dropboxEl.querySelector('.ev-select-dropbox-items') || dropboxEl;
+      innerScrollTarget.dispatchEvent(new Event('scroll', { bubbles: true }));
       await nextTick();
       await nextTick();
 
-      // changeDropboxPosition이 다시 호출되어 새 selectRect.bottom을 사용해야 한다
-      expect(dropboxEl.style.top).toBe('80px');
+      expect(document.querySelector('body > .ev-select-dropbox')).not.toBeNull();
       wrapper.unmount();
     });
 
-    it('teleport 모드에서 ResizeObserver 콜백 시 dropbox 위치가 재계산된다', async () => {
+    it('teleport 모드에서 ResizeObserver 콜백 시 dropbox가 닫힌다 (첫 콜백은 무시)', async () => {
       let observerCb = null;
       class MockResizeObserver {
         constructor(cb) {
@@ -532,19 +561,51 @@ describe('EvSelect Component', () => {
       await nextTick();
       await nextTick();
 
-      const dropboxEl = document.querySelector('body > .ev-select-dropbox');
-      expect(dropboxEl.style.top).toBe('130px');
+      expect(document.querySelector('body > .ev-select-dropbox')).not.toBeNull();
       expect(observerCb).not.toBeNull();
 
-      // select 자체 크기/위치 변화로 ResizeObserver 콜백 발화
-      wrapperRectRef.current = { top: 200, bottom: 240, left: 50, width: 200, height: 40, y: 200 };
+      // 첫 콜백(observe() 직후 spec상 1회)은 무시되어 dropbox가 열린 채 유지되어야 한다
       observerCb([{ target: wrapper.find('.ev-select__wrapper').element }]);
       await nextTick();
       await nextTick();
+      expect(document.querySelector('body > .ev-select-dropbox')).not.toBeNull();
 
-      expect(dropboxEl.style.top).toBe('240px');
+      // 두 번째 콜백(실제 size 변화)에서는 닫힘
+      observerCb([{ target: wrapper.find('.ev-select__wrapper').element }]);
+      await nextTick();
+      await nextTick();
+      expect(document.querySelector('body > .ev-select-dropbox')).toBeNull();
 
       vi.unstubAllGlobals();
+      wrapper.unmount();
+    });
+
+    it('teleport 모드에서 window resize 시 dropbox가 닫힌다', async () => {
+      const wrapperRectRef = {
+        current: { top: 100, bottom: 130, left: 50, width: 200, height: 30, y: 100 },
+      };
+      mockMutableTeleportBounds({
+        wrapperRectRef,
+        dropboxRect: { height: 175 },
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, teleport: 'body' },
+        attachTo: document.body,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      expect(document.querySelector('body > .ev-select-dropbox')).not.toBeNull();
+
+      window.dispatchEvent(new Event('resize'));
+      await nextTick();
+      await nextTick();
+
+      expect(document.querySelector('body > .ev-select-dropbox')).toBeNull();
       wrapper.unmount();
     });
 

--- a/src/components/select/Select.spec.js
+++ b/src/components/select/Select.spec.js
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
 import EvSelect from './Select.vue';
 
 describe('EvSelect Component', () => {
@@ -80,6 +81,284 @@ describe('EvSelect Component', () => {
       await wrapper.find('.ev-input').trigger('click');
 
       expect(wrapper.find('.ev-select-dropbox').exists()).toBe(true);
+    });
+  });
+
+  describe('Dropbox flip 동작', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    /**
+     * 부모/조부모 등 임의의 ancestor에 적용할 computed style을 mock한다.
+     * (해당 ancestor가 세로 스크롤 컨테이너로 인식되도록 overflowY: auto 부여)
+     */
+    const mockBounds = ({
+      selectWrapperRect,
+      dropboxRect,
+      scrollContainer,
+      scrollContainerRect,
+      docClientHeight = 1000,
+    }) => {
+      vi.spyOn(document.documentElement, 'clientHeight', 'get').mockReturnValue(docClientHeight);
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function rect() {
+        if (this.classList?.contains('ev-select__wrapper')) return selectWrapperRect;
+        if (this.classList?.contains('ev-select-dropbox')) return dropboxRect;
+        if (scrollContainer && this === scrollContainer) return scrollContainerRect;
+        return { top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0, x: 0, y: 0 };
+      });
+      if (scrollContainer) {
+        const original = window.getComputedStyle.bind(window);
+        vi.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
+          if (el === scrollContainer) {
+            return { overflow: 'visible', overflowY: 'auto' };
+          }
+          return original(el);
+        });
+      }
+    };
+
+    it('스크롤 ancestor가 없으면 viewport 기준으로 dropDown 한다', async () => {
+      mockBounds({
+        selectWrapperRect: { top: 100, bottom: 130, height: 30, y: 100 },
+        dropboxRect: { height: 175 },
+        docClientHeight: 1000,
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        attachTo: document.body,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = wrapper.find('.ev-select-dropbox').element;
+      expect(dropboxEl.style.top).toBe('30px');
+      wrapper.unmount();
+    });
+
+    it('스크롤 ancestor가 없고 viewport 하단을 넘으면 위로 펼친다', async () => {
+      mockBounds({
+        selectWrapperRect: { top: 900, bottom: 930, height: 30, y: 900 },
+        dropboxRect: { height: 175 },
+        docClientHeight: 1000,
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        attachTo: document.body,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = wrapper.find('.ev-select-dropbox').element;
+      expect(dropboxEl.style.top).toBe('-175px');
+      wrapper.unmount();
+    });
+
+    it('스크롤 ancestor 경계를 넘고 위에 공간이 있으면 위로 펼친다 (회귀 가드)', async () => {
+      const scrollContainer = document.createElement('div');
+      document.body.appendChild(scrollContainer);
+
+      const selectMount = document.createElement('div');
+      scrollContainer.appendChild(selectMount);
+
+      mockBounds({
+        selectWrapperRect: { top: 480, bottom: 510, height: 30, y: 480 },
+        dropboxRect: { height: 175 },
+        scrollContainer,
+        scrollContainerRect: { top: 100, bottom: 540, height: 440, y: 100 },
+        docClientHeight: 1000,
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        attachTo: selectMount,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = wrapper.find('.ev-select-dropbox').element;
+      expect(dropboxEl.style.top).toBe('-175px');
+
+      wrapper.unmount();
+      document.body.removeChild(scrollContainer);
+    });
+
+    it('스크롤 ancestor 안에 충분한 공간이 있으면 dropDown 유지', async () => {
+      const scrollContainer = document.createElement('div');
+      document.body.appendChild(scrollContainer);
+
+      const selectMount = document.createElement('div');
+      scrollContainer.appendChild(selectMount);
+
+      mockBounds({
+        selectWrapperRect: { top: 150, bottom: 180, height: 30, y: 150 },
+        dropboxRect: { height: 175 },
+        scrollContainer,
+        scrollContainerRect: { top: 100, bottom: 540, height: 440, y: 100 },
+        docClientHeight: 1000,
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        attachTo: selectMount,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = wrapper.find('.ev-select-dropbox').element;
+      expect(dropboxEl.style.top).toBe('30px');
+
+      wrapper.unmount();
+      document.body.removeChild(scrollContainer);
+    });
+
+    it('스크롤 ancestor가 viewport 하단 아래로 벗어난 경우에도 위로 펼친다', async () => {
+      // ev-window를 viewport 하단까지 드래그해서 컨테이너 일부가 화면 밖으로 잘린 상황.
+      // container.bottom > viewport.bottom 이라도 dropDown이 화면 밖에 그려지지 않도록
+      // viewport와 교집합을 잡아 flip 되어야 한다.
+      const scrollContainer = document.createElement('div');
+      document.body.appendChild(scrollContainer);
+
+      const selectMount = document.createElement('div');
+      scrollContainer.appendChild(selectMount);
+
+      mockBounds({
+        selectWrapperRect: { top: 850, bottom: 880, height: 30, y: 850 },
+        dropboxRect: { height: 175 },
+        scrollContainer,
+        scrollContainerRect: { top: 500, bottom: 1400, height: 900, y: 500 },
+        docClientHeight: 1000,
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        attachTo: selectMount,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = wrapper.find('.ev-select-dropbox').element;
+      expect(dropboxEl.style.top).toBe('-175px');
+
+      wrapper.unmount();
+      document.body.removeChild(scrollContainer);
+    });
+
+    it('스크롤 ancestor 안에서 양쪽 모두 dropbox를 못 담아도 위쪽이 더 넓으면 위로 펼친다', async () => {
+      // ev-window 내부 스크롤로 select 위/아래 모두 dropbox 전체를 담을 공간이 없는 상황.
+      // spaceAbove(135) > spaceBelow(65) 이므로 더 많이 보이는 쪽인 위로 펼친다.
+      const scrollContainer = document.createElement('div');
+      document.body.appendChild(scrollContainer);
+
+      const selectMount = document.createElement('div');
+      scrollContainer.appendChild(selectMount);
+
+      mockBounds({
+        selectWrapperRect: { top: 235, bottom: 265, height: 30, y: 235 },
+        dropboxRect: { height: 175 },
+        scrollContainer,
+        scrollContainerRect: { top: 100, bottom: 330, height: 230, y: 100 },
+        docClientHeight: 1000,
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        attachTo: selectMount,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = wrapper.find('.ev-select-dropbox').element;
+      expect(dropboxEl.style.top).toBe('-175px');
+
+      wrapper.unmount();
+      document.body.removeChild(scrollContainer);
+    });
+
+    it('스크롤 ancestor 안에서 양쪽 모두 dropbox를 못 담고 아래쪽이 더 넓으면 dropDown 유지', async () => {
+      // 대칭 케이스: 위쪽이 좁고 아래쪽이 넓으면 dropDown 으로 떨어진다.
+      const scrollContainer = document.createElement('div');
+      document.body.appendChild(scrollContainer);
+
+      const selectMount = document.createElement('div');
+      scrollContainer.appendChild(selectMount);
+
+      mockBounds({
+        selectWrapperRect: { top: 170, bottom: 200, height: 30, y: 170 },
+        dropboxRect: { height: 175 },
+        scrollContainer,
+        scrollContainerRect: { top: 100, bottom: 330, height: 230, y: 100 },
+        docClientHeight: 1000,
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        attachTo: selectMount,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = wrapper.find('.ev-select-dropbox').element;
+      expect(dropboxEl.style.top).toBe('30px');
+
+      wrapper.unmount();
+      document.body.removeChild(scrollContainer);
+    });
+
+    it('스크롤 ancestor가 viewport 상단 위로 벗어난 경우에도 dropDown 한다', async () => {
+      // 반대 케이스: 컨테이너 top이 음수(화면 위로 잘림). topBoundary가 0으로 clamp 되어야 한다.
+      const scrollContainer = document.createElement('div');
+      document.body.appendChild(scrollContainer);
+
+      const selectMount = document.createElement('div');
+      scrollContainer.appendChild(selectMount);
+
+      mockBounds({
+        selectWrapperRect: { top: 50, bottom: 80, height: 30, y: 50 },
+        dropboxRect: { height: 175 },
+        scrollContainer,
+        scrollContainerRect: { top: -200, bottom: 700, height: 900, y: -200 },
+        docClientHeight: 1000,
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        attachTo: selectMount,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = wrapper.find('.ev-select-dropbox').element;
+      expect(dropboxEl.style.top).toBe('30px');
+
+      wrapper.unmount();
+      document.body.removeChild(scrollContainer);
     });
   });
 

--- a/src/components/select/Select.spec.js
+++ b/src/components/select/Select.spec.js
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import EvSelect from './Select.vue';
+
+const SELECT_SFC_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'Select.vue');
+const SELECT_SFC_SOURCE = readFileSync(SELECT_SFC_PATH, 'utf-8');
 
 describe('EvSelect Component', () => {
   const defaultProps = {
@@ -20,27 +26,6 @@ describe('EvSelect Component', () => {
     },
   };
 
-  describe('렌더링', () => {
-    it('기본 셀렉트가 렌더링된다', () => {
-      const wrapper = mount(EvSelect, {
-        props: defaultProps,
-        ...globalConfig,
-      });
-
-      expect(wrapper.find('.ev-select').exists()).toBe(true);
-      expect(wrapper.find('.ev-input').exists()).toBe(true);
-    });
-
-    it('화살표 아이콘이 렌더링된다', () => {
-      const wrapper = mount(EvSelect, {
-        props: defaultProps,
-        ...globalConfig,
-      });
-
-      expect(wrapper.find('.ev-input-suffix-arrow').exists()).toBe(true);
-    });
-  });
-
   describe('Props', () => {
     it('disabled prop이 적용된다', () => {
       const wrapper = mount(EvSelect, {
@@ -50,24 +35,6 @@ describe('EvSelect Component', () => {
 
       expect(wrapper.classes()).toContain('disabled');
       expect(wrapper.find('.ev-input').element.disabled).toBe(true);
-    });
-
-    it('placeholder prop이 적용된다', () => {
-      const wrapper = mount(EvSelect, {
-        props: { ...defaultProps, placeholder: '선택하세요' },
-        ...globalConfig,
-      });
-
-      expect(wrapper.find('.ev-input').attributes('placeholder')).toBe('선택하세요');
-    });
-
-    it('multiple prop이 적용되면 다중 선택 UI가 렌더링된다', () => {
-      const wrapper = mount(EvSelect, {
-        props: { ...defaultProps, multiple: true, modelValue: [] },
-        ...globalConfig,
-      });
-
-      expect(wrapper.find('.ev-select-tag-wrapper').exists()).toBe(true);
     });
   });
 
@@ -81,6 +48,95 @@ describe('EvSelect Component', () => {
       await wrapper.find('.ev-input').trigger('click');
 
       expect(wrapper.find('.ev-select-dropbox').exists()).toBe(true);
+    });
+
+    it('multiple + tagMaxRows>0 에서 tag-wrapper 클릭 시 드롭박스가 열린다 (회귀 가드)', async () => {
+      // has-max-rows일 때 input.multiple은 pointer-events:none이라 click이 input을 통과해
+      // tag-wrapper로 위임된다. 이렇게 해야 input이 wrapper overflow scroll/wheel을 가리지 않는다.
+      // tagMaxRows=0 (기본)에서는 input @click이 그대로 동작하므로 사이드 이펙트가 없다.
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, multiple: true, tagMaxRows: 3, modelValue: [] },
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-select-tag-wrapper').trigger('click');
+
+      expect(wrapper.find('.ev-select-dropbox').exists()).toBe(true);
+    });
+
+    it('multiple 기본 모드(tagMaxRows=0)에서는 input click이 그대로 dropbox를 연다 (사이드 이펙트 가드)', async () => {
+      // tagMaxRows=0에서는 pointer-events:none이 적용되지 않으므로
+      // 기존 input @click 경로를 통해 dropbox가 열려야 한다.
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, multiple: true, modelValue: [] },
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input.multiple').trigger('click');
+
+      expect(wrapper.find('.ev-select-dropbox').exists()).toBe(true);
+    });
+
+    it('multiple + tagMaxRows>0 에서 선택된 tag 본문 클릭은 드롭박스를 토글하지 않는다 (회귀 가드)', async () => {
+      // tag-wrapper @click → clickSelectInput 이지만, tag 내부 click이 wrapper로 bubble되면
+      // 사용자가 tag-name을 클릭할 때마다 dropbox가 토글된다.
+      // .ev-select-tag 에 @click.stop이 걸려 있어 wrapper 토글을 막아야 한다.
+      const wrapper = mount(EvSelect, {
+        props: {
+          ...defaultProps,
+          multiple: true,
+          tagMaxRows: 3,
+          modelValue: ['opt1'],
+        },
+        ...globalConfig,
+      });
+
+      // 먼저 wrapper 클릭으로 한 번 열어둔다.
+      await wrapper.find('.ev-select-tag-wrapper').trigger('click');
+      expect(wrapper.find('.ev-select-dropbox').exists()).toBe(true);
+
+      // tag 본문 클릭이 wrapper로 bubble되어 다시 토글(=닫힘)되면 안 된다.
+      await wrapper.find('.ev-select-tag .ev-tag-name').trigger('click');
+      expect(wrapper.find('.ev-select-dropbox').exists()).toBe(true);
+    });
+
+    it('multiple + tagMaxRows>0 일 때 input.multiple은 readonly + tabindex=-1 로 유지된다 (스펙 가드)', () => {
+      // pointer-events:none 효과는 jsdom에서 검증할 수 없어 SFC raw text 가드를 따로 둔다.
+      // 여기서는 input 자체의 접근성/탭 흐름 속성만 본다.
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, multiple: true, tagMaxRows: 3, modelValue: [] },
+        ...globalConfig,
+      });
+
+      const inputEl = wrapper.find('.ev-input.multiple').element;
+      expect(inputEl.hasAttribute('readonly')).toBe(true);
+      expect(inputEl.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('multiple 기본 모드(tagMaxRows=0)에서는 input.multiple에 tabindex가 적용되지 않는다 (회귀 가드)', () => {
+      // 위의 스펙 가드 대칭. `hasMaxRows ? -1 : null` 바인딩에서 `> 0` 조건이 `>= 0` 등으로
+      // 무너지면 기본 모드에서도 tabindex=-1이 박혀 키보드 탭 도달 경로가 사라진다.
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, multiple: true, modelValue: [] },
+        ...globalConfig,
+      });
+
+      const inputEl = wrapper.find('.ev-input.multiple').element;
+      // null binding → 속성 자체가 DOM에 박히지 않아야 한다.
+      expect(inputEl.hasAttribute('tabindex')).toBe(false);
+    });
+
+    it('Select.vue SFC: has-max-rows 분기에 pointer-events:none 이 살아 있다 (스타일 회귀 가드)', () => {
+      // jsdom은 CSS를 적용하지 않으므로 실효 검증이 안 된다.
+      // 의도가 silent하게 사라지는 회귀(파일에서 규칙이 지워짐)를 잡기 위해 SFC 텍스트를 검사한다.
+      // 기본 모드(tagMaxRows=0)에는 적용되지 않아야 한다는 점이 핵심이므로 has-max-rows 스코프로만 매칭.
+      expect(SELECT_SFC_SOURCE).toMatch(
+        /\.ev-select-tag-wrapper\.has-max-rows\s+\.ev-input\.multiple\s*\{[^}]*pointer-events:\s*none/,
+      );
+      // 기본 모드 input.multiple 블록에는 pointer-events 규칙이 들어가지 않아야 한다.
+      const multipleBlockMatch = SELECT_SFC_SOURCE.match(/&\.multiple\s*\{([^}]*)\}/);
+      expect(multipleBlockMatch).not.toBeNull();
+      expect(multipleBlockMatch[1]).not.toMatch(/pointer-events/);
     });
   });
 
@@ -261,9 +317,10 @@ describe('EvSelect Component', () => {
       document.body.removeChild(scrollContainer);
     });
 
-    it('스크롤 ancestor 안에서 양쪽 모두 dropbox를 못 담아도 위쪽이 더 넓으면 위로 펼친다', async () => {
-      // ev-window 내부 스크롤로 select 위/아래 모두 dropbox 전체를 담을 공간이 없는 상황.
-      // spaceAbove(135) > spaceBelow(65) 이므로 더 많이 보이는 쪽인 위로 펼친다.
+    it('스크롤 ancestor 안에서 양쪽 모두 부족하지만 위가 더 넓으면 위로 펼친다 (native select 일관성)', async () => {
+      // ev-window 내부에서 select 위/아래 모두 dropbox 전체를 담을 공간이 없는 상황.
+      // 양쪽 다 부족하더라도 더 넓은 쪽(위)으로 펼쳐서 더 많은 항목을 노출한다 —
+      // 컨테이너 안에서 가려지는 것보다 native select와 동일하게 더 큰 쪽으로 펼친다.
       const scrollContainer = document.createElement('div');
       document.body.appendChild(scrollContainer);
 
@@ -288,6 +345,7 @@ describe('EvSelect Component', () => {
       await nextTick();
       await nextTick();
 
+      // spaceAbove=135, spaceBelow=65, overflowsBottom=true, spaceAbove > spaceBelow → dropTop
       const dropboxEl = wrapper.find('.ev-select-dropbox').element;
       expect(dropboxEl.style.top).toBe('-175px');
 
@@ -323,6 +381,134 @@ describe('EvSelect Component', () => {
 
       const dropboxEl = wrapper.find('.ev-select-dropbox').element;
       expect(dropboxEl.style.top).toBe('30px');
+
+      wrapper.unmount();
+      document.body.removeChild(scrollContainer);
+    });
+
+    /**
+     * 도중 selectWrapperRect 를 갈아끼울 수 있는 변형 mock.
+     * tag wrap 등으로 wrapper height 가 바뀌는 시나리오를 시뮬레이트한다.
+     */
+    const mockMutableBounds = ({
+      wrapperRectRef,
+      dropboxRect,
+      scrollContainer,
+      scrollContainerRect,
+      docClientHeight = 1000,
+    }) => {
+      vi.spyOn(document.documentElement, 'clientHeight', 'get').mockReturnValue(docClientHeight);
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function rect() {
+        if (this.classList?.contains('ev-select__wrapper')) return wrapperRectRef.current;
+        if (this.classList?.contains('ev-select-dropbox')) return dropboxRect;
+        if (scrollContainer && this === scrollContainer) return scrollContainerRect;
+        return { top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0, x: 0, y: 0 };
+      });
+      if (scrollContainer) {
+        const original = window.getComputedStyle.bind(window);
+        vi.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
+          if (el === scrollContainer) {
+            return { overflow: 'visible', overflowY: 'auto' };
+          }
+          return original(el);
+        });
+      }
+    };
+
+    it('multiple+checkable open 후 wrapper height가 늘어나도 flip 방향이 점프하지 않는다 (회귀 가드)', async () => {
+      // window 내부 multiple+checkable 에서 항목 선택으로 wrapper height 가 늘어나면
+      // mv.value watch 가 changeDropboxPosition 을 호출한다. 이 때 flip 방향을 재판정하면
+      // dropbox 가 dropDown → dropTop 으로 점프하며 ev-window 상단 경계 밖으로 빠져나가 잘린다.
+      // open 시점 결정 방향은 유지되어야 한다.
+      const scrollContainer = document.createElement('div');
+      document.body.appendChild(scrollContainer);
+
+      const selectMount = document.createElement('div');
+      scrollContainer.appendChild(selectMount);
+
+      const wrapperRectRef = {
+        current: { top: 300, bottom: 330, height: 30, y: 300 },
+      };
+
+      mockMutableBounds({
+        wrapperRectRef,
+        dropboxRect: { height: 175 },
+        scrollContainer,
+        scrollContainerRect: { top: 100, bottom: 540, height: 440, y: 100 },
+        docClientHeight: 1000,
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, multiple: true, checkable: true, modelValue: [] },
+        attachTo: selectMount,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = wrapper.find('.ev-select-dropbox').element;
+      // open 시점: spaceAbove=200, spaceBelow=210, overflowsBottom=false → dropDown
+      expect(dropboxEl.style.top).toBe('30px');
+
+      // tag wrap 으로 wrapper height 가 30 → 110 으로 늘어난 상황 시뮬레이트.
+      // 이 상태에서 flip 을 재판정하면 spaceBelow=130 < dropboxHeight=175,
+      // spaceAbove=200 >= 175 이라 dropTop 으로 점프할 조건이 된다.
+      wrapperRectRef.current = { top: 300, bottom: 410, height: 110, y: 300 };
+      await wrapper.setProps({ modelValue: ['opt1', 'opt2'] });
+      await nextTick();
+      await nextTick();
+
+      // 방향은 유지되어야 하므로 여전히 dropDown. top 은 새 selectHeight(110) 추종.
+      expect(dropboxEl.style.top).toBe('110px');
+
+      wrapper.unmount();
+      document.body.removeChild(scrollContainer);
+    });
+
+    it('multiple+checkable open(dropTop) 후 wrapper height가 늘어나도 방향이 점프하지 않는다 (회귀 가드)', async () => {
+      // 대칭 케이스: open 시점에 dropTop으로 결정된 뒤 wrapper height가 늘어도 dropTop 유지.
+      const scrollContainer = document.createElement('div');
+      document.body.appendChild(scrollContainer);
+
+      const selectMount = document.createElement('div');
+      scrollContainer.appendChild(selectMount);
+
+      const wrapperRectRef = {
+        current: { top: 400, bottom: 430, height: 30, y: 400 },
+      };
+
+      mockMutableBounds({
+        wrapperRectRef,
+        dropboxRect: { height: 175 },
+        scrollContainer,
+        scrollContainerRect: { top: 100, bottom: 530, height: 430, y: 100 },
+        docClientHeight: 1000,
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, multiple: true, checkable: true, modelValue: [] },
+        attachTo: selectMount,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = wrapper.find('.ev-select-dropbox').element;
+      // open 시점: spaceAbove=300, spaceBelow=100, overflowsBottom=true, spaceAbove>=175 → dropTop
+      expect(dropboxEl.style.top).toBe('-175px');
+
+      // wrapper height 30 → 110 (tag wrap 시뮬레이트). dropTop은 wrapper top 기준 절대 위치라
+      // wrapper height가 늘어도 top 값 자체는 변하지 않는다. 핵심은 dropDown으로 점프하지 않는 것.
+      wrapperRectRef.current = { top: 400, bottom: 510, height: 110, y: 400 };
+      await wrapper.setProps({ modelValue: ['opt1', 'opt2'] });
+      await nextTick();
+      await nextTick();
+
+      expect(dropboxEl.style.top).toBe('-175px');
 
       wrapper.unmount();
       document.body.removeChild(scrollContainer);
@@ -528,6 +714,46 @@ describe('EvSelect Component', () => {
       wrapper.unmount();
     });
 
+    it('teleport 모드에서 select root 내부 scroll(tagMaxRows wrapper 등)은 dropbox를 닫지 않는다 (회귀 가드)', async () => {
+      // tagMaxRows로 인해 .ev-select-tag-wrapper에 overflow-y:auto가 적용되면
+      // wrapper 내부 wheel/touch scroll 이벤트가 발생한다. capture-phase scroll 리스너가
+      // 이걸 외부 스크롤로 오인해 dropbox를 닫지 않아야 한다.
+      const wrapperRectRef = {
+        current: { top: 100, bottom: 130, left: 50, width: 200, height: 30, y: 100 },
+      };
+      mockMutableTeleportBounds({
+        wrapperRectRef,
+        dropboxRect: { height: 175 },
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: {
+          ...defaultProps,
+          teleport: 'body',
+          multiple: true,
+          checkable: true,
+          tagMaxRows: 3,
+          modelValue: [],
+        },
+        attachTo: document.body,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      expect(document.querySelector('body > .ev-select-dropbox')).not.toBeNull();
+
+      const tagWrapper = wrapper.find('.ev-select-tag-wrapper').element;
+      tagWrapper.dispatchEvent(new Event('scroll', { bubbles: true }));
+      await nextTick();
+      await nextTick();
+
+      expect(document.querySelector('body > .ev-select-dropbox')).not.toBeNull();
+      wrapper.unmount();
+    });
+
     it('teleport 모드에서 window resize 시 dropbox가 닫힌다', async () => {
       const wrapperRectRef = {
         current: { top: 100, bottom: 130, left: 50, width: 200, height: 30, y: 100 },
@@ -588,24 +814,6 @@ describe('EvSelect Component', () => {
       expect(scrollRemoves.length).toBeGreaterThan(0);
 
       wrapper.unmount();
-    });
-  });
-
-  describe('기본값', () => {
-    it('컴포넌트 이름이 EvSelect이다', () => {
-      expect(EvSelect.name).toBe('EvSelect');
-    });
-
-    it('기본 multiple은 false이다', () => {
-      expect(EvSelect.props.multiple.default).toBe(false);
-    });
-
-    it('기본 clearable은 false이다', () => {
-      expect(EvSelect.props.clearable.default).toBe(false);
-    });
-
-    it('기본 filterable은 false이다', () => {
-      expect(EvSelect.props.filterable.default).toBe(false);
     });
   });
 });

--- a/src/components/select/Select.spec.js
+++ b/src/components/select/Select.spec.js
@@ -783,6 +783,109 @@ describe('EvSelect Component', () => {
       wrapper.unmount();
     });
 
+    it('teleport+multiple+checkable: 항목 선택으로 wrapper height가 늘어나도 dropbox top이 새 selectRect.bottom을 추종한다 (회귀 가드)', async () => {
+      // multiple+checkable에서 modelValue가 바뀔 때 mv.value watch가 changeDropboxPosition()을
+      // recomputeDirection: false 로 호출 — teleport branch는 viewport 절대 좌표를 쓰므로
+      // 변경된 wrapper bottom에 dropbox.top이 그대로 따라붙어야 한다.
+      // cf8d3911 fix(multi+teleport tag wrap close)가 silent하게 회귀하면 여기서 잡힌다.
+      const wrapperRectRef = {
+        current: { top: 100, bottom: 130, left: 50, width: 200, height: 30, y: 100 },
+      };
+      mockMutableTeleportBounds({
+        wrapperRectRef,
+        dropboxRect: { height: 175 },
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: {
+          ...defaultProps,
+          teleport: 'body',
+          multiple: true,
+          checkable: true,
+          modelValue: [],
+        },
+        attachTo: document.body,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = document.querySelector('body > .ev-select-dropbox');
+      expect(dropboxEl).not.toBeNull();
+      expect(dropboxEl.style.top).toBe('130px');
+
+      // tag wrap으로 wrapper height 30 → 110 시뮬레이트
+      wrapperRectRef.current = {
+        top: 100,
+        bottom: 210,
+        left: 50,
+        width: 200,
+        height: 110,
+        y: 100,
+      };
+      await wrapper.setProps({ modelValue: ['opt1', 'opt2'] });
+      await nextTick();
+      await nextTick();
+
+      expect(dropboxEl.style.top).toBe('210px');
+      wrapper.unmount();
+    });
+
+    it('teleport+multiple+checkable: open 시점에 dropTop으로 결정되면 wrapper height 변화 후에도 방향이 유지된다 (회귀 가드)', async () => {
+      // open 시점에 한 번 결정한 flip 방향(isDropTop)이 wrapper height 변화로
+      // 재판정되면 위/아래 점프가 발생한다. mv.value watch는 recomputeDirection: false 로
+      // 호출되어야 하며, top 좌표만 새 selectRect.top - dropboxHeight 로 갱신되어야 한다.
+      const wrapperRectRef = {
+        current: { top: 900, bottom: 930, left: 50, width: 200, height: 30, y: 900 },
+      };
+      mockMutableTeleportBounds({
+        wrapperRectRef,
+        dropboxRect: { height: 175 },
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: {
+          ...defaultProps,
+          teleport: 'body',
+          multiple: true,
+          checkable: true,
+          modelValue: [],
+        },
+        attachTo: document.body,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = document.querySelector('body > .ev-select-dropbox');
+      expect(dropboxEl).not.toBeNull();
+      // open 시점 dropTop: top = selectRect.top - dropboxHeight = 900 - 175 = 725
+      expect(dropboxEl.style.top).toBe('725px');
+
+      // 항목 선택으로 wrapper top이 위로 밀려나는 상황 (height 30 → 110, top 900 → 820)
+      wrapperRectRef.current = {
+        top: 820,
+        bottom: 930,
+        left: 50,
+        width: 200,
+        height: 110,
+        y: 820,
+      };
+      await wrapper.setProps({ modelValue: ['opt1', 'opt2'] });
+      await nextTick();
+      await nextTick();
+
+      // dropTop 유지 + top만 갱신: 820 - 175 = 645
+      // (recomputeDirection 누설 회귀 시 spaceAbove 820 / spaceBelow 70 으로 여전히 dropTop이지만
+      //  dropDown으로 점프하는 다른 회귀가 들어와도 이 expect로 잡힌다)
+      expect(dropboxEl.style.top).toBe('645px');
+      wrapper.unmount();
+    });
+
     it('teleport 모드에서 dropbox close 시 scroll listener가 해제된다', async () => {
       const addSpy = vi.spyOn(window, 'addEventListener');
       const removeSpy = vi.spyOn(window, 'removeEventListener');

--- a/src/components/select/Select.spec.js
+++ b/src/components/select/Select.spec.js
@@ -452,6 +452,134 @@ describe('EvSelect Component', () => {
       expect(dropboxEl.style.width).toBe('200px');
       wrapper.unmount();
     });
+
+    /**
+     * scroll/ResizeObserver 회귀 가드용 mock — selectWrapperRect를 ref-like 객체로 받아
+     * 테스트 도중 갱신하면 다음 getBoundingClientRect 호출에서 새 값을 돌려준다.
+     */
+    const mockMutableTeleportBounds = ({ wrapperRectRef, dropboxRect, docClientHeight = 1000 }) => {
+      vi.spyOn(document.documentElement, 'clientHeight', 'get').mockReturnValue(docClientHeight);
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function rect() {
+        if (this.classList?.contains('ev-select__wrapper')) return wrapperRectRef.current;
+        if (this.classList?.contains('ev-select-dropbox')) return dropboxRect;
+        return { top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0, x: 0, y: 0 };
+      });
+    };
+
+    it('teleport 모드에서 window scroll 시 dropbox 위치가 재계산된다', async () => {
+      const wrapperRectRef = {
+        current: { top: 100, bottom: 130, left: 50, width: 200, height: 30, y: 100 },
+      };
+      mockMutableTeleportBounds({
+        wrapperRectRef,
+        dropboxRect: { height: 175 },
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, teleport: 'body' },
+        attachTo: document.body,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = document.querySelector('body > .ev-select-dropbox');
+      expect(dropboxEl.style.top).toBe('130px');
+
+      // 페이지가 위로 50px 스크롤된 상황: selectWrapperRect도 위로 이동
+      wrapperRectRef.current = { top: 50, bottom: 80, left: 50, width: 200, height: 30, y: 50 };
+      window.dispatchEvent(new Event('scroll'));
+      await nextTick();
+      await nextTick();
+
+      // changeDropboxPosition이 다시 호출되어 새 selectRect.bottom을 사용해야 한다
+      expect(dropboxEl.style.top).toBe('80px');
+      wrapper.unmount();
+    });
+
+    it('teleport 모드에서 ResizeObserver 콜백 시 dropbox 위치가 재계산된다', async () => {
+      let observerCb = null;
+      class MockResizeObserver {
+        constructor(cb) {
+          observerCb = cb;
+        }
+
+        observe() {}
+
+        disconnect() {}
+
+        unobserve() {}
+      }
+      vi.stubGlobal('ResizeObserver', MockResizeObserver);
+
+      const wrapperRectRef = {
+        current: { top: 100, bottom: 130, left: 50, width: 200, height: 30, y: 100 },
+      };
+      mockMutableTeleportBounds({
+        wrapperRectRef,
+        dropboxRect: { height: 175 },
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, teleport: 'body' },
+        attachTo: document.body,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl = document.querySelector('body > .ev-select-dropbox');
+      expect(dropboxEl.style.top).toBe('130px');
+      expect(observerCb).not.toBeNull();
+
+      // select 자체 크기/위치 변화로 ResizeObserver 콜백 발화
+      wrapperRectRef.current = { top: 200, bottom: 240, left: 50, width: 200, height: 40, y: 200 };
+      observerCb([{ target: wrapper.find('.ev-select__wrapper').element }]);
+      await nextTick();
+      await nextTick();
+
+      expect(dropboxEl.style.top).toBe('240px');
+
+      vi.unstubAllGlobals();
+      wrapper.unmount();
+    });
+
+    it('teleport 모드에서 dropbox close 시 scroll listener가 해제된다', async () => {
+      const addSpy = vi.spyOn(window, 'addEventListener');
+      const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+      mockTeleportBounds({
+        selectWrapperRect: { top: 100, bottom: 130, left: 50, width: 200, height: 30, y: 100 },
+        dropboxRect: { height: 175 },
+        docClientHeight: 1000,
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: { ...defaultProps, teleport: 'body' },
+        attachTo: document.body,
+        ...globalConfig,
+      });
+
+      // open → scroll listener 등록
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+      const scrollAdds = addSpy.mock.calls.filter(([type]) => type === 'scroll');
+      expect(scrollAdds.length).toBeGreaterThan(0);
+
+      // close → scroll listener 해제
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+      const scrollRemoves = removeSpy.mock.calls.filter(([type]) => type === 'scroll');
+      expect(scrollRemoves.length).toBeGreaterThan(0);
+
+      wrapper.unmount();
+    });
   });
 
   describe('기본값', () => {

--- a/src/components/select/Select.spec.js
+++ b/src/components/select/Select.spec.js
@@ -548,6 +548,107 @@ describe('EvSelect Component', () => {
     });
   });
 
+  describe('Dropbox width 재계산', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    /**
+     * 비-teleport 모드에서 dropbox width 측정에 필요한 layout 속성들을 mock한다.
+     * jsdom은 layout을 계산하지 않으므로 offsetWidth/clientWidth/scrollWidth를 직접 흉내낸다.
+     *
+     * 회귀 가드 핵심: .ev-select-dropbox-item.scrollWidth가 "item이 dropbox content 폭으로
+     * stretch된 결과"를 반환하도록 모의한다. 실제 브라우저에서 block-level item이 부모 폭에
+     * 맞춰 stretch되어 scrollWidth가 그 폭을 반환하는 동작을 재현. 이 동작이 들어와야
+     * "이전 open에서 stretch된 폭이 다음 open의 측정에 누설되는" 버그가 재현된다.
+     */
+    const mockWidthLayout = ({ wrapperOffsetWidthRef }) => {
+      vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(function offset() {
+        if (this.classList?.contains('ev-select__wrapper')) {
+          return wrapperOffsetWidthRef.current;
+        }
+        if (this.classList?.contains('ev-select-dropbox-list')) {
+          const dropbox = this.closest('.ev-select-dropbox');
+          return dropbox ? parseFloat(dropbox.style.width || '0') : 0;
+        }
+        return 0;
+      });
+      // clientWidth는 Element.prototype에 정의되어 있다 (HTMLElement가 아님).
+      vi.spyOn(Element.prototype, 'clientWidth', 'get').mockImplementation(function client() {
+        if (this.classList?.contains('ev-select-dropbox-list')) {
+          const dropbox = this.closest('.ev-select-dropbox');
+          return dropbox ? parseFloat(dropbox.style.width || '0') : 0;
+        }
+        return 0;
+      });
+      vi.spyOn(Element.prototype, 'scrollWidth', 'get').mockImplementation(function scroll() {
+        if (this.classList?.contains('ev-select-dropbox-item')) {
+          // 실제 브라우저 동작 모사: item은 dropbox content 폭으로 stretch되어
+          // 콘텐츠가 짧으면 scrollWidth = clientWidth = 부모 폭이 된다.
+          const dropbox = this.closest('.ev-select-dropbox');
+          return dropbox ? parseFloat(dropbox.style.width || '0') : 0;
+        }
+        return 0;
+      });
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function rect() {
+        if (this.classList?.contains('ev-select-dropbox')) {
+          return { top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0, x: 0, y: 0 };
+        }
+        return { top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0, x: 0, y: 0 };
+      });
+      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1000);
+    };
+
+    it('wrapper 너비가 줄어든 뒤 재오픈 시 dropbox width가 새 wrapper 너비에 맞게 줄어든다 (회귀 가드)', async () => {
+      // 이전 open에서 늘어난 dropboxWidth가 남아있으면 다음 open에서 item이 그 폭으로
+      // stretch되어 item.scrollWidth가 stretch된 폭을 반환 → finalWidth가 이전 폭에 갇혀
+      // 너비가 줄어들지 않는다. calculateDropboxWidth 진입 시 base 폭으로 리셋한 뒤
+      // 측정하는지 검증.
+      const wrapperOffsetWidthRef = { current: 400 };
+      mockWidthLayout({ wrapperOffsetWidthRef });
+
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        attachTo: document.body,
+        ...globalConfig,
+      });
+
+      // 1차 open (wrapper 400px)
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl1 = wrapper.find('.ev-select-dropbox').element;
+      const initialWidth = parseFloat(dropboxEl1.style.width);
+      expect(initialWidth).toBeGreaterThanOrEqual(400);
+
+      // close
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      expect(wrapper.find('.ev-select-dropbox').exists()).toBe(false);
+
+      // wrapper 너비 축소 (ev-window 리사이즈 시뮬레이션)
+      wrapperOffsetWidthRef.current = 200;
+
+      // 2차 open — dropbox는 새 wrapper 폭(200)에 맞게 줄어야 함
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+      await nextTick();
+
+      const dropboxEl2 = wrapper.find('.ev-select-dropbox').element;
+      const newWidth = parseFloat(dropboxEl2.style.width);
+
+      // 가드: 새 wrapper 폭에 가까운 값이어야 한다. 스크롤바/border 가산을 고려해
+      // 정확한 수치 대신 directional inequality로 검증.
+      expect(newWidth).toBeLessThan(initialWidth);
+      expect(newWidth).toBeLessThanOrEqual(220);
+
+      wrapper.unmount();
+    });
+  });
+
   describe('Teleport 모드 dropbox flip 동작', () => {
     afterEach(() => {
       vi.restoreAllMocks();

--- a/src/components/select/Select.spec.js
+++ b/src/components/select/Select.spec.js
@@ -519,7 +519,7 @@ describe('EvSelect Component', () => {
       expect(dropboxEl).not.toBeNull();
 
       // dropbox 내부 element에서 발생한 scroll은 capture phase에서도 무시되어야 한다
-      const innerScrollTarget = dropboxEl.querySelector('.ev-select-dropbox-items') || dropboxEl;
+      const innerScrollTarget = dropboxEl.querySelector('.ev-select-dropbox-list') || dropboxEl;
       innerScrollTarget.dispatchEvent(new Event('scroll', { bubbles: true }));
       await nextTick();
       await nextTick();

--- a/src/components/select/Select.spec.js
+++ b/src/components/select/Select.spec.js
@@ -317,10 +317,10 @@ describe('EvSelect Component', () => {
       document.body.removeChild(scrollContainer);
     });
 
-    it('스크롤 ancestor 안에서 양쪽 모두 부족하지만 위가 더 넓으면 위로 펼친다 (native select 일관성)', async () => {
+    it('스크롤 ancestor 안에서 양쪽 모두 dropbox를 못 담으면 아래로 펼친다', async () => {
       // ev-window 내부에서 select 위/아래 모두 dropbox 전체를 담을 공간이 없는 상황.
-      // 양쪽 다 부족하더라도 더 넓은 쪽(위)으로 펼쳐서 더 많은 항목을 노출한다 —
-      // 컨테이너 안에서 가려지는 것보다 native select와 동일하게 더 큰 쪽으로 펼친다.
+      // 위로 빠져나간 영역은 스크롤로 도달이 어려운 반면 아래로 잘린 영역은 컨테이너
+      // 스크롤로 접근 가능하므로, 양쪽 모두 부족하면 아래로 펼친다 (teleport와 동일 룰).
       const scrollContainer = document.createElement('div');
       document.body.appendChild(scrollContainer);
 
@@ -345,9 +345,10 @@ describe('EvSelect Component', () => {
       await nextTick();
       await nextTick();
 
-      // spaceAbove=135, spaceBelow=65, overflowsBottom=true, spaceAbove > spaceBelow → dropTop
+      // spaceAbove=135, spaceBelow=65, overflowsBottom=true, spaceAbove(135) < dropboxHeight(175)
+      // → dropTop 조건 불충족이므로 dropDown 유지
       const dropboxEl = wrapper.find('.ev-select-dropbox').element;
-      expect(dropboxEl.style.top).toBe('-175px');
+      expect(dropboxEl.style.top).toBe('30px');
 
       wrapper.unmount();
       document.body.removeChild(scrollContainer);
@@ -384,6 +385,59 @@ describe('EvSelect Component', () => {
 
       wrapper.unmount();
       document.body.removeChild(scrollContainer);
+    });
+
+    it('overflow:hidden 중간 ancestor가 overflow:auto 바깥 ancestor보다 먼저 잡혀 flip 기준이 된다 (회귀 가드)', async () => {
+      // 실제 소비처(splitpanes__pane[overflow:auto] > host-view__chart[overflow:hidden] > select)
+      // 케이스 재현. 가까운 hidden 을 무시하고 바깥 auto 만 잡으면 spaceAbove 가 과장되어
+      // 위로 펼쳐지는 버그가 있었다. 가까운 clip 경계(hidden)를 잡아야 정확한 dropDown 이 나온다.
+      const outerPane = document.createElement('div');
+      document.body.appendChild(outerPane);
+      const innerCard = document.createElement('div');
+      outerPane.appendChild(innerCard);
+      const selectMount = document.createElement('div');
+      innerCard.appendChild(selectMount);
+
+      const outerPaneRect = { top: 0, bottom: 288, height: 288, y: 0 };
+      const innerCardRect = { top: 169, bottom: 288, height: 119, y: 169 };
+
+      vi.spyOn(document.documentElement, 'clientHeight', 'get').mockReturnValue(1000);
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function rect() {
+        if (this.classList?.contains('ev-select__wrapper')) {
+          return { top: 195, bottom: 225, height: 30, y: 195 };
+        }
+        if (this.classList?.contains('ev-select-dropbox')) return { height: 175 };
+        if (this === outerPane) return outerPaneRect;
+        if (this === innerCard) return innerCardRect;
+        return { top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0, x: 0, y: 0 };
+      });
+
+      const original = window.getComputedStyle.bind(window);
+      vi.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
+        if (el === outerPane) return { overflow: 'auto', overflowY: 'auto' };
+        if (el === innerCard) return { overflow: 'hidden', overflowY: 'hidden' };
+        return original(el);
+      });
+
+      const wrapper = mount(EvSelect, {
+        props: defaultProps,
+        attachTo: selectMount,
+        ...globalConfig,
+      });
+
+      await wrapper.find('.ev-input').trigger('click');
+      await nextTick();
+      await nextTick();
+
+      // 가까운 hidden(innerCard) 기준: spaceAbove=195-169=26, spaceBelow=288-225=63
+      // → spaceAbove(26) < spaceBelow(63) 이므로 dropDown.
+      // 만약 hidden 을 건너뛰고 바깥 auto(outerPane)을 잡으면 spaceAbove=195, spaceBelow=63
+      // 이 되어 dropTop 으로 잘못 펼쳐진다.
+      const dropboxEl = wrapper.find('.ev-select-dropbox').element;
+      expect(dropboxEl.style.top).toBe('30px');
+
+      wrapper.unmount();
+      document.body.removeChild(outerPane);
     });
 
     /**

--- a/src/components/select/Select.spec.js
+++ b/src/components/select/Select.spec.js
@@ -454,7 +454,7 @@ describe('EvSelect Component', () => {
     });
 
     /**
-     * scroll/ResizeObserver 회귀 가드용 mock — selectWrapperRect를 ref-like 객체로 받아
+     * scroll 회귀 가드용 mock — selectWrapperRect를 ref-like 객체로 받아
      * 테스트 도중 갱신하면 다음 getBoundingClientRect 호출에서 새 값을 돌려준다.
      */
     const mockMutableTeleportBounds = ({ wrapperRectRef, dropboxRect, docClientHeight = 1000 }) => {
@@ -525,58 +525,6 @@ describe('EvSelect Component', () => {
       await nextTick();
 
       expect(document.querySelector('body > .ev-select-dropbox')).not.toBeNull();
-      wrapper.unmount();
-    });
-
-    it('teleport 모드에서 ResizeObserver 콜백 시 dropbox가 닫힌다 (첫 콜백은 무시)', async () => {
-      let observerCb = null;
-      class MockResizeObserver {
-        constructor(cb) {
-          observerCb = cb;
-        }
-
-        observe() {}
-
-        disconnect() {}
-
-        unobserve() {}
-      }
-      vi.stubGlobal('ResizeObserver', MockResizeObserver);
-
-      const wrapperRectRef = {
-        current: { top: 100, bottom: 130, left: 50, width: 200, height: 30, y: 100 },
-      };
-      mockMutableTeleportBounds({
-        wrapperRectRef,
-        dropboxRect: { height: 175 },
-      });
-
-      const wrapper = mount(EvSelect, {
-        props: { ...defaultProps, teleport: 'body' },
-        attachTo: document.body,
-        ...globalConfig,
-      });
-
-      await wrapper.find('.ev-input').trigger('click');
-      await nextTick();
-      await nextTick();
-
-      expect(document.querySelector('body > .ev-select-dropbox')).not.toBeNull();
-      expect(observerCb).not.toBeNull();
-
-      // 첫 콜백(observe() 직후 spec상 1회)은 무시되어 dropbox가 열린 채 유지되어야 한다
-      observerCb([{ target: wrapper.find('.ev-select__wrapper').element }]);
-      await nextTick();
-      await nextTick();
-      expect(document.querySelector('body > .ev-select-dropbox')).not.toBeNull();
-
-      // 두 번째 콜백(실제 size 변화)에서는 닫힘
-      observerCb([{ target: wrapper.find('.ev-select__wrapper').element }]);
-      await nextTick();
-      await nextTick();
-      expect(document.querySelector('body > .ev-select-dropbox')).toBeNull();
-
-      vi.unstubAllGlobals();
       wrapper.unmount();
     });
 

--- a/src/components/select/Select.vue
+++ b/src/components/select/Select.vue
@@ -33,11 +33,16 @@
         />
       </template>
       <template v-else>
-        <div class="ev-select-tag-wrapper">
+        <div
+          class="ev-select-tag-wrapper"
+          :class="{ 'has-max-rows': hasMaxRows }"
+          :style="hasMaxRows ? { '--ev-select-tag-max-rows': tagMaxRows } : null"
+          @click="clickSelectInput"
+        >
           <span
             v-if="!clearable || !isClearableIcon"
             class="ev-input-suffix"
-            @click="clickSelectInput"
+            @click.stop="clickSelectInput"
           >
             <i
               class="ev-input-suffix-arrow ev-icon-s-arrow-down"
@@ -50,12 +55,13 @@
             type="text"
             class="ev-input multiple"
             readonly
+            :tabindex="hasMaxRows ? -1 : null"
             :placeholder="computedPlaceholder"
             :disabled="disabled"
-            @click="clickSelectInput"
+            @click.stop="clickSelectInput"
           />
           <template v-if="!collapseTags">
-            <div v-for="item in selectedModel" :key="item" class="ev-select-tag">
+            <div v-for="item in selectedModel" :key="item" class="ev-select-tag" @click.stop>
               <span class="ev-tag-name">
                 {{ item.name }}
               </span>
@@ -68,7 +74,7 @@
             </div>
           </template>
           <template v-else>
-            <div v-if="selectedModel.length" class="ev-select-tag">
+            <div v-if="selectedModel.length" class="ev-select-tag" @click.stop>
               <span class="ev-tag-name">
                 {{ selectedModel[0].name }}
               </span>
@@ -79,7 +85,7 @@
                 <i class="ev-tag-suffix-close ev-icon-error" />
               </span>
             </div>
-            <div v-if="selectedModel.length > 1" class="ev-select-tag num">
+            <div v-if="selectedModel.length > 1" class="ev-select-tag num" @click.stop>
               <span class="ev-tag-name"> + {{ selectedModel.length - 1 }} </span>
             </div>
           </template>
@@ -226,6 +232,7 @@
 </template>
 
 <script>
+import { computed } from 'vue';
 import { selectClickoutside as clickoutside } from '@/directives/clickoutside';
 import EvCheckboxGroup from '@/components/checkboxGroup/CheckboxGroup';
 import EvCheckbox from '@/components/checkbox/Checkbox';
@@ -297,12 +304,24 @@ export default {
       type: String,
       default: '',
     },
+    // multiple 모드에서 tag wrapper가 몇 줄까지 노출될지 결정.
+    // 0(기본) 이면 무제한 wrap, 양수면 그 줄 수까지 표시하고 그 이상은 내부 scroll.
+    // 항목이 많이 선택되어 wrapper 가 폭발적으로 커질 때
+    // ① teleport 모드에서 dropbox 가 window/viewport 밖으로 밀려나는 문제와
+    // ② non-teleport 모드에서 wrapper height 변화로 flip 이 점프하는 문제를 막을 수 있다.
+    tagMaxRows: {
+      type: Number,
+      default: 0,
+      validator: (v) => Number.isInteger(v) && v >= 0,
+    },
   },
   emits: {
     'update:modelValue': null,
     change: null,
   },
-  setup() {
+  setup(props) {
+    const hasMaxRows = computed(() => props.tagMaxRows > 0);
+
     const {
       mv,
       selectedModel,
@@ -335,6 +354,8 @@ export default {
     } = useDropdown({ mv, changeMv });
 
     return {
+      hasMaxRows,
+
       mv,
       selectedModel,
       computedPlaceholder,
@@ -392,6 +413,24 @@ export default {
     }
   }
 
+  // tagMaxRows > 0 (has-max-rows) 일 때만 wrapper에 overflow-y: auto가 적용된다.
+  // 이때 absolute로 깔린 input.multiple이 wrapper의 wheel/touch scroll 영역을 가려
+  // 마우스가 input 위에 있을 때 내부 스크롤이 동작하지 않는 회귀가 있어,
+  // 해당 모드에서만 pointer-events를 통과시키고 클릭은 tag-wrapper @click 으로 위임한다.
+  // 기본(tagMaxRows=0) 모드는 기존 input 클릭 동작을 그대로 유지해 사이드 이펙트를 최소화한다.
+  .ev-select-tag-wrapper.has-max-rows .ev-input.multiple {
+    pointer-events: none;
+  }
+
+  // has-max-rows 모드에서 input.multiple은 pointer-events:none 이라 :hover가 발화하지 않는다.
+  // multi 모드에서도 select hover 시 border 색이 primary로 바뀌는 시각 피드백이 사라지지 않도록
+  // 부모 hover로 cascade 시켜 유지한다.
+  &:not(.disabled):hover .ev-select-tag-wrapper.has-max-rows .ev-input.multiple {
+    @include evThemify() {
+      border-color: evThemed('primary');
+    }
+  }
+
   .ev-input-suffix {
     display: flex;
     position: absolute;
@@ -423,6 +462,14 @@ export default {
     flex-wrap: wrap;
     align-items: center;
     z-index: 100;
+
+    // tagMaxRows prop이 설정된 경우에만 적용.
+    // wrapper가 무제한으로 늘어나서 teleport dropbox가 window 밖에 펼쳐지거나
+    // non-teleport에서 wrapper height 변화로 flip이 점프하는 문제를 옵트인 방식으로 막는다.
+    &.has-max-rows {
+      max-height: calc(#{$select-height} * var(--ev-select-tag-max-rows));
+      overflow-y: auto;
+    }
   }
 }
 

--- a/src/components/select/Select.vue
+++ b/src/components/select/Select.vue
@@ -95,49 +95,79 @@
         </span>
       </template>
       <div class="ev-select-dropbox-wrapper">
-        <div
-          v-if="isDropbox"
-          ref="dropbox"
-          class="ev-select-dropbox"
-          :style="[dropboxPosition, { width: dropboxWidth }]"
-        >
-          <template v-if="filterable">
-            <slot
-              name="search-filter"
-              :item="{
-                value: filterTextRef,
-                onInput: changeFilterText,
-                class: 'ev-input-query',
-                placeholder: searchPlaceholder,
-              }"
-            >
-              <input
-                type="text"
-                class="ev-input-query"
-                :placeholder="searchPlaceholder"
-                :value="filterTextRef"
-                @input="changeFilterText"
-              />
-            </slot>
-          </template>
-          <template v-if="checkable">
-            <div
-              v-if="multiple"
-              class="ev-select-dropbox-item all-check"
-              :class="{
-                selected: allCheck,
-              }"
-              @click.self.prevent="[changeAllCheck(false), changeDropboxPosition()]"
-            >
-              <ev-checkbox
-                v-model="allCheck"
-                :label="allCheckLabel"
-                @change="[changeAllCheck(true), changeDropboxPosition()]"
-              />
-            </div>
-            <div ref="itemWrapper" class="ev-select-dropbox-list">
-              <template v-if="multiple">
-                <ev-checkbox-group v-model="mv">
+        <teleport :to="teleportTarget" :disabled="!teleport">
+          <div
+            v-if="isDropbox"
+            ref="dropbox"
+            class="ev-select-dropbox"
+            :class="{ teleported: !!teleport }"
+            :style="[dropboxPosition, { width: dropboxWidth }]"
+          >
+            <template v-if="filterable">
+              <slot
+                name="search-filter"
+                :item="{
+                  value: filterTextRef,
+                  onInput: changeFilterText,
+                  class: 'ev-input-query',
+                  placeholder: searchPlaceholder,
+                }"
+              >
+                <input
+                  type="text"
+                  class="ev-input-query"
+                  :placeholder="searchPlaceholder"
+                  :value="filterTextRef"
+                  @input="changeFilterText"
+                />
+              </slot>
+            </template>
+            <template v-if="checkable">
+              <div
+                v-if="multiple"
+                class="ev-select-dropbox-item all-check"
+                :class="{
+                  selected: allCheck,
+                }"
+                @click.self.prevent="[changeAllCheck(false), changeDropboxPosition()]"
+              >
+                <ev-checkbox
+                  v-model="allCheck"
+                  :label="allCheckLabel"
+                  @change="[changeAllCheck(true), changeDropboxPosition()]"
+                />
+              </div>
+              <div ref="itemWrapper" class="ev-select-dropbox-list">
+                <template v-if="multiple">
+                  <ev-checkbox-group v-model="mv">
+                    <ul v-if="filteredItems.length" class="ev-select-dropbox-ul">
+                      <li
+                        v-for="(item, idx) in filteredItems"
+                        :key="`${item.value}_${idx}`"
+                        class="ev-select-dropbox-item"
+                        :class="{
+                          selected: selectedItemClass(item.value),
+                          disabled: item.disabled,
+                        }"
+                        :title="item.name"
+                        @click.self.prevent="
+                          item.disabled ? [] : [clickItem(item.value), changeDropboxPosition()]
+                        "
+                      >
+                        <ev-checkbox :label="item.value" :disabled="item.disabled">
+                          <i v-if="item.iconClass" :class="item.iconClass" />
+                          {{ item.name }}
+                        </ev-checkbox>
+                      </li>
+                    </ul>
+                    <ul v-else>
+                      <li class="ev-select-dropbox-item disabled">
+                        {{ noMatchingText }}
+                      </li>
+                    </ul>
+                  </ev-checkbox-group>
+                </template>
+                <template v-else>
                   <ul v-if="filteredItems.length" class="ev-select-dropbox-ul">
                     <li
                       v-for="(item, idx) in filteredItems"
@@ -148,24 +178,21 @@
                         disabled: item.disabled,
                       }"
                       :title="item.name"
-                      @click.self.prevent="
+                      @click.stop.prevent="
                         item.disabled ? [] : [clickItem(item.value), changeDropboxPosition()]
                       "
                     >
-                      <ev-checkbox :label="item.value" :disabled="item.disabled">
+                      <ev-checkbox :model-value="mv === item.value" :disabled="item.disabled">
                         <i v-if="item.iconClass" :class="item.iconClass" />
                         {{ item.name }}
                       </ev-checkbox>
                     </li>
                   </ul>
-                  <ul v-else>
-                    <li class="ev-select-dropbox-item disabled">
-                      {{ noMatchingText }}
-                    </li>
-                  </ul>
-                </ev-checkbox-group>
-              </template>
-              <template v-else>
+                </template>
+              </div>
+            </template>
+            <template v-else>
+              <div ref="itemWrapper" class="ev-select-dropbox-list">
                 <ul v-if="filteredItems.length" class="ev-select-dropbox-ul">
                   <li
                     v-for="(item, idx) in filteredItems"
@@ -180,43 +207,19 @@
                       item.disabled ? [] : [clickItem(item.value), changeDropboxPosition()]
                     "
                   >
-                    <ev-checkbox :model-value="mv === item.value" :disabled="item.disabled">
-                      <i v-if="item.iconClass" :class="item.iconClass" />
-                      {{ item.name }}
-                    </ev-checkbox>
+                    <i v-if="item.iconClass" :class="item.iconClass" />
+                    {{ item.name }}
                   </li>
                 </ul>
-              </template>
-            </div>
-          </template>
-          <template v-else>
-            <div ref="itemWrapper" class="ev-select-dropbox-list">
-              <ul v-if="filteredItems.length" class="ev-select-dropbox-ul">
-                <li
-                  v-for="(item, idx) in filteredItems"
-                  :key="`${item.value}_${idx}`"
-                  class="ev-select-dropbox-item"
-                  :class="{
-                    selected: selectedItemClass(item.value),
-                    disabled: item.disabled,
-                  }"
-                  :title="item.name"
-                  @click.stop.prevent="
-                    item.disabled ? [] : [clickItem(item.value), changeDropboxPosition()]
-                  "
-                >
-                  <i v-if="item.iconClass" :class="item.iconClass" />
-                  {{ item.name }}
-                </li>
-              </ul>
-              <ul v-else>
-                <li class="ev-select-dropbox-item disabled">
-                  {{ noMatchingText }}
-                </li>
-              </ul>
-            </div>
-          </template>
-        </div>
+                <ul v-else>
+                  <li class="ev-select-dropbox-item disabled">
+                    {{ noMatchingText }}
+                  </li>
+                </ul>
+              </div>
+            </template>
+          </div>
+        </teleport>
       </div>
     </div>
   </div>
@@ -290,6 +293,10 @@ export default {
       type: String,
       default: 'Select All',
     },
+    teleport: {
+      type: String,
+      default: '',
+    },
   },
   emits: {
     'update:modelValue': null,
@@ -324,6 +331,7 @@ export default {
       allCheck,
       changeAllCheck,
       dropboxWidth,
+      teleportTarget,
     } = useDropdown({ mv, changeMv });
 
     return {
@@ -352,6 +360,7 @@ export default {
       allCheck,
       changeAllCheck,
       dropboxWidth,
+      teleportTarget,
     };
   },
 };
@@ -475,6 +484,12 @@ export default {
   z-index: 100;
   cursor: pointer;
   overflow: hidden;
+
+  // ev-window(z-index: 700) 등 다른 floating layer 위에 떠야 한다.
+  &.teleported {
+    position: fixed;
+    z-index: 710;
+  }
 
   ul {
     list-style: none;

--- a/src/components/select/uses.js
+++ b/src/components/select/uses.js
@@ -162,21 +162,21 @@ export const useDropdown = (param) => {
   };
 
   /**
-   * dropbox flip 판단에 쓰일 가장 가까운 스크롤 가능한 ancestor를 찾는다.
-   * `.ev-window-content`처럼 자체 스크롤을 가진 컨테이너 내부에서도
-   * 컨테이너 경계 기준으로 dropTop/dropDown을 정확히 결정하기 위함.
+   * dropbox flip 판단에 쓰일 가장 가까운 clip 경계 ancestor를 찾는다.
+   * overflow-y가 visible이 아닌 ancestor(auto/scroll/overlay/hidden/clip)는 모두
+   * 세로 방향으로 dropbox를 잘라낸다 — 스크롤 가능 여부와 무관하게 그렇다.
+   * 가장 가까운 clip 경계를 잡아야 dropTop/dropDown을 정확히 결정할 수 있다.
+   * (예: overflow:auto 패널 안에 overflow:hidden 카드가 중첩된 레이아웃에서,
+   *  바깥 auto 만 잡으면 select가 카드 안에서 flip 방향이 카드 경계와 어긋난다.)
    * 못 찾으면 viewport(document.documentElement)로 폴백.
    * @param {HTMLElement | null | undefined} el
    * @returns {HTMLElement}
    */
-  const findScrollableAncestor = (el) => {
+  const findClipBoundary = (el) => {
     let parent = el?.parentElement;
     while (parent && parent !== document.documentElement) {
       const cs = window.getComputedStyle(parent);
-      const verticallyScrollable =
-        /(auto|scroll|overlay)/.test(cs.overflowY) ||
-        (/(auto|scroll|overlay)/.test(cs.overflow) && parent.scrollHeight > parent.clientHeight);
-      if (verticallyScrollable) {
+      if (/(auto|scroll|overlay|hidden|clip)/.test(cs.overflowY)) {
         return parent;
       }
       parent = parent.parentElement;
@@ -215,7 +215,6 @@ export const useDropdown = (param) => {
         // 위로 펼쳐도 충분히 들어갈 때에 한해서만 위로. 양쪽 모두 부족하면 아래로 —
         // teleport는 viewport에 position:fixed 라 위로 빠져나가면 페이지 스크롤로
         // 도달 불가능한 반면, 아래는 페이지 스크롤로 도달 가능하기 때문.
-        // (non-teleport는 컨테이너 자체가 viewport에 고정될 수 있어 다른 룰을 쓴다)
         isDropTop.value = overflowsBottom && spaceAbove > spaceBelow && spaceAbove >= dropboxHeight;
       }
       dropboxPosition.top = isDropTop.value
@@ -226,7 +225,7 @@ export const useDropdown = (param) => {
     }
 
     if (recomputeDirection) {
-      const container = findScrollableAncestor(selectWrapper.value);
+      const container = findClipBoundary(selectWrapper.value);
       const isViewport = container === document.documentElement;
       const containerRect = container.getBoundingClientRect();
       const viewportHeight = document.documentElement.clientHeight;
@@ -241,10 +240,10 @@ export const useDropdown = (param) => {
       const spaceBelow = bottomBoundary - (selectY + selectHeight);
       const overflowsBottom = dropboxHeight > spaceBelow;
 
-      // 아래가 부족하면 더 넓은 쪽으로 펼친다 (native select와 동일한 UX).
-      // 양쪽 모두 dropbox 전체를 담지 못하더라도 위쪽이 더 넓으면 위로 — 더 많은 항목을
-      // 노출하는 게 컨테이너 안에서 잘려 가려지는 것보다 낫다.
-      isDropTop.value = overflowsBottom && spaceAbove > spaceBelow;
+      // 아래가 부족하고 위쪽이 dropbox 전체를 담을 수 있을 때에 한해 위로 펼친다.
+      // 양쪽 모두 부족하면 아래로 — 위로 빠져나간 영역은 스크롤로 도달하기 어려운 반면
+      // 아래로 잘린 영역은 페이지/컨테이너 스크롤로 접근 가능하기 때문 (teleport와 동일 룰).
+      isDropTop.value = overflowsBottom && spaceAbove > spaceBelow && spaceAbove >= dropboxHeight;
     }
 
     if (isDropTop.value) {

--- a/src/components/select/uses.js
+++ b/src/components/select/uses.js
@@ -427,9 +427,9 @@ export const useDropdown = (param) => {
     },
   );
 
-  // teleport 모드에서는 viewport resize / select 자체 resize 모두 dropbox를 닫는다
-  // (native select와 동일 UX). non-teleport 모드는 dropbox가 wrapper 내부에 있어
-  // 자연스럽게 따라가므로 기존 너비/위치 재계산을 유지.
+  // teleport 모드에서는 viewport resize 시 dropbox를 닫는다 (native select와 동일 UX).
+  // non-teleport 모드는 dropbox가 wrapper 내부에 있어 자연스럽게 따라가므로 기존
+  // 너비/위치 재계산을 유지.
   const handleResize = () => {
     if (!isDropbox.value) {
       return;
@@ -467,10 +467,9 @@ export const useDropdown = (param) => {
     window.removeEventListener('resize', handleResize);
   });
 
-  // teleport 모드 + dropbox open일 때만 listener/observer를 활성화한다.
+  // teleport 모드 + dropbox open일 때만 scroll listener를 활성화한다.
   // dropbox가 닫혀있는 동안 capture-phase scroll 핸들러가 페이지 전체 스크롤마다 호출되는
-  // 비용을 피하고, ResizeObserver도 의미 있는 시점에만 동작시킨다.
-  // flush:'post'로 dropbox DOM이 마운트된 뒤 selectWrapper.value 기준으로 observe한다.
+  // 비용을 피한다.
   watch(
     () => !!props.teleport && isDropbox.value,
     (active, _prev, onCleanup) => {
@@ -479,29 +478,10 @@ export const useDropdown = (param) => {
       }
       window.addEventListener('scroll', handleScroll, { capture: true, passive: true });
 
-      // teleport 모드 + open 상태일 때만 select 자체 size 변화도 닫기로 처리.
-      // (위치 재계산은 dropbox가 body에 fixed로 떠있는 동안 어색한 추적이 되기 쉬움)
-      // ResizeObserver는 observe() 직후 초기 size로 콜백을 1회 발화하는 spec이므로
-      // 첫 콜백은 무시해야 dropbox가 열리자마자 즉시 닫히지 않는다.
-      let observer = null;
-      if (typeof ResizeObserver !== 'undefined' && selectWrapper.value) {
-        let isInitialCallback = true;
-        observer = new ResizeObserver(() => {
-          if (isInitialCallback) {
-            isInitialCallback = false;
-            return;
-          }
-          clickOutsideDropbox();
-        });
-        observer.observe(selectWrapper.value);
-      }
-
       onCleanup(() => {
         window.removeEventListener('scroll', handleScroll, { capture: true });
-        observer?.disconnect();
       });
     },
-    { flush: 'post' },
   );
 
   return {

--- a/src/components/select/uses.js
+++ b/src/components/select/uses.js
@@ -9,6 +9,7 @@ import {
   onUnmounted,
 } from 'vue';
 import { getRegExp, engToKor, korToEng } from 'korean-regexp';
+import { resolveTeleportTarget } from '@/common/utils.teleport';
 
 export const useModel = () => {
   const { props, emit } = getCurrentInstance();
@@ -121,7 +122,12 @@ export const useDropdown = (param) => {
   const initialDropboxWidth = ref(null);
   const dropboxPosition = reactive({
     top: 0,
+    left: 'auto',
   });
+
+  // teleport target은 dropbox가 열리는 시점에 clickSelectInput에서 동기적으로 resolve한다.
+  // (Select보다 늦게 마운트되는 target도 잡히도록 매 open 시 재평가)
+  const teleportTarget = ref('body');
 
   /**
    * filterable 모드 시 인풋박스에 입력된 텍스트가 포함된 목록 가져오기
@@ -179,9 +185,31 @@ export const useDropdown = (param) => {
    */
   const changeDropboxPosition = async () => {
     await nextTick();
-    const selectHeight = selectWrapper.value?.getBoundingClientRect().height;
-    const selectY = selectWrapper.value?.getBoundingClientRect().y;
-    const dropboxHeight = dropbox.value?.getBoundingClientRect().height;
+    if (!selectWrapper.value || !dropbox.value) {
+      return;
+    }
+    const selectRect = selectWrapper.value.getBoundingClientRect();
+    const selectHeight = selectRect.height;
+    const selectY = selectRect.y;
+    const dropboxHeight = dropbox.value.getBoundingClientRect().height;
+
+    // teleport 모드는 dropbox가 body로 옮겨져 부모(예: ev-window) 컨테이너 경계의
+    // overflow:hidden 영향을 받지 않으므로 viewport만 기준으로 flip 계산하고
+    // position:fixed + viewport 절대 좌표를 사용한다.
+    if (props.teleport) {
+      const viewportHeight = document.documentElement.clientHeight;
+      const spaceAbove = selectRect.top;
+      const spaceBelow = viewportHeight - selectRect.bottom;
+      const overflowsBottom = dropboxHeight > spaceBelow;
+
+      if (overflowsBottom && spaceAbove > spaceBelow) {
+        dropboxPosition.top = `${selectRect.top - dropboxHeight}px`; // dropTop
+      } else {
+        dropboxPosition.top = `${selectRect.bottom}px`; // dropDown
+      }
+      dropboxPosition.left = `${selectRect.left}px`;
+      return;
+    }
 
     const container = findScrollableAncestor(selectWrapper.value);
     const isViewport = container === document.documentElement;
@@ -205,6 +233,7 @@ export const useDropdown = (param) => {
     } else {
       dropboxPosition.top = `${selectHeight}px`; // dropDown
     }
+    dropboxPosition.left = 'auto';
   };
 
   /**
@@ -303,6 +332,17 @@ export const useDropdown = (param) => {
     if (props.items.length && !props.disabled) {
       isDropbox.value = !isDropbox.value;
       if (isDropbox.value) {
+        // teleport 모드는 body에 옮겨지므로 target/초기 너비/위치를 동기적으로 잡아
+        // 첫 렌더 프레임에서 body 전체 너비로 펼쳐졌다가 줄어드는 깜빡임을 막는다.
+        if (props.teleport) {
+          teleportTarget.value = resolveTeleportTarget(props.teleport, 'EvSelect');
+          if (selectWrapper.value) {
+            const rect = selectWrapper.value.getBoundingClientRect();
+            dropboxWidth.value = `${rect.width}px`;
+            dropboxPosition.top = `${rect.bottom}px`;
+            dropboxPosition.left = `${rect.left}px`;
+          }
+        }
         await changeDropboxPosition();
       }
     }
@@ -394,6 +434,19 @@ export const useDropdown = (param) => {
     }
   };
 
+  // teleport 모드에서는 dropbox가 body에 고정(position:fixed)되므로
+  // ev-window content 등 스크롤 가능한 ancestor가 스크롤되거나 select 자체가 리사이즈되면
+  // select와 dropbox 위치가 어긋난다.
+  // - scroll: capture phase로 어떤 ancestor의 scroll이라도 잡아 재배치
+  // - ResizeObserver: select 자체의 size 변화(레이아웃 변화로 위치가 바뀌는 경우 포함)를 감지.
+  //   ev-window 단순 드래그처럼 select size가 불변인 위치-only 이동은 잡지 못한다 — 그 경우
+  //   드래그 시작 시 dropbox를 닫는 UX가 권장된다.
+  const handleScroll = () => {
+    if (isDropbox.value) {
+      changeDropboxPosition();
+    }
+  };
+
   onMounted(() => {
     window.addEventListener('resize', handleResize);
   });
@@ -401,6 +454,34 @@ export const useDropdown = (param) => {
   onUnmounted(() => {
     window.removeEventListener('resize', handleResize);
   });
+
+  // props.teleport가 동적으로 변경되어도 listener/observer가 정확히 add/remove 되도록
+  // watch + onCleanup으로 일원화한다. flush:'post' + immediate로 마운트 직후 selectWrapper.value 보장.
+  watch(
+    () => props.teleport,
+    (teleport, _prev, onCleanup) => {
+      if (!teleport) {
+        return;
+      }
+      window.addEventListener('scroll', handleScroll, { capture: true, passive: true });
+
+      let observer = null;
+      if (typeof ResizeObserver !== 'undefined' && selectWrapper.value) {
+        observer = new ResizeObserver(() => {
+          if (isDropbox.value) {
+            changeDropboxPosition();
+          }
+        });
+        observer.observe(selectWrapper.value);
+      }
+
+      onCleanup(() => {
+        window.removeEventListener('scroll', handleScroll, { capture: true });
+        observer?.disconnect();
+      });
+    },
+    { immediate: true, flush: 'post' },
+  );
 
   return {
     select,
@@ -420,5 +501,6 @@ export const useDropdown = (param) => {
     allCheck,
     changeAllCheck,
     dropboxWidth,
+    teleportTarget,
   };
 };

--- a/src/components/select/uses.js
+++ b/src/components/select/uses.js
@@ -152,6 +152,29 @@ export const useDropdown = (param) => {
   };
 
   /**
+   * dropbox flip 판단에 쓰일 가장 가까운 스크롤 가능한 ancestor를 찾는다.
+   * `.ev-window-content`처럼 자체 스크롤을 가진 컨테이너 내부에서도
+   * 컨테이너 경계 기준으로 dropTop/dropDown을 정확히 결정하기 위함.
+   * 못 찾으면 viewport(document.documentElement)로 폴백.
+   * @param {HTMLElement | null | undefined} el
+   * @returns {HTMLElement}
+   */
+  const findScrollableAncestor = (el) => {
+    let parent = el?.parentElement;
+    while (parent && parent !== document.documentElement) {
+      const cs = window.getComputedStyle(parent);
+      const verticallyScrollable =
+        /(auto|scroll|overlay)/.test(cs.overflowY) ||
+        (/(auto|scroll|overlay)/.test(cs.overflow) && parent.scrollHeight > parent.clientHeight);
+      if (verticallyScrollable) {
+        return parent;
+      }
+      parent = parent.parentElement;
+    }
+    return document.documentElement;
+  };
+
+  /**
    * dropdown box 위치 변경하는 메소드
    */
   const changeDropboxPosition = async () => {
@@ -159,8 +182,25 @@ export const useDropdown = (param) => {
     const selectHeight = selectWrapper.value?.getBoundingClientRect().height;
     const selectY = selectWrapper.value?.getBoundingClientRect().y;
     const dropboxHeight = dropbox.value?.getBoundingClientRect().height;
-    const docHeight = document.documentElement.clientHeight;
-    if (docHeight < selectY + selectHeight + dropboxHeight) {
+
+    const container = findScrollableAncestor(selectWrapper.value);
+    const isViewport = container === document.documentElement;
+    const containerRect = container.getBoundingClientRect();
+    const viewportHeight = document.documentElement.clientHeight;
+    // ev-window를 viewport 밖으로 드래그한 경우처럼 컨테이너가 viewport를 벗어날 수 있으므로
+    // 컨테이너 경계와 viewport 경계의 교집합을 실제 가시 영역으로 사용한다.
+    const bottomBoundary = isViewport
+      ? viewportHeight
+      : Math.min(containerRect.bottom, viewportHeight);
+    const topBoundary = isViewport ? 0 : Math.max(containerRect.top, 0);
+
+    const spaceAbove = selectY - topBoundary;
+    const spaceBelow = bottomBoundary - (selectY + selectHeight);
+    const overflowsBottom = dropboxHeight > spaceBelow;
+
+    // 위쪽에 dropbox가 fully fit 하지 않더라도, 아래쪽이 더 좁으면 위로 펼친다.
+    // (ev-window 내부 스크롤처럼 양쪽 모두 부족한 경우 더 많은 항목이 보이는 쪽 선택)
+    if (overflowsBottom && spaceAbove > spaceBelow) {
       dropboxPosition.top = `-${dropboxHeight}px`; // dropTop
     } else {
       dropboxPosition.top = `${selectHeight}px`; // dropDown

--- a/src/components/select/uses.js
+++ b/src/components/select/uses.js
@@ -124,6 +124,10 @@ export const useDropdown = (param) => {
     top: 0,
     left: 'auto',
   });
+  // open 시점에 결정한 flip 방향. dropbox가 열려있는 동안 multiple+checkable 등에서
+  // wrapper height가 변할 때마다 flip 재판정으로 위/아래 점프해 컨테이너 경계 밖으로
+  // dropbox가 잘리는 문제를 막기 위해 유지한다 (native select와 동일 UX).
+  const isDropTop = ref(false);
 
   // teleport target은 dropbox가 열리는 시점에 clickSelectInput에서 동기적으로 resolve한다.
   // (Select보다 늦게 마운트되는 target도 잡히도록 매 open 시 재평가)
@@ -182,8 +186,14 @@ export const useDropdown = (param) => {
 
   /**
    * dropdown box 위치 변경하는 메소드
+   * @param {{ recomputeDirection?: boolean }} [options]
+   *  - recomputeDirection: true 면 spaceAbove/spaceBelow 기준으로 flip 방향을 새로 결정한다.
+   *    open / window resize 처럼 컨텍스트 자체가 바뀌는 트리거에서만 true.
+   *    false 면 isDropTop.value(open 시점 결정값)를 유지하고 position만 갱신한다.
+   *    (multiple+checkable에서 tag wrap으로 wrapper가 늘어나거나, filterable에서 검색어
+   *     입력/삭제로 dropbox 크기가 바뀌어도 open 시점의 방향이 유지되어 점프하지 않도록)
    */
-  const changeDropboxPosition = async () => {
+  const changeDropboxPosition = async ({ recomputeDirection = false } = {}) => {
     await nextTick();
     if (!selectWrapper.value || !dropbox.value) {
       return;
@@ -198,37 +208,46 @@ export const useDropdown = (param) => {
     // position:fixed + viewport 절대 좌표를 사용한다.
     if (props.teleport) {
       const viewportHeight = document.documentElement.clientHeight;
-      const spaceAbove = selectRect.top;
-      const spaceBelow = viewportHeight - selectRect.bottom;
-      const overflowsBottom = dropboxHeight > spaceBelow;
-
-      if (overflowsBottom && spaceAbove > spaceBelow) {
-        dropboxPosition.top = `${selectRect.top - dropboxHeight}px`; // dropTop
-      } else {
-        dropboxPosition.top = `${selectRect.bottom}px`; // dropDown
+      if (recomputeDirection) {
+        const spaceAbove = selectRect.top;
+        const spaceBelow = viewportHeight - selectRect.bottom;
+        const overflowsBottom = dropboxHeight > spaceBelow;
+        // 위로 펼쳐도 충분히 들어갈 때에 한해서만 위로. 양쪽 모두 부족하면 아래로 —
+        // teleport는 viewport에 position:fixed 라 위로 빠져나가면 페이지 스크롤로
+        // 도달 불가능한 반면, 아래는 페이지 스크롤로 도달 가능하기 때문.
+        // (non-teleport는 컨테이너 자체가 viewport에 고정될 수 있어 다른 룰을 쓴다)
+        isDropTop.value = overflowsBottom && spaceAbove > spaceBelow && spaceAbove >= dropboxHeight;
       }
+      dropboxPosition.top = isDropTop.value
+        ? `${selectRect.top - dropboxHeight}px` // dropTop
+        : `${selectRect.bottom}px`; // dropDown
       dropboxPosition.left = `${selectRect.left}px`;
       return;
     }
 
-    const container = findScrollableAncestor(selectWrapper.value);
-    const isViewport = container === document.documentElement;
-    const containerRect = container.getBoundingClientRect();
-    const viewportHeight = document.documentElement.clientHeight;
-    // ev-window를 viewport 밖으로 드래그한 경우처럼 컨테이너가 viewport를 벗어날 수 있으므로
-    // 컨테이너 경계와 viewport 경계의 교집합을 실제 가시 영역으로 사용한다.
-    const bottomBoundary = isViewport
-      ? viewportHeight
-      : Math.min(containerRect.bottom, viewportHeight);
-    const topBoundary = isViewport ? 0 : Math.max(containerRect.top, 0);
+    if (recomputeDirection) {
+      const container = findScrollableAncestor(selectWrapper.value);
+      const isViewport = container === document.documentElement;
+      const containerRect = container.getBoundingClientRect();
+      const viewportHeight = document.documentElement.clientHeight;
+      // ev-window를 viewport 밖으로 드래그한 경우처럼 컨테이너가 viewport를 벗어날 수 있으므로
+      // 컨테이너 경계와 viewport 경계의 교집합을 실제 가시 영역으로 사용한다.
+      const bottomBoundary = isViewport
+        ? viewportHeight
+        : Math.min(containerRect.bottom, viewportHeight);
+      const topBoundary = isViewport ? 0 : Math.max(containerRect.top, 0);
 
-    const spaceAbove = selectY - topBoundary;
-    const spaceBelow = bottomBoundary - (selectY + selectHeight);
-    const overflowsBottom = dropboxHeight > spaceBelow;
+      const spaceAbove = selectY - topBoundary;
+      const spaceBelow = bottomBoundary - (selectY + selectHeight);
+      const overflowsBottom = dropboxHeight > spaceBelow;
 
-    // 위쪽에 dropbox가 fully fit 하지 않더라도, 아래쪽이 더 좁으면 위로 펼친다.
-    // (ev-window 내부 스크롤처럼 양쪽 모두 부족한 경우 더 많은 항목이 보이는 쪽 선택)
-    if (overflowsBottom && spaceAbove > spaceBelow) {
+      // 아래가 부족하면 더 넓은 쪽으로 펼친다 (native select와 동일한 UX).
+      // 양쪽 모두 dropbox 전체를 담지 못하더라도 위쪽이 더 넓으면 위로 — 더 많은 항목을
+      // 노출하는 게 컨테이너 안에서 잘려 가려지는 것보다 낫다.
+      isDropTop.value = overflowsBottom && spaceAbove > spaceBelow;
+    }
+
+    if (isDropTop.value) {
       dropboxPosition.top = `-${dropboxHeight}px`; // dropTop
     } else {
       dropboxPosition.top = `${selectHeight}px`; // dropDown
@@ -312,16 +331,12 @@ export const useDropdown = (param) => {
   watch(
     () => filteredItems.value,
     async () => {
+      // filter 결과 변경으로 dropbox 크기가 바뀌면 dropTop 모드의 좌표(top)가 달라지므로
+      // position만 재계산한다. 방향(isDropTop)은 open 시점 값을 유지해 검색어 입력/삭제로
+      // dropDown ↔ dropTop 점프가 발생하지 않도록 한다.
       await changeDropboxPosition();
     },
   );
-
-  if (props.filterable) {
-    watch(
-      () => filteredItems.value,
-      () => changeDropboxPosition(),
-    );
-  }
 
   /**
    * 인풋박스 클릭 이벤트
@@ -343,7 +358,8 @@ export const useDropdown = (param) => {
             dropboxPosition.left = `${rect.left}px`;
           }
         }
-        await changeDropboxPosition();
+        // open 시점에 flip 방향을 결정. 이후 wrapper height 변화에도 방향은 유지된다.
+        await changeDropboxPosition({ recomputeDirection: true });
       }
     }
   };
@@ -439,21 +455,26 @@ export const useDropdown = (param) => {
       return;
     }
     calculateDropboxWidth();
-    changeDropboxPosition();
+    // viewport 변화는 ancestor 가시 영역도 같이 바뀌므로 flip 재판정.
+    changeDropboxPosition({ recomputeDirection: true });
   };
 
   // teleport 모드에서는 dropbox가 body에 고정(position:fixed)되므로
   // ev-window content 등 스크롤 가능한 ancestor가 스크롤되면 select와 dropbox 위치가 어긋난다.
   // 위치 재계산 대신 닫는다(native select와 동일한 UX). 단 dropbox 내부 스크롤
-  // (필터 input 포커싱, item 리스트 스크롤)은 닫기 트리거에서 제외한다.
+  // (필터 input 포커싱, item 리스트 스크롤)이나 select root 내부 스크롤
+  // (tagMaxRows로 인한 tag wrapper 내부 scroll 등)은 닫기 트리거에서 제외한다.
   const handleScroll = (event) => {
     if (!isDropbox.value) {
       return;
     }
     // event.target이 window/document인 페이지-레벨 scroll은 외부 스크롤로 간주해 닫는다.
-    // Element이면서 dropbox 내부에서 발생한 scroll(필터 input 포커싱, item 리스트 scroll)만 무시.
+    // Element이면서 dropbox 내부 또는 select root 내부에서 발생한 scroll은 무시.
     const target = event.target;
-    if (target instanceof Element && dropbox.value?.contains(target)) {
+    const isInternal =
+      target instanceof Element &&
+      (dropbox.value?.contains(target) || select.value?.contains(target));
+    if (isInternal) {
       return;
     }
     clickOutsideDropbox();

--- a/src/components/select/uses.js
+++ b/src/components/select/uses.js
@@ -427,24 +427,36 @@ export const useDropdown = (param) => {
     },
   );
 
+  // teleport 모드에서는 viewport resize / select 자체 resize 모두 dropbox를 닫는다
+  // (native select와 동일 UX). non-teleport 모드는 dropbox가 wrapper 내부에 있어
+  // 자연스럽게 따라가므로 기존 너비/위치 재계산을 유지.
   const handleResize = () => {
-    if (isDropbox.value) {
-      calculateDropboxWidth();
-      changeDropboxPosition();
+    if (!isDropbox.value) {
+      return;
     }
+    if (props.teleport) {
+      clickOutsideDropbox();
+      return;
+    }
+    calculateDropboxWidth();
+    changeDropboxPosition();
   };
 
   // teleport 모드에서는 dropbox가 body에 고정(position:fixed)되므로
-  // ev-window content 등 스크롤 가능한 ancestor가 스크롤되거나 select 자체가 리사이즈되면
-  // select와 dropbox 위치가 어긋난다.
-  // - scroll: capture phase로 어떤 ancestor의 scroll이라도 잡아 재배치
-  // - ResizeObserver: select 자체의 size 변화(레이아웃 변화로 위치가 바뀌는 경우 포함)를 감지.
-  //   ev-window 단순 드래그처럼 select size가 불변인 위치-only 이동은 잡지 못한다 — 그 경우
-  //   드래그 시작 시 dropbox를 닫는 UX가 권장된다.
-  const handleScroll = () => {
-    if (isDropbox.value) {
-      changeDropboxPosition();
+  // ev-window content 등 스크롤 가능한 ancestor가 스크롤되면 select와 dropbox 위치가 어긋난다.
+  // 위치 재계산 대신 닫는다(native select와 동일한 UX). 단 dropbox 내부 스크롤
+  // (필터 input 포커싱, item 리스트 스크롤)은 닫기 트리거에서 제외한다.
+  const handleScroll = (event) => {
+    if (!isDropbox.value) {
+      return;
     }
+    // event.target이 window/document인 페이지-레벨 scroll은 외부 스크롤로 간주해 닫는다.
+    // Element이면서 dropbox 내부에서 발생한 scroll(필터 input 포커싱, item 리스트 scroll)만 무시.
+    const target = event.target;
+    if (target instanceof Element && dropbox.value?.contains(target)) {
+      return;
+    }
+    clickOutsideDropbox();
   };
 
   onMounted(() => {
@@ -467,9 +479,20 @@ export const useDropdown = (param) => {
       }
       window.addEventListener('scroll', handleScroll, { capture: true, passive: true });
 
+      // teleport 모드 + open 상태일 때만 select 자체 size 변화도 닫기로 처리.
+      // (위치 재계산은 dropbox가 body에 fixed로 떠있는 동안 어색한 추적이 되기 쉬움)
+      // ResizeObserver는 observe() 직후 초기 size로 콜백을 1회 발화하는 spec이므로
+      // 첫 콜백은 무시해야 dropbox가 열리자마자 즉시 닫히지 않는다.
       let observer = null;
       if (typeof ResizeObserver !== 'undefined' && selectWrapper.value) {
-        observer = new ResizeObserver(() => changeDropboxPosition());
+        let isInitialCallback = true;
+        observer = new ResizeObserver(() => {
+          if (isInitialCallback) {
+            isInitialCallback = false;
+            return;
+          }
+          clickOutsideDropbox();
+        });
         observer.observe(selectWrapper.value);
       }
 

--- a/src/components/select/uses.js
+++ b/src/components/select/uses.js
@@ -289,6 +289,18 @@ export const useDropdown = (param) => {
         initialDropboxWidth.value = selectWrapper.value.offsetWidth;
       }
 
+      // 비-teleport에서 이전 측정에서 늘어난 dropboxWidth가 남아있으면
+      // .ev-select-dropbox-item이 그 폭으로 stretch되어 item.scrollWidth가 실제 content
+      // 너비가 아닌 stretch된 폭으로 측정된다 → 너비가 줄어드는 방향으로 재계산되지 않음.
+      // wrapper 폭(=base)으로 리셋한 뒤 한 프레임 기다리고 측정해, ev-window 축소 후
+      // 재오픈/리사이즈 시 dropbox가 새 wrapper 폭에 맞게 줄어들도록 한다.
+      // teleport 모드는 매 open마다 clickSelectInput이 rect.width로 동기화하므로 이 리셋이
+      // 필요 없다.
+      if (!props.teleport) {
+        dropboxWidth.value = `${initialDropboxWidth.value}px`;
+        await nextTick();
+      }
+
       const items = itemWrapper.value.querySelectorAll('.ev-select-dropbox-item');
       let maxWidth = 0;
 

--- a/src/components/select/uses.js
+++ b/src/components/select/uses.js
@@ -455,23 +455,21 @@ export const useDropdown = (param) => {
     window.removeEventListener('resize', handleResize);
   });
 
-  // props.teleport가 동적으로 변경되어도 listener/observer가 정확히 add/remove 되도록
-  // watch + onCleanup으로 일원화한다. flush:'post' + immediate로 마운트 직후 selectWrapper.value 보장.
+  // teleport 모드 + dropbox open일 때만 listener/observer를 활성화한다.
+  // dropbox가 닫혀있는 동안 capture-phase scroll 핸들러가 페이지 전체 스크롤마다 호출되는
+  // 비용을 피하고, ResizeObserver도 의미 있는 시점에만 동작시킨다.
+  // flush:'post'로 dropbox DOM이 마운트된 뒤 selectWrapper.value 기준으로 observe한다.
   watch(
-    () => props.teleport,
-    (teleport, _prev, onCleanup) => {
-      if (!teleport) {
+    () => !!props.teleport && isDropbox.value,
+    (active, _prev, onCleanup) => {
+      if (!active) {
         return;
       }
       window.addEventListener('scroll', handleScroll, { capture: true, passive: true });
 
       let observer = null;
       if (typeof ResizeObserver !== 'undefined' && selectWrapper.value) {
-        observer = new ResizeObserver(() => {
-          if (isDropbox.value) {
-            changeDropboxPosition();
-          }
-        });
+        observer = new ResizeObserver(() => changeDropboxPosition());
         observer.observe(selectWrapper.value);
       }
 
@@ -480,7 +478,7 @@ export const useDropdown = (param) => {
         observer?.disconnect();
       });
     },
-    { immediate: true, flush: 'post' },
+    { flush: 'post' },
   );
 
   return {


### PR DESCRIPTION
## 이슈

`EvSelect`의 dropbox flip 판정이 `document.documentElement.clientHeight`(viewport) 만을 기준으로 한다.
그래서 자체 스크롤을 가진 컨테이너(`ev-window-content` 등) 안에서 select를 열면 다음 케이스에서 dropbox가 펼쳐지면서 부모의 스크롤이 움직여 UX를 헤침

https://github.com/user-attachments/assets/81028f46-8350-44e9-927e-37471be3e183

## 변경 요약

1. src/components/select/uses.js flip 판정 로직 개선

  - 가장 가까운 스크롤 가능한 조상을 탐색 (overflow/overflowY가 auto|scroll|overlay). 없으면 viewport 폴백.
  - 컨테이너 경계와 viewport 경계의 교집합을 가시 영역으로 사용 → 컨테이너가 viewport 밖으로 잘려도
  안전.
  - 양쪽 모두 dropbox 전체를 담지 못하면 위가 더 넓더라도 dropDown 으로 떨어지도록

2. teleport 옵션 추가 (Select.vue, uses.js, src/common/utils.teleport.js)

  - flip 만으로는 ev-window 등 overflow: hidden 부모 컨테이너 경계 자체에 dropbox가 잘리는 문제는
해결되지 않으므로, dropbox를 외부 컨테이너로 옮길 수 있는 teleport prop 추가.
  - 사용법: teleport="body" / ".my-class" / "#some-id" 같은 CSS selector. 빈 문자열이면 teleport
비활성.
  - selector 매칭 실패 또는 syntax error → document.body로 fallback + console.warn. 같은
(componentName, selector) 조합은 1회만 warn하여 콘솔 누적 오염 방지 (resolveTeleportTarget() 유틸).
  - 위치 계산: open 시점에 viewport 절대 좌표(position: fixed)로 동기 계산.
  - close 트리거: open 동안 ancestor/viewport scroll, window resize 발생 시 native select와 동일하게 dropbox를 닫는다.
    · dropbox 내부 element scroll(item list, 필터 input 포커싱)은 close 가드로 제외
  - props.teleport + isDropbox 조합에 따라 scroll listener가 정확히 add/remove 되도록 watch +
onCleanup으로 일원화.

## 기대 동작

https://github.com/user-attachments/assets/53a208a7-94ec-414a-987a-48f64b374b08

## 테스트 가이드

- http://localhost:9999/EVUI/select#in-window 에서 테스트하실 수 있습니다.

- EVUI 내에 window 안에 select 예제가 없다보니 아래 코드로 다른 브랜치에서 기존 동작에 대해 테스트 하실 수 있습니다.

<details><summary>기존 동작 테스트를 위한 코드</summary>

```vue
<template>
  <div class="case">
    <p class="case-title">Dropbox flip (window 상단 근처) - 기본값</p>
    <ev-window
      v-model:visible="isVisible2"
      title="Select near window top"
      width="500px"
      height="320px"
    >
      <div class="window-row">
        <label>Top Select</label>
        <ev-select v-model="selectVal2" :items="manyItems" placeholder="Please select value." />
      </div>
      <div class="filler" />
      <div class="description">
        window content 상단에 가까운 select. 위로 펼칠 공간이 부족하므로
        <strong>아래쪽으로 펼쳐져야</strong> 한다.
      </div>
    </ev-window>
    <div class="description">
      <button class="btn" @click="clickButton2">click to open window!</button>
    </div>
  </div>

  <div class="case">
    <p class="case-title">Dropbox flip (window 하단 근처)</p>
    <ev-window
      v-model:visible="isVisible1"
      title="Select near window bottom"
      width="500px"
      height="320px"
    >
      <div class="filler" />
      <div class="window-row">
        <label>Bottom Select</label>
        <ev-select v-model="selectVal1" :items="manyItems" placeholder="Please select value." />
      </div>
      <div class="description">
        window content 하단에 가까운 select. 옵션 레이어가 viewport에는 들어가도 window 컨테이너
        하단을 넘기면 <strong>위쪽으로 펼쳐져야</strong> 한다.
      </div>
    </ev-window>
    <div class="description">
      <button class="btn" @click="clickButton1">click to open window!</button>
    </div>
  </div>

  <div class="case">
    <p class="case-title">Draggable / Resizable window + Footer + Select</p>
    <ev-window
      v-model:visible="isVisible3"
      title="Window with footer (non-scrollable)"
      width="500px"
      height="320px"
      draggable
      resizable
      maximizable
    >
      <div class="filler" />
      <div class="window-row">
        <label>Select</label>
        <ev-select v-model="selectVal3" :items="manyItems" placeholder="Please select value." />
      </div>
      <div class="description">
        window를 화면 하단까지 드래그해서 옮긴 후 select를 열어보세요. viewport 하단과 window 하단
        모두에 의해 flip 이 결정되어야 한다.
        <br />
        <br />
        <br />
      </div>
      <template #footer>
        <div class="window-footer-buttons">
          <ev-button @click="closeWindow3">닫기</ev-button>
        </div>
      </template>
    </ev-window>
    <div class="description">
      <button class="btn" @click="clickButton3">click to open window!</button>
    </div>
  </div>
</template>

<script>
import { ref } from 'vue';

export default {
  setup() {
    const manyItems = ref(
      Array.from({ length: 10 }, (_, i) => ({
        name: `name${i}`,
        value: `value${i}`,
      })),
    );

    const isVisible1 = ref(false);
    const isVisible2 = ref(false);
    const isVisible3 = ref(false);

    const clickButton1 = () => {
      isVisible1.value = true;
    };
    const clickButton2 = () => {
      isVisible2.value = true;
    };
    const clickButton3 = () => {
      isVisible3.value = true;
    };
    const closeWindow3 = () => {
      isVisible3.value = false;
    };

    const selectVal1 = ref('');
    const selectVal2 = ref('');
    const selectVal3 = ref('');

    return {
      manyItems,
      isVisible1,
      isVisible2,
      isVisible3,
      clickButton1,
      clickButton2,
      clickButton3,
      closeWindow3,
      selectVal1,
      selectVal2,
      selectVal3,
    };
  },
};
</script>

<style lang="scss" scoped>
.window-row {
  display: flex;
  align-items: center;
  gap: 10px;
  margin: 8px 0;

  label {
    min-width: 100px;
  }
}
.filler {
  height: 140px;
  background-color: #f5f5f5;
  border: 1px dashed #ccc;

  &.tall {
    height: 600px;
  }
}
.window-footer-buttons {
  display: flex;
  justify-content: flex-end;
  gap: 8px;
}
</style>
```
</details>
