### PR TITLE
fix(chart): 툴팁 가상스크롤 — 비-row 요소(그룹 헤더·marker) 순서 보존

### DIFF
--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -321,7 +321,7 @@ const chartData =
 | showHeader          | Boolean                     | true                                       | Tooltip의 Header 영역 표시 여부                         |
 | formatter           | function / Object           | null                                       | 데이터가 표시되기 전에 데이터의 형식을 지정하는 데 사용 | (아래 코드 참고)                                                    |
 | returnValue         | function                    | null                                       | 외부 컴포넌트 커스텀 툴팁을 구현할 때 사용하는 함수                 | (아래 코드 참고)                                                    |
-| virtualScroll       | Object                      | { use: 'auto', threshold: 50, estimatedRowHeight: 28, overscan: 5 } | `formatter.html` 사용 시 가상 스크롤로 보이는 행만 라이브 DOM에 부착. 시리즈당 wrapper element에 `data-evui-tooltip-row` 속성을 부여하면 안정적으로 활성화됨 | use: 'auto' \| true \| false (auto는 threshold 초과 시 자동) |
+| virtualScroll       | Object                      | { use: 'auto', threshold: 50, estimatedRowHeight: 28, overscan: 5 } | `formatter.html` 사용 시 가상 스크롤로 보이는 범위만 라이브 DOM에 부착. 시리즈당 wrapper element에 `data-evui-tooltip-row` 속성을 부여하면 안정적으로 활성화됨. 행 사이에 섞인 비-row 요소(그룹 헤더·구분선·marker 등)는 원래 순서를 보존한 채 함께 스크롤됨 | use: 'auto' \| true \| false (auto는 threshold 초과 시 자동) |
 
 ```ts
 const chartOptions = {

--- a/src/components/chart/plugins/plugins.tooltip.virtualScroll.js
+++ b/src/components/chart/plugins/plugins.tooltip.virtualScroll.js
@@ -5,16 +5,20 @@ import Util from '../helpers/helpers.util';
  *
  * 동작 개요:
  *  1) `tooltip.formatter.html(items)`로 사용자가 반환한 HTML을 파싱한다.
- *  2) 파싱된 트리에서 row를 찾는다 (우선순위 순):
- *     a. `[data-evui-tooltip-row]` 속성이 있는 element들 — **권장**.
+ *  2) 파싱된 트리에서 가상화 대상 "컨테이너"를 찾는다 (행 탐지 기준, 우선순위 순):
+ *     a. `[data-evui-tooltip-row]` 속성 행의 개수가 series 수와 일치하고 부모가 동일 → 그 부모.
  *        - 사용자는 시리즈당 wrapper element 하나에 이 속성만 추가하면 된다.
  *     b. 휴리스틱: BFS로 자식 수가 `items.length`와 일치하는 가장 얕은 element.
  *        - row가 단순한 한 단계의 자식들로 구성된 경우에만 동작.
  *  3) 둘 다 실패하면 가상 스크롤 비활성, 기존 경로로 fallback (경고 1회).
- *  4) 사용자의 wrapper 구조는 그대로 두고, row만 분리하여 가상 스크롤 viewport를 통해
- *     가시 범위 행만 라이브 DOM에 부착한다.
- *  5) 가시 행은 부착 직후 측정하여 prefix sum 갱신, 앵커 보정으로 스크롤 점프 방지.
- *  6) ResizeObserver로 컨테이너 폭 변화 시 측정 무효화 후 재렌더.
+ *  4) **컨테이너의 직속 자식 전체**를 순서 보존 "아이템"으로 가상화한다.
+ *     - 행 = `[data-evui-tooltip-row]` 보유 / 비-row = 그 외 모든 직속 자식(그룹 헤더·구분선·marker 등).
+ *       분류 기준은 오직 `data-evui-tooltip-row` 속성 유무이며, 소비처 클래스명은 보지 않는다.
+ *     - 비-row는 자기 위치(자기 그룹 행 위/사이)를 보존한 채 행과 함께 스크롤되어 들어오고 나간다.
+ *  5) 가시 범위(행+비-row 통합 좌표계)의 아이템만 viewport에 부착하고 상/하 spacer로 나머지 높이 보전.
+ *  6) 가시 아이템은 부착 직후 측정하여 prefix sum 갱신, 앵커 보정으로 스크롤 점프 방지.
+ *     - 학습 평균/추정 높이는 **행 아이템만** 대상으로 계산해 키가 다른 비-row가 행 추정을 오염시키지 않게 한다.
+ *  7) ResizeObserver로 컨테이너 폭 변화 시 측정 무효화 후 재렌더.
  */
 
 const DEFAULT_MAX_HEIGHT = 480;
@@ -43,16 +47,18 @@ const modules = {
   },
 
   /**
-   * 파싱된 트리에서 row 배열과 그 공통 부모(rowContainer)를 찾는다.
+   * 파싱된 트리에서 가상화 대상 컨테이너를 찾는다.
+   * 컨테이너의 직속 자식 전체(행 + 비-row 데코레이션)가 가상화 아이템이 된다.
    *
    * @param {Element} root
-   * @param {number} itemsCount
-   * @returns {{rows: Element[], rowContainer: Element}|null}
+   * @param {number} itemsCount  series 수
+   * @returns {Element|null}
    */
-  _findCustomTooltipRows(root, itemsCount) {
+  _findCustomTooltipContainer(root, itemsCount) {
     if (!root || !root.querySelectorAll) return null;
 
-    // 1) 명시적 마커
+    // 1) 명시적 마커 — 행 개수가 series 수와 일치하고 부모가 동일하면 그 부모가 컨테이너.
+    //    부모에 비-row 형제(그룹 헤더·구분선·marker 등)가 섞여 있어도 컨테이너로 인정한다.
     const marked = root.querySelectorAll('[data-evui-tooltip-row]');
     if (marked.length === itemsCount && marked.length > 0) {
       const firstParent = marked[0].parentElement;
@@ -64,16 +70,17 @@ const modules = {
         }
       }
       if (sameParent) {
-        return { rows: Array.from(marked), rowContainer: firstParent };
+        return firstParent;
       }
     }
 
     // 2) BFS 휴리스틱 — 자식 수가 itemsCount와 일치하는 가장 얕은 element
+    //    (이 경로의 컨테이너 자식들은 전부 행이므로 비-row가 없는 기존 동작과 동일)
     const queue = [root];
     while (queue.length) {
       const node = queue.shift();
       if (node.children && node.children.length === itemsCount) {
-        return { rows: Array.from(node.children), rowContainer: node };
+        return node;
       }
       if (node.children) {
         for (let i = 0; i < node.children.length; i++) {
@@ -173,12 +180,13 @@ const modules = {
   },
 
   /**
-   * 가시 범위 행만 viewport에 부착한다. 다른 행은 detach 상태(this.vsState.rows 배열에 보존).
+   * 가시 범위 아이템만 viewport에 부착한다(행/비-row 무관, 원래 순서 보존).
+   * 다른 아이템은 detach 상태(this.vsState.items 배열에 보존).
    * 새 range가 직전 range와 동일하면 viewport 재구성을 건너뛰고 spacer만 갱신한다.
    */
   _renderVisibleCustomTooltipRows() {
     const s = this.vsState;
-    if (!s || !s.rows.length) return;
+    if (!s || !s.items.length) return;
 
     const range = this._computeCustomTooltipVisibleRange();
     const same = s.range.start === range.start && s.range.end === range.end;
@@ -190,8 +198,8 @@ const modules = {
       }
       const frag = document.createDocumentFragment();
       for (let i = range.start; i <= range.end; i++) {
-        const row = s.rows[i];
-        if (row) frag.appendChild(row);
+        const item = s.items[i];
+        if (item) frag.appendChild(item);
       }
       s.viewport.appendChild(frag);
       s.range = range;
@@ -225,8 +233,9 @@ const modules = {
   },
 
   /**
-   * viewport 자식들의 실제 높이를 측정해 캐시 업데이트.
-   * 첫 측정 시 미측정 row들도 학습된 평균으로 보정해 totalHeight 점프를 흡수한다.
+   * viewport 자식들의 실제 높이를 측정해 캐시 업데이트(행/비-row 모두 실측).
+   * 학습 평균은 **행 아이템만** 대상으로 계산해 키가 다른 비-row가 행 추정을 오염시키지 않게 하고,
+   * 미측정 '행'에만 평균을 적용해 totalHeight 점프를 흡수한다. (미측정 비-row는 실측 전까지 추정 유지)
    * 추정과 다르면 prefix sum 재계산 + 앵커 보정 후 다시 렌더.
    */
   _measureVisibleCustomTooltipRows() {
@@ -241,7 +250,8 @@ const modules = {
     const oldAnchorOffset = s.prefixSums[anchorIdx] || 0;
 
     let changed = false;
-    let sum = 0;
+    let rowSum = 0;
+    let rowCount = 0;
     for (let k = 0; k < count; k++) {
       const idx = s.range.start + k;
       const h = children[k].offsetHeight;
@@ -255,20 +265,26 @@ const modules = {
         }
         s.measured[idx] = true;
       }
-      sum += h;
+      // 학습 평균은 행 아이템만 대상으로 (키 큰 헤더 등 비-row가 행 추정을 오염시키지 않게)
+      if (s.isRow[idx] && h > 0) {
+        rowSum += h;
+        rowCount += 1;
+      }
     }
 
-    // 학습된 평균을 누적 (다음 세션 estimated)
-    const avg = sum / count;
-    s.learnedAverageHeight = avg;
+    // 학습된 행 평균을 누적 (다음 세션 estimated 부트스트랩)
+    if (rowCount > 0) {
+      const avg = rowSum / rowCount;
+      s.learnedAverageHeight = avg;
 
-    // 미측정 row들에 평균을 적용해 totalHeight 추정을 보정 (초기 점프 제거)
-    if (avg > 0 && Math.abs(avg - s.estimatedRowHeight) > 0.5) {
-      s.estimatedRowHeight = avg;
-      for (let i = 0; i < s.heights.length; i++) {
-        if (!s.measured[i] && s.heights[i] !== avg) {
-          s.heights[i] = avg;
-          changed = true;
+      // 미측정 '행'에만 평균을 적용해 totalHeight 추정을 보정 (초기 점프 제거)
+      if (avg > 0 && Math.abs(avg - s.estimatedRowHeight) > 0.5) {
+        s.estimatedRowHeight = avg;
+        for (let i = 0; i < s.heights.length; i++) {
+          if (s.isRow[i] && !s.measured[i] && s.heights[i] !== avg) {
+            s.heights[i] = avg;
+            changed = true;
+          }
         }
       }
     }
@@ -333,8 +349,8 @@ const modules = {
     const parsed = Util.htmlToElement(htmlString);
     if (!parsed || !parsed.children) return false;
 
-    const found = this._findCustomTooltipRows(parsed, seriesList.length);
-    if (!found) {
+    const container = this._findCustomTooltipContainer(parsed, seriesList.length);
+    if (!container) {
       // 동일 마크업이 유지되는 동안 재시도(formatter+파싱 2회/move)를 막는다. render()에서 리셋.
       this._vsDetectFailed = true;
       if (!this._vsWarnedFallback) {
@@ -350,41 +366,41 @@ const modules = {
       return false;
     }
 
-    const { rows, rowContainer } = found;
+    // 컨테이너 직속 자식 전체를 순서 보존 "아이템"으로 수집한다(행 + 비-row 데코레이션).
+    //  - 행 = `[data-evui-tooltip-row]` 보유 / 비-row = 그 외 모든 직속 자식.
+    //  - 분류 기준은 오직 속성 유무. 소비처 클래스명은 보지 않는다.
+    //  - 단, 마크된 행이 하나도 없으면(휴리스틱 BFS로 탐지된 균일-행 본문) 전부 '행'으로 간주해
+    //    학습 평균 보정 등 기존 동작을 보존한다.
+    const items = Array.from(container.children);
+    if (!items.length) return false;
+    const hasMark = (el) => !!(el.hasAttribute && el.hasAttribute('data-evui-tooltip-row'));
+    const markedExists = items.some(hasMark);
+    const isRow = items.map((el) => (markedExists ? hasMark(el) : true));
 
-    // 가상 스크롤 trio를 끼워넣을 위치 결정:
-    //  - 첫 행의 다음 형제부터 따라가며 "행 집합에 속하지 않는" 첫 노드를 anchor로 잡는다.
-    //    못 찾으면 null (= rowContainer 끝에 append).
-    //  - 이렇게 해야 비-row 형제(header/footer 등)는 그대로 보존되면서, 동시에 anchor가
-    //    이후 detach로 부모를 잃는 일이 없다.
-    const rowSet = new Set(rows);
-    const firstRow = rows[0];
-    let anchorBefore = firstRow ? firstRow.nextSibling : null;
-    while (anchorBefore && rowSet.has(anchorBefore)) {
-      anchorBefore = anchorBefore.nextSibling;
+    // 모든 아이템 detach(배열에 보존) 후 컨테이너를 비우고 trio를 그 자리에 삽입한다.
+    // 비-row도 아이템으로 함께 가상화하므로 더 이상 제자리 보존(anchorBefore) 로직이 필요 없다.
+    for (let i = 0; i < items.length; i++) {
+      const el = items[i];
+      if (el.parentNode) el.parentNode.removeChild(el);
+    }
+    while (container.firstChild) {
+      container.removeChild(container.firstChild);
     }
 
-    // 행 분리 (보존)
-    for (let i = 0; i < rows.length; i++) {
-      const row = rows[i];
-      if (row.parentNode) row.parentNode.removeChild(row);
-    }
-
-    // trio 생성·삽입. insertBefore(node, null)은 spec상 appendChild와 동치.
     const { topSpacer, viewport, bottomSpacer } = this._createVirtualScrollAnatomy();
-    rowContainer.insertBefore(topSpacer, anchorBefore);
-    rowContainer.insertBefore(viewport, anchorBefore);
-    rowContainer.insertBefore(bottomSpacer, anchorBefore);
+    container.appendChild(topSpacer);
+    container.appendChild(viewport);
+    container.appendChild(bottomSpacer);
 
-    // row 컨테이너를 스크롤 가능하게 설정 (사용자 CSS를 inline으로 덮어씀)
+    // 컨테이너를 스크롤 가능하게 설정 (사용자 CSS를 inline으로 덮어씀)
     const maxHeight = opt.maxHeight || DEFAULT_MAX_HEIGHT;
-    rowContainer.style.maxHeight = `${maxHeight}px`;
-    rowContainer.style.overflowY = 'auto';
-    rowContainer.style.overflowX = 'hidden';
+    container.style.maxHeight = `${maxHeight}px`;
+    container.style.overflowY = 'auto';
+    container.style.overflowX = 'hidden';
     // 가상 스크롤에서 spacer 높이가 바뀔 때마다 브라우저의 scroll anchoring이
     // scrollTop을 자동 보정해 휠 플릭 시 스크롤이 끝까지 튕겨가는 현상이 발생한다.
     // 우리가 prefix sum + 앵커 인덱스로 직접 위치를 관리하므로 브라우저 보정을 끈다.
-    rowContainer.style.overflowAnchor = 'none';
+    container.style.overflowAnchor = 'none';
 
     // 기존 정리 (이전 세션 리스너/옵저버 해제)
     this._teardownCustomTooltipVirtualScroll();
@@ -397,13 +413,14 @@ const modules = {
       learned ?? vs.estimatedRowHeight ?? DEFAULT_ESTIMATED_ROW_HEIGHT;
 
     this.vsState = {
-      scrollEl: rowContainer,
+      scrollEl: container,
       topSpacer,
       viewport,
       bottomSpacer,
-      rows,
-      heights: new Array(rows.length).fill(estimated),
-      measured: new Array(rows.length).fill(false),
+      items,
+      isRow,
+      heights: new Array(items.length).fill(estimated),
+      measured: new Array(items.length).fill(false),
       prefixSums: [],
       totalHeight: 0,
       range: { start: 0, end: -1 },
@@ -431,15 +448,15 @@ const modules = {
         this._renderVisibleCustomTooltipRows();
       });
     };
-    rowContainer.addEventListener('scroll', onScroll, { passive: true });
+    container.addEventListener('scroll', onScroll, { passive: true });
     this.vsState.onScroll = onScroll;
 
     // ResizeObserver: 폭 변화 시 측정 무효화
     if (typeof ResizeObserver !== 'undefined') {
-      let lastWidth = rowContainer.clientWidth;
+      let lastWidth = container.clientWidth;
       const ro = new ResizeObserver(() => {
         if (!this.vsState) return;
-        const w = rowContainer.clientWidth;
+        const w = container.clientWidth;
         if (w !== lastWidth) {
           lastWidth = w;
           this.vsState.measured.fill(false);
@@ -448,7 +465,7 @@ const modules = {
           this._renderVisibleCustomTooltipRows();
         }
       });
-      ro.observe(rowContainer);
+      ro.observe(container);
       this.vsState.resizeObserver = ro;
     }
 
@@ -464,7 +481,7 @@ const modules = {
     this.tooltipDOM.style.border = `1px solid ${opt.borderColor}`;
     this.tooltipDOM.style.color = opt.fontColor?.title ?? opt.fontColor;
 
-    // 첫 렌더 (이때 maxHeight 적용된 rowContainer는 clientHeight를 가지므로 가시 범위 계산 가능)
+    // 첫 렌더 (이때 maxHeight 적용된 container는 clientHeight를 가지므로 가시 범위 계산 가능)
     this._renderVisibleCustomTooltipRows();
 
     // 학습된 평균을 인스턴스 레벨에 보존 (다음 세션 estimated 부트스트랩)

--- a/src/components/chart/plugins/plugins.tooltip.virtualScroll.spec.js
+++ b/src/components/chart/plugins/plugins.tooltip.virtualScroll.spec.js
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import VirtualScroll from './plugins.tooltip.virtualScroll';
+
+/**
+ * 커스텀 툴팁 가상 스크롤 — 비-row 요소(그룹 헤더·구분선·marker) 순서 보존 테스트.
+ *
+ * 검증 축:
+ *  1) 컨테이너 직속 자식 전체를 순서 보존 "아이템"으로 가상화한다(행 + 비-row).
+ *  2) 비-row 요소가 bottom spacer 뒤로 적층되지 않는다(고아 헤더 0개).
+ *  3) 스크롤 시 비-row가 자기 그룹 행과 함께 들어오고 나간다(통합 좌표계).
+ *  4) 비-row 높이가 행 높이와 달라도 spacer 총합/스크롤 범위가 정확하다.
+ *  5) 행만 있는 본문은 기존 동작과 동일(회귀 없음).
+ *
+ * jsdom은 offsetHeight=0이므로, 높이 의존 검증은 vsState에 명시 높이를 주입해
+ * 순수 계산(prefixSums/visibleRange/spacer/render)을 직접 검증한다.
+ */
+
+// ---- 헬퍼 ---------------------------------------------------------------
+
+const ROW_ATTR = 'data-evui-tooltip-row';
+
+/** 그룹 구조 HTML 생성. groups: [{ header, rows }] */
+const buildGroupedHtml = (groups) => {
+  let body = '';
+  groups.forEach((g, gi) => {
+    if (g.header != null) {
+      body += `<div class="series-name">${g.header}</div>`;
+    }
+    for (let r = 0; r < g.rows; r++) {
+      body += `<div class="row" ${ROW_ATTR}>g${gi}r${r}</div>`;
+    }
+  });
+  return (
+    '<div class="ev-chart-tooltip-custom">' +
+    '<div class="ev-chart-tooltip-custom__header">H</div>' +
+    `<div class="ev-chart-tooltip-custom__body">${body}</div>` +
+    '</div>'
+  );
+};
+
+const countRows = (groups) => groups.reduce((acc, g) => acc + g.rows, 0);
+
+/** hitInfoItems 모킹 — formatter는 무시하므로 키 개수만 맞으면 된다. */
+const makeHitInfoItems = (n) => {
+  const items = {};
+  for (let i = 0; i < n; i++) {
+    items[`s${i}`] = { data: { o: i }, color: '#000', name: `s${i}`, id: `s${i}`, index: i };
+  }
+  return items;
+};
+
+/** drawCustomTooltipVirtual 진입용 모킹 차트. */
+const createChart = (html, vsOpt = { use: true, estimatedRowHeight: 25, overscan: 5 }) =>
+  Object.assign(Object.create(VirtualScroll), {
+    vsState: null,
+    _vsLearnedAverageHeight: undefined,
+    _vsDetectFailed: false,
+    _vsWarnedFallback: false,
+    tooltipDOM: document.createElement('div'),
+    options: {
+      tooltip: {
+        maxHeight: 480,
+        backgroundColor: '#fff',
+        borderColor: '#ccc',
+        fontColor: { title: '#333' },
+        virtualScroll: vsOpt,
+        formatter: { html: () => html },
+      },
+    },
+  });
+
+/** 명시 높이로 vsState를 직접 구성(순수 계산 검증용). spec: [{ label, isRow, height }] */
+const setupVsState = (chart, spec, { clientHeight = 100, scrollTop = 0, overscan = 0 } = {}) => {
+  const items = spec.map((s) => {
+    const el = document.createElement('div');
+    if (s.isRow) el.setAttribute(ROW_ATTR, '');
+    el.textContent = s.label;
+    el.dataset.label = s.label;
+    return el;
+  });
+  const scrollEl = document.createElement('div');
+  Object.defineProperty(scrollEl, 'clientHeight', { value: clientHeight, configurable: true });
+  scrollEl.scrollTop = scrollTop;
+
+  chart.vsState = {
+    scrollEl,
+    topSpacer: document.createElement('div'),
+    viewport: document.createElement('div'),
+    bottomSpacer: document.createElement('div'),
+    items,
+    isRow: spec.map((s) => s.isRow),
+    heights: spec.map((s) => s.height),
+    measured: spec.map(() => true), // 사전 측정 처리 → render가 측정 패스를 타지 않음(jsdom offsetHeight=0)
+    prefixSums: [],
+    totalHeight: 0,
+    range: { start: 0, end: -1 },
+    estimatedRowHeight: 25,
+    overscan,
+    maxHeight: 480,
+    rafPending: false,
+    suppressScroll: false,
+    measureDepth: 0,
+  };
+  chart._recomputeCustomTooltipPrefixSums();
+  return chart.vsState;
+};
+
+const labelsOf = (parent) => Array.from(parent.children).map((c) => c.dataset.label);
+
+// ---- 컨테이너 탐지 + 아이템 분류 ---------------------------------------
+
+describe('_findCustomTooltipContainer + 아이템 분류', () => {
+  it('마크된 행 부모를 컨테이너로 찾고, 비-row 형제도 컨테이너로 인정한다', () => {
+    const chart = createChart('');
+    const html = buildGroupedHtml([{ header: 'A', rows: 3 }, { header: 'B', rows: 2 }]);
+    const root = document.createElement('template');
+    root.innerHTML = html.trim();
+    const parsed = root.content.firstChild;
+
+    const container = chart._findCustomTooltipContainer(parsed, 5);
+    expect(container).not.toBeNull();
+    expect(container.classList.contains('ev-chart-tooltip-custom__body')).toBe(true);
+    // 직속 자식 = 헤더2 + 행5 = 7
+    expect(container.children.length).toBe(7);
+  });
+
+  it('마크가 없고 자식 수가 series 수와 일치하면 BFS로 컨테이너를 찾는다', () => {
+    const chart = createChart('');
+    const html =
+      '<div class="body"><div>r0</div><div>r1</div><div>r2</div></div>';
+    const root = document.createElement('template');
+    root.innerHTML = html.trim();
+    const parsed = root.content.firstChild;
+
+    const container = chart._findCustomTooltipContainer(parsed, 3);
+    expect(container).not.toBeNull();
+    expect(container.children.length).toBe(3);
+  });
+});
+
+// ---- 통합: drawCustomTooltipVirtual (순서/고아 검증) --------------------
+
+describe('drawCustomTooltipVirtual — 혼합 아이템 순서 보존', () => {
+  it('행+헤더가 섞인 본문에서 모든 아이템이 원래 순서대로 viewport에 들어간다', () => {
+    const groups = [
+      { header: 'A', rows: 3 },
+      { header: 'B', rows: 2 },
+      { header: 'C', rows: 2 },
+    ];
+    const html = buildGroupedHtml(groups);
+    const chart = createChart(html);
+
+    const ok = chart.drawCustomTooltipVirtual(makeHitInfoItems(countRows(groups)));
+    expect(ok).toBe(true);
+
+    const body = chart.tooltipDOM.querySelector('.ev-chart-tooltip-custom__body');
+    // 컨테이너 직속 자식은 trio(top spacer / viewport / bottom spacer)뿐
+    expect(body.children.length).toBe(3);
+    expect(body.children[0].classList.contains('ev-chart-tooltip-virtual__spacer')).toBe(true);
+    expect(body.children[1].classList.contains('ev-chart-tooltip-virtual__viewport')).toBe(true);
+    expect(body.children[2].classList.contains('ev-chart-tooltip-virtual__spacer')).toBe(true);
+
+    // 작은 본문(9 아이템<윈도우)이라 전부 viewport에 들어가며 원래 순서를 보존한다.
+    const viewport = body.children[1];
+    const texts = Array.from(viewport.children).map((c) => c.textContent);
+    expect(texts).toEqual([
+      'A', 'g0r0', 'g0r1', 'g0r2',
+      'B', 'g1r0', 'g1r1',
+      'C', 'g2r0', 'g2r1',
+    ]);
+  });
+
+  it('헤더는 fixed 영역으로 보존되고, 본문에 고아 헤더가 0개다', () => {
+    const groups = [{ header: 'A', rows: 2 }, { header: 'B', rows: 2 }];
+    const html = buildGroupedHtml(groups);
+    const chart = createChart(html);
+
+    chart.drawCustomTooltipVirtual(makeHitInfoItems(countRows(groups)));
+
+    const root = chart.tooltipDOM.querySelector('.ev-chart-tooltip-custom');
+    // __header(차트 제목)는 __body 밖에 그대로 보존
+    expect(root.querySelector(':scope > .ev-chart-tooltip-custom__header')).not.toBeNull();
+
+    const body = chart.tooltipDOM.querySelector('.ev-chart-tooltip-custom__body');
+    // 그룹 헤더(.series-name)가 컨테이너 직속(=spacer 뒤)에 적층되지 않음
+    expect(body.querySelectorAll(':scope > .series-name').length).toBe(0);
+    // 모든 .series-name 은 viewport 내부에 존재
+    const viewport = body.querySelector('.ev-chart-tooltip-virtual__viewport');
+    expect(viewport.querySelectorAll('.series-name').length).toBe(2);
+    // bottom spacer 뒤에는 아무 형제도 없다(고아 0)
+    const bottomSpacer = body.children[body.children.length - 1];
+    expect(bottomSpacer.nextElementSibling).toBeNull();
+  });
+
+  it('vsState.isRow 가 속성 유무대로 분류된다(헤더=false, 행=true)', () => {
+    const groups = [{ header: 'A', rows: 2 }, { header: 'B', rows: 1 }];
+    const html = buildGroupedHtml(groups);
+    const chart = createChart(html);
+
+    chart.drawCustomTooltipVirtual(makeHitInfoItems(countRows(groups)));
+    // 순서: A(header), g0r0, g0r1, B(header), g1r0
+    expect(chart.vsState.isRow).toEqual([false, true, true, false, true]);
+  });
+});
+
+// ---- 회귀: 행만 있는 본문 ----------------------------------------------
+
+describe('회귀 — 행만 있는 본문', () => {
+  it('마크된 행만 있는 본문은 전부 행으로 처리되고 순서 보존된다', () => {
+    const groups = [{ header: null, rows: 6 }];
+    const html = buildGroupedHtml(groups);
+    const chart = createChart(html);
+
+    const ok = chart.drawCustomTooltipVirtual(makeHitInfoItems(6));
+    expect(ok).toBe(true);
+    expect(chart.vsState.items.length).toBe(6);
+    expect(chart.vsState.isRow).toEqual([true, true, true, true, true, true]);
+
+    const viewport = chart.tooltipDOM.querySelector('.ev-chart-tooltip-virtual__viewport');
+    expect(Array.from(viewport.children).map((c) => c.textContent)).toEqual([
+      'g0r0', 'g0r1', 'g0r2', 'g0r3', 'g0r4', 'g0r5',
+    ]);
+  });
+
+  it('마크가 없는 휴리스틱(BFS) 본문은 모든 아이템을 행으로 간주한다(학습 동작 보존)', () => {
+    const html = '<div class="body"><div>r0</div><div>r1</div><div>r2</div><div>r3</div></div>';
+    const chart = createChart(html);
+
+    const ok = chart.drawCustomTooltipVirtual(makeHitInfoItems(4));
+    expect(ok).toBe(true);
+    expect(chart.vsState.isRow).toEqual([true, true, true, true]);
+  });
+});
+
+// ---- 높이/스크롤 범위 정확성 (명시 높이 주입) ---------------------------
+
+describe('통합 좌표계 — 비-row 높이≠행 높이', () => {
+  // 3그룹 × [헤더(20), 행(30), 행(30)] → 인덱스 0..8
+  const spec = [
+    { label: 'H0', isRow: false, height: 20 },
+    { label: 'g0r0', isRow: true, height: 30 },
+    { label: 'g0r1', isRow: true, height: 30 },
+    { label: 'H1', isRow: false, height: 20 },
+    { label: 'g1r0', isRow: true, height: 30 },
+    { label: 'g1r1', isRow: true, height: 30 },
+    { label: 'H2', isRow: false, height: 20 },
+    { label: 'g2r0', isRow: true, height: 30 },
+    { label: 'g2r1', isRow: true, height: 30 },
+  ];
+  // total = 3*(20+30+30) = 240
+
+  let chart;
+  beforeEach(() => {
+    chart = createChart('');
+  });
+
+  it('totalHeight 가 행+비-row 높이를 모두 합산한다', () => {
+    setupVsState(chart, spec, { clientHeight: 100, scrollTop: 0 });
+    expect(chart.vsState.totalHeight).toBe(240);
+  });
+
+  it('최상단에서 첫 윈도우가 헤더-행 순서를 정확히 잡는다', () => {
+    setupVsState(chart, spec, { clientHeight: 100, scrollTop: 0, overscan: 0 });
+    chart._renderVisibleCustomTooltipRows();
+    const viewport = chart.vsState.viewport;
+    // scrollTop=0, clientHeight=100 → prefixSums: 0,20,50,80,100,...
+    // start=0, end: prefixSums[i]>=100 인 최소 i = 4 → [0..4]
+    expect(labelsOf(viewport)).toEqual(['H0', 'g0r0', 'g0r1', 'H1', 'g1r0']);
+    // 첫 헤더 H0 가 자기 행 위에 위치
+    expect(viewport.firstChild.dataset.label).toBe('H0');
+  });
+
+  it('맨 아래로 스크롤하면 마지막 그룹 헤더가 자기 행 위에 들어온다(고아 없음)', () => {
+    // scrollTop = total - clientHeight = 140
+    setupVsState(chart, spec, { clientHeight: 100, scrollTop: 140, overscan: 0 });
+    chart._renderVisibleCustomTooltipRows();
+    const viewport = chart.vsState.viewport;
+    // prefixSums: [0,20,50,80,100,130,160,180,210,240]
+    // start: prefixSums[i+1]>140 → i=5(g1r1) ; end: prefixSums[i]>=240 → 8
+    const labels = labelsOf(viewport);
+    expect(labels).toEqual(['g1r1', 'H2', 'g2r0', 'g2r1']);
+    // 마지막 헤더 H2 가 자기 그룹 행(g2r0)보다 앞에 위치
+    expect(labels.indexOf('H2')).toBeLessThan(labels.indexOf('g2r0'));
+  });
+
+  it('spacer 총합 불변식: topSpacer + 가시영역 + bottomSpacer = totalHeight', () => {
+    const s = setupVsState(chart, spec, { clientHeight: 100, scrollTop: 140, overscan: 0 });
+    chart._renderVisibleCustomTooltipRows();
+    const topH = parseFloat(s.topSpacer.style.height);
+    const bottomH = parseFloat(s.bottomSpacer.style.height);
+    let visibleH = 0;
+    for (let i = s.range.start; i <= s.range.end; i++) visibleH += s.heights[i];
+    expect(topH + visibleH + bottomH).toBe(s.totalHeight);
+    // 맨 아래라 bottom spacer = 0 (적층 공간 없음)
+    expect(bottomH).toBe(0);
+  });
+
+  it('overscan 이 가시 범위를 양쪽으로 확장한다', () => {
+    setupVsState(chart, spec, { clientHeight: 100, scrollTop: 80, overscan: 1 });
+    const range = chart._computeCustomTooltipVisibleRange();
+    const rangeNoOverscan = (() => {
+      chart.vsState.overscan = 0;
+      return chart._computeCustomTooltipVisibleRange();
+    })();
+    expect(range.start).toBeLessThanOrEqual(rangeNoOverscan.start);
+    expect(range.end).toBeGreaterThanOrEqual(rangeNoOverscan.end);
+  });
+});


### PR DESCRIPTION
## 배경
EVUI 차트 툴팁 가상스크롤(`tooltip.virtualScroll`)은 `formatter.html`로 만든 커스텀 본문을 가상화한다. 소비처(대시보드)는 본문을 **행 + 비-row 데코레이션이 교차하는 그룹 구조**로 만든다:

```
[그룹헤더A] [행][행][행] [그룹헤더B] [행][행] [구분선][marker제목][marker행]...
```

- 행 = `<div data-evui-tooltip-row>` (EVUI 계약 속성)
- 비-row = `data-evui-tooltip-row`가 없는 모든 직속 자식(그룹 헤더·구분선·marker 등)

## 문제
가상스크롤이 `data-evui-tooltip-row` **행만** 수집해 하나의 viewport로 몰아넣고, **비-row 요소는 위치 보존 없이** bottom spacer 뒤로 밀려났다. 결과적으로 그룹 헤더가 "행 없는 고아 헤더"로 본문 맨 아래 적층됐다.

## 변경 내용
가상화 단위를 **"행"에서 "순서 있는 혼합 아이템(컨테이너 직속 자식 전체)"** 으로 확장.

- `_findCustomTooltipRows` → `_findCustomTooltipContainer`: 행 배열 대신 **컨테이너**만 반환. 부모에 비-row 형제가 섞여 있어도 컨테이너로 인정.
- `items` / `isRow` 모델 도입. 분류 기준은 **오직 `data-evui-tooltip-row` 속성 유무** (소비처 클래스명 하드코딩 없음). 기존 `anchorBefore`(비-row 제자리 보존) 로직 제거.
- 가시 범위 아이템을 **원래 순서대로** viewport에 부착(행/비-row 무관).
- 높이 계산: 모든 아이템 실측하되, **학습 평균/추정 높이는 행 아이템만** 대상으로 계산해 키가 다른 비-row(헤더)가 행 추정을 오염시키지 않게 함. prefixSums/spacer/visibleRange는 행+비-row **통합 좌표계**로 확장.
- 회귀 방지: 마크된 행이 하나도 없는 휴리스틱(BFS) 본문은 전부 '행'으로 간주해 기존 학습 동작 보존.
- 외부 참조는 `vsState.scrollEl` 하나뿐이라 내부 리팩터링은 안전.

> sticky 그룹 헤더(작업지시 6, 선택)는 버그 해소에 불필요하여 제외.

## 테스트
신규 `plugins.tooltip.virtualScroll.spec.js` 12개:
- 컨테이너 탐지 / 아이템 분류(isRow)
- 혼합 본문 순서 보존, **고아 헤더 0개**, 헤더 fixed 영역 보존
- 통합 좌표계: totalHeight 합산, 첫 윈도우 순서, **맨 아래 스크롤 시 마지막 헤더가 자기 행 위**, spacer 총합 불변식, overscan 확장
- 회귀: 행만 있는 본문(마크/BFS 양쪽)

검증: 신규 12개 통과 / 차트 전체 스위트 **589개 통과** / eslint 0건 (Node 20)

## 수용 기준
- [x] 비-row 요소가 원래 위치(자기 그룹 행 위/사이)에 유지
- [x] bottom spacer 뒤 적층 없음 → 고아 헤더 0개
- [x] 헤더·구분선·marker가 행과 함께 스크롤
- [x] 비그룹(행만) 툴팁 회귀 없음
- [x] 보이는 윈도우 + overscan만 렌더(가상화 성질 유지)
- [x] `use:'auto'` threshold, `estimatedRowHeight`/`overscan` 의미 유지

## 변경 파일
- `src/components/chart/plugins/plugins.tooltip.virtualScroll.js`
- `src/components/chart/plugins/plugins.tooltip.virtualScroll.spec.js` (신규)
- `docs/views/lineChart/api/lineChart.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
