### PR TITLE
feat: InputNumber > disableEmpty 옵션 추가

### DIFF
--- a/docs/views/inputNumber/api/inputNumber.md
+++ b/docs/views/inputNumber/api/inputNumber.md
@@ -26,6 +26,7 @@ height: 35px;
 | min | Number | -Infinity | value 의 최소값 | |
 | step | Number | 1 | 우측 화살표 클릭 및 키보드 ArrowUp / ArrowDown 입력 이벤트를 통한 변화 값 | |
 | step-strictly | Boolean | false | 설정한 step에 맞는 수만 허용. `modelValue`가 없을 경우 `props.min`을 기준으로 세팅됨(`props.min`을 따로 설정하지 않았을 경우, 0으로 세팅됨) | |
+| disable-empty | Boolean | false | 값을 비우는 것을 허용하지 않음. true로 설정하면 빈 값 입력 시 `null` 대신 `0`을 기준값으로 세팅하고 `min`/`max` 범위로 보정함. `step-strictly`와 함께 사용하면 기준값 0을 가장 가까운 step 값으로 스냅함(예: `min=-3, step=2` → `-1`) | true, false |
 | precision | Number |  | 고정 소수점 값. 0~100 사이의 정수 | |
 | trim-trailing-zero | Boolean | false | precision 사용 시 후행 0 제거 여부. true로 설정하면 `1.500` → `1.5`, `0.000` → `0`으로 표시 | true, false |
 

--- a/src/components/inputNumber/InputNumber.spec.js
+++ b/src/components/inputNumber/InputNumber.spec.js
@@ -158,6 +158,19 @@ describe('EvInputNumber Component', () => {
       expect(emitted[emitted.length - 1][0]).toBe(10);
     });
 
+    it('disableEmpty=true 이고 stepStrictly 면 빈 값이 0 에 가장 가까운 step 값으로 스냅된다', async () => {
+      const wrapper = mount(EvInputNumber, {
+        props: { modelValue: 5, disableEmpty: true, stepStrictly: true, min: -3, max: 10, step: 2 },
+      });
+      const input = wrapper.find('.ev-input');
+      await input.setValue('');
+      await input.trigger('change');
+
+      // 허용 step 값: -3, -1, 1, ... → 0 에 가장 가까운 값은 -1
+      const emitted = wrapper.emitted('update:modelValue');
+      expect(emitted[emitted.length - 1][0]).toBe(-1);
+    });
+
     it('기본 disableEmpty는 false이다', () => {
       expect(EvInputNumber.props.disableEmpty.default).toBe(false);
     });

--- a/src/components/inputNumber/InputNumber.spec.js
+++ b/src/components/inputNumber/InputNumber.spec.js
@@ -115,6 +115,54 @@ describe('EvInputNumber Component', () => {
     });
   });
 
