### PR TITLE
perf(chart): custom tooltip hover 비용 절감 (시그니처 기반 redraw 스킵 + 포맷·필터 캐시)

### DIFF
--- a/docs/views/lineChart/example/CustomTooltip.vue
+++ b/docs/views/lineChart/example/CustomTooltip.vue
@@ -34,25 +34,67 @@ export default {
       ),
     });
 
+    // 고객사 환경(고비용 value formatter; big.js 기반 단위 변환과 비슷한 부하)을 흉내내기 위해
+    // 매 호출마다 약간의 산술/문자열 작업을 의도적으로 끼워 넣는다.
+    const heavyFormatNumber = (n) => {
+      let x = Number(n);
+      // 일부러 비싼 path: 자릿수 분해 + 단위 변환 시늉
+      let scaled = x;
+      const units = ['', 'K', 'M', 'G', 'T'];
+      let uIdx = 0;
+      while (Math.abs(scaled) >= 1000 && uIdx < units.length - 1) {
+        scaled /= 1000;
+        uIdx += 1;
+      }
+      const fixed = scaled.toFixed(4);
+      // 천 단위 콤마
+      const parts = fixed.split('.');
+      parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+      // 부동소수 약간의 추가 연산
+      const noise = Math.sqrt(Math.abs(x) + 1) * Math.log(Math.abs(x) + 2);
+      return `${parts.join('.')} ${units[uIdx]} (~${noise.toFixed(2)})`;
+    };
+
     const useHtml = ref(true);
     const htmlTooltipFormatter = {
+      // 고객사처럼 value formatter 도 함께 사용 — findHitItem 루프에서 시리즈마다 호출됨
+      value: ({ y }) => heavyFormatNumber(y),
       html: (seriesList) => {
-        let result = '<div class="ev-chart-tooltip-custom" style="width: 250px">';
+        let result = '<div class="ev-chart-tooltip-custom" style="width: 320px">';
         result += `<div class="ev-chart-tooltip-custom__header"> ${dayjs(seriesList?.[0]?.data?.x).format('mm:ss')}</div>`;
         result += '<div class="ev-chart-tooltip-custom__body">';
         seriesList.forEach((series) => {
           // 가상 스크롤(자동 활성)을 위해 시리즈당 wrapper에 data-evui-tooltip-row 마커를 부여한다.
+          const arr = chartData.data[series?.sId] || [];
+          const sum = arr.reduce((a, b) => a + b, 0);
+          const avg = arr.length ? sum / arr.length : 0;
+          let min = Infinity;
+          let max = -Infinity;
+          for (let i = 0; i < arr.length; i++) {
+            if (arr[i] < min) min = arr[i];
+            if (arr[i] > max) max = arr[i];
+          }
           result += '<div data-evui-tooltip-row>';
           result += '<br/>';
           result += '<div class="row">';
           result += `<div class="color-circle" style="background-color: ${series.color}"></div>`;
           result += `<div class="series-name">${series.name} 값 </div>`;
-          result += `<div class="value">${series.data?.y}</div>`;
+          result += `<div class="value">${heavyFormatNumber(series.data?.y)}</div>`;
           result += '</div>';
           result += '<div class="row">';
           result += `<div class="color-circle" style="background-color: ${series.color}"></div>`;
-          result += '<div class="series-name">전체 합계 </div>';
-          result += `<div class="value">${chartData.data[series?.sId].reduce((a, b) => a + b, 0)}</div>`;
+          result += '<div class="series-name">합계 </div>';
+          result += `<div class="value">${heavyFormatNumber(sum)}</div>`;
+          result += '</div>';
+          result += '<div class="row">';
+          result += `<div class="color-circle" style="background-color: ${series.color}"></div>`;
+          result += '<div class="series-name">평균 </div>';
+          result += `<div class="value">${heavyFormatNumber(avg)}</div>`;
+          result += '</div>';
+          result += '<div class="row">';
+          result += `<div class="color-circle" style="background-color: ${series.color}"></div>`;
+          result += `<div class="series-name">min / max </div>`;
+          result += `<div class="value">${heavyFormatNumber(min)} / ${heavyFormatNumber(max)}</div>`;
           result += '</div>';
           result += '</div>';
         });

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -1006,6 +1006,11 @@ class EvChart {
       return;
     }
 
+    // 데이터 갱신 시 hover fast-path 시그니처를 무효화한다.
+    if (updateData || updateSeries) {
+      this._lastHoverSig = '';
+    }
+
     this.updateScrollbar(updateData, updateByScrollbar);
 
     this.resetProps();

--- a/src/components/chart/element/element.line.js
+++ b/src/components/chart/element/element.line.js
@@ -59,6 +59,24 @@ class Line {
   }
 
   /**
+   * x가 null/undefined가 아닌 데이터만 필터링한 배열을 반환한다.
+   * mousemove마다 호출되는 findGraphData가 매번 새 배열을 만들지 않도록
+   * this.data 참조(+ length)로 메모이즈한다. 새 배열로 교체되거나 길이가 바뀌면
+   * 자동으로 재계산된다. (in-place push에 의한 stale도 length 비교로 감지)
+   */
+  _getValidGData() {
+    const src = this.data;
+    const cache = this._validGDataCache;
+    if (cache && cache.src === src && cache.length === src.length) {
+      return cache.value;
+    }
+
+    const value = src.filter((data) => !Util.isNullOrUndefined(data.x));
+    this._validGDataCache = { src, length: src.length, value };
+    return value;
+  }
+
+  /**
    * @typedef {Object} LineDrawParam
    * @property {CanvasRenderingContext2D} ctx - 캔버스 렌더링 컨텍스트
    * @property {object} chartRect - 차트 영역 정보
@@ -472,7 +490,7 @@ class Line {
     const xp = offset[0];
     const yp = offset[1];
     const item = { data: null, hit: false, color: this.color };
-    const gdata = this.data.filter((data) => !Util.isNullOrUndefined(data.x));
+    const gdata = this._getValidGData();
     const isLinearInterpolation = this.useLinearInterpolation();
 
     // line 포인트 "정확 히트" 판정용 반경.

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -31,30 +31,56 @@ const modules = {
       }
 
       const ctx = this.overlayCtx;
+      const itemKeys = Object.keys(hitInfo.items);
+      const hasItems = itemKeys.length > 0;
+
+      // hover 시그니처: hitId + 시리즈/dataIndex 집합이 동일하면 같은 데이터 포인트 위.
+      // formatter.html 경로에서 비용 가장 큰 drawCustomTooltip(고객 formatter + htmlToElement +
+      // virtualScroll teardown→reinit) 만 스킵하고, 나머지(overlay/indicator/listener/hoveredLabel)
+      // 흐름은 그대로 유지한다. fast path 를 더 넓히면 부수 효과가 생길 수 있어 보수적으로 둔다.
+      let hoverSig = '';
+      if (hasItems) {
+        hoverSig = `h=${hitInfo.hitId}`;
+        const sortedKeys = itemKeys.slice().sort();
+        for (let i = 0; i < sortedKeys.length; i++) {
+          const k = sortedKeys[i];
+          hoverSig += `|${k}:${hitInfo.items[k].index}`;
+        }
+      }
+
+      const skipCustomTooltipRedraw =
+        hoverSig !== '' &&
+        hoverSig === this._lastHoverSig &&
+        this.tooltipDOM &&
+        this.tooltipDOM.style.display !== 'none';
 
       this.overlayClear();
 
-      if (Object.keys(hitInfo.items).length) {
+      if (hasItems) {
         if (tooltip.use && this.isInitTooltip) {
           this.drawItemsHighlight(hitInfo, ctx);
 
           if (typeof tooltip?.returnValue === 'function') {
             const seriesList = [];
-            Object.keys(hitInfo.items).forEach((sId) => {
+            for (let i = 0; i < itemKeys.length; i++) {
+              const sId = itemKeys[i];
+              const it = hitInfo.items[sId];
               seriesList.push({
                 sId,
-                data: hitInfo.items[sId].data,
-                color: hitInfo.items[sId].color,
-                name: hitInfo.items[sId].name,
-                dataId: hitInfo.items[sId].id,
-                index: hitInfo.items[sId].index,
+                data: it.data,
+                color: it.color,
+                name: it.name,
+                dataId: it.id,
+                index: it.index,
               });
-            });
+            }
 
             this.hideTooltipDOM();
             tooltip.returnValue(seriesList, e);
           } else if (tooltip?.formatter?.html) {
-            this.drawCustomTooltip(hitInfo?.items);
+            if (!skipCustomTooltipRedraw) {
+              this.drawCustomTooltip(hitInfo?.items);
+            }
             this.setCustomTooltipLayoutPosition(hitInfo, e);
           } else {
             this.setTooltipLayoutPosition(hitInfo, e);
@@ -94,6 +120,8 @@ const modules = {
 
         this.hideTooltipDOM();
       }
+
+      this._lastHoverSig = hoverSig;
 
       if (this.dragInfoBackup) {
         this.drawSelectionArea(this.dragInfoBackup);
@@ -157,6 +185,9 @@ const modules = {
 
         this.tooltipClear();
       }
+
+      // 다음 hover 진입 시 fast path 가 stale 시그니처로 잘못 매치되지 않도록 초기화한다.
+      this._lastHoverSig = '';
 
       // 다음 hover 시작 시 레이아웃 변화를 반영하도록 캐시를 무효화한다.
       this.invalidateClientRectCache();
@@ -1255,6 +1286,24 @@ const modules = {
         ? tooltipOpt?.formatter
         : tooltipOpt?.formatter?.value;
 
+    // 동일 itemData 객체에 대한 포맷 결과를 캐시한다.
+    // 데이터가 새 배열/새 객체로 갱신되면 WeakMap 키가 사라져 자동 GC되므로 무효화도 자동.
+    // 같은 mousemove 윈도우 안에서 hover 중 큰 비용(고객 value formatter; big.js 등)을 1회만 부담.
+    const useCache =
+      itemData !== null && typeof itemData === 'object' && tooltipValueFormatter;
+    if (useCache) {
+      if (!this._tooltipValueCache) {
+        this._tooltipValueCache = new WeakMap();
+      }
+      const bucket = this._tooltipValueCache.get(itemData);
+      if (bucket !== undefined) {
+        const cached = bucket[seriesId];
+        if (cached !== undefined) {
+          return cached;
+        }
+      }
+    }
+
     let formattedTxt = value;
     if (tooltipValueFormatter) {
       if (opt.type === 'pie') {
@@ -1291,6 +1340,15 @@ const modules = {
       } else {
         formattedTxt = numberWithComma(value);
       }
+    }
+
+    if (useCache) {
+      let bucket = this._tooltipValueCache.get(itemData);
+      if (!bucket) {
+        bucket = Object.create(null);
+        this._tooltipValueCache.set(itemData, bucket);
+      }
+      bucket[seriesId] = formattedTxt;
     }
 
     return formattedTxt;


### PR DESCRIPTION
### 개요
chartOption.tooltip.formatter.html 사용 환경에서 mousemove 처리 비용 분석 결과,
`drawCustomTooltip`, `findHitItem > getFormattedTooltipValue`, `element.line > findGraphData` 에서 CPU 사용률이 높음을 확인함 

### 변경내역
1. Hover 했던 아이템 기억 (plugins.interaction.js)
   - onMouseMove에 hitId|sId:dataIndex 형태의 시그니처를 두고, 직전과 동일 + tooltipDOM이 가시 상태일 때 drawCustomTooltip 한 줄만 스킵
2. getFormattedTooltipValue WeakMap 캐시(plugins.interaction.js)
   -  value formatter가 설정된 경우에만 캐시 사용 (기본 numberWithComma 분기는 우회).
   - 데이터가 새 배열/새 point 객체로 갱신되면 WeakMap 키가 자동 소멸 → GC.
3. findGraphData의 valid-data filter 캐시 (element.line.js)
4. chart.update()의 캐시 무효화 (chart.core.js)

### 메모리 영향
<img width="1135" height="187" alt="image" src="https://github.com/user-attachments/assets/8f423f1f-fddf-4bb1-874f-d351e4827814" />

### 성능 측정 결과
워크로드: docs/views/lineChart/example/CustomTooltip.vue (500 시리즈, value formatter + heavy html formatter, 150 mousemove dispatch, 35ms 간격
<img width="1113" height="365" alt="image" src="https://github.com/user-attachments/assets/005184fe-ed4f-42e8-b4a6-4a9c59d781fc" />
