### PR TITLE
perf(chart): line 시리즈 포인트 그리기 batching 으로 캔버스 flush 횟수 감소 - 점 그리기 속도 개선 

### DIFF
--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -348,40 +348,53 @@ class Line {
       // 모든 점을 단일 path 에 모아 fill/stroke 를 1회만 호출하도록 batching 한다.
       const canBatch = !NON_CIRCLE_POINT_STYLES.has(pointStyle);
 
+      // 점 그리기 판정은 circle/비-circle 두 분기 공통이므로 이 함수 한 곳에서만 관리한다.
+      // (두 분기는 "어떤 점을 그리느냐"가 아니라 "어떻게 그리느냐"만 달라야 한다.)
+      // 반환값: 0 = 그리지 않음, 1 = 일반(blur), 2 = 강조(focus).
+      // hot loop라 점당 객체 할당을 피하려고 객체 대신 정수 코드를 반환한다.
+      const pointDrawKind = (ix) => {
+        const curr = data[ix];
+        if (curr.xp === null || curr.yp === null || curr.o === null) {
+          return 0;
+        }
+
+        let isSingle;
+        if (isLinearSingle) {
+          isSingle = true;
+        } else if (!isLinearInterpolation) {
+          const prevO = ix > 0 ? data[ix - 1].o : null;
+          const nextO = ix + 1 < dataLen ? data[ix + 1].o : null;
+          isSingle = prevO == null && nextO == null;
+        } else {
+          isSingle = false;
+        }
+
+        const isSelectedLabel = selectedLabelIndexSet ? selectedLabelIndexSet.has(ix) : false;
+        if (!(this.point || isSingle || isSelectedLabel)) {
+          return 0;
+        }
+        return isSelectedLabel && !legendHitInfo ? 2 : 1;
+      };
+
       if (canBatch) {
         let blurPathOpen = false;
         let focusPoints = null;
 
         for (let ix = 0; ix < dataLen; ix++) {
-          const curr = data[ix];
-          if (curr.xp !== null && curr.yp !== null && curr.o !== null) {
-            let isSingle;
-            if (isLinearSingle) {
-              isSingle = true;
-            } else if (!isLinearInterpolation) {
-              const prevO = ix > 0 ? data[ix - 1].o : null;
-              const nextO = ix + 1 < dataLen ? data[ix + 1].o : null;
-              isSingle = prevO == null && nextO == null;
+          const kind = pointDrawKind(ix);
+          if (kind !== 0) {
+            const curr = data[ix];
+            if (kind === 2) {
+              if (focusPoints === null) focusPoints = [];
+              focusPoints.push(curr);
             } else {
-              isSingle = false;
-            }
-
-            const isSelectedLabel = selectedLabelIndexSet
-              ? selectedLabelIndexSet.has(ix)
-              : false;
-            if (this.point || isSingle || isSelectedLabel) {
-              if (isSelectedLabel && !legendHitInfo) {
-                if (focusPoints === null) focusPoints = [];
-                focusPoints.push(curr);
-              } else {
-                if (!blurPathOpen) {
-                  ctx.beginPath();
-                  blurPathOpen = true;
-                }
-                // arc 직전 moveTo 로 sub-path 를 분리해 점 사이 line 연결을 막는다.
-                ctx.moveTo(curr.xp + pointSize, curr.yp);
-                ctx.arc(curr.xp, curr.yp, pointSize, 0, TWO_PI);
+              if (!blurPathOpen) {
+                ctx.beginPath();
+                blurPathOpen = true;
               }
+              // arc 직전 moveTo 로 sub-path 를 분리해 점 사이 line 연결을 막는다.
+              ctx.moveTo(curr.xp + pointSize, curr.yp);
+              ctx.arc(curr.xp, curr.yp, pointSize, 0, TWO_PI);
             }
           }
         }
@@ -403,26 +416,11 @@ class Line {
         }
       } else {
         for (let ix = 0; ix < dataLen; ix++) {
-          const curr = data[ix];
-          if (curr.xp !== null && curr.yp !== null && curr.o !== null) {
-            let isSingle;
-            if (isLinearSingle) {
-              isSingle = true;
-            } else if (!isLinearInterpolation) {
-              const prevO = ix > 0 ? data[ix - 1].o : null;
-              const nextO = ix + 1 < dataLen ? data[ix + 1].o : null;
-              isSingle = prevO == null && nextO == null;
-            } else {
-              isSingle = false;
-            }
-
-            const isSelectedLabel = selectedLabelIndexSet
-              ? selectedLabelIndexSet.has(ix)
-              : false;
-            if (this.point || isSingle || isSelectedLabel) {
-              ctx.fillStyle = isSelectedLabel && !legendHitInfo ? focusStyle : blurStyle;
-              Canvas.drawPoint(ctx, pointStyle, pointSize, curr.xp, curr.yp);
-            }
+          const kind = pointDrawKind(ix);
+          if (kind !== 0) {
+            const curr = data[ix];
+            ctx.fillStyle = kind === 2 ? focusStyle : blurStyle;
+            Canvas.drawPoint(ctx, pointStyle, pointSize, curr.xp, curr.yp);
           }
         }
       }

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -3,6 +3,21 @@ import { COLOR, LINE_OPTION } from '../helpers/helpers.constant';
 import Util from '../helpers/helpers.util';
 import Canvas from '../helpers/helpers.canvas';
 
+// Canvas.drawPoint 의 switch 에서 default 분기 (원/circle) 로 떨어지는 스타일은
+// 모든 점을 단일 path 에 합쳐 fill/stroke 1회로 그릴 수 있다.
+// 그 외 스타일은 도형별 closePath 처리가 달라 batching 대상에서 제외한다.
+const NON_CIRCLE_POINT_STYLES = new Set([
+  'triangle',
+  'rect',
+  'rectRounded',
+  'rectRot',
+  'cross',
+  'crossRot',
+  'star',
+  'line',
+]);
+const TWO_PI = Math.PI * 2;
+
 class Line {
   constructor(sId, opt, sIdx) {
     const merged = defaultsDeep({}, opt, LINE_OPTION);
@@ -305,25 +320,112 @@ class Line {
       ctx.strokeStyle = Util.colorStringToRgba(mainColor, mainColorOpacity);
       const focusStyle = Util.colorStringToRgba(pointFillColor, 1);
       const blurStyle = Util.colorStringToRgba(pointFillColor, pointFillColorOpacity);
-      const isLinearSingle =
-        this.interpolation === 'linear' && this.data.filter((item) => item.o !== null).length === 1;
 
-      this.data.forEach((curr, ix) => {
-        if (curr.xp === null || curr.yp === null || curr.o === null) {
-          return;
+      // isLinearSingle: 전체 filter 대신 2개 발견 시점에 즉시 종료.
+      let isLinearSingle = false;
+      if (this.interpolation === 'linear') {
+        let nonNullCount = 0;
+        for (let i = 0; i < this.data.length; i++) {
+          if (this.data[i].o !== null) {
+            nonNullCount++;
+            if (nonNullCount > 1) break;
+          }
         }
+        isLinearSingle = nonNullCount === 1;
+      }
 
-        const prevData = this.data[ix - 1]?.o;
-        const nextData = this.data[ix + 1]?.o;
+      // includes(O(n)) → Set(O(1))
+      const selectedLabelIndexSet = selectedLabelIndexList.length
+        ? new Set(selectedLabelIndexList)
+        : null;
 
-        const isSingle =
-          (!isLinearInterpolation && isNil(prevData) && isNil(nextData)) || isLinearSingle;
-        const isSelectedLabel = selectedLabelIndexList.includes(ix);
-        if (this.point || isSingle || isSelectedLabel) {
-          ctx.fillStyle = isSelectedLabel && !legendHitInfo ? focusStyle : blurStyle;
-          Canvas.drawPoint(ctx, this.pointStyle, this.pointSize, curr.xp, curr.yp);
+      const pointSize = this.pointSize;
+      const pointStyle = this.pointStyle;
+      const data = this.data;
+      const dataLen = data.length;
+      // 다수 series × 다수 point 환경에서 점마다 beginPath/fill/stroke 를 호출하면
+      // 캔버스 rasterizer flush 가 수만 회 발생한다. circle 스타일(default)일 때는
+      // 모든 점을 단일 path 에 모아 fill/stroke 를 1회만 호출하도록 batching 한다.
+      const canBatch = !NON_CIRCLE_POINT_STYLES.has(pointStyle);
+
+      if (canBatch) {
+        let blurPathOpen = false;
+        let focusPoints = null;
+
+        for (let ix = 0; ix < dataLen; ix++) {
+          const curr = data[ix];
+          if (curr.xp !== null && curr.yp !== null && curr.o !== null) {
+            let isSingle;
+            if (isLinearSingle) {
+              isSingle = true;
+            } else if (!isLinearInterpolation) {
+              const prevO = ix > 0 ? data[ix - 1].o : null;
+              const nextO = ix + 1 < dataLen ? data[ix + 1].o : null;
+              isSingle = prevO == null && nextO == null;
+            } else {
+              isSingle = false;
+            }
+
+            const isSelectedLabel = selectedLabelIndexSet
+              ? selectedLabelIndexSet.has(ix)
+              : false;
+            if (this.point || isSingle || isSelectedLabel) {
+              if (isSelectedLabel && !legendHitInfo) {
+                if (focusPoints === null) focusPoints = [];
+                focusPoints.push(curr);
+              } else {
+                if (!blurPathOpen) {
+                  ctx.beginPath();
+                  blurPathOpen = true;
+                }
+                // arc 직전 moveTo 로 sub-path 를 분리해 점 사이 line 연결을 막는다.
+                ctx.moveTo(curr.xp + pointSize, curr.yp);
+                ctx.arc(curr.xp, curr.yp, pointSize, 0, TWO_PI);
+              }
+            }
+          }
         }
-      });
+        if (blurPathOpen) {
+          ctx.fillStyle = blurStyle;
+          ctx.fill();
+          ctx.stroke();
+        }
+        if (focusPoints !== null) {
+          ctx.beginPath();
+          for (let i = 0; i < focusPoints.length; i++) {
+            const p = focusPoints[i];
+            ctx.moveTo(p.xp + pointSize, p.yp);
+            ctx.arc(p.xp, p.yp, pointSize, 0, TWO_PI);
+          }
+          ctx.fillStyle = focusStyle;
+          ctx.fill();
+          ctx.stroke();
+        }
+      } else {
+        for (let ix = 0; ix < dataLen; ix++) {
+          const curr = data[ix];
+          if (curr.xp !== null && curr.yp !== null && curr.o !== null) {
+            let isSingle;
+            if (isLinearSingle) {
+              isSingle = true;
+            } else if (!isLinearInterpolation) {
+              const prevO = ix > 0 ? data[ix - 1].o : null;
+              const nextO = ix + 1 < dataLen ? data[ix + 1].o : null;
+              isSingle = prevO == null && nextO == null;
+            } else {
+              isSingle = false;
+            }
+
+            const isSelectedLabel = selectedLabelIndexSet
+              ? selectedLabelIndexSet.has(ix)
+              : false;
+            if (this.point || isSingle || isSelectedLabel) {
+              ctx.fillStyle = isSelectedLabel && !legendHitInfo ? focusStyle : blurStyle;
+              Canvas.drawPoint(ctx, pointStyle, pointSize, curr.xp, curr.yp);
+            }
+          }
+        }
+      }
     }
 
     ctx.restore();


### PR DESCRIPTION
# line 시리즈 포인트 그리기 batching

`d8270a73 perf(chart): line 시리즈 포인트 그리기 batching 으로 캔버스 flush 횟수 감소`

## 원인

라인 차트의 `draw()` 안 "Draw points" 루프는 각 데이터 포인트마다 `Canvas.drawPoint()`를 호출하고, 내부적으로 `beginPath → fill → stroke` 가 매 포인트마다 일어났다. 시리즈 N개 × 포인트 M개 환경에서 **N×M 회의 캔버스 rasterizer flush** 가 발생하여, 시리즈가 많은 차트(예: 500시리즈 × 120포인트)에서 매 redraw마다 큰 비용이 들었다.

추가로 같은 루프에서 다음 두 가지 자잘한 비용도 누적:
- 매 포인트마다 `selectedLabelIndexList.includes(ix)` (O(N)) 호출
- `isLinearSingle` 계산을 위한 `this.data.filter(...).length` 전체 순회

## 변경 요약
- circle 스타일 포인트 batching
   - `Canvas.drawPoint` switch의 default 분기로 떨어지는 스타일(원/circle, 가장 흔함)일 때, 모든 blur 포인트를 **단일 path에 arc로 모아 fill/stroke 1회만 호출**. selected 포인트는 별도 path로 묶어 1회 호출. → 캔버스 호출 N×M → 1~2회.


### 변경 Deep 디테일 
1. `triangle`, `rect`, `rectRounded`, `rectRot`, `cross`, `crossRot`, `star`, `line` 등 closePath 처리가 다른 도형들은 `NON_CIRCLE_POINT_STYLES`에 명시해 **기존 per-point 경로를 유지** (시각·동작 동일).
2. `selectedLabelIndex` Set 변환
- Before: `selectedLabelIndexList.includes(ix)` — O(N) 매 포인트
- After: 루프 밖에서 `new Set(selectedLabelIndexList)` 1회 생성 후 `set.has(ix)` — O(1)
3. `isLinearSingle` 조기 종료
- Before: `this.data.filter(item => item.o !== null).length === 1` — 전체 순회 + 배열 할당
- After: `non-null 개수 2개 발견 시 즉시 break` 하는 early-exit 루프
4. hot loop 호이스팅
`this.pointSize`, `this.pointStyle`, `this.data`, `this.data.length` 등 루프 안에서 반복 참조되던 인스턴스 속성을 루프 밖 지역 변수로 호이스팅.
5. `TWO_PI` 모듈 상수
`Math.PI * 2`를 매 arc 호출시 재계산하지 않도록 모듈 상수로 추출.