### PR TITLE
fix(chart): clamp tooltip indicator to plot area

### DIFF
--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1544,11 +1544,25 @@ const modules = {
 
     if (horizontal) {
       // 수평 차트에서는 Y축 라벨 위치에 수평선
-      const yPosition = firstItem.data.yp + (firstItem.data.h ? firstItem.data.h / 2 : 0);
+      let yPosition = firstItem.data.yp + (firstItem.data.h ? firstItem.data.h / 2 : 0);
+      if (yPosition < graphPos.y1) {
+        yPosition = graphPos.y1;
+      }
+
+      if (yPosition > graphPos.y2) {
+        yPosition = graphPos.y2;
+      }
       indicatorPosition = [graphPos.x1, yPosition];
     } else {
       // 수직 차트에서는 X축 라벨 위치에 수직선
-      const xPosition = firstItem.data.xp + (firstItem.data.w ? firstItem.data.w / 2 : 0);
+      let xPosition = firstItem.data.xp + (firstItem.data.w ? firstItem.data.w / 2 : 0);
+      if (xPosition < graphPos.x1) {
+        xPosition = graphPos.x1;
+      }
+
+      if (xPosition > graphPos.x2) {
+        xPosition = graphPos.x2;
+      }
       indicatorPosition = [xPosition, graphPos.y1];
     }
 

--- a/src/components/chart/plugins/plugins.interaction.spec.js
+++ b/src/components/chart/plugins/plugins.interaction.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import modules from './plugins.interaction';
 
 /**
@@ -22,6 +22,38 @@ const createChartForClosestIndex = (seriesList, opts = {}) =>
     seriesList,
     options: { horizontal: false, ...opts },
   });
+
+const createOverlayCtx = () => ({
+  beginPath: vi.fn(),
+  save: vi.fn(),
+  restore: vi.fn(),
+  closePath: vi.fn(),
+  stroke: vi.fn(),
+  setLineDash: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+});
+
+const createIndicatorChart = (horizontal = false) => {
+  const chartRect = { x1: 0, x2: 300, y1: 0, y2: 200 };
+  const labelOffset = { left: 20, right: 20, top: 15, bottom: 20 };
+  const graphPos = {
+    x1: chartRect.x1 + labelOffset.left,
+    x2: chartRect.x2 - labelOffset.right,
+    y1: chartRect.y1 + labelOffset.top,
+    y2: chartRect.y2 - labelOffset.bottom,
+  };
+
+  return {
+    graphPos,
+    chart: Object.assign(Object.create(modules), {
+      chartRect,
+      labelOffset,
+      options: { horizontal },
+      overlayCtx: createOverlayCtx(),
+    }),
+  };
+};
 
 /**
  * findGraphData가 고정된 item을 리턴하는 mock 시리즈.
@@ -61,6 +93,52 @@ const createClosestSeries = ({
   interpolation,
   passingValue,
   hasPassingValueInData,
+});
+
+describe('plugins.interaction drawIndicatorForTooltip', () => {
+  it('수직 차트 indicator X 위치를 graph 영역 안으로 제한한다', () => {
+    const { chart, graphPos } = createIndicatorChart();
+    const hitInfo = {
+      items: {
+        series1: {
+          data: { x: 'A', xp: graphPos.x2 + 50, w: 20 },
+        },
+      },
+    };
+    const rawXPosition = hitInfo.items.series1.data.xp + hitInfo.items.series1.data.w / 2;
+
+    const result = chart.drawIndicatorForTooltip(hitInfo, '#000');
+    const drawnX = chart.overlayCtx.moveTo.mock.calls[0][0];
+    const drawnLineX = chart.overlayCtx.lineTo.mock.calls[0][0];
+
+    expect(result.position[0]).toBe(graphPos.x2);
+    expect(drawnX - 0.5).toBeLessThanOrEqual(graphPos.x2);
+    expect(drawnX).toBe(graphPos.x2 + 0.5);
+    expect(drawnLineX).toBe(graphPos.x2 + 0.5);
+    expect(drawnX).not.toBe(rawXPosition + 0.5);
+  });
+
+  it('수평 차트 indicator Y 위치를 graph 영역 안으로 제한한다', () => {
+    const { chart, graphPos } = createIndicatorChart(true);
+    const hitInfo = {
+      items: {
+        series1: {
+          data: { y: 'A', yp: graphPos.y2 + 50, h: 20 },
+        },
+      },
+    };
+    const rawYPosition = hitInfo.items.series1.data.yp + hitInfo.items.series1.data.h / 2;
+
+    const result = chart.drawIndicatorForTooltip(hitInfo, '#000');
+    const drawnY = chart.overlayCtx.moveTo.mock.calls[0][1];
+    const drawnLineY = chart.overlayCtx.lineTo.mock.calls[0][1];
+
+    expect(result.position[1]).toBe(graphPos.y2);
+    expect(drawnY - 0.5).toBeLessThanOrEqual(graphPos.y2);
+    expect(drawnY).toBe(graphPos.y2 + 0.5);
+    expect(drawnLineY).toBe(graphPos.y2 + 0.5);
+    expect(drawnY).not.toBe(rawYPosition + 0.5);
+  });
 });
 
 describe('plugins.interaction findHitItem', () => {


### PR DESCRIPTION
## Summary

Clamp the chart tooltip indicator so it can no longer be drawn outside the plot area (#2276).

## Background

`drawIndicatorForTooltip` positions the indicator from the hovered data point's pixel coordinate (`data.xp + w/2` for vertical charts, `data.yp + h/2` for horizontal). That value was used directly, with no bound on the plot region. When the hovered point sits at or beyond the axis end, the indicator line/marker is rendered past the chart edge. The two screenshots in #2276 show exactly this: the indicator appears to the right of the x-axis end on a line and bar chart, and past the right edge on a horizontal bar chart. The sibling `dragStart` path already clamps its position into the same graph bounds, so the indicator path was simply missing the equivalent guard.

## Changes

- Clamp the indicator's variable-axis position into the graph bounds in `drawIndicatorForTooltip`: `[graphPos.x1, graphPos.x2]` for vertical charts and `[graphPos.y1, graphPos.y2]` for horizontal charts, mirroring the clamp in `dragStart`. The fixed-axis endpoints are unchanged.
- Add vitest regression tests for both orientations: an out-of-bounds hovered point now yields a drawn coordinate clamped to the plot edge instead of the raw position.

## Verification

- `vitest run src/components/chart/plugins/plugins.interaction.spec.js` passes (16 tests, including the 2 new cases).
- `eslint` clean on both changed files.

Fixes #2276
