### PR TITLE
perf(chart): 차트 렌더 성능 개선 (shallowOptionsWatch · deferPollingRedraw · 선택 라인 최상위)

### DIFF
--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -467,6 +467,34 @@ chartData.value = {
 <ev-chart :data="chartData" :options="chartOptions" />
 ```
 
+#### shallowOptionsWatch
+
+`options` prop에 대한 deep watch를 끄는 **성능 최적화 opt-in**(기본 `false`). `options`를 자주 갱신하는(예: 축 범위를 computed로 매 틱 새로 만드는) 라이브 차트에서 deep traverse 비용을 제거할 때 사용한다.
+
+- 기본(`false`)일 때 차트는 `options`를 deep watch하여 중첩된 값의 in-place 변경까지 자동 감지한다. 이 deep 추적은 옵션 트리 전체를 매 갱신마다 순회하는 비용을 유발한다.
+- `true`로 켜면 deep 추적을 끄고 **`options`의 top-level 참조가 바뀔 때만** 갱신한다. 따라서 options를 변경할 때 **반드시 새 객체 참조를 할당**해야 한다(in-place 변경만 하면 차트가 갱신되지 않는다).
+- **이 옵션은 차트 생성(mount) 시점에 1회만 평가된다.** 런타임에 값을 바꿔도 적용되지 않으며, 바꾸려면 `:key` 등으로 차트를 remount해야 한다.
+- `shallowDataWatch`와 동일한 계약이다(`data` 대신 `options` 대상).
+
+##### Example
+
+```js
+const chartOptions = ref({ type: 'line', shallowOptionsWatch: true });
+
+// ✅ 갱신: 새 top-level 참조 할당 → 차트 갱신됨
+chartOptions.value = {
+  ...chartOptions.value,
+  axesX: [{ ...chartOptions.value.axesX[0], range: [0, 100] }],
+};
+
+// ❌ in-place 변경: 참조가 그대로라 차트가 갱신되지 않음
+// chartOptions.value.axesX[0].range = [0, 100];
+```
+
+```vue
+<ev-chart :data="chartData" :options="chartOptions" />
+```
+
 #### selectLabel
 
 | 이름                | 타입                        | 디폴트              | 설명                                                                       | 종류(예시)      |

--- a/docs/views/zoomChart/api/zoomChart.md
+++ b/docs/views/zoomChart/api/zoomChart.md
@@ -136,3 +136,36 @@ const options = {
   },
 }
 ```
+
+<br/>
+
+>## Methods
+
+<차트 그룹>의 `ref`로 호출하는 메서드.
+
+### deferPollingRedraw(durationMs)
+
+차트 클릭으로 detail 패널/popup을 여는 순간, 그룹 폴링(데이터 자동 갱신) redraw를 짧게 양보해 사용자가 연 것이 먼저 페인트되도록 한다. detail/popup을 띄우는 클릭 핸들러에서 호출한다. 미호출 시 양보 로직은 비활성(폴링 redraw가 평소대로 동작)이다.
+
+- `durationMs` (Number, 디폴트 `800`): 폴링 redraw를 미룰 시간(ms). `0`~`2000`(상한)으로 클램프된다.
+- one-shot이며 시간창이 지나면 자동으로 재개된다(별도 resume API 없음). detail이 열려 있는 동안에도 시간창 이후에는 차트가 계속 라이브 갱신된다.
+- 반복 호출하면 더 미래로 연장되되 `현재 시각 + 2000ms`로 상한이 걸려 무한 연장되지 않는다.
+- 그룹 내부의 자식 차트(또는 위젯)에서는 `inject('deferPollingRedraw')`로 동일 함수를 주입받아 직접 호출할 수도 있다.
+
+#### Example
+
+```vue
+<ev-chart-group ref="groupRef" :options="options">
+  <ev-chart ... @click="onOpenDetail" />
+</ev-chart-group>
+```
+
+```js
+const groupRef = ref();
+
+const onOpenDetail = () => {
+  // detail 패널을 여는 동안(디폴트 800ms) 그룹 폴링 redraw를 양보해 detail을 먼저 페인트
+  groupRef.value.deferPollingRedraw();
+  openDetailPanel();
+};
+```

--- a/src/components/chart/Chart.scheduleUpdate.spec.js
+++ b/src/components/chart/Chart.scheduleUpdate.spec.js
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { reactive } from 'vue';
+import { mount, flushPromises } from '@vue/test-utils';
+
+/**
+ * Chart.vue scheduleUpdate 의 폴링 redraw 양보(deferUntil) semantics 회귀 가드.
+ *
+ * scheduleUpdate 는 데이터/옵션 변경(폴링 포함)을 받아 evChart.update() 를 예약하는데,
+ * groupInteraction.deferUntil(deferPollingRedraw 가 설정) 까지 polling 재렌더를 미룬다.
+ * 또한 타이머가 떠 있는 사이 deferUntil 이 연장되면 fire 시점에 재무장한다.
+ * 실제 canvas 렌더는 불필요하므로 EvChart 를 mock 으로 대체해 update() 호출 타이밍만 검증한다.
+ * 시계가 performance.now() 이므로 fake timer 가 performance 까지 fake 하도록 toFake 를 명시한다.
+ */
+
+const updateSpy = vi.fn();
+
+vi.mock('./chart.core', () => ({
+  default: vi.fn().mockImplementation(function EvChartMock(target, data, options) {
+    this.data = data;
+    this.options = options;
+    this.init = vi.fn();
+    this.update = updateSpy;
+    this.destroy = vi.fn();
+    this.emitLegendData = vi.fn();
+    this.selectItemByData = vi.fn();
+    this.selectLabelByData = vi.fn();
+    this.selectSeriesByData = vi.fn();
+  }),
+}));
+
+// eslint-disable-next-line import/first
+import EvChartComponent from './Chart.vue';
+
+const makeData = () => ({
+  series: { s1: { name: 's1' } },
+  data: { s1: [1, 2, 3] },
+  labels: ['a', 'b', 'c'],
+  groups: [],
+});
+
+// 폴링 데이터 변경을 모사한다(deep watch 가 in-place mutation 을 감지).
+const pushData = async (wrapper, v) => {
+  wrapper.props().data.data.s1.push(v);
+  await flushPromises();
+};
+
+const mountChart = (provide) =>
+  mount(EvChartComponent, {
+    props: { data: reactive(makeData()), options: { type: 'line' } },
+    global: { provide: { isChartGroup: true, ...provide }, directives: { resize: {} } },
+  });
+
+beforeEach(() => {
+  vi.useFakeTimers({
+    toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date', 'performance'],
+  });
+  updateSpy.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('Chart.vue scheduleUpdate — deferUntil 폴링 양보', () => {
+  it('deferUntil 미설정: 데이터 변경이 즉시 update 를 발화한다', async () => {
+    const gi = { deferUntil: 0 };
+    const wrapper = mountChart({ groupInteraction: gi });
+    await flushPromises();
+    updateSpy.mockClear();
+
+    await pushData(wrapper, 4);
+    vi.advanceTimersByTime(0);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('deferUntil = now+1000: 1000ms 까지 미호출 후 정확히 1회 update', async () => {
+    const gi = { deferUntil: performance.now() + 1000 };
+    const wrapper = mountChart({ groupInteraction: gi });
+    await flushPromises();
+    updateSpy.mockClear();
+
+    await pushData(wrapper, 4);
+    vi.advanceTimersByTime(999);
+    expect(updateSpy).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('재무장: 타이머가 떠 있는 사이 deferUntil 을 연장하면 그만큼 더 지연된다', async () => {
+    const gi = { deferUntil: performance.now() + 500 };
+    const wrapper = mountChart({ groupInteraction: gi });
+    await flushPromises();
+    updateSpy.mockClear();
+
+    await pushData(wrapper, 4);
+    // 타이머(500ms)가 떠 있는 동안 deferUntil 을 now+1000 으로 연장한다(deferPollingRedraw 모사).
+    gi.deferUntil = performance.now() + 1000;
+
+    vi.advanceTimersByTime(500); // 원래 타이머 fire → 재무장만, update 미호출
+    expect(updateSpy).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(500); // 재무장 타이머 fire → update
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesce: 보류 중 데이터 2회 변경 → update 는 1회만', async () => {
+    const gi = { deferUntil: performance.now() + 1000 };
+    const wrapper = mountChart({ groupInteraction: gi });
+    await flushPromises();
+    updateSpy.mockClear();
+
+    await pushData(wrapper, 4);
+    await pushData(wrapper, 5);
+    vi.advanceTimersByTime(1000);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('deferUntil 이 과거면 즉시 update(기존 동일)', async () => {
+    const gi = { deferUntil: performance.now() - 100 };
+    const wrapper = mountChart({ groupInteraction: gi });
+    await flushPromises();
+    updateSpy.mockClear();
+
+    await pushData(wrapper, 4);
+    vi.advanceTimersByTime(0);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('단일 차트(groupInteraction 미제공): defer 경로 미진입, 즉시 update', async () => {
+    const wrapper = mountChart();
+    await flushPromises();
+    updateSpy.mockClear();
+    // 인터랙션이 한참 전이라 양보가 끝난 상태를 모사한다(시계를 충분히 진행).
+    vi.advanceTimersByTime(1000);
+
+    await pushData(wrapper, 4);
+    vi.advanceTimersByTime(0);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/chart/Chart.shallowOptionsWatch.spec.js
+++ b/src/components/chart/Chart.shallowOptionsWatch.spec.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { reactive } from 'vue';
+import { mount, flushPromises } from '@vue/test-utils';
+
+/**
+ * options.shallowOptionsWatch opt-in 의 options watch 발화 semantics 회귀 가드.
+ *
+ * Chart.vue 의 props.options watch 는 기본 deep:true(중첩 in-place 변경 자동 감지)이고,
+ * shallowOptionsWatch:true 면 deep:false(top-level 참조 교체 시에만 발화)로 등록된다.
+ * EvChart 를 mock 으로 대체해 evChart.update() 호출 여부로 발화를 검증한다.
+ */
+
+const updateSpy = vi.fn();
+
+vi.mock('./chart.core', () => ({
+  default: vi.fn().mockImplementation(function EvChartMock(target, data, options) {
+    this.data = data;
+    this.options = options;
+    this.init = vi.fn();
+    this.update = updateSpy;
+    this.destroy = vi.fn();
+    this.emitLegendData = vi.fn();
+    this.selectItemByData = vi.fn();
+    this.selectLabelByData = vi.fn();
+    this.selectSeriesByData = vi.fn();
+  }),
+}));
+
+// eslint-disable-next-line import/first
+import EvChartComponent from './Chart.vue';
+
+const makeData = () => ({
+  series: { s1: { name: 's1' } },
+  data: { s1: [1, 2, 3] },
+  labels: ['a', 'b', 'c'],
+  groups: [],
+});
+
+const mountChart = (options) =>
+  mount(EvChartComponent, {
+    props: { data: reactive(makeData()), options: reactive({ type: 'line', ...options }) },
+    global: { provide: { isChartGroup: true }, directives: { resize: {} } },
+  });
+
+const settle = async () => {
+  await flushPromises();
+  vi.runAllTimers();
+  await flushPromises();
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  updateSpy.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('options.shallowOptionsWatch — options watch 발화 semantics', () => {
+  it('기본(deep): options 중첩 in-place 변경이 update 를 발화시킨다', async () => {
+    const wrapper = mountChart();
+    await settle();
+    updateSpy.mockClear();
+
+    wrapper.props().options.padding = { top: 99 };
+    await settle();
+
+    expect(updateSpy).toHaveBeenCalled();
+  });
+
+  it('shallowOptionsWatch:true: 중첩 in-place 는 미발화, top-level 참조 교체는 발화', async () => {
+    const wrapper = mountChart({ shallowOptionsWatch: true });
+    await settle();
+    updateSpy.mockClear();
+
+    // in-place 변경 → deep 추적 없음 → 미발화
+    wrapper.props().options.padding = { top: 99 };
+    await settle();
+    expect(updateSpy).not.toHaveBeenCalled();
+
+    // top-level 참조 교체 → 발화
+    await wrapper.setProps({ options: { type: 'line', shallowOptionsWatch: true, padding: { top: 5 } } });
+    await settle();
+    expect(updateSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -99,6 +99,7 @@ export default {
     const injectGroupHoveredLabel = inject('groupHoveredLabel', null);
     const injectBrushIdx = inject('brushIdx', { start: 0, end: -1 });
     const injectEvChartPropsInGroup = inject('evChartPropsInGroup', []);
+    const injectGroupInteraction = inject('groupInteraction', null);
 
     const {
       eventListeners,
@@ -134,6 +135,7 @@ export default {
           injectEvChartPropsInGroup,
         );
 
+    const nowMs = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
     let pendingUpdate = null;
     let pendingTimer = null;
 
@@ -151,14 +153,30 @@ export default {
         }
       }
 
-      clearTimeout(pendingTimer);
-      pendingTimer = setTimeout(() => {
+      // fire 시점에 deferUntil 을 재검사한다. 타이머가 떠 있는 사이 deferPollingRedraw 가
+      // deferUntil 을 더 미래로 연장했을 수 있는데(그룹은 차트별 클로저 타이머를 직접 못 만짐),
+      // 그 경우 아직 미래면 남은 시간만큼 재예약(in-flight 재무장)한다.
+      const flush = () => {
+        const deferUntil = injectGroupInteraction?.deferUntil ?? 0;
+        const remaining = deferUntil - nowMs();
+        if (remaining > 0) {
+          pendingTimer = setTimeout(flush, remaining);
+          return;
+        }
         if (pendingUpdate && evChart) {
           evChart.update(pendingUpdate);
         }
         pendingUpdate = null;
         pendingTimer = null;
-      }, 0);
+      };
+
+      clearTimeout(pendingTimer);
+      // deferPollingRedraw 가 설정한 deferUntil 까지 데이터/polling 재렌더를 미룬다(detail/popup 우선 페인트).
+      // 미뤄도 pendingUpdate 는 최신값으로 coalesce 되고 보류가 끝나면 곧 flush 된다.
+      const now = nowMs();
+      const deferUntil = injectGroupInteraction?.deferUntil ?? 0;
+      const deferDelay = deferUntil > now ? deferUntil - now : 0;
+      pendingTimer = setTimeout(flush, deferDelay);
     };
 
     const createChart = () => {

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -244,7 +244,9 @@ export default {
           setOptionsForUseZoom(newOpt);
         }
       },
-      { deep: true, flush: 'post' },
+      // shallowOptionsWatch opt-in 이면 deep 추적을 끈다(매 갱신 deep traverse 비용 제거).
+      // 소비자는 options 변경 시 새 top-level 참조를 할당해야 한다(in-place 변경은 미감지).
+      { deep: !normalizedOptions.shallowOptionsWatch, flush: 'post' },
     );
 
     watch(

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -16,6 +16,7 @@ import TooltipVirtualScroll from './plugins/plugins.tooltip.virtualScroll';
 import Pie from './plugins/plugins.pie';
 import Tip from './element/element.tip';
 import Blit from './chart.blit';
+import Selection from './chart.selection';
 import { WorkerRenderGate } from './render/render.worker.gate';
 import { toRenderSnapshot, packSeries } from './render/render.snapshot';
 
@@ -477,6 +478,13 @@ class EvChart {
     } else {
       this.drawStaticLayer(this.bufferCtx, hitInfo);
       this.drawSeriesLayer(this.bufferCtx, hitInfo);
+      // 선택 line 을 dimmed 시리즈 위에 한 번 더 그려 항상 최상위로(묻힘 방지). full redraw 는 선택
+      // 시리즈를 z-order 제자리에 그려 뒤 dimmed 시리즈에 묻히는데, 이 패스로 selected 를 맨 위로
+      // 통일한다(게이트 미충족 시 미적용=무회귀).
+      // transform 은 initScale→prepareLayout 가 pixelRatio 로 세팅한 상태가 유지되므로 추가 setTransform 불필요.
+      if (this.shouldDrawSelectedOnTop(hitInfo)) {
+        this.drawSelectedSeriesOnly();
+      }
     }
     this.drawSeriesOverlay();
 
@@ -911,7 +919,7 @@ class EvChart {
     });
   }
 
-  drawSeriesLayer(bufferCtx, hitInfo) {
+  drawSeriesLayer(bufferCtx, hitInfo, layerOptions = {}) {
     const {
       maxTip,
       selectLabel,
@@ -922,15 +930,20 @@ class EvChart {
       unSelectedOpacity,
     } = this.options;
 
+    // noSelection: chart.selection 의 base 라스터용. selection/maxTip/selectItem 을 무력화해
+    // 모든 시리즈를 정상 opacity 로 그린다(partial 렌더에서 흐리게 합성할 baseline).
+    const noSel = layerOptions.noSelection === true;
+    const emptySel = { seriesId: [], dataIndex: [] };
+
     const opt = {
       ctx: bufferCtx,
       chartRect: this.chartRect,
       labelOffset: this.labelOffset,
       axesSteps: this.axesSteps,
       maxTipOpt: { background: maxTip.background, color: maxTip.color },
-      selectLabel: { option: selectLabel, selected: this.defaultSelectInfo },
-      selectSeries: { option: selectSeries, selected: this.defaultSelectInfo },
-      selectItem: { option: selectItem, selected: this.defaultSelectItemInfo },
+      selectLabel: { option: selectLabel, selected: noSel ? emptySel : this.defaultSelectInfo },
+      selectSeries: { option: selectSeries, selected: noSel ? emptySel : this.defaultSelectInfo },
+      selectItem: { option: selectItem, selected: noSel ? {} : this.defaultSelectItemInfo },
       isBrush: !!brush,
       displayOverflow,
       unSelectedOpacity,
@@ -1188,11 +1201,8 @@ class EvChart {
    * 주입받아 worker가 자체 OffscreenCanvas ctx로 축을 래스터할 수 있게 한다(main 경로에선
    * this.bufferCtx와 동일하므로 픽셀 변화 없음).
    *
-   * 캐시 결정: **캐시 보류**(분리만 수행). drawAxis는 완전 static이 아니라 — 상호작용 상태
-   * (hitInfo blurred label·selectItem.showLabelTip, scale.js:374-442)와 동적 rescale(scale min/max·
-   * 범례 토글 series.show — model/model.store.js:1400)·plotLines/plotBands를 같은 패스에서 소비한다.
-   * 안전한 캐시 키가 이 상태를 빠짐없이 포함해야 하는데 그 범위가 너무 넓어 stale axis 오염 위험이
-   * 크므로, 캐시는 후속 단계로 미루고 RenderCore 경계 분리(=worker ctx 주입점)만 둔다.
+   * 캐시 결정: full 경로는 **캐시 안 함** — drawAxis가 상호작용 상태(hitInfo·selectItem.showLabelTip,
+   * scale.js:374-442)와 동적 rescale·plotLines를 같은 패스에서 소비해 안전한 캐시 키 범위가 너무 넓다.
    * @param {CanvasRenderingContext2D} bufferCtx   destination buffer context (worker 경로에선 주입됨)
    * @param {any} [hitInfo=undefined]   hit/hover information for axis interaction labels
    *
@@ -2206,5 +2216,7 @@ class EvChart {
 // (chart.core.blitGate.spec.js)가 Object.create(EvChart.prototype) 로 인스턴스 없이 메서드를
 // 호출하므로, 다른 plugin mixin 처럼 this(인스턴스)가 아니라 prototype 에 합쳐야 한다.
 Object.assign(EvChart.prototype, Blit);
+// selectSeries 강조 부분 렌더 메서드(chart.selection.js)를 prototype 에 합친다(Blit 과 동일 이유).
+Object.assign(EvChart.prototype, Selection);
 
 export default EvChart;

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -919,7 +919,7 @@ class EvChart {
     });
   }
 
-  drawSeriesLayer(bufferCtx, hitInfo, layerOptions = {}) {
+  drawSeriesLayer(bufferCtx, hitInfo) {
     const {
       maxTip,
       selectLabel,
@@ -930,20 +930,15 @@ class EvChart {
       unSelectedOpacity,
     } = this.options;
 
-    // noSelection: chart.selection 의 base 라스터용. selection/maxTip/selectItem 을 무력화해
-    // 모든 시리즈를 정상 opacity 로 그린다(partial 렌더에서 흐리게 합성할 baseline).
-    const noSel = layerOptions.noSelection === true;
-    const emptySel = { seriesId: [], dataIndex: [] };
-
     const opt = {
       ctx: bufferCtx,
       chartRect: this.chartRect,
       labelOffset: this.labelOffset,
       axesSteps: this.axesSteps,
       maxTipOpt: { background: maxTip.background, color: maxTip.color },
-      selectLabel: { option: selectLabel, selected: noSel ? emptySel : this.defaultSelectInfo },
-      selectSeries: { option: selectSeries, selected: noSel ? emptySel : this.defaultSelectInfo },
-      selectItem: { option: selectItem, selected: noSel ? {} : this.defaultSelectItemInfo },
+      selectLabel: { option: selectLabel, selected: this.defaultSelectInfo },
+      selectSeries: { option: selectSeries, selected: this.defaultSelectInfo },
+      selectItem: { option: selectItem, selected: this.defaultSelectItemInfo },
       isBrush: !!brush,
       displayOverflow,
       unSelectedOpacity,

--- a/src/components/chart/chart.selection.js
+++ b/src/components/chart/chart.selection.js
@@ -1,0 +1,94 @@
+/**
+ * EvChart selectSeries 선택 라인 최상위 보정 모듈.
+ * chart.core.js 의 EvChart.prototype 에 Object.assign 으로 합쳐진다(메서드는 this 로 인스턴스에 접근).
+ *
+ * 배경: selectSeries 강조는 선택 시리즈를 정상 opacity 로, 비선택을 unSelectedOpacity 로 그린다.
+ * 그런데 full redraw 는 선택 시리즈를 z-order 제자리에 그려, 뒤(higher-z) dimmed 시리즈에 묻힐 수 있다.
+ * 이 모듈은 full redraw(drawChart) 직후 선택 line 만 한 번 더 덧그려 항상 최상위로 통일한다.
+ */
+const selection = {
+  /**
+   * 선택 시리즈가 전부 '맨 위로 덧그리기' 가능한 타입(line, non-fill, non-isExistGrp)인지.
+   * selectSeries 강조를 실제로 소비하는 element 는 line 뿐이고, scatter/heatMap 은 미지원이며
+   * scatter 는 drawSelectedSeriesOnly 경로(duple 미전달)에서 크래시하므로 line 만 허용한다.
+   * 빈 선택은 제약이 없어 true 를 반환한다(호출부 shouldDrawSelectedOnTop 가 빈 선택을 먼저 걸러낸다).
+   * @returns {boolean}
+   */
+  selectedSeriesAllLineSafe() {
+    const selectedIds = this.defaultSelectInfo?.seriesId ?? [];
+    for (let i = 0; i < selectedIds.length; i++) {
+      const s = this.seriesList[selectedIds[i]];
+      if (!s || s.type !== 'line' || s.fill || s.isExistGrp) {
+        return false;
+      }
+    }
+    return true;
+  },
+
+  /**
+   * full redraw(drawChart) 직후 선택 line 을 dimmed 시리즈 위에 한 번 더 그려 최상위로 올릴지 판정한다.
+   * full redraw 는 선택 시리즈를 z-order 제자리에 그려 뒤(higher-z) dimmed 시리즈에 묻히는데, 이 패스로
+   * '선택 = 최상위' 로 통일한다(무회귀: false 면 미적용).
+   *
+   * 라스터 스타일이 실제로 달라지는 legend hit/hover 만 막는다(selectItem/selectLabel 은 line.draw 의
+   * selectSeries 분기가 우선이라 덧그리기가 제자리 그림과 idempotent). worker 는 별도 z-order(snapshot)라 제외.
+   * @param {any} hitInfo   drawChart 의 hitInfo
+   * @returns {boolean}
+   */
+  shouldDrawSelectedOnTop(hitInfo) {
+    const opt = this.options;
+    if (!opt.selectSeries?.use || opt.brush || opt.realTimeScatter?.use || opt.workerRender) {
+      return false;
+    }
+    if (hitInfo?.legend || this.legendHover) {
+      return false;
+    }
+    if (!this.defaultSelectInfo?.seriesId?.length) {
+      return false;
+    }
+    return this.selectedSeriesAllLineSafe();
+  },
+
+  /**
+   * 선택된 시리즈만 정상 opacity(highlight)로 bufferCtx 에 덧그린다(dimmed 시리즈 위 → z-order 최상위).
+   * @returns {undefined}
+   */
+  drawSelectedSeriesOnly() {
+    const {
+      maxTip,
+      selectLabel,
+      selectItem,
+      selectSeries,
+      brush,
+      displayOverflow,
+      unSelectedOpacity,
+    } = this.options;
+
+    const opt = {
+      ctx: this.bufferCtx,
+      chartRect: this.chartRect,
+      labelOffset: this.labelOffset,
+      axesSteps: this.axesSteps,
+      maxTipOpt: { background: maxTip.background, color: maxTip.color },
+      selectLabel: { option: selectLabel, selected: this.defaultSelectInfo },
+      selectSeries: { option: selectSeries, selected: this.defaultSelectInfo },
+      selectItem: { option: selectItem, selected: this.defaultSelectItemInfo },
+      isBrush: !!brush,
+      displayOverflow,
+      unSelectedOpacity,
+      isHorizontal: this.options.horizontal,
+      dataEpoch: this._dataEpoch,
+      scaleVersion: this._scaleVersion,
+    };
+
+    const selectedIds = this.defaultSelectInfo?.seriesId ?? [];
+    for (let i = 0; i < selectedIds.length; i++) {
+      const series = this.seriesList[selectedIds[i]];
+      if (series && series.show) {
+        series.draw({ ...opt });
+      }
+    }
+  },
+};
+
+export default selection;

--- a/src/components/chart/chart.selection.spec.js
+++ b/src/components/chart/chart.selection.spec.js
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest';
+import EvChart from './chart.core';
+
+/**
+ * selectSeries 선택 라인 최상위 보정(chart.selection.js) 검증.
+ *
+ * full redraw 는 선택 시리즈를 z-order 제자리에 그려 뒤(higher-z) dimmed 시리즈에 묻히므로,
+ * drawSeriesLayer 뒤 선택 line 만 한 번 더 덧그려 항상 최상위로 올린다.
+ *  1) shouldDrawSelectedOnTop 게이트: line-only 선택 프레임만 on-top 허용, 나머지는 미적용.
+ *  2) drawSelectedSeriesOnly 대상: defaultSelectInfo.seriesId 의 시리즈만 draw.
+ *  3) drawChart on-top 패스: drawSeriesLayer 뒤 선택 line 덧그리기 순서.
+ *
+ * 실제 렌더 대신 서브 메서드를 호출 기록 stub 으로 교체해 계약만 검증한다(DOM 불필요).
+ */
+const rec =
+  (calls, name, ret) =>
+  (...args) => {
+    calls.push({ name, args });
+    return ret;
+  };
+
+const makeSelChart = (overrides = {}) => {
+  const calls = [];
+  const baseOptions = {
+    selectSeries: { use: true },
+    selectItem: { use: false },
+    selectLabel: { use: false },
+    maxTip: { background: '#000', color: '#fff' },
+    unSelectedOpacity: 0.3,
+    horizontal: false,
+    brush: false,
+  };
+  const options = { ...baseOptions, ...(overrides.options ?? {}) };
+  delete overrides.options;
+
+  const chart = Object.assign(Object.create(EvChart.prototype), {
+    options,
+    seriesList: {
+      l1: { type: 'line', show: true, fill: false, isExistGrp: false, draw: rec(calls, 'series.draw') },
+    },
+    defaultSelectInfo: { seriesId: ['l1'] },
+    defaultSelectItemInfo: null,
+    bufferCtx: {},
+    chartRect: { x1: 0, x2: 200, chartWidth: 200, chartHeight: 100 },
+    labelOffset: { left: 0, right: 0, top: 0, bottom: 0 },
+    axesSteps: { x: [], y: [] },
+    _dataEpoch: 1,
+    _scaleVersion: 1,
+    legendHover: null,
+    ...overrides,
+  });
+  return { chart, calls };
+};
+
+const names = (calls) => calls.map((c) => c.name);
+
+describe('shouldDrawSelectedOnTop 게이트 (full redraw on-top)', () => {
+  it('selectSeries.use + 단일 line 선택 + 무상태 → true', () => {
+    const { chart } = makeSelChart();
+    expect(chart.shouldDrawSelectedOnTop()).toBe(true);
+  });
+
+  it('다중 line 선택 → true', () => {
+    const { chart } = makeSelChart({
+      seriesList: {
+        l1: { type: 'line', show: true, fill: false, isExistGrp: false },
+        l2: { type: 'line', show: true, fill: false, isExistGrp: false },
+      },
+      defaultSelectInfo: { seriesId: ['l1', 'l2'] },
+    });
+    expect(chart.shouldDrawSelectedOnTop()).toBe(true);
+  });
+
+  it('selectSeries.use=false → false', () => {
+    const { chart } = makeSelChart({ options: { selectSeries: { use: false } } });
+    expect(chart.shouldDrawSelectedOnTop()).toBe(false);
+  });
+
+  it('brush → false', () => {
+    const { chart } = makeSelChart({ options: { brush: true } });
+    expect(chart.shouldDrawSelectedOnTop()).toBe(false);
+  });
+
+  it('realTimeScatter → false', () => {
+    const { chart } = makeSelChart({ options: { realTimeScatter: { use: true } } });
+    expect(chart.shouldDrawSelectedOnTop()).toBe(false);
+  });
+
+  it('workerRender → false (worker 별도 z-order, 범위 밖)', () => {
+    const { chart } = makeSelChart({ options: { workerRender: true } });
+    expect(chart.shouldDrawSelectedOnTop()).toBe(false);
+  });
+
+  it('legend hit(hitInfo.legend) → false', () => {
+    const { chart } = makeSelChart();
+    expect(chart.shouldDrawSelectedOnTop({ legend: { sId: 'l1' } })).toBe(false);
+  });
+
+  it('legendHover 잔류 → false', () => {
+    const { chart } = makeSelChart({ legendHover: { sId: 'l1' } });
+    expect(chart.shouldDrawSelectedOnTop()).toBe(false);
+  });
+
+  it('선택 없음(seriesId []) → false (덧그릴 것 없음, full redraw 가 이미 정상)', () => {
+    const { chart } = makeSelChart({ defaultSelectInfo: { seriesId: [] } });
+    expect(chart.shouldDrawSelectedOnTop()).toBe(false);
+  });
+
+  it('선택 시리즈 scatter → false', () => {
+    const { chart } = makeSelChart({
+      seriesList: { l1: { type: 'scatter', show: true, fill: false, isExistGrp: false } },
+    });
+    expect(chart.shouldDrawSelectedOnTop()).toBe(false);
+  });
+
+  it('선택 시리즈 heatMap → false', () => {
+    const { chart } = makeSelChart({
+      seriesList: { l1: { type: 'heatMap', show: true, fill: false, isExistGrp: false } },
+    });
+    expect(chart.shouldDrawSelectedOnTop()).toBe(false);
+  });
+
+  it('선택 시리즈 bar → false', () => {
+    const { chart } = makeSelChart({
+      seriesList: { l1: { type: 'bar', show: true, fill: false, isExistGrp: false } },
+    });
+    expect(chart.shouldDrawSelectedOnTop()).toBe(false);
+  });
+
+  it('선택 line + fill → false', () => {
+    const { chart } = makeSelChart({
+      seriesList: { l1: { type: 'line', show: true, fill: true, isExistGrp: false } },
+    });
+    expect(chart.shouldDrawSelectedOnTop()).toBe(false);
+  });
+
+  it('선택 line + isExistGrp(stack) → false', () => {
+    const { chart } = makeSelChart({
+      seriesList: { l1: { type: 'line', show: true, fill: false, isExistGrp: true } },
+    });
+    expect(chart.shouldDrawSelectedOnTop()).toBe(false);
+  });
+
+  it('line + scatter 혼합 선택 → false (all-or-nothing)', () => {
+    const { chart } = makeSelChart({
+      seriesList: {
+        l1: { type: 'line', show: true, fill: false, isExistGrp: false },
+        s1: { type: 'scatter', show: true, fill: false, isExistGrp: false },
+      },
+      defaultSelectInfo: { seriesId: ['l1', 's1'] },
+    });
+    expect(chart.shouldDrawSelectedOnTop()).toBe(false);
+  });
+
+  it('선택 id 가 seriesList 에 없음 → false', () => {
+    const { chart } = makeSelChart({ defaultSelectInfo: { seriesId: ['nope'] } });
+    expect(chart.shouldDrawSelectedOnTop()).toBe(false);
+  });
+});
+
+describe('drawSelectedSeriesOnly 대상', () => {
+  it('defaultSelectInfo.seriesId 의 시리즈만 draw 한다', () => {
+    const calls = [];
+    const { chart } = makeSelChart({
+      seriesList: {
+        l1: { type: 'line', show: true, fill: false, isExistGrp: false, draw: rec(calls, 'draw.l1') },
+        l2: { type: 'line', show: true, fill: false, isExistGrp: false, draw: rec(calls, 'draw.l2') },
+      },
+      defaultSelectInfo: { seriesId: ['l1'] },
+    });
+    chart.drawSelectedSeriesOnly();
+    expect(names(calls)).toEqual(['draw.l1']);
+  });
+});
+
+/**
+ * drawChart 의 on-top 패스(drawSeriesLayer 뒤 선택 line 덧그리기) 검증.
+ * 실제 drawChart(EvChart.prototype)를 태우되 부수효과/DOM·worker 의존 서브메서드를 호출 기록 stub 으로
+ * 교체한다(shouldDrawSelectedOnTop/selectedSeriesAllLineSafe 는 실제 메서드 사용).
+ */
+const makeDrawChartChart = (overrides = {}) => {
+  const calls = [];
+  const options = {
+    selectSeries: { use: true },
+    brush: false,
+    realTimeScatter: { use: false },
+    ...(overrides.options ?? {}),
+  };
+  delete overrides.options;
+
+  const chart = Object.assign(Object.create(EvChart.prototype), {
+    options,
+    renderEpoch: 0,
+    scrollbar: { x: { use: false }, y: { use: false } },
+    legendHover: null,
+    defaultSelectInfo: { seriesId: ['l1'] },
+    seriesList: { l1: { type: 'line', show: true, fill: false, isExistGrp: false } },
+    bufferCtx: {},
+    bufferCanvas: {},
+    displayCtx: {},
+    listeners: {},
+    initScale: rec(calls, 'initScale'),
+    prepareScale: rec(calls, 'prepareScale', { scaleChange: false, scrollbarLabelOffset: 0 }),
+    computeScaleVersion: rec(calls, 'computeScaleVersion'),
+    emitDataMaxChange: rec(calls, 'emitDataMaxChange'),
+    tryDrawSeriesOnWorker: rec(calls, 'tryDrawSeriesOnWorker', false),
+    drawAxisAndSeries: rec(calls, 'drawAxisAndSeries'),
+    drawStaticLayer: rec(calls, 'drawStaticLayer'),
+    drawSeriesLayer: rec(calls, 'drawSeriesLayer'),
+    drawSeriesOverlay: rec(calls, 'drawSeriesOverlay'),
+    drawTip: rec(calls, 'drawTip'),
+    commitToDisplay: rec(calls, 'commitToDisplay'),
+    drawSelectedSeriesOnly: rec(calls, 'drawSelectedSeriesOnly'),
+    ...overrides,
+  });
+  return { chart, calls };
+};
+
+describe('drawChart on-top 패스 (데이터 업데이트 프레임 묻힘 보정)', () => {
+  it('selection(line) 활성 full redraw → drawSeriesLayer < drawSelectedSeriesOnly < drawSeriesOverlay', () => {
+    const { chart, calls } = makeDrawChartChart();
+    chart.drawChart();
+
+    const order = names(calls);
+    expect(order.indexOf('drawSeriesLayer')).toBeLessThan(order.indexOf('drawSelectedSeriesOnly'));
+    expect(order.indexOf('drawSelectedSeriesOnly')).toBeLessThan(order.indexOf('drawSeriesOverlay'));
+  });
+
+  it('선택 없음 → drawSelectedSeriesOnly 미호출(평범한 full redraw)', () => {
+    const { chart, calls } = makeDrawChartChart({ defaultSelectInfo: { seriesId: [] } });
+    chart.drawChart();
+
+    expect(names(calls)).toContain('drawSeriesLayer');
+    expect(names(calls)).not.toContain('drawSelectedSeriesOnly');
+  });
+
+  it('realTimeScatter 프레임 → realtime 분기(drawAxisAndSeries), drawSelectedSeriesOnly 미호출', () => {
+    const { chart, calls } = makeDrawChartChart({ options: { realTimeScatter: { use: true } } });
+    chart.drawChart();
+
+    expect(names(calls)).toContain('drawAxisAndSeries');
+    expect(names(calls)).not.toContain('drawSelectedSeriesOnly');
+  });
+});

--- a/src/components/chart/chart.selection.visual.spec.js
+++ b/src/components/chart/chart.selection.visual.spec.js
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'vitest-browser-vue';
+import EvChart from './Chart.vue';
+
+/**
+ * selectSeries 강조 — 겹친 시리즈의 "선택 = 최상위 불투명" 정합을 픽셀로 검증한다.
+ *
+ * full redraw 는 선택 시리즈를 z-order 제자리에 그리므로, 선택 시리즈가 비선택보다 먼저(아래)
+ * 그려지면 위에 깔리는 비선택 dim 라인에 묻혀 선택색이 흐려진다. shouldDrawSelectedOnTop→
+ * drawSelectedSeriesOnly 가 선택 line 을 맨 위에 한 번 더 불투명하게 덧그려 이를 보정한다.
+ *
+ * 계약 수준 spec(chart.selection.spec.js)은 호출 순서/게이트만 보므로, 이 픽셀 단언이 없으면
+ * draw-order 가 바뀌어 깜빡임이 되살아나도 모든 spec 이 green 으로 남는다.
+ *
+ * 검증 전략: 두 라인을 완전히 겹쳐 두고 각 시리즈를 번갈아 선택해 "선택색 순수 픽셀 수"를 잰다.
+ * 보정이 작동하면 어느 쪽을 선택하든 선택색이 라인 전체를 불투명하게 덮어 두 값이 대칭이다.
+ * 보정이 빠지면 z-order 하위를 선택한 쪽만 비선택 dim 에 절반 묻혀 순수색이 급감해 비대칭이 된다
+ * (실측: 보정 OFF 시 하위 선택 1976→988, 상위 선택은 1976 유지 → min/max=0.5).
+ */
+describe('EvChart selectSeries 겹침 최상위 색 정합', () => {
+  const RED = '#DF6264'; // series1
+  const BLUE = '#3CA0FF'; // series2
+
+  // 두 시리즈를 동일 y(완전 겹침)로 둔다.
+  const makeData = () => ({
+    series: {
+      series1: { name: 's1', color: RED, point: false },
+      series2: { name: 's2', color: BLUE, point: false },
+    },
+    labels: [0, 1, 2, 3, 4],
+    data: { series1: [50, 50, 50, 50, 50], series2: [50, 50, 50, 50, 50] },
+  });
+
+  const options = {
+    type: 'line',
+    width: '600px',
+    height: '400px',
+    selectSeries: { use: true },
+    unSelectedOpacity: 0.3,
+    legend: { show: false },
+    tooltip: { use: false },
+    axesX: [{ type: 'linear', showGrid: false }],
+    axesY: [{ type: 'linear', showGrid: false, range: [0, 100] }],
+    padding: { top: 20, right: 20, bottom: 20, left: 40 },
+  };
+
+  const settle = async () => {
+    await new Promise((r) => setTimeout(r, 120));
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    await new Promise((r) => setTimeout(r, 80));
+  };
+
+  const getImg = (container) => {
+    const canvas = container.querySelector('canvas:not(.overlay-canvas)');
+    return canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height);
+  };
+
+  // 선택색이 dim 과 섞이지 않은 '순수' 픽셀만 센다(섞이면 채널 차가 줄어 임계 미달).
+  // 회색 축 라벨(r≈b)·저 alpha 배경은 자동 제외된다.
+  const measure = (img) => {
+    const d = img.data;
+    let pureRed = 0;
+    let pureBlue = 0;
+    for (let i = 0; i < d.length; i += 4) {
+      if (d[i + 3] >= 32) {
+        const r = d[i];
+        const b = d[i + 2];
+        if (r > 180 && r - b > 80) {
+          pureRed += 1;
+        }
+        if (b > 180 && b - r > 80) {
+          pureBlue += 1;
+        }
+      }
+    }
+    return { pureRed, pureBlue };
+  };
+
+  // 무선택으로 그린 뒤 sel 을 선택(props.selectedSeries watch 발화 = 클릭 대응)하고 측정한다.
+  const renderSelect = async (sel) => {
+    const { container, rerender } = render(EvChart, {
+      props: { data: makeData(), options, selectedSeries: { seriesId: [] } },
+    });
+    await settle();
+    await rerender({ data: makeData(), options, selectedSeries: { seriesId: [sel] } });
+    await settle();
+    return measure(getImg(container));
+  };
+
+  it('겹친 두 시리즈 중 어느 쪽을 선택해도 선택색이 동등하게 순수(불투명 최상위)해야 한다', async () => {
+    const redPure = (await renderSelect('series1')).pureRed;
+    const bluePure = (await renderSelect('series2')).pureBlue;
+
+    // 선택 라인이 실제로 그려졌는지(sanity).
+    expect(redPure, 'series1 선택 라인 미검출').toBeGreaterThan(200);
+    expect(bluePure, 'series2 선택 라인 미검출').toBeGreaterThan(200);
+
+    // z-order 무관하게 선택색이 동등 순수해야 한다. 한쪽만 비선택 dim 에 묻히면(최상위 보정 회귀)
+    // 비대칭으로 깨진다.
+    const lo = Math.min(redPure, bluePure);
+    const hi = Math.max(redPure, bluePure);
+    expect(
+      lo,
+      `선택색 순도 비대칭(최상위 보정 회귀) series1=${redPure} series2=${bluePure}`,
+    ).toBeGreaterThan(hi * 0.85);
+  }, 60000);
+
+  it('폴링(재렌더) 전후로 선택색 농도가 유지된다(클릭↔폴링 깜빡임 방지)', async () => {
+    const { container, rerender } = render(EvChart, {
+      props: { data: makeData(), options, selectedSeries: { seriesId: [] } },
+    });
+    await settle();
+
+    // z-order 하위(보정 적용 대상)인 series1 을 선택.
+    await rerender({ data: makeData(), options, selectedSeries: { seriesId: ['series1'] } });
+    await settle();
+    const before = measure(getImg(container)).pureRed;
+
+    // 데이터 새 참조로 재렌더(폴링) — 선택 유지.
+    await rerender({ data: makeData(), options, selectedSeries: { seriesId: ['series1'] } });
+    await settle();
+    const after = measure(getImg(container)).pureRed;
+
+    expect(before, '선택 라인 미검출').toBeGreaterThan(200);
+    expect(
+      Math.abs(after - before),
+      `폴링 전후 선택색 농도 급변(깜빡임) before=${before} after=${after}`,
+    ).toBeLessThan(before * 0.3);
+  }, 60000);
+});

--- a/src/components/chart/plugins.interaction.selectSeries.spec.js
+++ b/src/components/chart/plugins.interaction.selectSeries.spec.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import interaction from './plugins/plugins.interaction';
+
+/**
+ * selectSeriesByData 재렌더 스킵 검증.
+ *
+ * 배경: 차트 그룹에서 한 차트를 선택하면 제품이 나머지 차트의 selectedSeries 를 빈 배열로
+ * 리셋(재할당)하고, deep watch 가 이를 변경으로 보고 selectSeriesByData([]) 를 매 인터랙션마다
+ * 호출한다. 이 스팸을 막기 위해 재렌더를 스킵한다.
+ *
+ * 단, 비교 기준은 defaultSelectInfo.seriesId 가 아니라 '마지막으로 render 한 선택'이다.
+ * onClick(setSelectedSeriesInfo)이 클릭 즉시 defaultSelectInfo.seriesId 를 선반영하므로, 그 값을
+ * 기준으로 비교하면 '클릭한 차트'는 선택/해제 모두 동일로 오판돼 render 가 스킵된다(하이라이트 누락).
+ */
+const makeChart = ({ rendered = null, selected } = {}) => {
+  const render = vi.fn();
+  // selected: onClick 이 선반영해 둔 defaultSelectInfo.seriesId (미지정 시 rendered 와 동일로 본다)
+  const ctx = {
+    defaultSelectInfo: { seriesId: selected ?? rendered ?? [] },
+    _renderedSelectSeriesIds: rendered,
+    render,
+  };
+  const chart = {
+    selectSeriesByData: (list) => interaction.selectSeriesByData.call(ctx, list),
+    get defaultSelectInfo() {
+      return ctx.defaultSelectInfo;
+    },
+  };
+  return { chart, render };
+};
+
+describe('selectSeriesByData: 마지막 render 한 선택 기준으로 스킵', () => {
+  it('그룹 빈배열 스팸(rendered [] → []): render 스킵', () => {
+    const { chart, render } = makeChart({ rendered: [] });
+    chart.selectSeriesByData([]);
+    expect(render).not.toHaveBeenCalled();
+  });
+
+  it('동일 선택 echo(rendered [s1] → [s1]): render 스킵', () => {
+    const { chart, render } = makeChart({ rendered: ['s1'] });
+    chart.selectSeriesByData(['s1']);
+    expect(render).not.toHaveBeenCalled();
+  });
+
+  it('첫 호출(rendered 미설정): render 1회', () => {
+    const { chart, render } = makeChart({ rendered: null });
+    chart.selectSeriesByData(['s1']);
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(chart.defaultSelectInfo.seriesId).toEqual(['s1']);
+  });
+
+  it('신규 선택(rendered [] → [s1]): render 1회', () => {
+    const { chart, render } = makeChart({ rendered: [] });
+    chart.selectSeriesByData(['s1']);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it('다른 seriesId(rendered [s1] → [s2]): render 1회', () => {
+    const { chart, render } = makeChart({ rendered: ['s1'] });
+    chart.selectSeriesByData(['s2']);
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(chart.defaultSelectInfo.seriesId).toEqual(['s2']);
+  });
+
+  it('클릭한 차트 선택: onClick 이 defaultSelectInfo 를 [s5] 로 선반영해도 render 1회', () => {
+    // rendered=[s1](마지막 render), onClick 이 defaultSelectInfo 를 [s5] 로 선반영 후 round-trip 으로
+    // selectSeriesByData([s5]) 호출. defaultSelectInfo 기준 비교면 스킵되던 버그 → render 돼야 한다.
+    const { chart, render } = makeChart({ rendered: ['s1'], selected: ['s5'] });
+    chart.selectSeriesByData(['s5']);
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(chart.defaultSelectInfo.seriesId).toEqual(['s5']);
+  });
+
+  it('클릭한 차트 해제: onClick 이 defaultSelectInfo 를 [] 로 선반영해도 render 1회', () => {
+    // 선택된 시리즈 재클릭으로 해제 → onClick 이 defaultSelectInfo 를 [] 로 선반영, selectSeriesByData([]).
+    // defaultSelectInfo 기준([]→[]) 비교면 스킵되던 버그 → 해제 render 돼야 한다.
+    const { chart, render } = makeChart({ rendered: ['s1'], selected: [] });
+    chart.selectSeriesByData([]);
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(chart.defaultSelectInfo.seriesId).toEqual([]);
+  });
+});

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -1518,7 +1518,18 @@ const modules = {
    * @returns {boolean}
    */
   selectSeriesByData(seriesIdList) {
+    // 차트 그룹에서 비선택 차트의 selectedSeries 가 빈 배열로 반복 리셋(재할당)되며 deep watch 가
+    // 매 인터랙션마다 selectSeriesByData([]) 를 호출하는 스팸을 차단한다. 단 비교 기준은
+    // defaultSelectInfo.seriesId 가 아니라 '마지막으로 render 한 선택(_renderedSelectSeriesIds)' 이다 —
+    // onClick(setSelectedSeriesInfo)이 클릭 즉시 defaultSelectInfo.seriesId 를 선반영하므로, 그 값을
+    // 기준으로 비교하면 클릭한 차트는 항상 동일로 판정돼 선택/해제 render 가 스킵된다(하이라이트 누락).
+    const next = seriesIdList ?? [];
+    const rendered = this._renderedSelectSeriesIds;
+    if (rendered && rendered.length === next.length && rendered.every((v, i) => v === next[i])) {
+      return;
+    }
     this.defaultSelectInfo.seriesId = seriesIdList;
+    this._renderedSelectSeriesIds = [...next];
     this.render();
   },
 

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -275,6 +275,10 @@ const DEFAULT_OPTIONS = {
   // 소비자는 갱신 시 props.data 에 새 top-level 객체 참조를 할당해야 한다(미할당 시 미갱신).
   // mount 시점 1회 평가 — 런타임 토글 불가(바꾸려면 :key 등으로 remount).
   shallowDataWatch: false,
+  // props.options deep-watch 를 끄는 opt-in(차트별). 기본 false(=deep watch 유지, 무회귀).
+  // true 면 options watch 가 deep:false 로 등록돼 매 갱신 deep traverse 비용을 없앤다. 단 deep 없이는
+  // in-place mutation 을 자동 감지 못 하므로 소비자는 options 변경 시 새 top-level 참조를 할당해야 한다.
+  shallowOptionsWatch: false,
 };
 
 const DEFAULT_DATA = {

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -278,6 +278,7 @@ const DEFAULT_OPTIONS = {
   // props.options deep-watch 를 끄는 opt-in(차트별). 기본 false(=deep watch 유지, 무회귀).
   // true 면 options watch 가 deep:false 로 등록돼 매 갱신 deep traverse 비용을 없앤다. 단 deep 없이는
   // in-place mutation 을 자동 감지 못 하므로 소비자는 options 변경 시 새 top-level 참조를 할당해야 한다.
+  // mount 시점 1회 평가 — 런타임 토글 불가(바꾸려면 :key 등으로 remount). shallowDataWatch 와 동일 계약.
   shallowOptionsWatch: false,
 };
 

--- a/src/components/chartGroup/ChartGroup.spec.js
+++ b/src/components/chartGroup/ChartGroup.spec.js
@@ -29,7 +29,7 @@ describe('EvChartGroup Component', () => {
     // 슬롯 자식이 그룹의 provide('groupInteraction') 를 inject 하도록 실제 중첩 구조를 재현한다.
     const Capture = {
       name: 'Capture',
-      inject: ['groupInteraction'],
+      inject: ['groupInteraction', 'deferPollingRedraw'],
       render: () => null,
     };
     const Root = {
@@ -103,6 +103,15 @@ describe('EvChartGroup Component', () => {
       expect(typeof vm.onClickToolbar).toBe('function');
       expect('zoomOptions' in vm).toBe(true);
       expect('evChartGroupRef' in vm).toBe(true);
+    });
+
+    it('provide: 자식이 inject 한 deferPollingRedraw 로 그룹 양보를 트리거한다', () => {
+      const { wrapper, gi } = mountGroup();
+      const childDefer = wrapper.findComponent(Capture).vm.deferPollingRedraw;
+      const now = performance.now();
+      expect(typeof childDefer).toBe('function');
+      childDefer(500);
+      expect(gi.deferUntil).toBe(now + 500);
     });
   });
 });

--- a/src/components/chartGroup/ChartGroup.spec.js
+++ b/src/components/chartGroup/ChartGroup.spec.js
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
 import EvChartGroup from './ChartGroup.vue';
 
 describe('EvChartGroup Component', () => {
@@ -21,6 +22,87 @@ describe('EvChartGroup Component', () => {
 
     it('기본 groupSelectedLabel은 null이다', () => {
       expect(EvChartGroup.props.groupSelectedLabel.default).toBeNull();
+    });
+  });
+
+  describe('deferPollingRedraw', () => {
+    // 슬롯 자식이 그룹의 provide('groupInteraction') 를 inject 하도록 실제 중첩 구조를 재현한다.
+    const Capture = {
+      name: 'Capture',
+      inject: ['groupInteraction'],
+      render: () => null,
+    };
+    const Root = {
+      components: { EvChartGroup, Capture },
+      template: '<ev-chart-group><Capture /></ev-chart-group>',
+    };
+
+    const mountGroup = () => {
+      const wrapper = mount(Root, { global: { directives: { resize: {} } } });
+      const gi = wrapper.findComponent(Capture).vm.groupInteraction;
+      const deferPollingRedraw = wrapper.findComponent(EvChartGroup).vm.deferPollingRedraw;
+      return { wrapper, gi, deferPollingRedraw };
+    };
+
+    // 시계가 performance.now() 라 fake timer 로 고정해 정확 비교한다(시간 진행 없음).
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ['Date', 'performance'] });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('인자 없으면 기본 800ms 양보(deferUntil = now+800)', () => {
+      const { gi, deferPollingRedraw } = mountGroup();
+      const now = performance.now();
+      deferPollingRedraw();
+      expect(gi.deferUntil).toBe(now + 800);
+    });
+
+    it('durationMs 인자를 반영한다', () => {
+      const { gi, deferPollingRedraw } = mountGroup();
+      const now = performance.now();
+      deferPollingRedraw(1200);
+      expect(gi.deferUntil).toBe(now + 1200);
+    });
+
+    it('상한(MAX_DEFER_MS=2000) 으로 clamp 된다', () => {
+      const { gi, deferPollingRedraw } = mountGroup();
+      const now = performance.now();
+      deferPollingRedraw(5000);
+      expect(gi.deferUntil).toBe(now + 2000);
+    });
+
+    it('음수는 0 으로 clamp 된다(deferUntil = now)', () => {
+      const { gi, deferPollingRedraw } = mountGroup();
+      const now = performance.now();
+      deferPollingRedraw(-100);
+      expect(gi.deferUntil).toBe(now);
+    });
+
+    it('NaN/비유한값은 기본 800ms 로 대체된다', () => {
+      const { gi, deferPollingRedraw } = mountGroup();
+      const now = performance.now();
+      deferPollingRedraw(NaN);
+      expect(gi.deferUntil).toBe(now + 800);
+    });
+
+    it('Math.max 로 연장만 하고 더 짧은 호출로 줄어들지 않는다', () => {
+      const { gi, deferPollingRedraw } = mountGroup();
+      const now = performance.now();
+      deferPollingRedraw(500);
+      deferPollingRedraw(300);
+      expect(gi.deferUntil).toBe(now + 500);
+    });
+
+    it('return 노출(expose 미사용): 기존 멤버 + deferPollingRedraw 가 모두 접근 가능', () => {
+      const { wrapper } = mountGroup();
+      const vm = wrapper.findComponent(EvChartGroup).vm;
+      expect(typeof vm.deferPollingRedraw).toBe('function');
+      expect(typeof vm.onClickToolbar).toBe('function');
+      expect('zoomOptions' in vm).toBe(true);
+      expect('evChartGroupRef' in vm).toBe(true);
     });
   });
 });

--- a/src/components/chartGroup/ChartGroup.vue
+++ b/src/components/chartGroup/ChartGroup.vue
@@ -50,6 +50,7 @@ export default {
       brushSeries,
       evChartGroupRef,
       evChartPropsInGroup,
+      groupInteraction,
     } = useGroupModel();
 
     const normalizedOptions = getNormalizedOptions(props.options);
@@ -57,6 +58,26 @@ export default {
     provide('isChartGroup', true);
     provide('brushSeries', brushSeries);
     provide('evChartPropsInGroup', evChartPropsInGroup);
+    provide('groupInteraction', groupInteraction);
+
+    // 차트 클릭으로 detail 패널/popup 을 여는 순간, 그룹 폴링 redraw 를 짧게(durationMs) 양보해
+    // 사용자가 연 것이 먼저 페인트되게 한다. one-shot bounded — 시간창이 지나면 자동 재개되므로
+    // detail 이 열려 있는 동안에도 차트는 계속 라이브 갱신된다(resume API 없음). 상태는 deferUntil
+    // 타임스탬프뿐이라 타이머/cleanup 불필요. 시계는 Chart.vue scheduleUpdate 와 동일하게 통일한다.
+    const MAX_DEFER_MS = 2000;
+    const DEFAULT_DEFER_MS = 800;
+    const nowMs = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+    const deferPollingRedraw = (durationMs = DEFAULT_DEFER_MS) => {
+      const ms = Number.isFinite(durationMs)
+        ? Math.min(Math.max(durationMs, 0), MAX_DEFER_MS)
+        : DEFAULT_DEFER_MS;
+      const now = nowMs();
+      // 기존 deferUntil 보다 미래면 연장하되, 반복 호출로 무한 연장되지 않도록 now+MAX 로 상한.
+      groupInteraction.deferUntil = Math.min(
+        Math.max(groupInteraction.deferUntil, now + ms),
+        now + MAX_DEFER_MS,
+      );
+    };
     const groupSelectedLabel = computed({
       get: () => props.groupSelectedLabel,
       set: (val) => emit('update:groupSelectedLabel', val),
@@ -140,6 +161,7 @@ export default {
       evChartToolbarRef,
       zoomOptions: toRef(evChartZoomOptions, 'zoom'),
       onClickToolbar,
+      deferPollingRedraw,
     };
   },
 };

--- a/src/components/chartGroup/ChartGroup.vue
+++ b/src/components/chartGroup/ChartGroup.vue
@@ -78,6 +78,9 @@ export default {
         now + MAX_DEFER_MS,
       );
     };
+    // 자식 차트(또는 위젯)에서 차트 클릭/더블클릭 등으로 무거운 detail/popup 을 열 때 직접 호출할 수
+    // 있도록 provide 한다(groupInteraction 과 동일 주입 경로). expose(return) 는 부모 ref 용으로 유지.
+    provide('deferPollingRedraw', deferPollingRedraw);
     const groupSelectedLabel = computed({
       get: () => props.groupSelectedLabel,
       set: (val) => emit('update:groupSelectedLabel', val),

--- a/src/components/chartGroup/uses.js
+++ b/src/components/chartGroup/uses.js
@@ -41,6 +41,9 @@ export const useGroupModel = () => {
   const evChartGroupRef = ref();
   const evChartPropsInGroup = ref([]);
   const brushSeries = reactive({ list: [], chartIdx: null });
+  // deferUntil 은 deferPollingRedraw 로 설정하는 절대 타임스탬프로, 그 시각까지 그룹 polling 재렌더를
+  // 미룬다(detail/popup 우선 페인트). Chart.vue scheduleUpdate 가 이 값까지 양보한다.
+  const groupInteraction = { deferUntil: 0 };
   const getNormalizedOptions = (options) => defaultsDeep({}, options, DEFAULT_OPTIONS);
 
   return {
@@ -49,5 +52,6 @@ export const useGroupModel = () => {
     brushSeries,
     evChartGroupRef,
     evChartPropsInGroup,
+    groupInteraction,
   };
 };

--- a/src/components/chartGroup/uses.spec.js
+++ b/src/components/chartGroup/uses.spec.js
@@ -38,4 +38,11 @@ describe('chartGroup uses', () => {
       expect(result.zoom.toolbar.items.reset.icon).toBe('ev-icon-redo');
     });
   });
+
+  describe('groupInteraction', () => {
+    it('기본값은 deferUntil:0 이다', () => {
+      const { groupInteraction } = useGroupModel();
+      expect(groupInteraction).toEqual({ deferUntil: 0 });
+    });
+  });
 });


### PR DESCRIPTION
## 요약
3.4 대비 차트 렌더 성능·정합성 개선 모음.

## 변경 내용 (커밋)
- **selectSeries 선택 라인 항상 최상위(dimmed 묻힘 방지)** — full redraw 시 선택 line 을 dimmed 시리즈 위에 한 번 더 덧그려 z-order 묻힘 방지
- **selectSeries 변화 없으면 재렌더 스킵** — 동일 선택 프레임 재렌더 회피
- **인터랙션 중 폴링 리드로우 양보(deferPollingRedraw)** — 인터랙션 중 무거운 폴링 리드로우 지연
- **ev-chart-group deferPollingRedraw provide** — 자식 차트에서 호출 가능하도록 provide
- **shallowOptionsWatch opt-in** — options deep watch 비용 제거(과렌더 cascade 완화)
- **docs** — shallowOptionsWatch 계약 문서/주석 정합화

## 비고
이전에 추가했던 selectSeries 부분 렌더(buffer-blit) 는 cross-series 겹침에서 partial↔full 픽셀 불일치가 구조적으로 발생했다(비선택 dim 겹침의 색/농도가 클릭 직후 연했다가 폴링 후 진해지는 깜빡임). 부분 렌더를 도입했던 기존 커밋을 수정하는 방향으로 해당 경로를 제거하고, 선택 인터랙션은 full redraw 로 처리한다. 선택 라인 최상위 보정·재렌더 스킵·deferPollingRedraw·shallowOptionsWatch 등 실제 병목을 해소한 최적화는 그대로 유지된다.

## 검증
- chart 단위 테스트 685개 통과, lint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)