### PR TITLE
3.4 > chart > 성능개선 

### DIFF
--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -133,6 +133,33 @@ export default {
           injectEvChartPropsInGroup,
         );
 
+    let pendingUpdate = null;
+    let pendingTimer = null;
+
+    const scheduleUpdate = (params) => {
+      if (!pendingUpdate) {
+        pendingUpdate = { ...params };
+      } else {
+        if (params.updateSeries) pendingUpdate.updateSeries = true;
+        if (params.updateData) pendingUpdate.updateData = true;
+        if (params.updateLegend) pendingUpdate.updateLegend = true;
+        if (params.updateTooltip) pendingUpdate.updateTooltip = true;
+        if (params.updateSelTip?.update) {
+          pendingUpdate.updateSelTip ??= {};
+          pendingUpdate.updateSelTip.update = true;
+        }
+      }
+
+      clearTimeout(pendingTimer);
+      pendingTimer = setTimeout(() => {
+        if (pendingUpdate && evChart) {
+          evChart.update(pendingUpdate);
+        }
+        pendingUpdate = null;
+        pendingTimer = null;
+      }, 0);
+    };
+
     const createChart = () => {
       let selected;
       if (normalizedOptions.selectLabel.use) {
@@ -181,7 +208,7 @@ export default {
 
         evChart.options = cloneDeep(newOpt);
 
-        evChart.update({
+        scheduleUpdate({
           updateSeries: false,
           updateSelTip: { update: false, keepDomain: false },
           updateLegend: isUpdateLegendType,
@@ -214,7 +241,7 @@ export default {
 
         evChart.data = props.options.realTimeScatter?.use ? newData : cloneDeep(newData);
 
-        evChart.update({
+        scheduleUpdate({
           updateSeries: isUpdateSeries,
           updateSelTip: { update: true, keepDomain: false },
           updateData: isUpdateData,
@@ -347,6 +374,10 @@ export default {
     });
 
     onBeforeUnmount(() => {
+      clearTimeout(pendingTimer);
+      pendingUpdate = null;
+      pendingTimer = null;
+
       if (evChart && 'destroy' in evChart) {
         evChart.destroy();
       }

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -553,11 +553,21 @@ const modules = {
       }
 
       if (ldata !== null) {
-        sdata.push(this.addData(
-          usePassingValue && gdata === passingValue ? 0 : gdata,
-          ldata,
-          gdata,
-        ));
+        const value = usePassingValue && gdata === passingValue ? 0 : gdata;
+
+        if ((value !== null && typeof value === 'object')
+          || (gdata !== null && typeof gdata === 'object')) {
+          sdata.push(this.addData(value, ldata, gdata));
+        } else {
+          const v = value ?? null;
+          const o = gdata ?? null;
+          sdata.push(isHorizontal
+            ? { x: v, y: ldata, o, b: null, xp: null, yp: null,
+                w: null, h: null, dataColor: null, dataTextColor: null }
+            : { x: ldata, y: v, o, b: null, xp: null, yp: null,
+                w: null, h: null, dataColor: null, dataTextColor: null },
+          );
+        }
       }
     }
 

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -69,11 +69,11 @@ const modules = {
               sData = new Array(rawData.length);
               for (let i = 0; i < rawData.length; i++) {
                 const item = rawData[i];
-                if (item === passingValue) {
+                if (interpolation === 'zero' && !item) {
+                  sData[i] = 0;
+                } else if (item === passingValue) {
                   hasPassingValueInData = true;
                   sData[i] = null;
-                } else if (interpolation === 'zero' && !item) {
-                  sData[i] = 0;
                 } else {
                   sData[i] = item;
                 }

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -46,7 +46,12 @@ const modules = {
             }
           });
         } else {
-          seriesIDs.forEach((seriesID) => {
+          // 시리즈마다 동일한 값이므로 루프 밖에서 1회만 계산 (O(N²) → O(N))
+          const firstSeriesId = seriesIDs[0];
+          const basePassingValue = this.seriesList[firstSeriesId]?.passingValue;
+
+          for (let s = 0; s < seriesIDs.length; s++) {
+            const seriesID = seriesIDs[s];
             const series = this.seriesList[seriesID];
             const rawData = data?.[seriesID];
             const { passingValue, interpolation } = series;
@@ -81,11 +86,16 @@ const modules = {
               if (series.isExistGrp && series.stackIndex && !series.isOverlapping) {
                 series.data = this.addSeriesStackDS(sData, label, series.bsIds, series.stackIndex);
               } else {
-                series.data = this.addSeriesDS(sData, label, series.isExistGrp);
+                series.data = this.addSeriesDS(
+                  sData,
+                  label,
+                  series.isExistGrp,
+                  basePassingValue,
+                );
               }
               series.minMax = this.getSeriesMinMax(series.data, series.passingValue);
             }
-          });
+          }
         }
       }
     });
@@ -536,11 +546,9 @@ const modules = {
    *
    * @returns {ChartSeriesDataPoint[]} data for each series
    */
-  addSeriesDS(data, label, isBase) {
+  addSeriesDS(data, label, isBase, passingValue) {
     const isHorizontal = this.options.horizontal;
     const sdata = [];
-    const firstSeriesId = Object.keys(this.seriesList)[0];
-    const passingValue = this.seriesList[firstSeriesId]?.passingValue;
     const usePassingValue = isBase && !Util.isNullOrUndefined(passingValue);
 
     for (let i = 0; i < data.length; i++) {
@@ -684,9 +692,11 @@ const modules = {
 
       for (let i = 0; i < data.length; i++) {
         const p = data[i];
-        const px = p.x?.value || p.x;
-        const py = p.y?.value || p.y;
-        const po = p.o?.value || p.o;
+        // addData/addSeriesDS/addSeriesDSforScatter/addSeriesDSForHeatMap 결과 객체의
+        // x/y/o는 항상 primitive(또는 null) — 옵셔널 체이닝 불필요
+        const px = p.x;
+        const py = p.y;
+        const po = p.o;
 
         if (!usePassingValue || po !== passingValue) {
           if (px <= minmax.minX) {

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -48,22 +48,34 @@ const modules = {
         } else {
           seriesIDs.forEach((seriesID) => {
             const series = this.seriesList[seriesID];
+            const rawData = data?.[seriesID];
+            const { passingValue, interpolation } = series;
+            const needsTransform = interpolation === 'zero'
+              || (passingValue != null && passingValue !== undefined);
 
-            const hasPassingValueInData = data?.[seriesID]?.some(
-              (item) => item === series.passingValue,
-            );
+            let hasPassingValueInData = false;
+            let sData;
+
+            if (!rawData) {
+              sData = rawData;
+            } else if (!needsTransform) {
+              sData = rawData;
+            } else {
+              sData = new Array(rawData.length);
+              for (let i = 0; i < rawData.length; i++) {
+                const item = rawData[i];
+                if (item === passingValue) {
+                  hasPassingValueInData = true;
+                  sData[i] = null;
+                } else if (interpolation === 'zero' && !item) {
+                  sData[i] = 0;
+                } else {
+                  sData[i] = item;
+                }
+              }
+            }
 
             series.hasPassingValueInData = hasPassingValueInData;
-
-            const sData = data?.[seriesID]?.map((item) => {
-              if (series.interpolation === 'zero' && !item) {
-                return 0;
-              }
-              if (item === series.passingValue) {
-                return null;
-              }
-              return item;
-            });
 
             if (series && sData) {
               if (series.isExistGrp && series.stackIndex && !series.isOverlapping) {
@@ -527,23 +539,27 @@ const modules = {
   addSeriesDS(data, label, isBase) {
     const isHorizontal = this.options.horizontal;
     const sdata = [];
-    const passingValue = this.seriesList[Object.keys(this.seriesList)[0]]?.passingValue;
+    const firstSeriesId = Object.keys(this.seriesList)[0];
+    const passingValue = this.seriesList[firstSeriesId]?.passingValue;
+    const usePassingValue = isBase && !Util.isNullOrUndefined(passingValue);
 
-    data.forEach((curr, index) => {
-      let gdata = curr;
-      let ldata = label[index];
+    for (let i = 0; i < data.length; i++) {
+      let gdata = data[i];
+      let ldata = label[i];
 
-      if (gdata && typeof gdata === 'object' && (curr.x || curr.y)) {
-        gdata = isHorizontal ? curr.x : curr.y;
-        ldata = isHorizontal ? curr.y : curr.x;
+      if (gdata && typeof gdata === 'object' && (gdata.x || gdata.y)) {
+        gdata = isHorizontal ? gdata.x : gdata.y;
+        ldata = isHorizontal ? data[i].y : data[i].x;
       }
 
       if (ldata !== null) {
-        const isPassingValueWithStack =
-          isBase && !Util.isNullOrUndefined(passingValue) && gdata === passingValue;
-        sdata.push(this.addData(isPassingValueWithStack ? 0 : gdata, ldata, gdata));
+        sdata.push(this.addData(
+          usePassingValue && gdata === passingValue ? 0 : gdata,
+          ldata,
+          gdata,
+        ));
       }
-    });
+    }
 
     return sdata;
   },
@@ -647,51 +663,51 @@ const modules = {
 
     if (data.length) {
       const usePassingValue = !Util.isNullOrUndefined(passingValue);
+      const minmax = {
+        minX: data[0].x,
+        minY: data[0].y,
+        maxX: data[0].x,
+        maxY: data[0].y,
+        maxDomain: isHorizontal ? data[0].y : data[0].x,
+        maxDomainIndex: 0,
+      };
 
-      return data.reduce(
-        (acc, p, index) => {
-          const minmax = acc;
-          const px = p.x?.value || p.x;
-          const py = p.y?.value || p.y;
-          const po = p.o?.value || p.o;
+      for (let i = 0; i < data.length; i++) {
+        const p = data[i];
+        const px = p.x?.value || p.x;
+        const py = p.y?.value || p.y;
+        const po = p.o?.value || p.o;
 
-          if (usePassingValue ? po !== passingValue && px <= minmax.minX : px <= minmax.minX) {
+        if (!usePassingValue || po !== passingValue) {
+          if (px <= minmax.minX) {
             minmax.minX = px === null ? 0 : px;
           }
 
-          if (usePassingValue ? po !== passingValue && py <= minmax.minY : py <= minmax.minY) {
+          if (py <= minmax.minY) {
             minmax.minY = py === null ? 0 : py;
           }
 
-          if (usePassingValue ? po !== passingValue && px >= minmax.maxX : px >= minmax.maxX) {
+          if (px >= minmax.maxX) {
             minmax.maxX = px === null ? 0 : px;
 
             if (isHorizontal && px !== null) {
               minmax.maxDomain = py;
-              minmax.maxDomainIndex = index;
+              minmax.maxDomainIndex = i;
             }
           }
 
-          if (usePassingValue ? po !== passingValue && py >= minmax.maxY : py >= minmax.maxY) {
+          if (py >= minmax.maxY) {
             minmax.maxY = py === null ? 0 : py;
 
             if (!isHorizontal && py !== null) {
               minmax.maxDomain = px;
-              minmax.maxDomainIndex = index;
+              minmax.maxDomainIndex = i;
             }
           }
+        }
+      }
 
-          return minmax;
-        },
-        {
-          minX: data[0].x,
-          minY: data[0].y,
-          maxX: data[0].x,
-          maxY: data[0].y,
-          maxDomain: isHorizontal ? data[0].y : data[0].x,
-          maxDomainIndex: 0,
-        },
-      );
+      return minmax;
     }
 
     return def;


### PR DESCRIPTION
# Chart 렌더링 성능 개선  1차                                                                                                                                           
                                                                                                                                                                     
### 문제                                                                                                                                                               
5초 주기 데이터 갱신 시 차트가 버벅이는 현상 발생. 프로파일링 결과 두 가지 원인 확인:                                                                              
  1. evChart.update() 중복 호출 — props.options와 props.data의 deep watcher가 같은 flush 사이클에서 각각 evChart.update()를 호출하여 2회 렌더링. 또한 update() 내부에서 emitAxesScaleChange, emitLegendData 등 이벤트가 부모 상태를 변경하면 캐스케이드 flush가 발생하여 추가 update() 호출 (최대 4~5회)                          
  2. createDataSet 병목 (~91ms) — series마다 .some() + .map()으로 데이터를 2회 순회하며, 변환이 불필요한 경우에도 배열을 복사                                        
                                                                                                                                                                     
### 해결                                                                                                                                                               
                                                                                                                                                                     
  1. Chart.vue — watcher update 배치 처리                                                                                                                                                                                                                                                                                      
      - scheduleUpdate 도입: setTimeout(fn, 0) 기반으로 evChart.update() 호출을 macrotask로 지연                                                                         
      - 같은 렌더 사이클의 watcher 호출 + 캐스케이드 flush를 모두 단일 update()로 통합                                                                                   
      - update params는 OR merge하여 필요한 플래그를 모두 반영                                                                                                           
                                                                                                                                                                     
  2. model.store.js — createDataSet 순회 최적화
        - createDataSet: .some() + .map() 2회 순회 → 변환 불필요 시 rawData 직접 사용 (0ms), 필요 시 단일 for 루프로 통합
        - addSeriesDS: Object.keys() 결과 캐시, passingValue 체크 루프 밖으로 호이스팅, .forEach → for 루프
        - getSeriesMinMax: .reduce() → for 루프, passingValue 조건 반전으로 조기 스킵

### 기대 효과
1. evChart.update() 호출: 최대 4~5회 → 1회
2. createDataSet 순회: series당 2회 → 0~1회


### 적용 예시 
<img width="1108" height="442" alt="image" src="https://github.com/user-attachments/assets/6a8614dc-e3f1-48dc-85fd-8d9203581b8d" />