+  describe('disableEmpty', () => {
+    it('기본값(false)에서는 값을 비우면 null 이 된다', async () => {
+      const wrapper = mount(EvInputNumber, { props: { modelValue: 80 } });
+      const input = wrapper.find('.ev-input');
+      await input.setValue('');
+      await input.trigger('change');
+
+      const emitted = wrapper.emitted('update:modelValue');
+      expect(emitted[emitted.length - 1][0]).toBe(null);
+    });
+
+    it('disableEmpty=true 이면 값을 비워도 0 이 된다', async () => {
+      const wrapper = mount(EvInputNumber, { props: { modelValue: 80, disableEmpty: true } });
+      const input = wrapper.find('.ev-input');
+      await input.setValue('');
+      await input.trigger('change');
+
+      const emitted = wrapper.emitted('update:modelValue');
+      expect(emitted[emitted.length - 1][0]).toBe(0);
+      expect(input.element.value).toBe('0');
+    });
+
+    it('disableEmpty=true 이고 값이 이미 0 일 때 비워도 화면에 0 이 표시된다', async () => {
+      const wrapper = mount(EvInputNumber, { props: { modelValue: 0, disableEmpty: true } });
+      const input = wrapper.find('.ev-input');
+      await input.setValue('');
+      await input.trigger('change');
+
+      expect(input.element.value).toBe('0');
+    });
+
+    it('disableEmpty=true 이면 min 보다 0 이 작을 때 min 으로 보정된다', async () => {
+      const wrapper = mount(EvInputNumber, {
+        props: { modelValue: 50, disableEmpty: true, min: 10 },
+      });
+      const input = wrapper.find('.ev-input');
+      await input.setValue('');
+      await input.trigger('change');
+
+      const emitted = wrapper.emitted('update:modelValue');
+      expect(emitted[emitted.length - 1][0]).toBe(10);
+    });
+
+    it('기본 disableEmpty는 false이다', () => {
+      expect(EvInputNumber.props.disableEmpty.default).toBe(false);
+    });
+  });
+
   describe('기본값', () => {
     it('컴포넌트 이름이 EvInputNumber이다', () => {
       expect(EvInputNumber.name).toBe('EvInputNumber');

--- a/src/components/inputNumber/InputNumber.vue
+++ b/src/components/inputNumber/InputNumber.vue
@@ -81,6 +81,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    disableEmpty: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ['update:modelValue', 'focus', 'blur', 'input', 'change'],
   setup() {

--- a/src/components/inputNumber/uses.js
+++ b/src/components/inputNumber/uses.js
@@ -78,9 +78,16 @@ export function useModel() {
     if (!val && val !== 0) {
       // 값이 없을 경우
       if (props.disableEmpty) {
-        // 빈 값 비허용: 0 을 기준으로 min/max 범위에 맞춰 보정
+        // 빈 값 비허용: 0 을 기준값으로 사용
         result = 0;
-        if ((props.min || props.min === 0) && result < props.min) {
+        if (props.stepStrictly) {
+          // step-strictly 와 함께면 0 을 step 그리드에 스냅 (충돌 해소)
+          result = getValueCloseToStep(result, {
+            min: props.min === -Infinity ? 0 : props.min,
+            max: props.max,
+            step: props.step,
+          });
+        } else if ((props.min || props.min === 0) && result < props.min) {
           result = props.min;
         } else if ((props.max || props.max === 0) && result > props.max) {
           result = props.max;

--- a/src/components/inputNumber/uses.js
+++ b/src/components/inputNumber/uses.js
@@ -77,7 +77,17 @@ export function useModel() {
 
     if (!val && val !== 0) {
       // 값이 없을 경우
-      result = props.stepStrictly ? previousValue.value : null;
+      if (props.disableEmpty) {
+        // 빈 값 비허용: 0 을 기준으로 min/max 범위에 맞춰 보정
+        result = 0;
+        if ((props.min || props.min === 0) && result < props.min) {
+          result = props.min;
+        } else if ((props.max || props.max === 0) && result > props.max) {
+          result = props.max;
+        }
+      } else {
+        result = props.stepStrictly ? previousValue.value : null;
+      }
     } else if (isNaN(val)) {
       // 숫자 아닐 경우 - 문자열 들어 왔을 경우
       result = previousValue.value;


### PR DESCRIPTION
### 개요
InputNumber에 빈 값(empty)을 허용하지 않는 disableEmpty 옵션을 추가합니다. 기본값은 false로 기존 동작에 영향이 없습니다.

### 배경 / 문제
1. 기존 EvInputNumber는 입력값을 모두 지우면 modelValue가 null이 됩니다.
2. "값이 비어 있으면 안 되는" 화면(예: 임계치 값 입력)에서는 빈 값 대신 **0으로 강제하고 싶은 요구가 있습니다.**
3. 단순히 부모에서 null → 0으로 보정하면, 이미 값이 0인 상태에서 지울 경우 modelValue가 0 → 0이라 내부 표시 갱신 watch(curr !== prev)가 동작하지 않아 화면만 빈칸으로 남는 문제가 있었습니다. 이를 컴포넌트 차원에서 해결합니다.

### 변경
1. prop 추가: disableEmpty: Boolean (default: false)
2. validateValue 빈 값 분기 보강:
   - disableEmpty = true이고 입력이 비면 → 0으로 보정하고, min/max 범위를 벗어나면 해당 경계값으로 클램프
   - disableEmpty = false(기본) → 기존과 동일 (null, stepStrictly일 때는 이전 값 유지)
3. 빈 값 처리 시 validateValue가 currentValue를 직접 세팅하므로, modelValue가 0 → 0이어도 화면이 정상적으로 0으로 표시됩니다.

### 사용법 
<img width="272" height="137" alt="image" src="https://github.com/user-attachments/assets/f88ad771-5495-412d-a9af-732e21cb6111" />
