### PR TITLE
perf(chart): EvChart 단일 redraw/갱신 비용 최적화

### DIFF
--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -18,11 +18,11 @@ import {
   toRef,
   computed,
 } from 'vue';
-import { cloneDeep, isEqual, debounce } from 'lodash-es';
+import { isEqual, debounce } from 'lodash-es';
 import { resize } from '@/directives/resize';
 import EvChart from './chart.core';
 import EvChartToolbar from './ChartToolbar';
-import { useModel, useWrapper, useZoomModel } from './uses';
+import { useModel, useWrapper, useZoomModel, cloneChartData } from './uses';
 
 export default {
   name: 'EvChart',
@@ -206,7 +206,9 @@ export default {
         const isUpdateTooltip =
           newOpt.tooltip.use && !isEqual(newOpt.tooltip, evChart.options.tooltip);
 
-        evChart.options = cloneDeep(newOpt);
+        // getNormalizedOptions는 defaultsDeep({}, ...)로 props와 분리된 새 객체를 반환하므로
+        // 추가 cloneDeep 없이 그대로 할당한다.
+        evChart.options = newOpt;
 
         scheduleUpdate({
           updateSeries: false,
@@ -232,14 +234,20 @@ export default {
         const newData = props.options.realTimeScatter?.use
           ? { ...chartData, groups: [], labels: [] }
           : getNormalizedData(chartData);
+        // series/groups를 두 번 깊은 비교하지 않도록 각 키를 한 번씩만 비교해 재사용한다.
+        const isUpdateSeriesData = !isEqual(newData.series, evChart.data.series);
+        const isUpdateGroups = !isEqual(newData.groups, evChart.data.groups);
+
         const isUpdateSeries =
-          !isEqual(newData.series, evChart.data.series) ||
-          !isEqual(newData.groups, evChart.data.groups) ||
-          props.options.type === 'heatMap';
+          isUpdateSeriesData || isUpdateGroups || props.options.type === 'heatMap';
 
-        const isUpdateData = !isEqual(newData, evChart.data);
+        const isUpdateData =
+          isUpdateSeriesData ||
+          isUpdateGroups ||
+          !isEqual(newData.labels, evChart.data.labels) ||
+          !isEqual(newData.data, evChart.data.data);
 
-        evChart.data = props.options.realTimeScatter?.use ? newData : cloneDeep(newData);
+        evChart.data = props.options.realTimeScatter?.use ? newData : cloneChartData(newData);
 
         scheduleUpdate({
           updateSeries: isUpdateSeries,

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -720,10 +720,13 @@ class EvChart {
       this.oldPixelRatio = this.pixelRatio;
     }
 
-    this.bufferCtx.scale(this.pixelRatio, this.pixelRatio);
+    // 누적형 scale() 대신 절대 변환(setTransform)을 사용해 idempotent하게 만든다.
+    // 이렇게 하면 매 update마다 canvas.width 재대입(트랜스폼 리셋)에 의존하지 않아도 되어
+    // setWidth/setHeight에서 크기 변경이 없을 때 비트맵 재할당을 건너뛸 수 있다.
+    this.bufferCtx.setTransform(this.pixelRatio, 0, 0, this.pixelRatio, 0, 0);
 
     if (this.overlayCtx) {
-      this.overlayCtx.scale(this.pixelRatio, this.pixelRatio);
+      this.overlayCtx.setTransform(this.pixelRatio, 0, 0, this.pixelRatio, 0, 0);
     }
   }
 
@@ -853,13 +856,22 @@ class EvChart {
       return;
     }
 
-    this.displayCanvas.width = width * this.pixelRatio;
+    // canvas.width 재대입은 크기가 같아도 비트맵 재할당+clear+컨텍스트 리셋을 유발한다.
+    // 실제 device-pixel 폭이 바뀐 경우에만 재설정해 매 update마다의 재할당을 제거한다.
+    // (clear()가 매 렌더에서 캔버스를 비우므로 재할당의 암묵적 clear는 불필요하다.)
+    const deviceWidth = width * this.pixelRatio;
+    if (this._deviceWidth === deviceWidth) {
+      return;
+    }
+    this._deviceWidth = deviceWidth;
+
+    this.displayCanvas.width = deviceWidth;
     this.displayCanvas.style.width = `${width}px`;
-    this.bufferCanvas.width = width * this.pixelRatio;
+    this.bufferCanvas.width = deviceWidth;
     this.bufferCanvas.style.width = `${width}px`;
 
     if (this.overlayCanvas) {
-      this.overlayCanvas.width = width * this.pixelRatio;
+      this.overlayCanvas.width = deviceWidth;
       this.overlayCanvas.style.width = `${width}px`;
     }
   }
@@ -875,13 +887,20 @@ class EvChart {
       return;
     }
 
-    this.displayCanvas.height = height * this.pixelRatio;
+    // setWidth와 동일하게 device-pixel 높이가 바뀐 경우에만 재설정한다.
+    const deviceHeight = height * this.pixelRatio;
+    if (this._deviceHeight === deviceHeight) {
+      return;
+    }
+    this._deviceHeight = deviceHeight;
+
+    this.displayCanvas.height = deviceHeight;
     this.displayCanvas.style.height = `${height}px`;
-    this.bufferCanvas.height = height * this.pixelRatio;
+    this.bufferCanvas.height = deviceHeight;
     this.bufferCanvas.style.height = `${height}px`;
 
     if (this.overlayCanvas) {
-      this.overlayCanvas.height = height * this.pixelRatio;
+      this.overlayCanvas.height = deviceHeight;
       this.overlayCanvas.style.height = `${height}px`;
     }
   }

--- a/src/components/chart/helpers/helpers.util.js
+++ b/src/components/chart/helpers/helpers.util.js
@@ -5,6 +5,11 @@ import { billions, millions, quadrillion, trillion, truthy } from '@/common/util
 const textMeasureCanvas = document.createElement('canvas');
 const textMeasureCtx = textMeasureCanvas.getContext('2d');
 
+// colorStringToRgba 결과 캐시. 시리즈 색상은 update 간 거의 불변이고 동일 (색,opacity)
+// 조합이 반복 파싱되므로, 불변 문자열 결과를 메모이즈해 정규식 재실행을 제거한다.
+const colorRgbaCache = new Map();
+const COLOR_RGBA_CACHE_MAX = 512;
+
 export default {
   /**
    * Transforming hex to rgb code
@@ -69,6 +74,12 @@ export default {
    * @returns {string} transformed rgba
    */
   colorStringToRgba(colorStr, opacity = 1) {
+    const cacheKey = `${colorStr}|${opacity}`;
+    const cached = colorRgbaCache.get(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
     const noneWhiteSpaceColorStr = colorStr.replace(/ /g, '');
     const colorType = this.getColorStringType(noneWhiteSpaceColorStr);
     let resultRGBA = '';
@@ -80,13 +91,23 @@ export default {
       case 'RGB':
         resultRGBA = noneWhiteSpaceColorStr.replace(')', `, ${opacity})`).replace('rgb', 'rgba');
         break;
-      case 'RGBA':
-        resultRGBA = noneWhiteSpaceColorStr.replace(`${this.getOpacity(colorStr)})`, `${opacity})`);
+      case 'RGBA': {
+        // 이미 RGBA로 판정됐으므로 getOpacity(=getColorStringType 재실행, 정규식 3개)를 호출하지 않고
+        // 현재 opacity 값을 직접 추출해 교체한다.
+        const curOpacity = noneWhiteSpaceColorStr.replace(/^.*,(.+)\)/, '$1');
+        resultRGBA = noneWhiteSpaceColorStr.replace(`${curOpacity})`, `${opacity})`);
         break;
+      }
       default:
         resultRGBA = `rgba(0, 0, 0, ${opacity})`;
         break;
     }
+
+    if (colorRgbaCache.size >= COLOR_RGBA_CACHE_MAX) {
+      colorRgbaCache.delete(colorRgbaCache.keys().next().value);
+    }
+
+    colorRgbaCache.set(cacheKey, resultRGBA);
 
     return resultRGBA;
   },

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -91,6 +91,7 @@ const modules = {
                   label,
                   series.isExistGrp,
                   basePassingValue,
+                  series.data,
                 );
               }
               series.minMax = this.getSeriesMinMax(series.data, series.passingValue);
@@ -546,10 +547,13 @@ const modules = {
    *
    * @returns {ChartSeriesDataPoint[]} data for each series
    */
-  addSeriesDS(data, label, isBase, passingValue) {
+  addSeriesDS(data, label, isBase, passingValue, prevData) {
     const isHorizontal = this.options.horizontal;
     const sdata = [];
     const usePassingValue = isBase && !Util.isNullOrUndefined(passingValue);
+    // 직전 데이터셋의 포인트 객체를 재사용해 매 update마다의 N개 객체 할당(GC 압력)을 제거한다.
+    // 모든 포인트 객체는 동일한 10필드 형태이고 아래에서 전 필드를 덮어쓰므로 stale 값 위험이 없다.
+    const pool = Array.isArray(prevData) ? prevData : null;
 
     for (let i = 0; i < data.length; i++) {
       let gdata = data[i];
@@ -569,12 +573,28 @@ const modules = {
         } else {
           const v = value ?? null;
           const o = gdata ?? null;
-          sdata.push(isHorizontal
-            ? { x: v, y: ldata, o, b: null, xp: null, yp: null,
-                w: null, h: null, dataColor: null, dataTextColor: null }
-            : { x: ldata, y: v, o, b: null, xp: null, yp: null,
-                w: null, h: null, dataColor: null, dataTextColor: null },
-          );
+          const reused = pool && pool[sdata.length];
+
+          if (reused && typeof reused === 'object') {
+            reused.x = isHorizontal ? v : ldata;
+            reused.y = isHorizontal ? ldata : v;
+            reused.o = o;
+            reused.b = null;
+            reused.xp = null;
+            reused.yp = null;
+            reused.w = null;
+            reused.h = null;
+            reused.dataColor = null;
+            reused.dataTextColor = null;
+            sdata.push(reused);
+          } else {
+            sdata.push(isHorizontal
+              ? { x: v, y: ldata, o, b: null, xp: null, yp: null,
+                  w: null, h: null, dataColor: null, dataTextColor: null }
+              : { x: ldata, y: v, o, b: null, xp: null, yp: null,
+                  w: null, h: null, dataColor: null, dataTextColor: null },
+            );
+          }
         }
       }
     }

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -1,5 +1,5 @@
 import { ref, reactive, computed, watch, getCurrentInstance, nextTick, onUpdated } from 'vue';
-import { cloneDeep, defaultsDeep, isEqual } from 'lodash-es';
+import { cloneDeep, cloneDeepWith, defaultsDeep, isEqual } from 'lodash-es';
 import { getQuantity } from '@/common/utils';
 import EvChartZoom from '@/components/chart/chartZoom.core';
 
@@ -264,6 +264,21 @@ const DEFAULT_DATA = {
   labels: [],
   data: {},
 };
+
+/**
+ * dayjs/Date 등 불변(immutable) 날짜 값은 깊은 복제 대상에서 제외하고 참조만 공유한다.
+ * 메서드가 새 인스턴스를 반환하는 불변 객체라 제자리 변형이 없으므로 스냅샷 격리가 깨지지 않으며,
+ * time-axis 차트에서 labels의 dayjs 인스턴스를 통째로 깊은 복제하던 비용(수천 개)을 제거한다.
+ */
+const isImmutableDateLike = (value) =>
+  value instanceof Date ||
+  (value !== null &&
+    typeof value === 'object' &&
+    typeof value.toDate === 'function' &&
+    typeof value.format === 'function');
+
+export const cloneChartData = (data) =>
+  cloneDeepWith(data, (value) => (isImmutableDateLike(value) ? value : undefined));
 
 const useWidgetClickEvent = () => {
   let timer = null;
@@ -630,7 +645,7 @@ export const useZoomModel = (
   const setDataForUseZoom = (newData) => {
     if (isUpdateDataForUseZoom.value) {
       if (!isExecuteZoom.value) {
-        evChartClone.data = evChartGroupRef ? cloneDeep(newData) : [cloneDeep(newData)];
+        evChartClone.data = evChartGroupRef ? cloneChartData(newData) : [cloneChartData(newData)];
 
         if (evChartZoomOptions.zoom.keepZoomStatus) {
           isUpdateDataForUseZoom.value = false;


### PR DESCRIPTION
## 개요
시계열 라인차트를 폴링으로 갱신할 때 단일 위젯에서도 redraw 1회가 ~100ms CPU를 소모하던 문제를 EVUI 내부에서 줄였습니다. 동작/시각 결과와 공개 API는 그대로 유지하면서, 갱신마다 반복되던 "불필요한 복사·재파싱·재할당·객체 할당"을 제거하는 것이 목표입니다.

## 변경사항
1. 데이터 감시(watch) 부담 줄이기 — Chart.vue, uses.js
   - 중복 복사 제거
   - 중복 비교 제거 
   - dayjs는 복사하지 않고 그대로 사용 
3. 차트 한 번 그릴 때(redraw) 비용 줄이기
   - 색상 기억 
   - 캔버스 재사용 
   - 데이터 객체 재사용
   
## 성능 결과 
<img width="1039" height="248" alt="image" src="https://github.com/user-attachments/assets/711d4732-f1e6-42a8-9bf0-1e90e72eb198" />

## 테스트 TODO 
- [ ] DPR + 리사이즈 시 렌더 결과 정상 
- [ ] chartGroup / Brush / zoom 정상 동작
- [ ] 툴팁 / selectItem / 범례 / 임계치 / 오토스케일 정상 
- [ ] time-axis(dayjs labels)차트 라벨/툴팁 정상