### PR TITLE
ci: release job 러너를 self-hosted로 변경

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## 변경 사항

`release` job 의 러너를 GitHub-hosted(`ubuntu-latest`)에서 self-hosted(`[self-hosted, linux, x64]`)로 변경합니다.

```diff
   release:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
```

## 배경

- CI 워크플로를 사내 self-hosted 러너에서 실행하도록 통일합니다.

## 영향 범위

- `.github/workflows/release.yml` 한 파일, `runs-on` 한 줄만 변경되어 릴리스 로직 변화는 없습니다.

## 체크리스트

- [ ] self-hosted 러너에서 `release` job 정상 동작 확인