### PR TITLE
feat(tabPanel): 활성화된 적 있는 탭만 mount하는 lazy prop 추가

### DIFF
--- a/docs/views/tab/api/tabs.md
+++ b/docs/views/tab/api/tabs.md
@@ -42,5 +42,6 @@
 |------|--------|------|------|------|
 | text | String, Number | null | <탭 패널>의 텍스트(라벨) | |
 | value | String, Number | null | <탭 패널>의 value | required |
+| lazy | Boolean | false | true면 한 번이라도 선택된 적 있는 <탭 패널>만 mount하고 이후 유지(방문 캐시). false는 모든 패널을 mount하고 v-show로 토글 | |
 
 

--- a/src/components/tabPanel/TabPanel.spec.js
+++ b/src/components/tabPanel/TabPanel.spec.js
@@ -54,5 +54,65 @@ describe('EvTabPanel Component', () => {
     it('기본 disabled는 false이다', () => {
       expect(EvTabPanel.props.disabled.default).toBe(false);
     });
+
+    it('기본 lazy는 false이다', () => {
+      expect(EvTabPanel.props.lazy.default).toBe(false);
+    });
+  });
+
+  describe('lazy', () => {
+    const mountWithSelectedRef = (props, selectedRef) =>
+      mount(EvTabPanel, {
+        props: { value: 'tab1', text: '탭1', ...props },
+        slots: { default: '<div class="panel-content">패널 내용</div>' },
+        global: { provide: { evTabs: selectedRef } },
+      });
+
+    it('lazy=false면 비선택 패널도 slot이 mount된다(기존 동작)', () => {
+      const wrapper = mountWithTabs({ value: 'tab1', lazy: false }, 'tab2');
+
+      expect(wrapper.find('.ev-tab-panel').exists()).toBe(true);
+      expect(wrapper.find('.panel-content').exists()).toBe(true);
+      expect(wrapper.find('.ev-tab-panel').isVisible()).toBe(false);
+    });
+
+    it('lazy=true면 한 번도 선택되지 않은 패널은 mount되지 않는다', () => {
+      const wrapper = mountWithTabs({ value: 'tab1', lazy: true }, 'tab2');
+
+      expect(wrapper.find('.ev-tab-panel').exists()).toBe(false);
+      expect(wrapper.find('.panel-content').exists()).toBe(false);
+    });
+
+    it('lazy=true에서 선택되면 mount되고, 비선택으로 바뀌어도 unmount되지 않는다(방문 캐시)', async () => {
+      const selected = ref('tab1');
+      const wrapper = mountWithSelectedRef({ value: 'tab1', lazy: true }, selected);
+
+      // 초기 선택 → mount
+      expect(wrapper.find('.ev-tab-panel').exists()).toBe(true);
+
+      // 다른 탭으로 전환 → v-show로 숨겨지지만 unmount되지 않고 slot 유지
+      selected.value = 'tab2';
+      await wrapper.vm.$nextTick();
+
+      const panel = wrapper.find('.ev-tab-panel');
+      expect(panel.exists()).toBe(true);
+      expect(panel.isVisible()).toBe(false);
+      expect(wrapper.find('.panel-content').exists()).toBe(true);
+    });
+
+    it('lazy=true에서 미방문 패널이 뒤늦게 선택되면 그 때 mount된다', async () => {
+      const selected = ref('tab2');
+      const wrapper = mountWithSelectedRef({ value: 'tab1', lazy: true }, selected);
+
+      // 아직 선택된 적 없음 → 미mount
+      expect(wrapper.find('.ev-tab-panel').exists()).toBe(false);
+
+      // 처음으로 선택됨 → mount + visible
+      selected.value = 'tab1';
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('.ev-tab-panel').exists()).toBe(true);
+      expect(wrapper.find('.ev-tab-panel').isVisible()).toBe(true);
+    });
   });
 });

--- a/src/components/tabPanel/TabPanel.vue
+++ b/src/components/tabPanel/TabPanel.vue
@@ -1,11 +1,11 @@
 <template>
-  <article v-show="isSelected" class="ev-tab-panel">
+  <article v-if="!lazy || hasBeenSelected" v-show="isSelected" class="ev-tab-panel">
     <slot />
   </article>
 </template>
 
 <script>
-import { computed, inject } from 'vue';
+import { computed, inject, ref, watch } from 'vue';
 
 export default {
   name: 'EvTabPanel',
@@ -23,14 +23,28 @@ export default {
       type: Boolean,
       default: false,
     },
+    // true면 한 번이라도 선택된 적 있는 탭만 mount하고 이후 유지(방문 캐시).
+    // 기본 false는 기존 동작(모든 패널 mount + v-show 토글)과 동일.
+    lazy: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: {},
   setup(props) {
     const evTabs = inject('evTabs', null);
     const isSelected = computed(() => props.value === evTabs.value);
+    // lazy 모드에서 한 번 선택되면 true로 고정되어 비선택 후에도 unmount되지 않는다.
+    const hasBeenSelected = ref(isSelected.value);
+    watch(isSelected, (selected) => {
+      if (selected) {
+        hasBeenSelected.value = true;
+      }
+    });
 
     return {
       isSelected,
+      hasBeenSelected,
     };
   },
 };


### PR DESCRIPTION
## 배경

소비 프로젝트의 슬라이드 상세(도메인 Detail)에서 `ev-tabs`를 쓸 때, 활성 탭뿐 아니라 **모든 탭의 내부 컴포넌트가 동시에 mount**되어 차트·그리드·에디터가 한꺼번에 초기화되는 성능 문제가 있다. 현재 `ev-tab-panel`은 비활성 탭을 `v-show`로 숨기기만 할 뿐 컴포넌트를 mount 상태로 유지하기 때문이다.

## 변경

`ev-tab-panel`에 opt-in `lazy` prop을 추가한다.

- `lazy=true`: 한 번이라도 선택된 적 있는 탭만 mount하고, 이후 비선택이 되어도 unmount하지 않는다(방문 캐시). 처음엔 활성 탭만 mount되어 비활성 탭의 무거운 컴포넌트 초기화 비용을 막는다.
- `lazy=false`(기본값): 기존 동작(모든 패널 mount + `v-show` 토글)과 완전히 동일 → 기존 소비처 무영향.

구현은 `v-if="!lazy || hasBeenSelected"`로 마운트를 게이팅하고, `hasBeenSelected`는 한 번 선택되면 `true`로 고정한다.

## 테스트

`TabPanel.spec.js`에 케이스 추가:
- 기본 `lazy=false`에서 비선택 패널도 mount되는지(기존 동작 회귀 가드)
- `lazy=true`에서 미방문 패널 미mount → 선택 시 mount → 비선택 후에도 유지(방문 캐시)
- 미방문 패널이 뒤늦게 선택되면 그 때 mount

전체 11개 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)