### PR TITLE
perf(chart): 스택 차트 데이터 처리 속도 개선

### DIFF
--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -50,6 +50,11 @@ const modules = {
           const firstSeriesId = seriesIDs[0];
           const basePassingValue = this.seriesList[firstSeriesId]?.passingValue;
 
+          // 스택 그룹별 부호별 누적 top(base 위치)을 유지해 base 조회를 O(1)로 만든다.
+          // (기존 addSeriesStackDS 의 bsIds 역방향 탐색 O(S) 제거 → 그룹 전체 O(L·S²)→O(L·S).
+          //  null 이 많아도 비용이 일정 — 매 포인트마다 바닥까지 훑던 최악 케이스가 사라진다.)
+          const stackTops = new Map();
+
           for (let s = 0; s < seriesIDs.length; s++) {
             const seriesID = seriesIDs[s];
             const series = this.seriesList[seriesID];
@@ -83,8 +88,18 @@ const modules = {
             series.hasPassingValueInData = hasPassingValueInData;
 
             if (series && sData) {
-              if (series.isExistGrp && series.stackIndex && !series.isOverlapping) {
-                series.data = this.addSeriesStackDS(sData, label, series.bsIds, series.stackIndex);
+              const inStackGroup = series.isExistGrp && !series.isOverlapping;
+              let tops = null;
+              if (inStackGroup) {
+                tops = stackTops.get(series.groupIndex);
+                if (!tops) {
+                  tops = { pos: [], neg: [] };
+                  stackTops.set(series.groupIndex, tops);
+                }
+              }
+
+              if (inStackGroup && series.stackIndex) {
+                series.data = this.addSeriesStackDS(sData, label, series.stackIndex, tops);
               } else {
                 series.data = this.addSeriesDS(
                   sData,
@@ -95,6 +110,11 @@ const modules = {
                 );
               }
               series.minMax = this.getSeriesMinMax(series.data, series.passingValue);
+
+              // 이 시리즈가 이후 스택 시리즈의 base 가 되므로 누적 top 갱신
+              if (inStackGroup) {
+                this.updateStackTops(tops, series);
+              }
             }
           }
         }
@@ -457,57 +477,23 @@ const modules = {
    * Take data and label to create stack data for each series
    * @param {object}  data    chart series info
    * @param {object}  label   chart label
-   * @param {array}   bsIds   stacked base data ID List
    * @param {number}  sIdx    series ordered index
+   * @param {{pos: number[], neg: number[]}}  tops  스택 그룹의 부호별 누적 top(base 위치)
    *
    * @typedef {import('./index').ChartSeriesDataPoint} ChartSeriesDataPoint
    *
    * @returns {ChartSeriesDataPoint[]} data for each series
    */
-  addSeriesStackDS(data, label, bsIds, sIdx = 0) {
-    const seriesList = this.seriesList;
+  addSeriesStackDS(data, label, sIdx = 0, tops = null) {
     const isHorizontal = this.options.horizontal;
     const sdata = [];
-    const basePositionCache = new Map();
+    const posTop = tops?.pos;
+    const negTop = tops?.neg;
 
-    const getBaseDataPosition = (baseIndex, dataIndex, curr) => {
-      const key = `${baseIndex}-${dataIndex}-${curr >= 0 ? 'pos' : 'neg'}`;
-      if (basePositionCache.has(key)) {
-        return basePositionCache.get(key);
-      }
-
-      let result = 0;
-      let idx = baseIndex;
-
-      while (idx >= 0) {
-        const baseSeries = seriesList[bsIds[idx]];
-        if (baseSeries?.show) {
-          const baseData = baseSeries.data[dataIndex];
-          const position = isHorizontal ? baseData?.x : baseData?.y;
-          const baseValue = baseData?.o;
-
-          const isPassingValue =
-            !Util.isNullOrUndefined(baseSeries.passingValue) &&
-            baseSeries.passingValue === baseValue;
-
-          const isSameSign = (curr >= 0 && baseValue >= 0) || (curr < 0 && baseValue < 0);
-
-          if (position != null && !isPassingValue && isSameSign) {
-            result = position;
-            break;
-          }
-        }
-        idx--;
-      }
-
-      basePositionCache.set(key, result);
-      return result;
-    };
-
-    const lastBaseIndex = bsIds.length - 1;
     data.forEach((curr, index) => {
-      const baseIndex = Math.max(0, lastBaseIndex);
-      let bdata = getBaseDataPosition(baseIndex, index, curr); // base(previous) series data
+      // base(아래 스택) 위치: 부호별 누적 top 에서 O(1) 조회.
+      // 기존 bsIds 역방향 탐색과 동치 — 가장 최근에 갱신된 "보이는 동일부호 유효 base"가 곧 누적 top.
+      let bdata = (curr >= 0 ? posTop?.[index] : negTop?.[index]) ?? 0; // base(previous) series data
       let odata = curr; // current series original data
       let ldata = label[index]; // label data
       let gdata = curr; // current series data which added previous series's value
@@ -535,6 +521,46 @@ const modules = {
     });
 
     return sdata;
+  },
+
+  /**
+   * 방금 data 가 계산된 스택 시리즈로 그룹의 부호별 누적 top(base 위치)을 갱신한다.
+   * addSeriesStackDS 의 base 조회를 O(1) 로 만들기 위한 보조 상태이며,
+   * 갱신 규칙은 기존 getBaseDataPosition 의 accept 조건과 동치다:
+   *   show 시리즈만, position(null 아님) && passingValue 아님 → 해당 부호 버킷에 기록.
+   * 인덱스는 series.data(압축본) 기준으로 기록하고 조회는 라벨 인덱스로 하므로
+   * 기존 `baseSeries.data[dataIndex]` 접근과 동일한 정렬을 유지한다.
+   * @param {{pos: number[], neg: number[]}}  tops  그룹 누적 top
+   * @param {object}  series  방금 data 가 계산된 시리즈
+   *
+   * @returns {undefined}
+   */
+  updateStackTops(tops, series) {
+    if (!series.show) {
+      return;
+    }
+
+    const isHorizontal = this.options.horizontal;
+    const passingValue = series.passingValue;
+    const usePassingValue = !Util.isNullOrUndefined(passingValue);
+    const data = series.data;
+    const pos = tops.pos;
+    const neg = tops.neg;
+
+    for (let i = 0; i < data.length; i++) {
+      const p = data[i];
+      const position = isHorizontal ? p.x : p.y;
+      const baseValue = p.o;
+      const isPassingValue = usePassingValue && baseValue === passingValue;
+
+      if (position != null && !isPassingValue) {
+        if (baseValue >= 0) {
+          pos[i] = position;
+        } else {
+          neg[i] = position;
+        }
+      }
+    }
   },
 
   /**

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -717,3 +717,116 @@ describe('model.store createRealTimeScatterDataSet (x,y) dedupe', () => {
     expect(totalPoints).toBe(4);
   });
 });
+
+describe('model.store createDataSet stack (누적 top 기반)', () => {
+  /**
+   * 세로 스택 막대 그룹 컨텍스트를 만든다.
+   * series: [{ id, data, show?, passingValue? }] (스택 순서대로 = bottom→top)
+   */
+  const buildStackStore = (series, options = {}) => {
+    const seriesList = {};
+    const rawData = {};
+    series.forEach((s, idx) => {
+      seriesList[s.id] = {
+        data: [],
+        passingValue: s.passingValue ?? null,
+        interpolation: null,
+        isExistGrp: true,
+        isOverlapping: false,
+        groupIndex: 0,
+        stackIndex: idx, // bottom(0) → addSeriesDS, 그 위는 addSeriesStackDS
+        show: s.show ?? true,
+        xAxisIndex: 0,
+        yAxisIndex: 0,
+      };
+      rawData[s.id] = s.data;
+    });
+
+    const store = Object.assign(Object.create(modules), {
+      seriesList,
+      options: { horizontal: false, sunburst: false, ...options },
+      seriesInfo: { charts: { bar: series.map((s) => s.id) } },
+    });
+
+    return { store, seriesList, rawData };
+  };
+
+  const ys = (series) => series.data.map((p) => p.y);
+  const bs = (series) => series.data.map((p) => p.b);
+
+  it('정상 값은 아래 시리즈의 누적 top 위에 쌓인다', () => {
+    const { store, seriesList, rawData } = buildStackStore([
+      { id: 's0', data: [10, 1, 5] },
+      { id: 's1', data: [20, 30, 2] },
+      { id: 's2', data: [5, 5, 5] },
+    ]);
+
+    store.createDataSet(rawData, [0, 1, 2]);
+
+    expect(ys(seriesList.s0)).toEqual([10, 1, 5]);
+    expect(ys(seriesList.s1)).toEqual([30, 31, 7]); // base + 값
+    expect(ys(seriesList.s2)).toEqual([35, 36, 12]);
+    expect(bs(seriesList.s2)).toEqual([30, 31, 7]); // 각 포인트의 base = 아래 누적 top
+  });
+
+  it('아래 시리즈가 null 인 라벨에서는 그 자리를 건너뛰고 다음 유효 base 위에 쌓인다', () => {
+    const { store, seriesList, rawData } = buildStackStore([
+      { id: 's0', data: [10, null, 5] }, // i1 null
+      { id: 's1', data: [20, 30, null] }, // i2 null
+      { id: 's2', data: [5, 5, 5] },
+    ]);
+
+    store.createDataSet(rawData, [0, 1, 2]);
+
+    // s1 i1: s0 가 null → baseline(0) 위에 쌓임
+    expect(seriesList.s1.data[1].b).toBe(0);
+    expect(seriesList.s1.data[1].y).toBe(30);
+    // s2 i2: s1 이 null → s0(=5) 위에 쌓임 (s1 자리를 건너뜀)
+    expect(seriesList.s2.data[2].b).toBe(5);
+    expect(seriesList.s2.data[2].y).toBe(10);
+  });
+
+  it('부호가 다른 base 는 건너뛰고 같은 부호의 누적 top 위에 쌓인다', () => {
+    const { store, seriesList, rawData } = buildStackStore([
+      { id: 's0', data: [10] }, // +
+      { id: 's1', data: [-5] }, // -
+      { id: 's2', data: [-3] }, // -
+      { id: 's3', data: [4] }, // + → s0(=10) 위에
+    ]);
+
+    store.createDataSet(rawData, [0]);
+
+    expect(seriesList.s1.data[0].b).toBe(0); // 첫 음수 → baseline
+    expect(seriesList.s2.data[0].b).toBe(-5); // 음수 누적 top
+    expect(seriesList.s2.data[0].y).toBe(-8);
+    expect(seriesList.s3.data[0].b).toBe(10); // 양수 base(s0) 위 — s1/s2(음수) 건너뜀
+    expect(seriesList.s3.data[0].y).toBe(14);
+  });
+
+  it('숨겨진(show=false) 시리즈는 누적 top 에 기여하지 않는다', () => {
+    const { store, seriesList, rawData } = buildStackStore([
+      { id: 's0', data: [10] },
+      { id: 's1', data: [100], show: false }, // 숨김 → base 에서 제외
+      { id: 's2', data: [5] },
+    ]);
+
+    store.createDataSet(rawData, [0]);
+
+    // s2 는 숨겨진 s1(=100)이 아니라 s0(=10) 위에 쌓여야 한다
+    expect(seriesList.s2.data[0].b).toBe(10);
+    expect(seriesList.s2.data[0].y).toBe(15);
+  });
+
+  it('passingValue 인 base 는 건너뛴다', () => {
+    const { store, seriesList, rawData } = buildStackStore([
+      { id: 's0', data: [10] },
+      { id: 's1', data: [-1], passingValue: -1 }, // passingValue → base 제외
+      { id: 's2', data: [5] },
+    ]);
+
+    store.createDataSet(rawData, [0]);
+
+    expect(seriesList.s2.data[0].b).toBe(10); // s1(passing) 건너뛰고 s0 위
+    expect(seriesList.s2.data[0].y).toBe(15);
+  });
+});


### PR DESCRIPTION
## 개요 
- 스택(누적) 막대/라인 차트에서 시리즈가 많고 데이터에 빈 값(null)이 많을 때 그리기 준비가 느려지던 문제를 개선했습니다.

## 병목 구간
- 스택 차트는 각 시리즈를 "아래 시리즈 위에 쌓아" 그립니다. 
- 그렇게 때문에 한 시리즈를 그리려면 바로 아래에 깔린 값이 어디까지 차 있는지를 먼저 알아야 합니다.
- 기존
   - "아래 높이"를 구할 때, 데이터 점 하나하나마다 아래 시리즈들을 맨 위에서부터 하나씩 거꾸로 뒤져 내려가며 값이 있는 시리즈를 찾았습니다.

## 변경 사항
- **"아래 시리즈들을 매번 뒤지지 말고, 쌓이는 순서대로 처리하면서 현재까지의 누적 높이를 기억해 두자"**
   - 시리즈를 아래에서 위로 순서대로 처리하면서, 양수/음수 각각의 누적 높이를 배열에 계속 기록
   - 다음 시리즈는 아래를 다시 뒤질 필요 없이, 기록된 누적 높이를 즉시(한 번에) 꺼냄
   - 결과적으로 탐색 비용이 사라져 처리 시간이 시리즈 수에 단순 비례하게 되고, 빈 값이 많아도 느려지지 않음
   - 더불어 실제로는 한 번도 적중하지 못하던(매 호출 새로 만들어지고 키가 매번 달라 항상 빗나가던) 내부 캐시를 제거해 불필요한 부하도 없음

## 기대 동작
- 기존과 완전히 동일
- 빈 값 건너뛰기, 숨긴 시리즈 제외, 양수/음수 구분, 특수 제외 값(passingValue) 처리 규칙을 그대로 유지

## 성능 결과 
- <img width="984" height="245" alt="image" src="https://github.com/user-attachments/assets/918a5daf-aed2-4acf-afab-e9546904f7b6" />

## 테스트 가이드
1. 자동 테스트: 스택 동작 회귀 테스트 5종 추가(정상 누적 / 아래가 빈 값일 때 건너뛰기 / 양수·음수 혼합 / 숨긴 시리즈 제외 / 제외 값 처리). 차트 전체 테스트 341개 전부 통과
   - `npx vitest run src/components/chart`
 2. 수동 테스트 
    - npm run docs 속 예제들이 기존과 동일하게 보이는지 확인 
       - http://localhost:9999/EVUI/lineChart#stack
       - http://localhost:9999/EVUI/barChart#stack
