### PR TITLE
fix(chart): Bar Chart > 스크롤바 thumb 위치와 표시 데이터 불일치 

### DIFF
--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -31,15 +31,14 @@ const module = {
 
     if (scrollbarOpt.resetPosition) {
       scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...axisOpt[0].range] : null;
-      this.resetScrollbarSavedPositions(dir);
     }
 
     if (!scrollbarOpt.isInit) {
       scrollbarOpt.type = axisOpt?.[0]?.type;
       scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...axisOpt[0].range] : null;
-      this.resetScrollbarSavedPositions(dir);
 
       this.initScrollbarRange(dir);
+      this.updateScrollbarAnchorEdge(dir);
       this.createScrollbarLayout(dir);
       this.createScrollbar(dir);
       this.createScrollEvent(dir);
@@ -115,19 +114,27 @@ const module = {
         const newOptRange = newOpt?.[0]?.range;
         const currentRange = this.scrollbar[dir].range;
         if (!isResetPosition && newOptRange?.length && currentRange?.length) {
-          // 리사이즈 등으로 range 크기만 변경된 경우, 현재 스크롤 위치(min)를 유지하고 크기만 조정
+          // 리사이즈 등으로 size 만 바뀌었을 때: anchorEdge 가 있으면 그 가장자리에 붙여
+          // 새 range 를 계산하고, 없으면 현재 시작점을 유지한다.
           const newSize = newOptRange[1] - newOptRange[0];
-          this.scrollbar[dir].range = [currentRange[0], currentRange[0] + newSize];
+          const anchorEdge = this.scrollbar[dir].anchorEdge;
+          const limits = anchorEdge ? this.getScrollbarLimits(dir) : null;
+          if (anchorEdge === 'start' && limits) {
+            this.scrollbar[dir].range = [limits.limitMin, limits.limitMin + newSize];
+          } else if (anchorEdge === 'end' && limits) {
+            this.scrollbar[dir].range = [limits.limitMax - newSize, limits.limitMax];
+          } else {
+            this.scrollbar[dir].range = [currentRange[0], currentRange[0] + newSize];
+          }
         } else {
           this.scrollbar[dir].range = newOptRange?.length ? [...newOptRange] : null;
         }
       }
 
-      if (isResetPosition || updateData) {
-        this.resetScrollbarSavedPositions(dir);
-      }
-
       this.initScrollbarRange(dir);
+      // range 가 갱신/clip 된 후 anchorEdge 재계산. 데이터만 업데이트 시 range 는 그대로
+      // 지만 limit 이 바뀌었을 수 있어 항상 호출한다.
+      this.updateScrollbarAnchorEdge(dir);
     }
     this.scrollbar[dir].use = !!newOpt?.[0].scrollbar?.use;
   },
