### PR TITLE
feat: Chart > DragSelection > canvas 바깥에서부터 드래그가능하도록 수정 필요

### DIFF
--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -243,6 +243,7 @@ const chartData =
 | keepDisplay | Boolean                     | true      | 드래그 후 선택영역 유지 여부 | true / false |
 | fillColor   | Hex, RGB, RGBA Code(String) | '#38ACEC' | 선택 영역 색상               |              |
 | opacity     | Number                      | 0.65      | 선택 영역 불투명도           | 0 ~ 1        |
+| startArea   | String (CSS Selector)       | ''        | drag-select를 시작할 수 있는 영역의 CSS 셀렉터. 차트의 조상 요소에서 탐색하며, 미지정하거나 일치하는 조상이 없으면 캔버스 안에서만 시작할 수 있습니다. | '.chart-wrapper' |
 
 #### tooltip
 

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -243,7 +243,7 @@ const chartData =
 | keepDisplay | Boolean                     | true      | 드래그 후 선택영역 유지 여부 | true / false |
 | fillColor   | Hex, RGB, RGBA Code(String) | '#38ACEC' | 선택 영역 색상               |              |
 | opacity     | Number                      | 0.65      | 선택 영역 불투명도           | 0 ~ 1        |
-| startArea   | String (CSS Selector)       | ''        | drag-select를 시작할 수 있는 영역의 CSS 셀렉터. 차트의 조상 요소에서 탐색하며, 미지정하거나 일치하는 조상이 없으면 캔버스 안에서만 시작할 수 있습니다. | '.chart-wrapper' |
+| startArea   | String (CSS Selector)       | ''        | drag-select를 시작할 수 있는 영역의 CSS 셀렉터. 차트의 조상 요소에서 탐색하며, 미지정하거나 일치하는 조상이 없으면 캔버스 안에서만 시작할 수 있습니다. 여러 차트를 사용할 때는 차트마다 고유한 셀렉터를 지정하세요(공통 조상을 지정하면 한 번의 드래그가 모든 차트의 selection을 트리거합니다). | '.chart-wrapper' |
 
 #### tooltip
 

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -515,6 +515,7 @@ chartData.value = {
 | keepDisplay | Boolean                     | true      | 드래그 후 선택영역 유지 여부 | true / false |
 | fillColor   | Hex, RGB, RGBA Code(String) | '#38ACEC' | 선택 영역 색상               |              |
 | opacity     | Number                      | 0.65      | 선택 영역 불투명도           | 0 ~ 1        |
+| startArea   | String (CSS Selector)       | ''        | drag-select를 시작할 수 있는 영역의 CSS 셀렉터. 차트의 조상 요소에서 탐색하며, 미지정하거나 일치하는 조상이 없으면 캔버스 안에서만 시작할 수 있습니다. | '.chart-wrapper' |
 
 
 ### 7. resize-timeout

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -515,7 +515,7 @@ chartData.value = {
 | keepDisplay | Boolean                     | true      | 드래그 후 선택영역 유지 여부 | true / false |
 | fillColor   | Hex, RGB, RGBA Code(String) | '#38ACEC' | 선택 영역 색상               |              |
 | opacity     | Number                      | 0.65      | 선택 영역 불투명도           | 0 ~ 1        |
-| startArea   | String (CSS Selector)       | ''        | drag-select를 시작할 수 있는 영역의 CSS 셀렉터. 차트의 조상 요소에서 탐색하며, 미지정하거나 일치하는 조상이 없으면 캔버스 안에서만 시작할 수 있습니다. | '.chart-wrapper' |
+| startArea   | String (CSS Selector)       | ''        | drag-select를 시작할 수 있는 영역의 CSS 셀렉터. 차트의 조상 요소에서 탐색하며, 미지정하거나 일치하는 조상이 없으면 캔버스 안에서만 시작할 수 있습니다. 여러 차트를 사용할 때는 차트마다 고유한 셀렉터를 지정하세요(공통 조상을 지정하면 한 번의 드래그가 모든 차트의 selection을 트리거합니다). | '.chart-wrapper' |
 
 
 ### 7. resize-timeout

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -252,9 +252,11 @@ const chartData =
 | fillColor | Hex, RGB, RGBA Code(String) | '#38ACEC' | 선택 영역 색상 | |
 | opacity | Number | 0.65 | 선택 영역 불투명도 | 0 ~ 1 |
 | startArea | String (CSS Selector) | '' | drag-select를 시작할 수 있는 영역의 CSS 셀렉터. 차트의 조상 요소에서 탐색하며, 미지정하거나 일치하는 조상이 없으면 캔버스 안에서만 시작할 수 있습니다. 여러 차트를 사용할 때는 차트마다 고유한 셀렉터를 지정하세요(공통 조상을 지정하면 한 번의 드래그가 모든 차트의 selection을 트리거합니다). | '.chart-wrapper' |
+| displayFromStartArea | Boolean | false | (scatter, PC 전용) 드래그 선택 영역을 캔버스 가장자리가 아니라 `startArea`에서 드래그를 시작한 지점부터 표시합니다. `startArea`가 지정되어야 동작합니다. 선택되는 데이터·`drag-select` range 페이로드는 영향받지 않고 화면 표시만 달라집니다. | true / false |
 
 - PC버전에서는 drag, Mobile에서는 touch로 선택 영역을 지정할 수 있습니다.
 - `startArea`를 지정하면 캔버스 바깥(지정한 영역 내부)에서 드래그를 시작해도 포인터가 캔버스에 진입하는 순간 선택이 시작됩니다.
+- `displayFromStartArea`를 `true`로 지정하면 `startArea`를 덮는 전용 캔버스(`pointer-events: none`)에 선택 영역을 그려, 드래그를 시작한 지점부터 사각형이 표시됩니다. 이때 `startArea` 요소가 `position: static`이면 라이브러리가 자동으로 `position: relative`로 설정하고 차트 destroy 시 원복합니다.
 
 #### tooltip
 

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -251,7 +251,7 @@ const chartData =
 | size | number | 50 | 모바일에서 선택 영역 크기 | only mobile |
 | fillColor | Hex, RGB, RGBA Code(String) | '#38ACEC' | 선택 영역 색상 | |
 | opacity | Number | 0.65 | 선택 영역 불투명도 | 0 ~ 1 |
-| startArea | String (CSS Selector) | '' | drag-select를 시작할 수 있는 영역의 CSS 셀렉터. 차트의 조상 요소에서 탐색하며, 미지정하거나 일치하는 조상이 없으면 캔버스 안에서만 시작할 수 있습니다. | '.chart-wrapper' |
+| startArea | String (CSS Selector) | '' | drag-select를 시작할 수 있는 영역의 CSS 셀렉터. 차트의 조상 요소에서 탐색하며, 미지정하거나 일치하는 조상이 없으면 캔버스 안에서만 시작할 수 있습니다. 여러 차트를 사용할 때는 차트마다 고유한 셀렉터를 지정하세요(공통 조상을 지정하면 한 번의 드래그가 모든 차트의 selection을 트리거합니다). | '.chart-wrapper' |
 
 - PC버전에서는 drag, Mobile에서는 touch로 선택 영역을 지정할 수 있습니다.
 - `startArea`를 지정하면 캔버스 바깥(지정한 영역 내부)에서 드래그를 시작해도 포인터가 캔버스에 진입하는 순간 선택이 시작됩니다.

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -251,8 +251,10 @@ const chartData =
 | size | number | 50 | 모바일에서 선택 영역 크기 | only mobile |
 | fillColor | Hex, RGB, RGBA Code(String) | '#38ACEC' | 선택 영역 색상 | |
 | opacity | Number | 0.65 | 선택 영역 불투명도 | 0 ~ 1 |
+| startArea | String (CSS Selector) | '' | drag-select를 시작할 수 있는 영역의 CSS 셀렉터. 차트의 조상 요소에서 탐색하며, 미지정하거나 일치하는 조상이 없으면 캔버스 안에서만 시작할 수 있습니다. | '.chart-wrapper' |
 
 - PC버전에서는 drag, Mobile에서는 touch로 선택 영역을 지정할 수 있습니다.
+- `startArea`를 지정하면 캔버스 바깥(지정한 영역 내부)에서 드래그를 시작해도 포인터가 캔버스에 진입하는 순간 선택이 시작됩니다.
 
 #### tooltip
 

--- a/docs/views/scatterChart/example/Event.vue
+++ b/docs/views/scatterChart/example/Event.vue
@@ -101,6 +101,7 @@ export default {
         use: true,
         keepDisplay: true,
         startArea: '.case',
+        displayFromStartArea: true,
       },
       axesX: [
         {

--- a/docs/views/scatterChart/example/Event.vue
+++ b/docs/views/scatterChart/example/Event.vue
@@ -100,6 +100,7 @@ export default {
       dragSelection: {
         use: true,
         keepDisplay: true,
+        startArea: '.case',
       },
       axesX: [
         {

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -1785,6 +1785,12 @@ class EvChart {
 
     this.render(renderHitInfo);
 
+    // displayFromStartArea 전용 캔버스는 render로 비워지지 않으므로, 재렌더마다 startArea 크기에
+    // 맞춰 갱신(클리어 포함)한 뒤 드래그 영역을 다시 그린다.
+    if (this.dragDisplayCanvas) {
+      this.refreshDragDisplayCanvas();
+    }
+
     const isDragMove = this.dragInfo && this.drawSelectionArea;
     if (isDragMove) {
       this.drawSelectionArea(this.dragInfo);
@@ -1884,6 +1890,9 @@ class EvChart {
     // resize 는 캔버스를 막 리사이즈해 display 가 비워진 상태 → worker 비동기 합성을 기다리면 깜빡인다.
     // 이 프레임은 main 으로 동기 렌더한다(steady-state tick 은 계속 worker 사용).
     this.drawChart(undefined, true);
+    if (this.dragDisplayCanvas) {
+      this.refreshDragDisplayCanvas();
+    }
     if (this.dragInfoBackup) {
       this.drawSelectionArea?.(this.dragInfoBackup);
     }
@@ -2132,6 +2141,18 @@ class EvChart {
       window.removeEventListener('click', this.dragTouchSelectionEvent);
       if (this.invalidateRectOnScroll) {
         window.removeEventListener('scroll', this.invalidateRectOnScroll, { capture: true });
+      }
+
+      // displayFromStartArea 전용 캔버스 제거 및 startArea position 원복
+      if (this.dragDisplayCanvas) {
+        this.dragDisplayCanvas.parentNode?.removeChild(this.dragDisplayCanvas);
+        this.dragDisplayCanvas = null;
+        this.dragDisplayCtx = null;
+        this.dragDisplayOffset = null;
+      }
+      if (this.dragStartTarget && this.dragStartAreaPrevPosition !== undefined) {
+        this.dragStartTarget.style.position = this.dragStartAreaPrevPosition;
+        this.dragStartAreaPrevPosition = undefined;
       }
     }
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -2127,7 +2127,7 @@ class EvChart {
       this.overlayCanvas.removeEventListener('mouseleave', this.onMouseLeave);
       this.overlayCanvas.removeEventListener('dblclick', this.onDblClick);
       this.overlayCanvas.removeEventListener('click', this.onClick);
-      this.overlayCanvas.removeEventListener('mousedown', this.onMouseDown);
+      this.dragStartTarget?.removeEventListener('mousedown', this.onMouseDown);
       this.overlayCanvas.removeEventListener('wheel', this.onWheel);
       window.removeEventListener('click', this.dragTouchSelectionEvent);
       if (this.invalidateRectOnScroll) {

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -833,8 +833,6 @@ const modules = {
     // displayFromStartArea가 활성화된 경우, 전용 캔버스에 raw(미clamp) displayRect를 그린다.
     // 그 외에는 기존과 동일하게 overlayCanvas에 clamped rect를 그린다.
     const useDedicated = !!this.dragDisplayCanvas;
-    const { xsp, ysp, width, height, range } =
-      useDedicated && dragInfo.displayRect ? dragInfo.displayRect : dragInfo;
     const ctx = useDedicated ? this.dragDisplayCtx : this.overlayCtx;
     const { fillColor, opacity } = this.options.dragSelection;
 
@@ -862,25 +860,65 @@ const modules = {
     ctx.fillStyle = fillColor;
     ctx.globalAlpha = opacity;
 
-    if (isEqual(newRange, range)) {
-      ctx.fillRect(xsp + offsetX, ysp + offsetY, width, height);
+    if (useDedicated && dragInfo.displayRect) {
+      // raw displayRect는 chart 영역을 벗어나 startArea까지 뻗는 픽셀 꼬리를 포함한다.
+      // resize(keepDisplay) 시 chart 영역 portion(clamped rect)만 chart-range 비율로 재스케일하고,
+      // startArea로 뻗은 꼬리는 chart range와 무관하므로 픽셀 길이를 그대로 유지한다.
+      // resize가 없으면(newRange === range) 아래 계산은 raw displayRect를 그대로 복원한다.
+      const raw = dragInfo.displayRect;
+      const { xsp, ysp, width, height, range } = dragInfo;
+
+      let clampedXsp = xsp;
+      let clampedYsp = ysp;
+      let clampedWidth = width;
+      let clampedHeight = height;
+      if (!isEqual(newRange, range)) {
+        const rectWidth = range.x2 - range.x1;
+        const rectHeight = range.y2 - range.y1;
+        const newRectWidth = newRange.x2 - newRange.x1;
+        const newRectHeight = newRange.y2 - newRange.y1;
+
+        clampedXsp = newRange.x1 + newRectWidth * ((xsp - range.x1) / rectWidth);
+        clampedYsp = newRange.y1 + newRectHeight * ((ysp - range.y1) / rectHeight);
+        clampedWidth = newRectWidth * (width / rectWidth);
+        clampedHeight = newRectHeight * (height / rectHeight);
+      }
+
+      // clamped rect와 raw rect의 픽셀 차이(startArea로 뻗은 꼬리)를 재스케일된 clamped rect에 다시 더한다.
+      const leftExt = xsp - raw.xsp;
+      const topExt = ysp - raw.ysp;
+      const rightExt = raw.xsp + raw.width - (xsp + width);
+      const bottomExt = raw.ysp + raw.height - (ysp + height);
+
+      ctx.fillRect(
+        clampedXsp - leftExt + offsetX,
+        clampedYsp - topExt + offsetY,
+        clampedWidth + leftExt + rightExt,
+        clampedHeight + topExt + bottomExt,
+      );
     } else {
-      const rectWidth = range.x2 - range.x1;
-      const rectHeight = range.y2 - range.y1;
-      const newRectWidth = newRange.x2 - newRange.x1;
-      const newRectHeight = newRange.y2 - newRange.y1;
+      const { xsp, ysp, width, height, range } = dragInfo;
 
-      const ratioX = (xsp - range.x1) / rectWidth;
-      const ratioY = (ysp - range.y1) / rectHeight;
-      const newXsp = newRange.x1 + newRectWidth * ratioX;
-      const newYsp = newRange.y1 + newRectHeight * ratioY;
+      if (isEqual(newRange, range)) {
+        ctx.fillRect(xsp + offsetX, ysp + offsetY, width, height);
+      } else {
+        const rectWidth = range.x2 - range.x1;
+        const rectHeight = range.y2 - range.y1;
+        const newRectWidth = newRange.x2 - newRange.x1;
+        const newRectHeight = newRange.y2 - newRange.y1;
 
-      const ratioWidth = width / rectWidth;
-      const ratioHeight = height / rectHeight;
-      const newWidth = newRectWidth * ratioWidth;
-      const newHeight = newRectHeight * ratioHeight;
+        const ratioX = (xsp - range.x1) / rectWidth;
+        const ratioY = (ysp - range.y1) / rectHeight;
+        const newXsp = newRange.x1 + newRectWidth * ratioX;
+        const newYsp = newRange.y1 + newRectHeight * ratioY;
 
-      ctx.fillRect(newXsp + offsetX, newYsp + offsetY, newWidth, newHeight);
+        const ratioWidth = width / rectWidth;
+        const ratioHeight = height / rectHeight;
+        const newWidth = newRectWidth * ratioWidth;
+        const newHeight = newRectHeight * ratioHeight;
+
+        ctx.fillRect(newXsp + offsetX, newYsp + offsetY, newWidth, newHeight);
+      }
     }
 
     ctx.globalAlpha = 1;

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -583,7 +583,13 @@ const modules = {
     this.overlayCanvas.addEventListener('mouseleave', this.onMouseLeave);
     this.overlayCanvas.addEventListener('dblclick', this.onDblClick);
     this.overlayCanvas.addEventListener('click', this.onClick);
-    this.overlayCanvas.addEventListener('mousedown', this.onMouseDown);
+
+    // dragSelection.startArea(CSS 셀렉터)가 지정되면 해당 영역에서 시작한 드래그도 인식한다.
+    // 기본값은 overlayCanvas이므로 캔버스 안에서 시작해야만 동작한다(기존 동작).
+    // 셀렉터는 차트 자신의 조상에서 탐색하므로 멀티 차트에서도 각자 자신의 영역만 바라본다.
+    const { startArea } = this.options.dragSelection;
+    this.dragStartTarget = (startArea && this.target.closest(startArea)) || this.overlayCanvas;
+    this.dragStartTarget.addEventListener('mousedown', this.onMouseDown);
 
     this.dragTouchSelectionEvent = (e) => this.dragTouchSelectionDestroy(e);
     window.addEventListener('click', this.dragTouchSelectionEvent);
@@ -603,7 +609,9 @@ const modules = {
    * @returns {undefined}
    */
   dragStart(evt, type) {
-    let [offsetX, offsetY] = this.getMousePosition(evt);
+    const [rawOffsetX, rawOffsetY, canvasWidth, canvasHeight] = this.getMousePosition(evt);
+    let offsetX = rawOffsetX;
+    let offsetY = rawOffsetY;
     const chartRect = this.chartRect;
     const labelOffset = this.labelOffset;
     const range = {
@@ -635,14 +643,43 @@ const modules = {
       range,
     };
 
+    // 포인터가 캔버스(차트 영역) 안에 있는지 판별
+    const isInsideCanvas = (x, y) => x >= 0 && x <= canvasWidth && y >= 0 && y <= canvasHeight;
+
+    // 드래그 활성화 여부. 캔버스 바깥에서 시작한 경우 포인터가 캔버스에 진입할 때 활성화된다.
+    let isActivated = false;
+    const activate = () => {
+      if (isActivated) {
+        return;
+      }
+      isActivated = true;
+      this.removeSelectionArea();
+    };
+
+    // 캔버스 안에서 드래그를 시작했다면 기존 동작과 동일하게 즉시 활성화
+    if (isInsideCanvas(rawOffsetX, rawOffsetY)) {
+      activate();
+    }
+
     /**
      * Calculate drag-section position and size, and drawing drag-section
      *
      * @returns {undefined}
      */
     const dragMove = (e) => {
-      e.preventDefault();
       const [aOffsetX, aOffsetY] = this.getMousePosition(e);
+
+      // 캔버스 바깥에서 시작한 드래그는 포인터가 캔버스에 진입한 순간 활성화한다.
+      // 진입 전에는 preventDefault를 호출하지 않아 페이지의 다른 인터랙션을 방해하지 않는다.
+      if (!isActivated) {
+        if (isInsideCanvas(aOffsetX, aOffsetY)) {
+          activate();
+        } else {
+          return;
+        }
+      }
+
+      e.preventDefault();
       const dragInfo = this.dragInfo;
       const { xcp, ycp, range: aRange } = dragInfo;
 
@@ -695,7 +732,7 @@ const modules = {
     const dragEnd = (e) => {
       const dragInfo = this.dragInfo;
 
-      if (dragInfo?.isMove && dragInfo?.width > 1 && dragInfo?.height > 1) {
+      if (isActivated && dragInfo?.isMove && dragInfo?.width > 1 && dragInfo?.height > 1) {
         const args = {
           e,
           data: this.findSelectedItems(dragInfo),

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -532,12 +532,6 @@ const modules = {
       const { dragSelection, type } = this.options;
 
       if (dragSelection.use && (type === 'scatter' || type === 'line' || type === 'heatMap')) {
-        // displayFromStartArea: 텍스트가 포함될 수 있는 startArea 위에서 드래그를 시작하면
-        // 브라우저가 텍스트를 선택하므로, mousedown 기본동작을 막아 텍스트 드래그 선택을 방지한다.
-        // (click 이벤트는 그대로 발생하므로 selectItem 등에는 영향이 없다.)
-        if (this.dragDisplayCanvas) {
-          e.preventDefault();
-        }
         this.removeSelectionArea();
         this.dragStart(e, type);
       }
@@ -633,6 +627,17 @@ const modules = {
     if (this.dragDisplayCanvas) {
       this.refreshDragDisplayCanvas();
     }
+
+    // displayFromStartArea: startArea 텍스트가 드래그 중 선택되는 것을 막는다.
+    // mousedown의 preventDefault는 포커스 이동까지 막아 startArea 안의 button/input 등
+    // 포커스 가능한 자식이 동작하지 않으므로, 포커스에 영향이 없는 user-select만 끈다.
+    // 드래그가 끝나면(dragEnd) 원래 인라인 값으로 되돌린다.
+    let prevUserSelect;
+    if (this.dragDisplayCanvas) {
+      prevUserSelect = this.dragStartTarget.style.userSelect;
+      this.dragStartTarget.style.userSelect = 'none';
+    }
+
     const [rawOffsetX, rawOffsetY, canvasWidth, canvasHeight] = this.getMousePosition(evt);
     let offsetX = rawOffsetX;
     let offsetY = rawOffsetY;
@@ -806,6 +811,10 @@ const modules = {
       }
 
       this.dragInfo = null;
+
+      if (prevUserSelect !== undefined) {
+        this.dragStartTarget.style.userSelect = prevUserSelect;
+      }
 
       window.removeEventListener('mousemove', dragMove);
       window.removeEventListener('mouseup', dragEnd);

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -123,7 +123,10 @@ const modules = {
 
       this._lastHoverSig = hoverSig;
 
-      if (this.dragInfoBackup) {
+      // 전용 드래그 캔버스를 쓰면 keepDisplay 영역이 그 캔버스에 그대로 남아 있어(매 hover의
+      // overlayClear는 메인 overlay만 비움) 여기서 다시 그릴 필요가 없다.
+      // (clear 없이 다시 그리면 opacity가 누적되어 짙어진다.)
+      if (this.dragInfoBackup && !this.dragDisplayCanvas) {
         this.drawSelectionArea(this.dragInfoBackup);
       }
 
@@ -529,6 +532,12 @@ const modules = {
       const { dragSelection, type } = this.options;
 
       if (dragSelection.use && (type === 'scatter' || type === 'line' || type === 'heatMap')) {
+        // displayFromStartArea: 텍스트가 포함될 수 있는 startArea 위에서 드래그를 시작하면
+        // 브라우저가 텍스트를 선택하므로, mousedown 기본동작을 막아 텍스트 드래그 선택을 방지한다.
+        // (click 이벤트는 그대로 발생하므로 selectItem 등에는 영향이 없다.)
+        if (this.dragDisplayCanvas) {
+          e.preventDefault();
+        }
         this.removeSelectionArea();
         this.dragStart(e, type);
       }
@@ -587,9 +596,21 @@ const modules = {
     // dragSelection.startArea(CSS 셀렉터)가 지정되면 해당 영역에서 시작한 드래그도 인식한다.
     // 기본값은 overlayCanvas이므로 캔버스 안에서 시작해야만 동작한다(기존 동작).
     // 셀렉터는 차트 자신의 조상에서 탐색하므로 멀티 차트에서도 각자 자신의 영역만 바라본다.
-    const { startArea } = this.options.dragSelection;
+    const { startArea, displayFromStartArea } = this.options.dragSelection;
     this.dragStartTarget = (startArea && this.target.closest(startArea)) || this.overlayCanvas;
     this.dragStartTarget.addEventListener('mousedown', this.onMouseDown);
+
+    // displayFromStartArea: scatter(PC)에서 드래그 영역을 startArea 지점부터 표시하기 위한 전용 캔버스.
+    // overlayCanvas는 .ev-chart-container(overflow:hidden) 안에 있어 캔버스 밖으로 그릴 수 없으므로,
+    // startArea를 덮는 별도의 pointer-events:none 캔버스가 필요하다.
+    if (
+      displayFromStartArea &&
+      this.options.type === 'scatter' &&
+      !this.isMobile &&
+      this.dragStartTarget !== this.overlayCanvas
+    ) {
+      this.createDragDisplayCanvas();
+    }
 
     this.dragTouchSelectionEvent = (e) => this.dragTouchSelectionDestroy(e);
     window.addEventListener('click', this.dragTouchSelectionEvent);
@@ -609,6 +630,9 @@ const modules = {
    * @returns {undefined}
    */
   dragStart(evt, type) {
+    if (this.dragDisplayCanvas) {
+      this.refreshDragDisplayCanvas();
+    }
     const [rawOffsetX, rawOffsetY, canvasWidth, canvasHeight] = this.getMousePosition(evt);
     let offsetX = rawOffsetX;
     let offsetY = rawOffsetY;
@@ -656,8 +680,9 @@ const modules = {
       this.removeSelectionArea();
     };
 
-    // 캔버스 안에서 드래그를 시작했다면 기존 동작과 동일하게 즉시 활성화
-    if (isInsideCanvas(rawOffsetX, rawOffsetY)) {
+    // 캔버스 안에서 드래그를 시작했다면 기존 동작과 동일하게 즉시 활성화.
+    // displayFromStartArea(전용 캔버스)면 startArea 지점부터 그려야 하므로 시작 즉시 활성화한다.
+    if (isInsideCanvas(rawOffsetX, rawOffsetY) || this.dragDisplayCanvas) {
       activate();
     }
 
@@ -718,6 +743,19 @@ const modules = {
         dragInfo.width = Math.ceil(Math.abs(xep - xcp));
         dragInfo.height =
           type === 'scatter' ? Math.ceil(Math.abs(yep - ycp)) : aRange.y2 - aRange.y1;
+      }
+
+      // displayFromStartArea: 선택/range 계산용 clamped rect(위)와 별개로,
+      // startArea 지점부터 그리기 위한 raw(미clamp) rect를 별도로 보관한다.
+      // 선택 동작과 drag-select range 페이로드는 기존과 동일하게 유지된다.
+      if (this.dragDisplayCanvas && type === 'scatter') {
+        dragInfo.displayRect = {
+          xsp: Math.min(rawOffsetX, aOffsetX),
+          ysp: Math.min(rawOffsetY, aOffsetY),
+          width: Math.ceil(Math.abs(aOffsetX - rawOffsetX)),
+          height: Math.ceil(Math.abs(aOffsetY - rawOffsetY)),
+          range: aRange,
+        };
       }
 
       this.overlayClear();
@@ -782,9 +820,26 @@ const modules = {
    *
    * @returns {undefined}
    */
-  drawSelectionArea({ xsp, ysp, width, height, range }) {
-    const ctx = this.overlayCtx;
+  drawSelectionArea(dragInfo) {
+    // displayFromStartArea가 활성화된 경우, 전용 캔버스에 raw(미clamp) displayRect를 그린다.
+    // 그 외에는 기존과 동일하게 overlayCanvas에 clamped rect를 그린다.
+    const useDedicated = !!this.dragDisplayCanvas;
+    const { xsp, ysp, width, height, range } =
+      useDedicated && dragInfo.displayRect ? dragInfo.displayRect : dragInfo;
+    const ctx = useDedicated ? this.dragDisplayCtx : this.overlayCtx;
     const { fillColor, opacity } = this.options.dragSelection;
+
+    // 전용 캔버스는 차트 영역만 덮는 overlayCanvas와 원점이 다르다(startArea를 덮음).
+    // 차트 좌표 → 전용 캔버스 좌표 변환 오프셋은 geometry가 바뀌는 시점(dragStart/render/resize)에
+    // refreshDragDisplayCanvas에서 미리 측정·캐시한 값을 쓴다. 매 프레임 getBoundingClientRect를
+    // 호출하지 않아 layout thrashing을 피한다.
+    let offsetX = 0;
+    let offsetY = 0;
+    if (useDedicated) {
+      this.dragDisplayClear();
+      offsetX = this.dragDisplayOffset?.x ?? 0;
+      offsetY = this.dragDisplayOffset?.y ?? 0;
+    }
 
     const chartRect = this.chartRect;
     const labelOffset = this.labelOffset;
@@ -799,7 +854,7 @@ const modules = {
     ctx.globalAlpha = opacity;
 
     if (isEqual(newRange, range)) {
-      ctx.fillRect(xsp, ysp, width, height);
+      ctx.fillRect(xsp + offsetX, ysp + offsetY, width, height);
     } else {
       const rectWidth = range.x2 - range.x1;
       const rectHeight = range.y2 - range.y1;
@@ -816,10 +871,108 @@ const modules = {
       const newWidth = newRectWidth * ratioWidth;
       const newHeight = newRectHeight * ratioHeight;
 
-      ctx.fillRect(newXsp, newYsp, newWidth, newHeight);
+      ctx.fillRect(newXsp + offsetX, newYsp + offsetY, newWidth, newHeight);
     }
 
     ctx.globalAlpha = 1;
+  },
+
+  /**
+   * Create a dedicated drag-display canvas mounted on the startArea element.
+   * Used only when dragSelection.displayFromStartArea is on (scatter, PC).
+   *
+   * @returns {undefined}
+   */
+  createDragDisplayCanvas() {
+    const startAreaEl = this.dragStartTarget;
+    if (!startAreaEl || startAreaEl === this.overlayCanvas) {
+      return;
+    }
+
+    // 전용 캔버스의 절대배치/크기 기준이 startArea가 되도록, static이면 relative로 승격한다.
+    // (chart destroy 시 원래 inline 값으로 복원)
+    if (window.getComputedStyle(startAreaEl).position === 'static') {
+      this.dragStartAreaPrevPosition = startAreaEl.style.position;
+      startAreaEl.style.position = 'relative';
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.className = 'ev-chart-drag-display-canvas';
+    canvas.style.position = 'absolute';
+    canvas.style.top = '0px';
+    canvas.style.left = '0px';
+    // overlayCanvas(z-index:2)보다 위에서 그려져 선택 영역이 차트 위에 보이도록 한다.
+    canvas.style.zIndex = '3';
+    // 그리기 전용 — startArea의 다른 인터랙션을 막지 않는다(mousedown은 startArea가 처리).
+    canvas.style.pointerEvents = 'none';
+
+    startAreaEl.appendChild(canvas);
+
+    this.dragDisplayCanvas = canvas;
+    this.dragDisplayCtx = canvas.getContext('2d');
+
+    this.refreshDragDisplayCanvas();
+  },
+
+  /**
+   * Resize the dedicated drag-display canvas to cover the current startArea bounds.
+   * Called on creation and on chart render/resize.
+   *
+   * @returns {undefined}
+   */
+  refreshDragDisplayCanvas() {
+    if (!this.dragDisplayCanvas || !this.dragStartTarget) {
+      return;
+    }
+
+    const { width, height } = this.dragStartTarget.getBoundingClientRect();
+    const cssWidth = Math.max(1, Math.round(width));
+    const cssHeight = Math.max(1, Math.round(height));
+    const deviceWidth = cssWidth * this.pixelRatio;
+    const deviceHeight = cssHeight * this.pixelRatio;
+
+    if (
+      this.dragDisplayCanvas.width !== deviceWidth ||
+      this.dragDisplayCanvas.height !== deviceHeight
+    ) {
+      this.dragDisplayCanvas.width = deviceWidth;
+      this.dragDisplayCanvas.height = deviceHeight;
+      this.dragDisplayCanvas.style.width = `${cssWidth}px`;
+      this.dragDisplayCanvas.style.height = `${cssHeight}px`;
+    }
+
+    // canvas.width 변경은 transform을 초기화하므로 매번 재설정한다.
+    this.dragDisplayCtx.setTransform(this.pixelRatio, 0, 0, this.pixelRatio, 0, 0);
+    this.dragDisplayClear();
+
+    // 차트 좌표 → 전용 캔버스 좌표 오프셋을 여기서 한 번만 측정해 캐시한다.
+    // 주의: 차트와 startArea 사이 조상에 CSS transform이 걸리거나 드래그 도중 startArea가
+    // 차트에 대해 내부 스크롤되면 오프셋이 어긋날 수 있다(일반적 사용에선 발생하지 않음).
+    const overlayRect = this.overlayCanvas.getBoundingClientRect();
+    const canvasRect = this.dragDisplayCanvas.getBoundingClientRect();
+    this.dragDisplayOffset = {
+      x: overlayRect.left - canvasRect.left,
+      y: overlayRect.top - canvasRect.top,
+    };
+  },
+
+  /**
+   * Clear the dedicated drag-display canvas.
+   *
+   * @returns {undefined}
+   */
+  dragDisplayClear() {
+    if (!this.dragDisplayCtx || !this.dragDisplayCanvas) {
+      return;
+    }
+
+    const ratio = this.pixelRatio < 1 ? this.pixelRatio : 1;
+    this.dragDisplayCtx.clearRect(
+      0,
+      0,
+      this.dragDisplayCanvas.width / ratio,
+      this.dragDisplayCanvas.height / ratio,
+    );
   },
 
   /** Remove drag selection area
@@ -828,6 +981,9 @@ const modules = {
   removeSelectionArea() {
     this.dragInfoBackup = null;
     this.overlayClear();
+    if (this.dragDisplayCanvas) {
+      this.dragDisplayClear();
+    }
   },
 
   /**

--- a/src/components/chart/plugins/plugins.interaction.spec.js
+++ b/src/components/chart/plugins/plugins.interaction.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import modules from './plugins.interaction';
 
 /**
@@ -407,5 +407,189 @@ describe('plugins.interaction buildLabelValidMask', () => {
     });
 
     expect(Array.from(chart.buildLabelValidMask())).toEqual([1]);
+  });
+});
+
+/**
+ * displayFromStartArea(전용 드래그 캔버스) 회귀 테스트.
+ * drawSelectionArea 시그니처 변경(구조분해 → dragInfo 객체)과,
+ * 전용 캔버스에 raw rect를 그릴 때의 좌표 오프셋 가산(xsp + offsetX) 로직을 격리 검증한다.
+ */
+const makeCtx = () => ({
+  fillStyle: '',
+  globalAlpha: 1,
+  fillRect: vi.fn(),
+  clearRect: vi.fn(),
+});
+
+const createDrawChart = (overrides = {}) =>
+  Object.assign(Object.create(modules), {
+    options: { dragSelection: { fillColor: '#ff0000', opacity: 0.3 } },
+    chartRect: { x1: 0, x2: 100, y1: 0, y2: 100 },
+    labelOffset: { left: 0, right: 0, top: 0, bottom: 0 },
+    overlayCtx: makeCtx(),
+    pixelRatio: 1,
+    ...overrides,
+  });
+
+describe('plugins.interaction drawSelectionArea 시그니처 호환 (overlay 경로)', () => {
+  it('단일 dragInfo 객체를 받아 overlayCtx에 clamped rect를 그린다', () => {
+    // 전용 캔버스가 없으면(기존 동작) overlayCtx에 오프셋 없이 그대로 그린다.
+    const chart = createDrawChart();
+    // labelOffset 0 + chartRect 0..100 → newRange === range 이므로 재스케일 없이 그대로.
+    const range = { x1: 0, x2: 100, y1: 0, y2: 100 };
+
+    chart.drawSelectionArea({ xsp: 10, ysp: 20, width: 30, height: 40, range });
+
+    expect(chart.overlayCtx.fillRect).toHaveBeenCalledTimes(1);
+    expect(chart.overlayCtx.fillRect).toHaveBeenCalledWith(10, 20, 30, 40);
+    expect(chart.overlayCtx.fillStyle).toBe('#ff0000');
+    expect(chart.overlayCtx.globalAlpha).toBe(1); // 그린 뒤 1로 복원
+  });
+});
+
+describe('plugins.interaction drawSelectionArea displayFromStartArea 좌표 오프셋', () => {
+  it('raw displayRect를 전용 캔버스에 (raw + offset) 위치로 그린다 (리사이즈 없음)', () => {
+    // startArea가 캔버스 위/왼쪽이라 raw 좌표가 음수여도 offset 가산 후 캔버스 내부 양수로 매핑된다.
+    const range = { x1: 0, x2: 100, y1: 0, y2: 100 };
+    const chart = createDrawChart({
+      dragDisplayCanvas: { width: 200, height: 150 },
+      dragDisplayCtx: makeCtx(),
+      dragDisplayOffset: { x: 20, y: 10 },
+    });
+
+    chart.drawSelectionArea({
+      // 선택/range 계산용 clamped rect (캔버스 안)
+      xsp: 0,
+      ysp: 0,
+      width: 60,
+      height: 50,
+      range,
+      // 그리기용 raw rect (startArea까지 뻗어 음수 시작)
+      displayRect: { xsp: -20, ysp: -10, width: 80, height: 60, range },
+    });
+
+    // raw.xsp + offsetX = -20 + 20 = 0, raw.ysp + offsetY = -10 + 10 = 0, 크기는 raw 그대로
+    expect(chart.dragDisplayCtx.fillRect).toHaveBeenCalledWith(0, 0, 80, 60);
+    // overlay에는 그리지 않는다
+    expect(chart.overlayCtx.fillRect).not.toHaveBeenCalled();
+    // 그리기 전 전용 캔버스를 항상 clear (opacity 누적 방지)
+    expect(chart.dragDisplayCtx.clearRect).toHaveBeenCalledWith(0, 0, 200, 150);
+  });
+
+  it('dragDisplayOffset이 없으면 오프셋 0으로 동작한다 (?? 0 fallback)', () => {
+    const range = { x1: 0, x2: 100, y1: 0, y2: 100 };
+    const chart = createDrawChart({
+      dragDisplayCanvas: { width: 200, height: 150 },
+      dragDisplayCtx: makeCtx(),
+      // dragDisplayOffset 미설정
+    });
+
+    chart.drawSelectionArea({
+      xsp: 0,
+      ysp: 0,
+      width: 60,
+      height: 50,
+      range,
+      displayRect: { xsp: -20, ysp: -10, width: 80, height: 60, range },
+    });
+
+    expect(chart.dragDisplayCtx.fillRect).toHaveBeenCalledWith(-20, -10, 80, 60);
+  });
+
+  it('keepDisplay 리사이즈 시 chart portion만 재스케일하고 startArea 꼬리는 픽셀 유지 (#3 드리프트 보정)', () => {
+    // chartRect를 2배(0..200)로 키워 리사이즈 발생. dragInfo.range는 리사이즈 전(0..100).
+    const range = { x1: 0, x2: 100, y1: 0, y2: 100 };
+    const chart = createDrawChart({
+      chartRect: { x1: 0, x2: 200, y1: 0, y2: 200 },
+      dragDisplayCanvas: { width: 400, height: 400 },
+      dragDisplayCtx: makeCtx(),
+      dragDisplayOffset: { x: 100, y: 50 },
+    });
+
+    chart.drawSelectionArea({
+      // clamped rect: 옛 chart(0..100) 안에서 x 20..70, y 20..70
+      xsp: 20,
+      ysp: 20,
+      width: 50,
+      height: 50,
+      range,
+      // raw rect: startArea로 뻗어 x -10..80, y -5..70
+      // leftExt=30, topExt=25, rightExt=10, bottomExt=0
+      displayRect: { xsp: -10, ysp: -5, width: 90, height: 75, range },
+    });
+
+    // clamped 2x 재스케일 → (40,40,100,100), 꼬리(30/25/10/0) 픽셀 유지, offset(100,50) 가산
+    // x = 40 - 30 + 100 = 110, y = 40 - 25 + 50 = 65
+    // w = 100 + 30 + 10 = 140, h = 100 + 25 + 0 = 125
+    expect(chart.dragDisplayCtx.fillRect).toHaveBeenCalledWith(110, 65, 140, 125);
+  });
+});
+
+describe('plugins.interaction 전용 드래그 캔버스 라이프사이클', () => {
+  it('refreshDragDisplayCanvas는 overlay와 전용 캔버스 rect 차이로 오프셋을 캐시한다', () => {
+    const chart = createDrawChart({
+      dragStartTarget: { getBoundingClientRect: () => ({ width: 200, height: 150 }) },
+      dragDisplayCanvas: {
+        width: 0,
+        height: 0,
+        style: {},
+        getBoundingClientRect: () => ({ left: 60, top: 20 }),
+      },
+      dragDisplayCtx: { setTransform: vi.fn(), clearRect: vi.fn() },
+      overlayCanvas: { getBoundingClientRect: () => ({ left: 100, top: 50 }) },
+    });
+
+    chart.refreshDragDisplayCanvas();
+
+    // offset = overlayRect - canvasRect = (100-60, 50-20)
+    expect(chart.dragDisplayOffset).toEqual({ x: 40, y: 30 });
+    // startArea 크기에 맞춰 device 픽셀로 리사이즈 (pixelRatio 1)
+    expect(chart.dragDisplayCanvas.width).toBe(200);
+    expect(chart.dragDisplayCanvas.height).toBe(150);
+    expect(chart.dragDisplayCtx.setTransform).toHaveBeenCalledWith(1, 0, 0, 1, 0, 0);
+  });
+
+  it('refreshDragDisplayCanvas는 전용 캔버스가 없으면 아무 일도 하지 않는다', () => {
+    const chart = createDrawChart({
+      dragStartTarget: { getBoundingClientRect: () => ({ width: 10, height: 10 }) },
+    });
+    expect(() => chart.refreshDragDisplayCanvas()).not.toThrow();
+    expect(chart.dragDisplayOffset).toBeUndefined();
+  });
+
+  it('dragDisplayClear는 ctx/canvas가 없으면 아무 일도 하지 않는다', () => {
+    const chart = createDrawChart({ dragDisplayCtx: null, dragDisplayCanvas: null });
+    expect(() => chart.dragDisplayClear()).not.toThrow();
+  });
+
+  it('removeSelectionArea는 backup을 비우고 전용 캔버스도 clear 한다', () => {
+    const dragDisplayCtx = { clearRect: vi.fn() };
+    const overlayClear = vi.fn();
+    const chart = createDrawChart({
+      dragInfoBackup: { xsp: 1 },
+      overlayClear,
+      dragDisplayCanvas: { width: 100, height: 80 },
+      dragDisplayCtx,
+    });
+
+    chart.removeSelectionArea();
+
+    expect(chart.dragInfoBackup).toBeNull();
+    expect(overlayClear).toHaveBeenCalled();
+    expect(dragDisplayCtx.clearRect).toHaveBeenCalledWith(0, 0, 100, 80);
+  });
+
+  it('createDragDisplayCanvas는 startArea가 overlayCanvas와 같으면 전용 캔버스를 만들지 않는다', () => {
+    // 가드는 overlayCanvas와의 동일성 비교뿐이라 실제 canvas가 필요 없다.
+    const overlayCanvas = {};
+    const chart = createDrawChart({
+      dragStartTarget: overlayCanvas,
+      overlayCanvas,
+    });
+
+    chart.createDragDisplayCanvas();
+
+    expect(chart.dragDisplayCanvas).toBeUndefined();
   });
 });

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -215,6 +215,7 @@ const DEFAULT_OPTIONS = {
     fillColor: '#38ACEC',
     opacity: 0.65,
     startArea: '',
+    displayFromStartArea: false,
   },
   zoom: {
     bufferMemoryCnt: 100,

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -214,6 +214,7 @@ const DEFAULT_OPTIONS = {
     size: 50,
     fillColor: '#38ACEC',
     opacity: 0.65,
+    startArea: '',
   },
   zoom: {
     bufferMemoryCnt: 100,


### PR DESCRIPTION
## 배경

기존 `dragSelection`은 차트 canvas 위에서 `mousedown`으로 드래그를 시작해야만 selection으로 인식했다.
캔버스 바깥(차트 주변 여백/컨테이너)에서 드래그를 시작하면 동작하지 않는 불편함이 있었다.

## 변경 사항

차트 드래그 선택(`dragSelection`)을 **캔버스 바깥에서도** 시작할 수 있게 하고, 선택 영역을 **드래그 시작 지점부터** 그릴 수 있게 했다.

### 새 옵션 2개

| 옵션 | 타입 | 기본값 | 설명 |
|------|------|--------|------|
| `dragSelection.startArea` | CSS Selector | `''` | 드래그를 시작할 수 있는 영역. 차트를 감싼 바깥 요소를 지정하면 캔버스 밖에서도 드래그 선택이 시작된다. |
| `dragSelection.displayFromStartArea` | boolean | `false` | 선택 사각형을 드래그 시작 지점(캔버스 밖 포함)부터 그린다. **scatter + PC**에서만 동작. |

```js
options: {
  dragSelection: {
    use: true,
    startArea: '.chart-wrapper',   // 이 영역에서 드래그 시작 가능
    displayFromStartArea: true,    // 시작 지점부터 선택 사각형 표시
  },
}
```

## 기존 동작
https://github.com/user-attachments/assets/e76ba20a-4180-45dc-b0ad-d08ebbf93047

## 기대 동작
**`startArea`만 켰을 때**: 캔버스 바깥에서 드래그를 시작해도, 포인터가 차트 캔버스에 들어오는 순간 선택이 시작된다. 선택 결과·콜백은 기존과 동일.

https://github.com/user-attachments/assets/8dac4e08-4482-4ed6-bdc5-51646804961e  

**`displayFromStartArea: true`**: 드래그 시작 지점부터 바로 선택 사각형이 그려진다. (선택된 데이터 값은 차트 영역 기준으로 동일하게 계산됨)

https://github.com/user-attachments/assets/df84d162-8d76-47bc-b3ac-67b4893d8065

## 테스트 방법
1. scatter chart 예제(`docs/views/scatterChart/example/Event.vue`)에서 `dragSelection.startArea: '.case'` 적용 확인.
2. 차트 **바깥 여백**에서 드래그를 시작해 캔버스로 진입 → 선택 영역이 정상적으로 그려지는지 확인.
3. `startArea` 미지정 시 기존처럼 캔버스 안에서만 시작되는지 회귀 확인.

closes #2286