### PR TITLE
fix: Bar Chart > range 변경 시 max tip이 range 구간을 벗어나는 문제

### DIFF
--- a/src/components/chart/element/element.tip.js
+++ b/src/components/chart/element/element.tip.js
@@ -91,9 +91,31 @@ const modules = {
     }
 
     if (maxTipOpt.use && !isExistSelectedLabel) {
-      const maxSID = this.minMax[isHorizontal ? 'x' : 'y'][0].maxSID;
-      const seriesInfo = this.seriesList[maxSID];
-      maxArgs = this.calculateTipInfo(seriesInfo, 'max', null);
+      // step/time-category 축은 range 없이도 minIndex=0, maxIndex=last를 채우므로 숫자 여부로는
+      // 클리핑을 판별 못 한다. 빈 윈도우=미표시, 부분 클리핑=윈도우 재계산, 전체=전역 캐시.
+      const axesSteps = isHorizontal ? this.axesSteps.y[0] : this.axesSteps.x[0];
+      const minIndex = axesSteps?.minIndex;
+      const maxIndex = axesSteps?.maxIndex;
+      const labelCount = (isHorizontal ? this.axesY[0] : this.axesX[0])?.labels?.length;
+      const fullLast = Number.isFinite(labelCount) ? labelCount - 1 : maxIndex;
+      const hasWindow = Number.isFinite(minIndex) && Number.isFinite(maxIndex);
+      const isEmptyWindow = hasWindow && maxIndex < minIndex;
+      const isClippingWindow = hasWindow && (minIndex > 0 || maxIndex < fullLast);
+
+      let maxSID;
+      let windowMax = null;
+      if (isEmptyWindow) {
+        maxSID = undefined;
+      } else if (isClippingWindow) {
+        windowMax = this.getVisibleWindowMaxSeries(minIndex, maxIndex);
+        maxSID = windowMax?.sId;
+      } else {
+        maxSID = this.minMax[isHorizontal ? 'x' : 'y'][0].maxSID;
+      }
+
+      const seriesInfo = maxSID ? this.seriesList[maxSID] : null;
+      if (seriesInfo) {
+        maxArgs = this.calculateTipInfo(seriesInfo, 'max', windowMax);
 
       // dp 가 null 이면 max 데이터가 axis range 밖이라는 신호. drawTextTip 이 null 을 0 으로
       // 강제 변환해 maxTip 이 좌상단에 찍히는 회귀를 막는다.
@@ -109,8 +131,9 @@ const modules = {
         }
         this.drawTextTip({ opt: maxTipOpt, tipType: 'max', seriesOpt: seriesInfo, ...maxArgs });
 
-        if (maxTipOpt.showIndicator) {
-          this.drawFixedIndicator({ opt: maxTipOpt, seriesOpt: seriesInfo, ...maxArgs });
+          if (maxTipOpt.showIndicator) {
+            this.drawFixedIndicator({ opt: maxTipOpt, seriesOpt: seriesInfo, ...maxArgs });
+          }
         }
       }
     }
@@ -158,7 +181,20 @@ const modules = {
       return false;
     }
 