@@ -137,15 +144,11 @@ const module = {
    */
   updateScrollbarPosition() {
     if (this.scrollbar.x?.use && this.scrollbar.x?.isInit) {
-      // resetPosition 옵션에 따라 preservePosition 결정
-      const preservePosition = !this.options.axesX?.[0]?.scrollbar?.resetPosition;
-      this.setScrollbarPosition('x', preservePosition);
+      this.setScrollbarPosition('x');
     }
 
     if (this.scrollbar.y?.use && this.scrollbar.y?.isInit) {
-      // resetPosition 옵션에 따라 preservePosition 결정
-      const preservePosition = !this.options.axesY?.[0]?.scrollbar?.resetPosition;
-      this.setScrollbarPosition('y', preservePosition);
+      this.setScrollbarPosition('y');
     }
   },
 
@@ -230,11 +233,11 @@ const module = {
   },
 
   /**
-   * set scrollbar position
+   * set scrollbar position. thumb 위치는 scrollbar.range 에서 파생되며,
+   * 부동소수점 누적 오차가 가장자리를 살짝 넘지 않도록 [0, maxPosition] 으로 보정한다.
    * @param dir axis direction ('x' | 'y')
-   * @param preservePosition 기존 위치를 유지할지 여부
    */
-  setScrollbarPosition(dir, preservePosition = false) {
+  setScrollbarPosition(dir) {
     const scrollbarOpt = this.scrollbar[dir];
     if (!scrollbarOpt.use || !scrollbarOpt.range) {
       return;
@@ -258,28 +261,8 @@ const module = {
     const trackSize = fullSize - (buttonSize * 2);
 
     const thumbSize = this.getScrollbarThumbSize(dir, trackSize);
-
-    // 비율로 저장된 위치가 있으면 새 track 크기에 맞게 복원
-    if (preservePosition && scrollbarOpt.savedPositionRatio !== undefined) {
-      const maxPosition = Math.max(0, trackSize - thumbSize.size);
-      if (scrollbarOpt.savedAtStart) {
-        thumbSize.position = 0;
-      } else if (scrollbarOpt.savedAtEnd) {
-        thumbSize.position = maxPosition;
-      } else {
-        thumbSize.position = Math.min(scrollbarOpt.savedPositionRatio * trackSize, maxPosition);
-      }
-    }
-
-    // 위치를 비율 및 처음/끝 고정 여부로 저장
-    // currentMaxPosition === 0 (thumbSize >= trackSize) 인 경우 저장하지 않음
-    // → trackSize가 다시 커졌을 때 이전 savedAtEnd/savedAtStart/savedPositionRatio 상태를 유지
-    const currentMaxPosition = Math.max(0, trackSize - thumbSize.size);
-    if (currentMaxPosition > 0) {
-      scrollbarOpt.savedPositionRatio = thumbSize.position / trackSize;
-      scrollbarOpt.savedAtStart = thumbSize.position <= 0;
-      scrollbarOpt.savedAtEnd = thumbSize.position >= currentMaxPosition;
-    }
+    const maxPosition = Math.max(0, trackSize - thumbSize.size);
+    thumbSize.position = Math.min(Math.max(thumbSize.position, 0), maxPosition);
 
     let scrollbarStyle = 'display: block;';
     let scrollbarTrackStyle;
@@ -456,9 +439,7 @@ const module = {
 
     if (!isOutOfRange) {
       scrollbarOpt.range = [minValue, maxValue];
-
-      // 사용자가 스크롤할 때는 저장된 위치를 초기화
-      this.resetScrollbarSavedPositions(dir);
+      this.updateScrollbarAnchorEdge(dir);
 
       this.update({
         updateSeries: false,
@@ -470,18 +451,44 @@ const module = {
   },
 
   /**
-   * reset scrollbar saved positions
+   * 축의 인덱스/값 한계 반환. step 은 labels 길이 기준, 그 외는 minMax 기준.
+   * @param dir axis direction ('x' | 'y')
+   * @returns {{limitMin: number, limitMax: number} | null}
+   */
+  getScrollbarLimits(dir) {
+    const scrollbarOpt = this.scrollbar[dir];
+    if (scrollbarOpt?.type === 'step') {
+      const labels = this.options.type === 'heatMap' ? this.data.labels[dir] : this.data.labels;
+      if (!labels?.length) return null;
+      return { limitMin: 0, limitMax: labels.length - 1 };
+    }
+    const minMax = this.minMax?.[dir]?.[0];
+    if (!minMax) return null;
+    return { limitMin: +minMax.min, limitMax: +minMax.max };
+  },
+
+  /**
+   * 현재 scrollbar.range 가 축 한계의 어느 쪽에 닿아있는지로 anchorEdge 를 갱신.
+   * 사용자의 "끝/시작에 붙여둔 상태" 의도를 보존해 사이즈 변경 시 재계산에 사용.
    * @param dir axis direction ('x' | 'y')
    */
-  resetScrollbarSavedPositions(dir) {
+  updateScrollbarAnchorEdge(dir) {
     const scrollbarOpt = this.scrollbar[dir];
-    if (!scrollbarOpt) {
+    if (!scrollbarOpt) return;
+
+    const range = scrollbarOpt.range;
+    const limits = this.getScrollbarLimits(dir);
+    if (!Array.isArray(range) || range.length !== 2 || !limits) {
+      scrollbarOpt.anchorEdge = null;
       return;
     }
-
-    delete scrollbarOpt.savedPositionRatio;
-    delete scrollbarOpt.savedAtStart;
-    delete scrollbarOpt.savedAtEnd;
+    if (range[0] <= limits.limitMin) {
+      scrollbarOpt.anchorEdge = 'start';
+    } else if (range[1] >= limits.limitMax) {
+      scrollbarOpt.anchorEdge = 'end';
+    } else {
+      scrollbarOpt.anchorEdge = null;
+    }
   },
 
   /**
@@ -694,9 +701,7 @@ const module = {
     }
 
     this.scrollbar[dir].range = [movedMin, movedMax];
-
-    // 사용자가 드래그로 스크롤할 때는 저장된 위치를 초기화
-    this.resetScrollbarSavedPositions(dir);
+    this.updateScrollbarAnchorEdge(dir);
 
     this.update({
       updateSeries: false,

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -31,6 +31,9 @@ const module = {
 
     if (scrollbarOpt.resetPosition) {
       scrollbarOpt.range = axisOpt?.[0]?.range?.length ? [...axisOpt[0].range] : null;
+      // range 변경 후엔 anchor 재계산(불변식). isInit 상태로 재진입(resize 등)할 때
+      // 아래 !isInit 블록을 타지 않아 anchorEdge 가 stale 해지는 것을 방지한다.
+      this.updateScrollbarAnchorEdge(dir);
     }
 
     if (!scrollbarOpt.isInit) {
@@ -48,23 +51,17 @@ const module = {
 
   initScrollbarRange(dir) {
     const scrollbarOpt = this.scrollbar[dir];
-    const axesType = scrollbarOpt.type;
     const labels = this.options.type === 'heatMap' ? this.data.labels[dir] : this.data.labels;
 
     if (scrollbarOpt.range?.length && labels.length) {
       const [min, max] = scrollbarOpt.range;
-      let limitMin;
-      let limitMax;
 
       if (truthyNumber(min) && truthyNumber(max)) {
-        if (axesType === 'step') {
-          limitMin = 0;
-          limitMax = labels.length - 1;
-        } else {
-          const minMax = this.minMax[dir]?.[0];
-          limitMin = +minMax.min;
-          limitMax = +minMax.max;
+        const limits = this.getScrollbarLimits(dir);
+        if (!limits) {
+          return;
         }
+        const { limitMin, limitMax } = limits;
 
         const originalWidth = max - min;
         const availableWidth = limitMax - limitMin;
@@ -459,12 +456,25 @@ const module = {
     const scrollbarOpt = this.scrollbar[dir];
     if (scrollbarOpt?.type === 'step') {
       const labels = this.options.type === 'heatMap' ? this.data.labels[dir] : this.data.labels;
-      if (!labels?.length) return null;
+      if (!labels?.length) {
+        return null;
+      }
       return { limitMin: 0, limitMax: labels.length - 1 };
     }
     const minMax = this.minMax?.[dir]?.[0];
-    if (!minMax) return null;
-    return { limitMin: +minMax.min, limitMax: +minMax.max };
+    // 데이터 min/max 가 아직 확정되지 않은 경우(첫 데이터 로드 직전의 stale minMax 등)
+    // null 을 +로 0 으로 강제하면(+null === 0) time/linear 축 range 가 [0,0] 으로
+    // 오염된다. 한계를 알 수 없을 때는 null 을 반환해 호출부가 range 를 건드리지 않게 한다.
+    if (minMax?.min == null || minMax?.max == null) {
+      return null;
+    }
+
+    const limitMin = +minMax.min;
+    const limitMax = +minMax.max;
+    if (!Number.isFinite(limitMin) || !Number.isFinite(limitMax)) {
+      return null;
+    }
+    return { limitMin, limitMax };
   },
 
   /**

--- a/src/components/chart/plugins/plugins.scrollbar.js
+++ b/src/components/chart/plugins/plugins.scrollbar.js
@@ -70,16 +70,23 @@ const module = {
           scrollbarOpt.range[0] = limitMin;
           scrollbarOpt.range[1] = limitMax;
         } else {
-          scrollbarOpt.range[0] = +min < limitMin ? limitMin : +min;
-          scrollbarOpt.range[1] = +max > limitMax ? limitMax : +max;
+          // 윈도우(폭 originalWidth)를 한계 [limitMin, limitMax] 안으로 이동시킨다.
+          // 라이브 데이터로 윈도우가 한계 밖으로 완전히 밀렸을 때 range 가 역전
+          // (range[0] > range[1])/붕괴되지 않도록 항상 폭을 유지한 채 가장자리에 정렬한다.
+          let lo = +min < limitMin ? limitMin : +min;
+          let hi = lo + originalWidth;
 
-          if (scrollbarOpt.range[1] - scrollbarOpt.range[0] < originalWidth) {
-            scrollbarOpt.range[0] = scrollbarOpt.range[1] - originalWidth;
+          if (hi > limitMax) {
+            hi = limitMax;
+            lo = hi - originalWidth;
 
-            if (scrollbarOpt.range[0] < limitMin) {
-              scrollbarOpt.range[0] = limitMin;
+            if (lo < limitMin) {
+              lo = limitMin;
             }
           }
+
+          scrollbarOpt.range[0] = lo;
+          scrollbarOpt.range[1] = hi;
         }
       }
     }
@@ -129,9 +136,14 @@ const module = {
       }
 
       this.initScrollbarRange(dir);
-      // range 가 갱신/clip 된 후 anchorEdge 재계산. 데이터만 업데이트 시 range 는 그대로
-      // 지만 limit 이 바뀌었을 수 있어 항상 호출한다.
-      this.updateScrollbarAnchorEdge(dir);
+      // anchorEdge 는 윈도우가 실제로 이동한 경우(range 옵션 변경=리사이즈/범위 지정 등)에만
+      // 재계산한다. 데이터만 업데이트된 경우 윈도우 위치는 그대로인데, 라이브 데이터로
+      // minMax(=한계)가 변하면 clip 으로 윈도우가 우연히 한계에 닿을 수 있다. 이때 anchorEdge
+      // 를 새로 만들면 자유 위치(중앙)에 둔 윈도우가 다음 리사이즈에 가장자리로 스냅되는
+      // 오탐이 생기므로(리뷰 #2), 데이터 업데이트 경로에서는 기존 anchorEdge 를 보존한다.
+      if (isUpdateAxesRange) {
+        this.updateScrollbarAnchorEdge(dir);
+      }
     }
     this.scrollbar[dir].use = !!newOpt?.[0].scrollbar?.use;
   },

--- a/src/components/chart/plugins/plugins.scrollbar.spec.js
+++ b/src/components/chart/plugins/plugins.scrollbar.spec.js
@@ -1,0 +1,369 @@
+import { describe, it, expect } from 'vitest';
+import modules from './plugins.scrollbar';
+
+/**
+ * plugins.scrollbar의 메서드들은 차트 인스턴스의 this 에 바인딩되어 동작하므로,
+ * 필요한 속성과 의존 메서드를 가진 가짜 컨텍스트를 만들어 직접 호출한다.
+ * (modules 를 프로토타입으로 두어 this.getScrollbarLimits 등 상호 호출도 동작하게 한다)
+ */
+const createChart = (overrides = {}) =>
+  Object.assign(Object.create(modules), {
+    options: { type: 'lineChart' },
+    data: { labels: [] },
+    minMax: { x: [{ min: null, max: null }], y: [{ min: null, max: null }] },
+    scrollbar: { x: {}, y: {} },
+    axesX: [{ range: null }],
+    axesY: [{ range: null }],
+    ...overrides,
+  });
+
+describe('getScrollbarLimits', () => {
+  it('step 축은 labels 길이 기준 한계를 반환한다', () => {
+    const chart = createChart({
+      data: { labels: ['a', 'b', 'c', 'd'] },
+      scrollbar: { x: { type: 'step' } },
+    });
+    expect(chart.getScrollbarLimits('x')).toEqual({ limitMin: 0, limitMax: 3 });
+  });
+
+  it('step 축에 labels 가 없으면 null 을 반환한다', () => {
+    const chart = createChart({
+      data: { labels: [] },
+      scrollbar: { x: { type: 'step' } },
+    });
+    expect(chart.getScrollbarLimits('x')).toBeNull();
+  });
+
+  it('heatMap step 축은 data.labels[dir] 를 사용한다', () => {
+    const chart = createChart({
+      options: { type: 'heatMap' },
+      data: { labels: { x: ['a', 'b', 'c'], y: ['p', 'q'] } },
+      scrollbar: { x: { type: 'step' }, y: { type: 'step' } },
+    });
+    expect(chart.getScrollbarLimits('x')).toEqual({ limitMin: 0, limitMax: 2 });
+    expect(chart.getScrollbarLimits('y')).toEqual({ limitMin: 0, limitMax: 1 });
+  });
+
+  it('비-step 축은 minMax 의 min/max 를 한계로 반환한다', () => {
+    const chart = createChart({
+      minMax: { x: [{ min: 10, max: 90 }] },
+      scrollbar: { x: { type: 'time' } },
+    });
+    expect(chart.getScrollbarLimits('x')).toEqual({ limitMin: 10, limitMax: 90 });
+  });
+
+  // 회귀: minMax 가 아직 확정되지 않았을 때(+null === 0) [0,0] 으로 강제되는 것을 막는다.
+  it('비-step 축에서 minMax.min/max 가 null 이면 null 을 반환한다 (heatMap 첫 로드 회귀)', () => {
+    const chart = createChart({
+      minMax: { x: [{ min: null, max: null }] },
+      scrollbar: { x: { type: 'time' } },
+    });
+    expect(chart.getScrollbarLimits('x')).toBeNull();
+  });
+
+  it('비-step 축에서 minMax 값이 유한수가 아니면 null 을 반환한다', () => {
+    const chart = createChart({
+      minMax: { x: [{ min: 'foo', max: 'bar' }] },
+      scrollbar: { x: { type: 'time' } },
+    });
+    expect(chart.getScrollbarLimits('x')).toBeNull();
+  });
+});
+
+describe('initScrollbarRange', () => {
+  const baseTimeChart = (range, minMax = { min: 0, max: 100 }) =>
+    createChart({
+      data: { labels: ['a', 'b'] },
+      minMax: { x: [minMax] },
+      scrollbar: { x: { type: 'time', range } },
+    });
+
+  it('한계 안의 윈도우는 그대로 둔다', () => {
+    const chart = baseTimeChart([20, 50]);
+    chart.initScrollbarRange('x');
+    expect(chart.scrollbar.x.range).toEqual([20, 50]);
+  });
+
+  it('originalWidth 가 availableWidth 이상이면 [limitMin, limitMax] 로 맞춘다', () => {
+    const chart = baseTimeChart([-10, 200]);
+    chart.initScrollbarRange('x');
+    expect(chart.scrollbar.x.range).toEqual([0, 100]);
+  });
+
+  it('왼쪽으로 벗어난 윈도우는 폭을 유지한 채 시작에 정렬한다', () => {
+    const chart = baseTimeChart([-30, 0]); // width 30, 한계 밖(왼쪽)
+    chart.initScrollbarRange('x');
+    expect(chart.scrollbar.x.range).toEqual([0, 30]);
+  });
+
+  it('오른쪽으로 벗어난 윈도우는 폭을 유지한 채 끝에 정렬한다', () => {
+    const chart = baseTimeChart([90, 130]); // width 40, max 초과
+    chart.initScrollbarRange('x');
+    expect(chart.scrollbar.x.range).toEqual([60, 100]);
+  });
+
+  // 회귀: 라이브 데이터로 윈도우가 한계 밖으로 완전히 밀렸을 때 range 가 역전되면 안 된다.
+  it('윈도우가 한계보다 완전히 아래에 있어도 range 가 역전되지 않는다', () => {
+    const chart = baseTimeChart([10, 40], { min: 200, max: 500 });
+    chart.initScrollbarRange('x');
+    const [lo, hi] = chart.scrollbar.x.range;
+    expect(lo).toBeLessThanOrEqual(hi);
+    expect(lo).toBeGreaterThanOrEqual(200);
+    expect(hi).toBeLessThanOrEqual(500);
+  });
+
+  it('윈도우가 한계보다 완전히 위에 있어도 range 가 역전되지 않는다', () => {
+    const chart = baseTimeChart([800, 830], { min: 200, max: 500 });
+    chart.initScrollbarRange('x');
+    const [lo, hi] = chart.scrollbar.x.range;
+    expect(lo).toBeLessThanOrEqual(hi);
+    expect(lo).toBeGreaterThanOrEqual(200);
+    expect(hi).toBeLessThanOrEqual(500);
+  });
+
+  // 회귀: 한계 미확정(stale minMax)일 때 range 를 [0,0] 등으로 오염시키지 않는다.
+  it('한계를 알 수 없으면(minMax null) range 를 건드리지 않는다', () => {
+    const chart = createChart({
+      data: { labels: ['a', 'b'] },
+      minMax: { x: [{ min: null, max: null }] },
+      scrollbar: { x: { type: 'time', range: [1000, 4000] } },
+    });
+    chart.initScrollbarRange('x');
+    expect(chart.scrollbar.x.range).toEqual([1000, 4000]);
+  });
+});
+
+describe('updateScrollbarAnchorEdge', () => {
+  const anchorChart = (range, minMax = { min: 0, max: 100 }) =>
+    createChart({
+      minMax: { x: [minMax] },
+      scrollbar: { x: { type: 'time', range, anchorEdge: undefined } },
+    });
+
+  it('range 가 시작 한계에 닿으면 start', () => {
+    const chart = anchorChart([0, 40]);
+    chart.updateScrollbarAnchorEdge('x');
+    expect(chart.scrollbar.x.anchorEdge).toBe('start');
+  });
+
+  it('range 가 끝 한계에 닿으면 end', () => {
+    const chart = anchorChart([60, 100]);
+    chart.updateScrollbarAnchorEdge('x');
+    expect(chart.scrollbar.x.anchorEdge).toBe('end');
+  });
+
+  it('range 가 중앙이면 null', () => {
+    const chart = anchorChart([30, 70]);
+    chart.updateScrollbarAnchorEdge('x');
+    expect(chart.scrollbar.x.anchorEdge).toBeNull();
+  });
+
+  it('한계를 알 수 없으면 null', () => {
+    const chart = anchorChart([30, 70], { min: null, max: null });
+    chart.updateScrollbarAnchorEdge('x');
+    expect(chart.scrollbar.x.anchorEdge).toBeNull();
+  });
+});
+
+describe('updateScrollbarInfo - 리뷰 #2: anchorEdge 오탐 방지', () => {
+  // 이미 init 된 time 축 스크롤바. 윈도우 [0,30] 은 시작 한계(0)에 닿아 있어,
+  // updateScrollbarAnchorEdge 가 호출되면 anchorEdge 가 'start' 로 계산되는 상황.
+  const createInitedChart = (axisRangeOpt) => {
+    const scrollbarX = {
+      isInit: true,
+      use: true,
+      type: 'time',
+      range: [0, 30],
+      anchorEdge: null,
+      resetPosition: false,
+    };
+    return createChart({
+      options: {
+        type: 'heatMap',
+        axesX: [{ type: 'time', range: axisRangeOpt, scrollbar: { use: true } }],
+        axesY: [{}],
+      },
+      data: { labels: { x: ['a', 'b'], y: ['p'] } },
+      minMax: { x: [{ min: 0, max: 100 }] },
+      scrollbar: { x: scrollbarX, y: {} },
+      // axisOpt(현재 그려진 축)의 range 는 [0,30]
+      axesX: [{ range: [0, 30] }],
+      axesY: [{ range: null }],
+    });
+  };
+
+  it('데이터만 업데이트되면(range 옵션 동일) anchorEdge 를 재계산하지 않고 보존한다', () => {
+    // range 옵션이 현재 축과 동일 -> isUpdateAxesRange=false, updateData=true
+    const chart = createInitedChart([0, 30]);
+    chart.updateScrollbarInfo('x', true);
+    // 윈도우가 시작에 닿아 있어도, 데이터 업데이트 경로에서는 anchorEdge 를 새로 만들지 않는다
+    expect(chart.scrollbar.x.anchorEdge).toBeNull();
+  });
+
+  it('range 옵션이 바뀌면(리사이즈/범위지정) anchorEdge 를 재계산한다', () => {
+    // range 옵션이 현재 축과 달라짐 -> isUpdateAxesRange=true
+    const chart = createInitedChart([10, 40]);
+    chart.updateScrollbarInfo('x', false);
+    expect(chart.scrollbar.x.anchorEdge).toBe('start');
+  });
+
+  it('의도적으로 끝에 붙여둔(anchorEdge=end) 윈도우는 데이터 업데이트에도 보존된다', () => {
+    // 사용자가 끝으로 스크롤한 상태(anchorEdge=end)에서 데이터만 업데이트되면
+    // anchorEdge 가 유지되어 다음 리사이즈 때 끝 붙임이 살아있어야 한다.
+    const scrollbarX = {
+      isInit: true,
+      use: true,
+      type: 'time',
+      range: [70, 100],
+      anchorEdge: 'end',
+      resetPosition: false,
+    };
+    const chart = createChart({
+      options: {
+        type: 'heatMap',
+        axesX: [{ type: 'time', range: [70, 100], scrollbar: { use: true } }],
+        axesY: [{}],
+      },
+      data: { labels: { x: ['a', 'b'], y: ['p'] } },
+      minMax: { x: [{ min: 0, max: 100 }] },
+      scrollbar: { x: scrollbarX, y: {} },
+      axesX: [{ range: [70, 100] }], // 동일 -> isUpdateAxesRange=false
+      axesY: [{ range: null }],
+    });
+    chart.updateScrollbarInfo('x', true);
+    expect(chart.scrollbar.x.anchorEdge).toBe('end');
+  });
+});
+
+describe('updateScrollbarInfo - 리사이즈 시 anchorEdge 기준 위치 보존', () => {
+  // range 옵션이 바뀌는(=isUpdateAxesRange) 리사이즈/범위지정 상황에서, 기존 anchorEdge 에
+  // 따라 새 윈도우(newSize)를 시작/끝에 붙이거나 현재 시작점을 유지하는 핵심 동작.
+  const createResizeChart = ({ anchorEdge, currentRange, newOptRange, resetPosition = false }) =>
+    createChart({
+      options: {
+        type: 'heatMap',
+        axesX: [{ type: 'time', range: newOptRange, scrollbar: { use: true, resetPosition } }],
+        axesY: [{}],
+      },
+      data: { labels: { x: ['a', 'b'], y: ['p'] } },
+      minMax: { x: [{ min: 0, max: 100 }] },
+      scrollbar: {
+        x: { isInit: true, use: true, type: 'time', range: currentRange, anchorEdge },
+        y: {},
+      },
+      axesX: [{ range: [60, 90] }], // 현재 그려진 축과 newOptRange 가 달라 isUpdateAxesRange=true
+      axesY: [{ range: null }],
+    });
+
+  it('anchorEdge=end 면 새 윈도우를 끝(limitMax)에 붙인다', () => {
+    const chart = createResizeChart({ anchorEdge: 'end', currentRange: [60, 90], newOptRange: [0, 40] });
+    chart.updateScrollbarInfo('x', false);
+    expect(chart.scrollbar.x.range).toEqual([60, 100]); // [limitMax-newSize, limitMax]
+    expect(chart.scrollbar.x.anchorEdge).toBe('end');
+  });
+
+  it('anchorEdge=start 면 새 윈도우를 시작(limitMin)에 붙인다', () => {
+    const chart = createResizeChart({ anchorEdge: 'start', currentRange: [60, 90], newOptRange: [0, 40] });
+    chart.updateScrollbarInfo('x', false);
+    expect(chart.scrollbar.x.range).toEqual([0, 40]); // [limitMin, limitMin+newSize]
+    expect(chart.scrollbar.x.anchorEdge).toBe('start');
+  });
+
+  it('anchorEdge=null 이면 현재 시작점을 유지한다', () => {
+    const chart = createResizeChart({ anchorEdge: null, currentRange: [20, 50], newOptRange: [0, 40] });
+    chart.updateScrollbarInfo('x', false);
+    expect(chart.scrollbar.x.range).toEqual([20, 60]); // [currentRange[0], currentRange[0]+newSize]
+    expect(chart.scrollbar.x.anchorEdge).toBeNull();
+  });
+
+  it('resetPosition 이면 anchorEdge 와 무관하게 옵션 range 로 리셋한다', () => {
+    const chart = createResizeChart({
+      anchorEdge: 'end',
+      currentRange: [60, 90],
+      newOptRange: [10, 50],
+      resetPosition: true,
+    });
+    chart.updateScrollbarInfo('x', false);
+    expect(chart.scrollbar.x.range).toEqual([10, 50]);
+  });
+});
+
+describe('initScrollbarInfo - 리뷰 #3: resetPosition 재진입 시 anchor 재계산', () => {
+  it('isInit 상태에서 resetPosition 으로 range 를 리셋하면 anchorEdge 도 재계산된다', () => {
+    const chart = createChart({
+      options: { type: 'heatMap' },
+      data: { labels: { x: ['a', 'b'], y: ['p'] } },
+      minMax: { x: [{ min: 0, max: 100 }] },
+      scrollbar: { x: { isInit: true, type: 'time', range: [60, 90], anchorEdge: 'end' }, y: {} },
+    });
+    chart.initScrollbarInfo(
+      [{ type: 'time', range: [0, 40], scrollbar: { use: true, resetPosition: true } }],
+      'x',
+    );
+    expect(chart.scrollbar.x.range).toEqual([0, 40]);
+    // 시작 한계에 닿은 새 range 에 맞춰 stale 'end' 가 'start' 로 갱신되어야 한다.
+    expect(chart.scrollbar.x.anchorEdge).toBe('start');
+  });
+});
+
+describe('initScrollbarRange - step 축 / 가드', () => {
+  const stepChart = (range, labelLen = 10) =>
+    createChart({
+      data: { labels: Array.from({ length: labelLen }, (_, i) => `L${i}`) },
+      scrollbar: { x: { type: 'step', range } },
+    });
+
+  it('step 축: 한계 안의 인덱스 윈도우는 그대로', () => {
+    const chart = stepChart([3, 7]);
+    chart.initScrollbarRange('x');
+    expect(chart.scrollbar.x.range).toEqual([3, 7]);
+  });
+
+  it('step 축: 끝 인덱스를 넘으면 폭 유지하며 끝에 정렬', () => {
+    const chart = stepChart([6, 14]); // width 8, max index 9 초과
+    chart.initScrollbarRange('x');
+    expect(chart.scrollbar.x.range).toEqual([1, 9]);
+  });
+
+  it('range 가 없으면 아무것도 하지 않는다', () => {
+    const chart = createChart({
+      data: { labels: ['a', 'b'] },
+      minMax: { x: [{ min: 0, max: 100 }] },
+      scrollbar: { x: { type: 'time', range: null } },
+    });
+    chart.initScrollbarRange('x');
+    expect(chart.scrollbar.x.range).toBeNull();
+  });
+
+  it('range 에 숫자가 아닌 값이 있으면 건드리지 않는다', () => {
+    const chart = createChart({
+      data: { labels: ['a', 'b'] },
+      minMax: { x: [{ min: 0, max: 100 }] },
+      scrollbar: { x: { type: 'time', range: [null, 50] } },
+    });
+    chart.initScrollbarRange('x');
+    expect(chart.scrollbar.x.range).toEqual([null, 50]);
+  });
+});
+
+describe('updateScrollbarAnchorEdge - 스펙/가드', () => {
+  // 리뷰 #1(양쪽 모두 닿을 때 기존 anchor 보존)은 스펙으로 롤백됨.
+  // 양쪽 모두 닿으면 우선순위상 'start' 로 판정되는 것이 현재 스펙임을 고정한다.
+  it('range 가 양쪽 한계 모두에 닿으면 우선순위에 따라 start 로 판정한다 (스펙)', () => {
+    const chart = createChart({
+      minMax: { x: [{ min: 0, max: 100 }] },
+      scrollbar: { x: { type: 'time', range: [0, 100], anchorEdge: 'end' } },
+    });
+    chart.updateScrollbarAnchorEdge('x');
+    expect(chart.scrollbar.x.anchorEdge).toBe('start');
+  });
+
+  it('range 가 2개 원소가 아니면 anchorEdge 를 null 로 둔다', () => {
+    const chart = createChart({
+      minMax: { x: [{ min: 0, max: 100 }] },
+      scrollbar: { x: { type: 'time', range: [5], anchorEdge: 'end' } },
+    });
+    chart.updateScrollbarAnchorEdge('x');
+    expect(chart.scrollbar.x.anchorEdge).toBeNull();
+  });
+});


### PR DESCRIPTION
## 이슈

바 차트 스크롤바 사용 시, 데이터 자동 업데이트가 진행 중인 상태에서 차트 리사이즈가 발생하면 스크롤바 thumb 위치와 실제 표시되는 데이터가 어긋나는 현상이 있었습니다.

재현 (LargeScrollbar 예제):

1. 데이터 자동 업데이트 ON
2. 스크롤바를 가장 위로 드래그
3. 차트 높이를 늘렸다가 다시 줄임

결과: thumb은 가장 위에 보이지만 표시되는 데이터는 첫 항목이 아님.

## 발생 원인

스크롤바의 위치를 두 갈래의 별도 상태로 관리하던 게 근본 원인이었습니다.

- 하나는 실제로 표시할 데이터 범위
- 다른 하나는 thumb의 시각적 위치를 보존하기 위한 별도 플래그 묶음 (시작에 닿음 / 끝에 닿음 / 비율)

리사이즈 시점에 thumb의 시각 위치를 가장자리로 강제로 맞추는 코드는 있었지만, 같은 시점에 데이터 범위까지 함께 맞추지는 않았습니다. 또한 한 번 "가장자리에 닿음" 플래그가 켜지면 강제로 맞춰진 thumb 위치 때문에 다시 같은 플래그로 저장되는 자기 강화 구조가 있어, 한번 어긋난 상태는 잘 풀리지 않았습니다.

평소에는 두 상태가 비슷한 시점에 갱신되어 차이가 표면화되지 않지만, **데이터 자동 업데이트와 차트 사이즈 변경이 같은 프레임에 합쳐져 처리되는 경우** 두 상태의 갱신 경로가 어긋나면서 사용자가 보는 불일치가 발생했습니다.

## 변경 내용

### 스크롤바 위치 상태를 하나로 통합

시각적 thumb 위치를 별도로 저장하던 플래그 세 개를 모두 폐기했습니다. 대신 사용자의 의도("시작에 붙여둠" / "끝에 붙여둠" / "자유 위치")를 하나의 anchor 값으로 표현하도록 단순화했습니다.

데이터 범위가 유일한 진실원이 되고, thumb 위치는 그 범위에서 자연스럽게 파생됩니다.

### thumb 위치 결정 로직 단순화

thumb의 시각 위치를 강제로 덮어쓰던 분기를 제거하고, 자연 계산된 위치에 부동소수점 누적 오차 보정(가장자리 범위 안으로 clamp)만 남겼습니다. 이로 인해 자기 강화 구조도 함께 사라집니다.

### anchor 갱신 시점 명시화

- 사용자가 드래그 / 휠 / 클릭으로 직접 스크롤할 때: 새 범위가 축 한계에 닿는지 검사해 anchor를 갱신
- 옵션이나 데이터 변경으로 범위가 갱신될 때: 갱신 직후 anchor를 다시 계산

### 사이즈 변경 시 범위 계산 규칙

- "시작에 붙여둠" 상태: 새 사이즈에서도 시작에 붙여 새 범위를 계산
- "끝에 붙여둠" 상태: 끝에 붙여 새 범위를 계산
- "자유 위치": 기존 동작 그대로 시작점을 유지

## 이전 동작

<img width="1584" height="1012" alt="Jun-05-2026 10-10-58" src="https://github.com/user-attachments/assets/389d52b6-0cd5-493d-aa4e-718ff4e9221f" />

## 이후 동작

<img width="1584" height="1012" alt="Jun-05-2026 10-08-53" src="https://github.com/user-attachments/assets/7dee5ab9-96ac-48d1-816d-9ff21dfcb124" />

## 테스트 가이드
bar > LargeScrollbar.vue 에 붙여넣기 한 후 테스트 가능합니다.

```
<template>
  <div class="case">
    <resizable-wrapper ref="chartWrapperRef">
      <ev-chart :data="chartData" :options="chartOptions" />
    </resizable-wrapper>

    <div class="description">
      <span class="toggle-label">데이터 자동 업데이트</span>
      <ev-toggle v-model="isLive" />
    </div>
  </div>
</template>

<script>
import { ref, reactive, watch, onMounted, onBeforeUnmount } from 'vue';
import { throttle, cloneDeep } from 'lodash-es';

export default {
  setup() {
    const labelCount = 30;
    const seriesCount = 100;

    const seriesKeys = Array.from({ length: seriesCount }, (_, i) => `series${i + 1}`);

    const generateData = () => {
      const data = [];
      for (let i = 0; i < labelCount; i++) {
        if (Math.random() < 0.1) {
          data.push(null);
        } else {
          data.push(Math.floor(Math.random() * 300) + 10);
        }
      }
      return data;
    };

    const series = {};
    seriesKeys.forEach((key, i) => {
      series[key] = { name: `series#${i + 1}` };
    });

    const data = {};
    seriesKeys.forEach((key) => {
      data[key] = generateData();
    });

    const chartData = reactive({
      series,
      groups: [seriesKeys],
      labels: Array.from({ length: labelCount }, (_, i) => `Label ${i + 1}`),
      data,
    });

    const BAR_THICKNESS = 30;

    const chartOptions = ref({
      type: 'bar',
      width: '100%',
      height: '80%',
      thickness: BAR_THICKNESS,
      title: {
        text: 'Title Test',
        show: true,
      },
      legend: {
        show: true,
        position: 'right',
      },
      horizontal: true,
      axesX: [
        {
          type: 'linear',
          startToZero: true,
          showGrid: false,
        },
      ],
      axesY: [
        {
          type: 'step',
          showGrid: false,
          labelStyle: {
            fitWidth: true,
            fitDir: 'left',
          },
          range: null,
          scrollbar: undefined,
        },
      ],
    });

    const isLive = ref(false);
    const liveInterval = ref(null);

    const updateData = () => {
      seriesKeys.forEach((key) => {
        chartData.data[key] = generateData();
      });
    };

    watch(isLive, (newValue) => {
      if (newValue) {
        updateData();
        liveInterval.value = setInterval(updateData, 2000);
      } else {
        clearInterval(liveInterval.value);
        liveInterval.value = null;
      }
    });

    const chartWrapperRef = ref(null);

    const updateScrollbarRange = () => {
      const height = chartWrapperRef.value?.$el?.clientHeight ?? 0;
      if (height <= 0) return;

      const visibleCount = Math.min(Math.ceil(height / BAR_THICKNESS), labelCount);

      // 보이는 개수에 맞춰 윈도우 크기(range 길이)만 정한다. 위치 보존(중앙/끝 등)은
      // 차트가 직전 스크롤 위치를 기억해 처리하므로 항상 끝(마지막 데이터) 기준으로 둔다.
      // 전부 보이면(visibleCount === labelCount) 스크롤할 영역이 없으므로 scrollbar.use 를
      // 꺼서 스크롤바를 숨긴다. 다시 줄이면 use 를 켜고 끝 기준으로 윈도우를 잡는다.
      const maxIndex = labelCount - 1;
      const minIndex = Math.max(maxIndex - visibleCount + 1, 0);
      const useScrollbar = visibleCount < labelCount;
      const currentRange = chartOptions.value.axesY[0].range;
      const currentUse = !!chartOptions.value.axesY[0].scrollbar?.use;
      if (
        currentRange?.[0] === minIndex
        && currentRange?.[1] === maxIndex
        && currentUse === useScrollbar
      ) return;
      chartOptions.value = {
        ...cloneDeep(chartOptions.value),
        axesY: [
          {
            ...chartOptions.value.axesY[0],
            range: [minIndex, maxIndex],
            scrollbar: {
              showButton: true,
              resetPosition: false,
              use: useScrollbar,
            },
          },
        ],
      };
    };

    let resizeObserver = null;

    onMounted(() => {
      resizeObserver = new ResizeObserver(throttle(() => updateScrollbarRange(), 100));

      if (chartWrapperRef.value?.$el) resizeObserver.observe(chartWrapperRef.value.$el);

      updateScrollbarRange();
    });

    onBeforeUnmount(() => {
      clearInterval(liveInterval.value);
      resizeObserver?.disconnect();
    });

    return {
      chartData,
      chartOptions,
      isLive,
      chartWrapperRef,
    };
  },
};
</script>

<style lang="scss" scoped>
.case {
  height: 100%;
}
.toggle-label {
  vertical-align: top;
  margin-right: 7px;
}
</style>

