### PR TITLE
ci: deploy job 러너를 self-hosted로 변경

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
 
     steps:
       - name: Use Checkout


### PR DESCRIPTION
## 변경 사항

`deploy` job 의 러너를 GitHub-hosted(`ubuntu-latest`)에서 self-hosted(`[self-hosted, linux, x64]`)로 변경합니다.

```diff
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
```

## 배경

- CI 워크플로를 사내 self-hosted 러너에서 실행하도록 통일합니다.

## 영향 범위

- `.github/workflows/deploy-docs.yml` 한 파일, `runs-on` 한 줄만 변경되어 배포 로직 변화는 없습니다.

## 체크리스트

- [ ] self-hosted 러너에서 docs `deploy` job 정상 동작 확인