-    let ldata = type === 'bar' ? maxDomainIndex : maxDomain;
+    // tipType === 'max' + hitInfo: drawTips에서 미리 산출한 가시 윈도우 max override.
+    // 일반 'max' 경로는 series.minMax(전역 캐시)를 그대로 사용.
+    // bar는 인덱스로, line/scatter는 도메인 값으로 위치를 잡으므로(maxDomainIndex/maxDomain
+    // 비대칭과 동일) override의 ldata도 타입에 맞춰 고른다.
+    const overrideLdata = type === 'bar' ? hitInfo?.index : hitInfo?.domain;
+    const hasMaxOverride = tipType === 'max' && hitInfo
+      && Number.isFinite(overrideLdata) && Number.isFinite(hitInfo.value);
+
+    let ldata;
+    if (hasMaxOverride) {
+      ldata = overrideLdata;
+    } else {
+      ldata = type === 'bar' ? maxDomainIndex : maxDomain;
+    }
 
     if (tipType === 'sel') {
       if (hitInfo && hitInfo.label !== null) {
@@ -169,7 +205,12 @@ const modules = {
       }
     }
 
-    let value = isHorizontal ? series.minMax.maxX : series.minMax.maxY;
+    let value;
+    if (hasMaxOverride) {
+      value = hitInfo.value;
+    } else {
+      value = isHorizontal ? series.minMax.maxX : series.minMax.maxY;
+    }
     let label;
     if (tipType === 'sel') {
       if (hitInfo && hitInfo.label !== null) {

--- a/src/components/chart/element/element.tip.spec.js
+++ b/src/components/chart/element/element.tip.spec.js
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import modules from './element.tip';
+import storeModules from '../model/model.store';
 
 const createCtx = ({ lastTip = { pos: null, value: null, label: null }, displayOverflow = false } = {}) =>
   Object.assign(Object.create(modules), {
@@ -149,5 +150,278 @@ describe('element.tip calculateTipInfo — displayOverflow 값축 초과 가드'
     const series = buildSeries({ minMax: { maxDomain: 5, maxDomainIndex: 0, maxX: 10, maxY: 80 } });
     const result = ctx.calculateTipInfo(series, 'max', null);
     expect(result).not.toBe(false);
+  });
+});
+
+// ────────────────────────────────────────────────
+// calculateTipInfo — max 분기 + 가시 윈도우 override
+//
+// axis range로 가시 인덱스 윈도우가 좁혀지면 drawTips가 미리 계산한
+// { sId, value, index, domain }을 hitInfo로 넘긴다. calculateTipInfo는 이 override를
+// series.minMax(전역 캐시) 대신 사용해 윈도우 안의 max로 maxTip을 표시한다.
+// bar는 index로, line/scatter는 domain(도메인 값)으로 위치를 잡는다.
+// ────────────────────────────────────────────────
+describe('element.tip calculateTipInfo — max 분기 가시 윈도우 override', () => {
+  // maxY 는 ctx 의 graphMax(100) 안이어야 displayOverflow 가드에 안 걸려 전역 폴백 value 가
+  // 관측된다(값이 graphMax 를 넘으면 가드가 false 를 반환해 무엇을 폴백했는지 가려진다).
+  const buildBarSeries = () => ({
+    type: 'bar',
+    size: { w: 10, h: 0, cat: 20, cPad: 0, bar: 10, ix: 0, bPad: 0 },
+    xAxisIndex: 0,
+    yAxisIndex: 0,
+    minMax: { maxDomain: 9, maxDomainIndex: 9, maxX: 10, maxY: 99 },
+  });
+
+  it('hitInfo가 valid한 override면 value/ldata가 그 값으로 적용된다', () => {
+    const ctx = createCtx();
+    const result = ctx.calculateTipInfo(buildBarSeries(), 'max', {
+      sId: 'b', value: 60, index: 3,
+    });
+    // ldata=3 → 윈도우 보정 없으므로 그대로 사용. value는 override의 60.
+    expect(result.value).toBe(60);
+  });
+
+  it('hitInfo가 null이면 series.minMax(전역 캐시)를 그대로 쓴다', () => {
+    const ctx = createCtx();
+    const result = ctx.calculateTipInfo(buildBarSeries(), 'max', null);
+    expect(result.value).toBe(99); // series.minMax.maxY
+  });
+
+  it('hitInfo.index가 비유한이면 override를 무시하고 전역 캐시 폴백', () => {
+    const ctx = createCtx();
+    const result = ctx.calculateTipInfo(buildBarSeries(), 'max', {
+      sId: 'b', value: 60, index: NaN,
+    });
+    expect(result.value).toBe(99);
+  });
+
+  it('hitInfo.value가 비유한이면 override를 무시하고 전역 캐시 폴백', () => {
+    const ctx = createCtx();
+    const result = ctx.calculateTipInfo(buildBarSeries(), 'max', {
+      sId: 'b', value: null, index: 3,
+    });
+    expect(result.value).toBe(99);
+  });
+
+  // line/scatter는 인덱스가 아니라 domain(도메인 값)으로 위치를 잡는다.
+  // override의 domain=2 → dp=ceil(100/10*2)=20. (index=3이면 30, 전역 maxDomain=5면 50)
+  it('line override는 index가 아니라 domain으로 위치를 잡는다', () => {
+    const ctx = createCtx();
+    const series = buildSeries({
+      type: 'line',
+      minMax: { maxDomain: 5, maxDomainIndex: 0, maxX: 10, maxY: 100 },
+    });
+    const result = ctx.calculateTipInfo(series, 'max', {
+      sId: 'b', value: 60, index: 3, domain: 2,
+    });
+    expect(result.value).toBe(60);
+    expect(result.dp).toBe(20);
+  });
+
+  // line override의 domain이 비유한이면 override를 무시하고 전역 캐시(maxDomain=5 → dp=50)로 폴백.
+  it('line override의 domain이 비유한이면 전역 캐시 폴백', () => {
+    const ctx = createCtx();
+    const series = buildSeries({
+      type: 'line',
+      minMax: { maxDomain: 5, maxDomainIndex: 0, maxX: 10, maxY: 100 },
+    });
+    const result = ctx.calculateTipInfo(series, 'max', {
+      sId: 'b', value: 60, index: 3, domain: NaN,
+    });
+    expect(result.value).toBe(100);
+    expect(result.dp).toBe(50);
+  });
+
+  // value가 0인 경우도 정상 값이다. 가드를 `if (value)`처럼 바꾸면 0을 "값이 없다"로
+  // 잘못 보고 전역 캐시로 빠지게 되는데, 그렇게 되지 않도록 막아두는 테스트.
+  it('override value가 0이어도 전역 폴백하지 않고 0을 그대로 쓴다', () => {
+    const ctx = createCtx();
+    const series = buildSeries({
+      type: 'line',
+      minMax: { maxDomain: 5, maxDomainIndex: 0, maxX: 10, maxY: 100 },
+    });
+    const result = ctx.calculateTipInfo(series, 'max', {
+      sId: 'b', value: 0, index: 3, domain: 2,
+    });
+    expect(result.value).toBe(0); // 전역 maxY(100)로 폴백하면 안 됨
+    expect(result.dp).toBe(20); // domain=2 기반 → 전역 maxDomain=5(dp=50)가 아님
+  });
+});
+
+// ────────────────────────────────────────────────
+// drawTips — window 판정 → 헬퍼 호출 → override 전달 통합
+//
+// 헬퍼/calculateTipInfo의 격리 테스트만으로는 drawTips의 실제 배선(어떤 조건에서
+// getVisibleWindowMaxSeries를 호출하고 그 결과를 어떻게 넘기는지)을 검증하지 못한다.
+// 예컨대 windowMax를 null로 되돌리는 회귀(=원래 버그 복원)도 격리 테스트는 전부 통과한다.
+// 여기서는 drawTextTip 스파이로 "어떤 시리즈/값으로 maxTip이 그려지는가"를 고정한다.
+// ────────────────────────────────────────────────
+describe('element.tip drawTips — 가시 윈도우 통합', () => {
+  const lineSeries = (sId, ys, minMax) => ({
+    sId, type: 'line', show: true,
+    data: ys.map((y, i) => ({ x: i, y })),
+    size: { comboOffset: 0 },
+    xAxisIndex: 0, yAxisIndex: 0,
+    minMax,
+  });
+  const barSeries = (sId, ys, minMax) => ({
+    sId, type: 'bar', show: true,
+    data: ys.map((y, i) => ({ x: i, y })),
+    size: { w: 10, h: 0, cat: 20, cPad: 0, bar: 10, ix: 0, bPad: 0 },
+    xAxisIndex: 0, yAxisIndex: 0,
+    minMax,
+  });
+  // horizontal bar: 값 축이 X라 p.x=값, p.y=카테고리 인덱스.
+  const hBarSeries = (sId, values, minMax) => ({
+    sId, type: 'bar', show: true,
+    data: values.map((x, i) => ({ x, y: i })),
+    size: { w: 0, h: 10, cat: 20, cPad: 0, bar: 10, ix: 0, bPad: 0 },
+    xAxisIndex: 0, yAxisIndex: 0,
+    minMax,
+  });
+
+  const createDrawCtx = ({ seriesList, windowAxis, globalMaxSID, horizontal = false, labelCount }) => {
+    const drawTextTip = vi.fn();
+    const valueAxis = { graphMin: 0, graphMax: 100 };
+    // labelCount가 주어지면 라벨 축에 labels를 달아 "전체를 덮는 윈도우" 판정을 가능케 한다.
+    const labelAxis = Number.isFinite(labelCount)
+      ? { labels: Array.from({ length: labelCount }, (_, i) => i) }
+      : undefined;
+    // 실제 헬퍼를 붙이되 스파이로 감싸 "full window에서 재스캔을 건너뛰는지"까지 검증한다.
+    const getVisibleWindowMaxSeries = vi.fn(storeModules.getVisibleWindowMaxSeries);
+    const ctx = Object.assign(Object.create(modules), {
+      options: {
+        horizontal,
+        displayOverflow: false,
+        type: 'line',
+        tooltip: {},
+        maxTip: { use: true, showIndicator: false, tipStyle: { height: 20 } },
+        selectItem: { use: false },
+        selectLabel: { use: false },
+      },
+      seriesList,
+      // 윈도잉(카테고리) 축은 vertical=X, horizontal=Y. 값 축은 반대편.
+      axesSteps: {
+        x: [horizontal ? valueAxis : windowAxis],
+        y: [horizontal ? windowAxis : valueAxis],
+      },
+      // 라벨 축: vertical=X, horizontal=Y. drawTips가 labels.length로 full window를 판정.
+      axesX: [horizontal ? undefined : labelAxis],
+      axesY: [horizontal ? labelAxis : undefined],
+      minMax: { x: [{ maxSID: globalMaxSID }], y: [{ maxSID: globalMaxSID }] },
+      chartRect: { x1: 0, x2: 100, y1: 0, y2: 100, chartWidth: 100, chartHeight: 100 },
+      labelOffset: { left: 0, right: 0, top: 0, bottom: 0 },
+      lastTip: { pos: null, value: null, label: null },
+      scrollbar: { x: {}, y: {} },
+      getVisibleWindowMaxSeries,
+      drawTextTip,
+      drawFixedIndicator: vi.fn(),
+    });
+    return { ctx, drawTextTip, getVisibleWindowMaxSeries };
+  };
+
+  it('window 활성: 전역 max가 bar여도 윈도우 max인 line 시리즈/값으로 maxTip을 그린다', () => {
+    // 윈도우 [1,3]: bar max=50(idx2), line max=80(idx1) → 윈도우 전체 max=80(line).
+    // 전역 maxSID는 bar1이지만 윈도우 판정이 우선해야 한다(combo 회귀 가드).
+    const { ctx, drawTextTip } = createDrawCtx({
+      seriesList: {
+        bar1: barSeries('bar1', [10, 20, 50, 30, 40],
+          { maxDomain: 2, maxDomainIndex: 2, maxX: 4, maxY: 50 }),
+        line1: lineSeries('line1', [5, 80, 60, 70, 15],
+          { maxDomain: 1, maxDomainIndex: 1, maxX: 4, maxY: 80 }),
+      },
+      windowAxis: { graphMin: 0, graphMax: 4, minIndex: 1, maxIndex: 3 },
+      globalMaxSID: 'bar1',
+    });
+
+    ctx.drawTips([]);
+
+    expect(drawTextTip).toHaveBeenCalledTimes(1);
+    const arg = drawTextTip.mock.calls[0][0];
+    expect(arg.tipType).toBe('max');
+    expect(arg.seriesOpt.sId).toBe('line1');
+    expect(arg.value).toBe(80);
+    expect(arg.dp).not.toBe(null);
+  });
+
+  it('빈 윈도우(maxIndex < minIndex): 윈도우 밖 전역 max를 그리지 않는다', () => {
+    // range가 데이터 밖이라 scale이 maxIndex=-1 반환. 보이는 데이터가 없으므로 maxTip 미표시.
+    // 기존 hasWindow 폴백이면 전역 max를 그려버린다 → RED.
+    const { ctx, drawTextTip } = createDrawCtx({
+      seriesList: {
+        g: lineSeries('g', [10, 20, 50, 30, 40],
+          { maxDomain: 2, maxDomainIndex: 2, maxX: 4, maxY: 50 }),
+      },
+      windowAxis: { graphMin: 0, graphMax: 4, minIndex: 0, maxIndex: -1 },
+      globalMaxSID: 'g',
+    });
+
+    ctx.drawTips([]);
+
+    expect(drawTextTip).not.toHaveBeenCalled();
+  });
+
+  it('비윈도잉 축(minIndex/maxIndex 없음): 전역 max로 maxTip을 그린다', () => {
+    // linear/time 등은 윈도잉이 없으므로 전역 maxSID 경로를 그대로 타야 한다.
+    const { ctx, drawTextTip } = createDrawCtx({
+      seriesList: {
+        g: lineSeries('g', [10, 20, 50, 30, 40],
+          { maxDomain: 2, maxDomainIndex: 2, maxX: 4, maxY: 50 }),
+      },
+      windowAxis: { graphMin: 0, graphMax: 4 },
+      globalMaxSID: 'g',
+    });
+
+    ctx.drawTips([]);
+
+    expect(drawTextTip).toHaveBeenCalledTimes(1);
+    const arg = drawTextTip.mock.calls[0][0];
+    expect(arg.seriesOpt.sId).toBe('g');
+    expect(arg.value).toBe(50);
+  });
+
+  it('horizontal: 윈도잉 축이 Y(axesSteps.y[0])이고 bar 좌표 보정 경로로 그린다', () => {
+    // horizontal에서 drawTips는 axesSteps.y[0]에서 minIndex/maxIndex를 읽어야 한다.
+    // 윈도우 [1,3]: 값(p.x) 20,80,30 → max=80(idx2). bar는 ldata -= minIndex 보정 후 위치.
+    const { ctx, drawTextTip } = createDrawCtx({
+      seriesList: {
+        b: hBarSeries('b', [10, 20, 80, 30, 40],
+          { maxDomain: 2, maxDomainIndex: 2, maxX: 80, maxY: 4 }),
+      },
+      windowAxis: { graphMin: 0, graphMax: 4, minIndex: 1, maxIndex: 3 },
+      globalMaxSID: 'b',
+      horizontal: true,
+    });
+
+    ctx.drawTips([]);
+
+    expect(drawTextTip).toHaveBeenCalledTimes(1);
+    const arg = drawTextTip.mock.calls[0][0];
+    expect(arg.seriesOpt.sId).toBe('b');
+    expect(arg.value).toBe(80);
+    expect(arg.dp).not.toBe(null);
+  });
+
+  it('full window(range 미적용): 재스캔을 건너뛰고 전역 maxSID 캐시로 그린다', () => {
+    // step/time-category 축은 range가 없어도 minIndex=0, maxIndex=last를 항상 세팅한다.
+    // 윈도우가 전체(labels 5개 → [0,4])를 덮으면 전역 캐시면 충분하므로
+    // getVisibleWindowMaxSeries(O(시리즈×포인트) 재스캔)를 호출하지 않아야 한다(perf 회귀 가드).
+    const { ctx, drawTextTip, getVisibleWindowMaxSeries } = createDrawCtx({
+      seriesList: {
+        g: lineSeries('g', [10, 20, 50, 30, 40],
+          { maxDomain: 2, maxDomainIndex: 2, maxX: 4, maxY: 50 }),
+      },
+      windowAxis: { graphMin: 0, graphMax: 4, minIndex: 0, maxIndex: 4 },
+      globalMaxSID: 'g',
+      labelCount: 5,
+    });
+
+    ctx.drawTips([]);
+
+    expect(getVisibleWindowMaxSeries).not.toHaveBeenCalled();
+    expect(drawTextTip).toHaveBeenCalledTimes(1);
+    const arg = drawTextTip.mock.calls[0][0];
+    expect(arg.seriesOpt.sId).toBe('g');
+    expect(arg.value).toBe(50);
   });
 });

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -820,6 +820,57 @@ const modules = {
     return def;
   },
 
+  /**
+   * 가시 윈도우 [minIndex, maxIndex] 안에서 visible 시리즈를 스캔해 최댓값 점을
+   * { sId, value, index, domain }으로 반환한다. axis range로 일부만 보일 때 maxTip이
+   * 윈도우 밖 전역 max를 가리키지 않게 하기 위함(전역 series.minMax 캐시는 안 건드림).
+   *
+   * bar/line/scatter 모두 후보다(combo에서 line이 윈도우 max거나 line-only 카테고리/step
+   * 축에서도 maxTip 필요). 위치 좌표가 타입별로 다르므로(bar=index, line/scatter=domain)
+   * 비교용 value와 위치용 domain을 함께 돌려준다.
+   *
+   * @param {number} minIndex 윈도우 시작 인덱스
+   * @param {number} maxIndex 윈도우 끝 인덱스 (inclusive)
+   * @returns {{sId: string, value: number, index: number, domain: number}|null}
+   *   value: 값 축 값(vertical=y, horizontal=x), domain: 도메인 축 값(vertical=x, horizontal=y).
+   *   null인 경우 두 가지:
+   *   (1) minIndex/maxIndex가 비유한이거나 빈 윈도우(maxIndex < minIndex),
+   *   (2) 윈도우 안에 유효한(finite) 값이 하나도 없음.
+   */
+  getVisibleWindowMaxSeries(minIndex, maxIndex) {
+    if (
+      !Number.isFinite(minIndex)
+      || !Number.isFinite(maxIndex)
+      || maxIndex < minIndex
+    ) {
+      return null;
+    }
+
+    const isHorizontal = this.options.horizontal;
+    let best = null;
+
+    const sIds = Object.keys(this.seriesList);
+    for (let s = 0; s < sIds.length; s += 1) {
+      const series = this.seriesList[sIds[s]];
+      if (series?.show && series.data?.length) {
+        const lo = Math.max(0, minIndex);
+        const hi = Math.min(series.data.length - 1, maxIndex);
+        for (let i = lo; i <= hi; i += 1) {
+          const p = series.data[i];
+          const v = isHorizontal ? p?.x : p?.y;
+          // null뿐 아니라 NaN/Infinity도 후보에서 제외한다. 비유한값이 best로 뽑히면
+          // calculateTipInfo의 Number.isFinite 가드에서 탈락해 윈도우와 무관한 전역 max로
+          // 조용히 폴백하기 때문(maxTip이 엉뚱한 위치에 그려짐).
+          if (Number.isFinite(v) && (!best || v > best.value)) {
+            best = { sId: series.sId, value: v, index: i, domain: isHorizontal ? p?.y : p?.x };
+          }
+        }
+      }
+    }
+
+    return best;
+  },
+
   getSeriesValueOptForHeatMap(series) {
     const { data, colorState, isGradient } = series;
     const colorOpt = this.options.heatMapColor;

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -865,3 +865,162 @@ describe('model.store createDataSet stack (누적 top 기반)', () => {
     expect(seriesList.s2.data[0].y).toBe(15);
   });
 });
+
+// ────────────────────────────────────────────────
+// getVisibleWindowMaxSeries
+// axis range로 가시 인덱스 윈도우가 좁혀졌을 때, 윈도우 안의 max를
+// { sId, value, index, domain }으로 반환. maxTip이 윈도우 밖 전역 max를 가리키지 않도록
+// 보정하는 헬퍼. bar/line/scatter 모든 타입을 후보로 스캔한다.
+// ────────────────────────────────────────────────
+describe('getVisibleWindowMaxSeries', () => {
+  const buildStore = (seriesList, options = {}) =>
+    Object.assign(Object.create(modules), {
+      seriesList,
+      options: { horizontal: false, ...options },
+    });
+
+  const barSeries = (sId, ys) => ({
+    sId,
+    type: 'bar',
+    show: true,
+    data: ys.map((y, i) => ({ x: i, y })),
+  });
+
+  it('윈도우 안의 최댓값 시리즈/인덱스/값을 반환한다', () => {
+    const store = buildStore({
+      a: barSeries('a', [10, 20, 100, 30, 40]),  // 전역 max 100 at idx=2
+      b: barSeries('b', [5, 50, 25, 60, 15]),    // 전역 max 60 at idx=3
+    });
+    // window [3, 4]: a는 30,40 / b는 60,15 → b의 idx=3, value=60이 윈도우 max
+    expect(store.getVisibleWindowMaxSeries(3, 4))
+      .toEqual({ sId: 'b', value: 60, index: 3, domain: 3 });
+  });
+
+  it('전역 max가 윈도우 안이면 그대로 그 시리즈를 반환한다', () => {
+    const store = buildStore({
+      a: barSeries('a', [10, 20, 100, 30, 40]),
+    });
+    expect(store.getVisibleWindowMaxSeries(1, 3))
+      .toEqual({ sId: 'a', value: 100, index: 2, domain: 2 });
+  });
+
+  it('horizontal 차트는 p.x를 비교하고 domain은 p.y가 된다', () => {
+    const store = Object.assign(Object.create(modules), {
+      seriesList: {
+        a: {
+          sId: 'a',
+          type: 'bar',
+          show: true,
+          data: [{ x: 5, y: 0 }, { x: 99, y: 1 }, { x: 7, y: 2 }],
+        },
+      },
+      options: { horizontal: true },
+    });
+    expect(store.getVisibleWindowMaxSeries(0, 2))
+      .toEqual({ sId: 'a', value: 99, index: 1, domain: 1 });
+  });
+
+  it('show=false 시리즈는 무시한다', () => {
+    const store = buildStore({
+      a: { ...barSeries('a', [10, 20, 30]), show: false },
+      b: barSeries('b', [5, 50, 15]),
+    });
+    expect(store.getVisibleWindowMaxSeries(0, 2))
+      .toEqual({ sId: 'b', value: 50, index: 1, domain: 1 });
+  });
+
+  // 회귀 가드(시나리오 2 — combo line+bar): line이 윈도우 max면 line을 반환해야 한다.
+  // bar로 제한하던 기존 동작이면 bar(50)에 잘못 anchor → RED.
+  it('combo: line이 윈도우 max면 line 시리즈를 반환한다', () => {
+    const store = buildStore({
+      bar: barSeries('bar', [5, 50, 15]),
+      line: { ...barSeries('line', [10, 80, 20]), type: 'line' },
+    });
+    expect(store.getVisibleWindowMaxSeries(0, 2))
+      .toEqual({ sId: 'line', value: 80, index: 1, domain: 1 });
+  });
+
+  // 회귀 가드(시나리오 1 — line-only 카테고리 축): bar가 없어도 null이 아니라
+  // line의 윈도우 max를 반환해야 maxTip이 사라지지 않는다.
+  it('line-only 차트도 윈도우 max를 반환한다', () => {
+    const store = buildStore({
+      a: { ...barSeries('a', [10, 70, 30]), type: 'line' },
+      b: { ...barSeries('b', [5, 40, 60]), type: 'line' },
+    });
+    expect(store.getVisibleWindowMaxSeries(0, 2))
+      .toEqual({ sId: 'a', value: 70, index: 1, domain: 1 });
+  });
+
+  it('윈도우가 data 길이 밖으로 넘어가도 안전하게 clamp 한다', () => {
+    const store = buildStore({
+      a: barSeries('a', [10, 20, 30]),
+    });
+    expect(store.getVisibleWindowMaxSeries(0, 100))
+      .toEqual({ sId: 'a', value: 30, index: 2, domain: 2 });
+  });
+
+  it('윈도우 안 모든 값이 null/undefined면 null을 반환한다', () => {
+    const store = buildStore({
+      a: { sId: 'a', type: 'bar', show: true, data: [{ x: 0, y: null }, { x: 1, y: null }] },
+    });
+    expect(store.getVisibleWindowMaxSeries(0, 1)).toBeNull();
+  });
+
+  // NaN/Infinity는 best로 뽑히면 안 된다(calculateTipInfo의 Number.isFinite 가드에서
+  // 탈락해 윈도우와 무관한 전역 max로 조용히 폴백). 유한한 실제 윈도우 max를 골라야 한다.
+  it('NaN/Infinity 값은 후보에서 제외하고 유한한 max를 반환한다', () => {
+    const store = buildStore({
+      a: { sId: 'a', type: 'bar', show: true,
+        data: [{ x: 0, y: NaN }, { x: 1, y: Infinity }, { x: 2, y: 42 }] },
+    });
+    expect(store.getVisibleWindowMaxSeries(0, 2))
+      .toEqual({ sId: 'a', value: 42, index: 2, domain: 2 });
+  });
+
+  it('윈도우 안 값이 NaN/Infinity뿐이면 null을 반환한다', () => {
+    const store = buildStore({
+      a: { sId: 'a', type: 'bar', show: true, data: [{ x: 0, y: NaN }, { x: 1, y: Infinity }] },
+    });
+    expect(store.getVisibleWindowMaxSeries(0, 1)).toBeNull();
+  });
+
+  // 0도 정상적인 max 값이다. 검사를 `if (v)`처럼 바꾸면 0을 "값이 없다"로 보고 건너뛰므로,
+  // 0이 제대로 max로 뽑히는지 막아두는 테스트.
+  it('value 0도 유효한 max로 선정한다(음수만 있는 윈도우)', () => {
+    const store = buildStore({
+      a: { sId: 'a', type: 'bar', show: true,
+        data: [{ x: 0, y: -5 }, { x: 1, y: 0 }, { x: 2, y: -3 }] },
+    });
+    expect(store.getVisibleWindowMaxSeries(0, 2))
+      .toEqual({ sId: 'a', value: 0, index: 1, domain: 1 });
+  });
+
+  it('minIndex/maxIndex가 비유한이면 null을 반환한다 (가드)', () => {
+    const store = buildStore({ a: barSeries('a', [1, 2, 3]) });
+    expect(store.getVisibleWindowMaxSeries(NaN, 2)).toBeNull();
+    expect(store.getVisibleWindowMaxSeries(0, undefined)).toBeNull();
+  });
+
+  it('maxIndex < minIndex (빈 윈도우)이면 null을 반환한다', () => {
+    const store = buildStore({ a: barSeries('a', [1, 2, 3]) });
+    expect(store.getVisibleWindowMaxSeries(2, 0)).toBeNull();
+  });
+
+  // addSeriesStackDS는 각 시리즈의 p.y에 stack 누적값을 저장하므로,
+  // (양수 stack 기준) index i에서 max p.y는 top 시리즈의 값(=stack 총합)이 된다.
+  // (음수 stack은 누적될수록 p.y가 더 음수 → top이 max가 아니므로 이 단정은 양수 한정.)
+  // 별도 분기 없이 일반 max 스캔만으로 양수 stack 차트가 자동 지원됨을 가드한다.
+  it('stack 차트(양수): top 시리즈가 stack 총합으로 윈도우 max를 결정한다', () => {
+    const store = buildStore({
+      base: { sId: 'base', type: 'bar', show: true,
+        data: [{ x: 0, y: 10, o: 10, b: 0 }, { x: 1, y: 20, o: 20, b: 0 }] },
+      mid:  { sId: 'mid',  type: 'bar', show: true,
+        data: [{ x: 0, y: 15, o: 5,  b: 10 }, { x: 1, y: 30, o: 10, b: 20 }] },
+      top:  { sId: 'top',  type: 'bar', show: true,
+        data: [{ x: 0, y: 18, o: 3,  b: 15 }, { x: 1, y: 35, o: 5,  b: 30 }] },
+    });
+    // 윈도우 [0, 1]: idx=1 stack 총합 35가 max, top 시리즈가 그 값을 보유.
+    expect(store.getVisibleWindowMaxSeries(0, 1))
+      .toEqual({ sId: 'top', value: 35, index: 1, domain: 1 });
+  });
+});


### PR DESCRIPTION
## 작업 배경

바차트에서 `axes.range` 옵션으로 가시 영역을 좁혔을 때, 전역 최댓값이 가시 윈도우 밖에 있으면 `maxTip`이 사라지거나 윈도우 밖의 막대를 가리키는 문제가 있었습니다.

원인: `drawTips`의 maxTip 계산이 `this.minMax[axis][0].maxSID`(전체 데이터 기준)과 `series.minMax.maxY/maxX`(전역 캐시)를 그대로 사용해, range 보정과 무관하게 동작했기 때문입니다. range 보정 코드가 추가된 이후로는 윈도우 밖 인덱스에서 `calculateTipInfo`가 `false`를 반환해 maxTip이 통째로 누락됩니다.

## 변경 내용

가시 윈도우 안에서 max를 재산출하도록 보정:

- **`getVisibleWindowMaxSeries(minIndex, maxIndex)`** 헬퍼 추가 (`model.store.js`)
  - 모든 visible bar 시리즈를 윈도우 안에서 스캔해 `{ sId, value, index }` 반환
  - `series.minMax` 전역 캐시는 건드리지 않음
- **`drawTips`** (`element.tip.js`)
  - axis range가 활성이면 헬퍼로 maxSID/value/index 재산출, 비활성이면 기존 경로 유지
- **`calculateTipInfo`의 'max' 분기**
  - 윈도우 max override(`hitInfo`)가 유효하면 그 값으로 ldata/value 설정
- 회귀 가드 테스트 13개 추가 (model.store 9 + element.tip 4)

## 이전 동작

<img width="788" height="550" alt="601388199-f0fc78d1-9d47-44a5-8f72-a5336a9c9662" src="https://github.com/user-attachments/assets/99bbad01-dc5e-4e1e-8ef3-6b065892488a" />

## 이후 동작
<img width="1366" height="752" alt="Jun-02-2026 20-02-59" src="https://github.com/user-attachments/assets/9d58acc2-2cc2-4e9a-8cef-382a618eec96" />


## 테스트 가이드

1. **range 활성 + 전역 max가 윈도우 밖**
   - `axes.range`를 전역 max 막대를 제외하도록 설정
   - maxTip이 윈도우 안의 가장 높은 막대 위에 표시되는지 확인
2. **다중 시리즈 + 시리즈 간 max 스위치**
   - 시리즈 A가 전체 max, 시리즈 B가 윈도우 안 max인 데이터 구성
   - range로 A의 max를 제외 → maxTip이 B로 스위치, 위치/값 정확
3. **stacked bar**
   - `stackIndex` 설정한 시리즈 묶음 + range 적용
   - maxTip이 stack top의 누적값을 가리키는지 확인
4. **range 미설정 차트 (회귀 가드)**
   - 기존 차트(시간/리니어/카테고리)에서 maxTip 위치/값이 변하지 않는지
5. **단위 테스트**
   - `npx vitest run src/components/chart/`
   - 348개 모두 통과 확인
