### PR TITLE
improv(chart): PlotLine/PlotBand 옵션 확장 및 라벨 렌더링 개선

### DIFF
--- a/docs/specs/plotline-plotband-label-spec.md
+++ b/docs/specs/plotline-plotband-label-spec.md
@@ -1,0 +1,263 @@
+# PlotLine / PlotBand 라벨 개선 스펙
+
+> EvChart 의 `plotLines` / `plotBands` 라벨 기능 개선 정의서.
+> 대상 파일: `src/components/chart/scale/{scale.js, scale.step.js, scale.time.js}`,
+> `src/components/chart/helpers/helpers.constant.js`,
+> (#6 한정) `src/components/chart/chart.core.js`, `src/components/chart/plugins/{plugins.interaction.js, plugins.tooltip.js}`
+
+---
+
+## 1. 배경
+
+현재 plot 라벨은 다음 제약이 있다.
+
+- Y-plot 라벨은 **plot 영역 바깥 우측 여백**(`textX = maxX + …`)에만 그려진다 → `padding.right` 여백에 의존하며, 데이터가 깔린 영역 안에는 둘 수 없다.
+- 라벨 텍스트는 단일 `text` 한 줄뿐. 임계값(value)이나 alias+value 조합, 반응형 축약을 표현할 수 없다.
+- 라벨 배경은 `fillColor` 박스만 있고 opacity 제어 개념이 없다.
+- PlotBand 모서리(start/end) stroke 스타일을 지정할 수 없다 (X/Y band 동작도 불일치).
+- `value`/`index`가 `0`일 때 falsy 가드 때문에 선/밴드/라벨이 누락된다.
+
+본 스펙은 위를 옵션 추가(하위호환 유지)로 개선한다.
+
+---
+
+## 2. 확정된 결정 (논의 결과)
+
+| 주제 | 결정 |
+|---|---|
+| **z-order** | **`maxTip > plot(line/band/label) > series`** 로 확정(스펙 변경 반영). plot 을 static 에서 떼어 **front 패스(`drawPlotsFront`)** 로 분리, `drawForeground`(`drawPlotsFront`→`drawTip`)를 통해 series 위·maxTip 아래에 그린다. 옵션화는 하지 않음. **순서 변경 시 `drawForeground`의 두 줄 swap.** (자세히는 §9) |
+| **0값 표시** | falsy 가드를 명시적 null/유한성 검사로 교체해 `0` 값/인덱스도 표시. |
+| **라벨 가로 배치** | 단일 옵션(`position`)으로 좌/우 끝 배치. alias·value를 좌/우로 **분리 배치하는 방안은 제외** — 묶어서 한쪽 끝에 표시. |
+| **라벨 텍스트** | 기존 `text`를 라벨(=alias)로 사용 (`alias` 신설 안 함). `showValue`로 value 합성. |
+| **배경 opacity** | 기존 `fillColor`가 rgba를 허용하므로 **별도 옵션 불필요**. `fillColor: 'rgba(...)'`로 opacity 지원. (`background` 옵션 도입 안 함 — 중복 방지) |
+| **value 포맷** | 해당 축의 `getLabelFormat()`(축 formatter) 적용. |
+| **PlotBand value** | `showValue` 시 `from`·`to` 양끝에 각각 라벨 표시(2개). |
+| **반응형 축약** | 너비 기준 3단계: 풀(text+value) → value만 → 미노출. |
+| **value-only hover tooltip** | 데스크탑 전용 / series tooltip 우선 / `showTextOnHover` 옵션(`use` **기본 false**) + **tooltip 스타일 지정 가능**. |
+
+---
+
+## 3. 옵션 스키마
+
+### 3.1 label (plotLine · plotBand 공통)
+
+```js
+label: {
+  // ── 기존 (유지, 기본 동작 불변) ──
+  show: false,
+  fontSize: 12,
+  fontColor: '#FF0000',
+  fillColor: '#FFFFFF',      // 박스 배경. rgba 허용 → opacity 지원 (별도 옵션 불필요)
+  lineColor: '#FF0000',
+  lineWidth: 0,
+  fontWeight: 400,
+  fontFamily: 'Roboto',
+  verticalAlign: 'middle',   // 선 기준 세로: 'top'(선 위) | 'middle' | 'bottom'(선 아래)
+  textAlign: 'center',       // 'left' | 'center' | 'right'
+  textOverflow: 'none',      // 'none' | 'ellipsis'
+  maxWidth: null,
+  text: null,                // 라벨 텍스트(=alias). showValue=false면 이 값을 그대로 표시
+
+  // ── 신규 ──
+  borderRadius: 0,           // 라벨 박스 모서리 반경(px). 0이면 사각
+  padding: null,             // 라벨 박스 안쪽 여백. number(단축) 또는 { top, right, bottom, left }
+                             //   (차트 padding·tooltip rowPadding 과 동일 형식). null이면 fontSize/4
+  pointer: {                 // 말풍선 꼬리. 방향은 배치 기준 자동, 크기 고정
+    show: false,             //   (위 배치=아래꼬리 / 인접선 방향 자동). plotLine·plotBand 라벨 공통
+    color: null,             //   null이면 박스 배경색(fillColor) 사용
+  },
+  position: 'outside',       // 'outside'(기존 plot 밖 우측 여백)
+                             // | 'innerStart'(plot 안 좌측 끝)
+                             // | 'innerEnd'(plot 안 우측 끝)
+  showValue: false,          // true → "text value" 합성 (value = 축 formatter)
+  responsive: {              // 차트(plot) 너비 기준 3단계 축약. 둘 다 null이면 항상 풀 표시
+    valueOnlyBelow: null,    //   너비 < 이 값 → value만 표시
+    hideBelow: null,         //   너비 < 이 값 → 라벨 미노출(선/밴드 본체는 유지)
+  },
+  // value-only 상태에서 hover 시 text를 tooltip 으로 표시 (데스크탑 전용, series tooltip 우선)
+  // 기존 `tooltip` 옵션과 동일하게 토글(use) + 스타일을 한 객체에 담는다.
+  showTextOnHover: {
+    use: false,              // 활성 여부 (기본 false)
+    backgroundColor: '#4C4C4C',
+    fontColor: '#FFFFFF',
+    borderColor: '#666666',
+    borderRadius: 4,
+    fontSize: 12,
+    fontFamily: 'Roboto',
+    useShadow: false,
+    shadowOpacity: 0.25,
+    padding: { top: 4, right: 8, bottom: 4, left: 8 },
+  },
+}
+```
+
+### 3.2 plotBand
+
+```js
+plotBands: [{
+  from,                      // 기존
+  to,                        // 기존
+  color,                     // 기존 (영역 fill)
+  border: null,              // 신규: { color: string, width: number, segments: number[] }
+                             //   start/end(from·to) 모서리 stroke. segments 지정 시 점선
+  label: { /* 3.1 공통 */ }, // showValue 시 from·to 양 끝에 각각 표시
+}]
+```
+
+---
+
+## 4. 동작 규칙
+
+### 4.1 라벨 텍스트 결정
+
+1. `showValue: true` → `"{text} {value}"` 합성 (`text`가 null이면 value만). value는 축 formatter 적용.
+2. `showValue: false` → 기존처럼 **`text` 그대로** (완전 하위호환).
+
+### 4.2 반응형 3단계 (`responsive`)
+
+plot 너비(넓음 → 좁음) 기준으로 표시 단계를 낮춘다.
+
+| 구간 | 표시 |
+|---|---|
+| 너비 ≥ `valueOnlyBelow` | **text + value** (예: `"심각 90"`) |
+| `hideBelow` ≤ 너비 < `valueOnlyBelow` | **value 만** (예: `"90"`) |
+| 너비 < `hideBelow` | **라벨 미노출** (선·밴드 본체는 계속 그려짐) |
+
+- 기본값 `valueOnlyBelow=null`, `hideBelow=null` → 반응형 비활성, 항상 풀 표시.
+- 판정 순서: `hideBelow`(미노출) → `valueOnlyBelow`(value만) → 풀. (`valueOnlyBelow > hideBelow` 전제, 어긋나면 hide 우선)
+
+### 4.3 가로 배치 (`position`) — Y축
+
+- `'outside'` : 기존 동작. Y-plot은 plot 밖 우측 여백.
+- `'innerStart'` : plot 영역 안 좌측 끝.
+- `'innerEnd'` : plot 영역 안 우측 끝.
+- 세로 위치는 기존 `verticalAlign`(top=선 위 / middle / bottom=선 아래)을 그대로 사용.
+
+### 4.3-X X축 plot 배치 (세로선)
+
+X축(`axesX`)의 plotLine/plotBand 라벨은 Y축과 기하가 달라 다음 규칙을 따른다(`position`/`verticalAlign` 무시):
+
+- **항상 plot 상단(top) 고정.** 라벨 박스는 plot 영역 위에 배치.
+- **가로 정렬은 `textAlign`(left/center/right) — 그려질 세로선 기준** 좌/센터/우. (`computeTopLabelBox`)
+- **말풍선 꼬리는 아래(↓), 끝(tip)은 항상 세로선의 x를 가리킨다** — 좌/우로 밀어도 자기 선을 지시(`pointerTipX`).
+- **plotBand from·to(showValue) 두 라벨은 자동 바깥쪽**: 작은 값(좌 edge)=`textAlign left`, 큰 값(우 edge)=`textAlign right` → 두 라벨이 안 겹침.
+- 그 외(borderRadius·padding·pointer·responsive·showValue·hover tooltip)는 Y축과 동일하게 적용.
+
+### 4.4 value-only hover tooltip (#6)
+
+value-only 상태(`hideBelow ≤ 너비 < valueOnlyBelow`)에서는 alias(text)가 가려지므로, hover 로 보완한다.
+
+- **활성 조건**: `showTextOnHover.use: true` **그리고** 현재 value-only 상태일 때만.
+- **데스크탑 전용**: 모바일(`isMobile`)은 동작하지 않음.
+- **우선순위**: `findHitItem` 의 series hit 이 있으면 series tooltip 이 우선. series hit 이 **없을 때만** 라벨 tooltip 표시.
+- **내용**: 해당 라벨의 `text`.
+- **표시 방식**: 경량 전용 DOM tooltip (series 용 `tooltipDOM` 과 별개). 커서 이탈 시 숨김.
+- **스타일**: `showTextOnHover` 의 `backgroundColor` / `fontColor` / `borderColor` / `borderRadius` / `fontSize` / `fontFamily` / `useShadow` / `shadowOpacity` / `padding` 으로 지정. 기본값은 series `tooltip` 룩앤필과 동일 계열.
+
+---
+
+## 5. 작업 항목 / 영향 범위
+
+| # | 작업 | 영향 계층 |
+|---|---|---|
+| 1 | **0값 표시** — falsy 가드 교체 (`scale.step.js:441, 468`, `scale.js:547, 668, 698`, band `checkValidPosition` `scale.js:635, 729`) | scale ×3 |
+| 2 | **`position` 가로 배치** — `getPlotLineLabelPosition`/`getPlotBandLabelPosition`(scale.js:796~909) 분기 확장 | scale ×3 |
+| 3 | **text/value + 반응형** — `getNormalizedLabelOptions`(scale.js:755)에 텍스트 합성·너비 분기 추가 | scale ×3 |
+| 4 | **배경 opacity** — 기존 `fillColor`(rgba)로 이미 지원됨. **코드 변경 없음**(동작 확인 + 문서화만) | — |
+| 5 | **PlotBand `border` stroke** — `setPlotBandStyle` / `drawXPlotBand`(632) / `drawYPlotBand`(726) | scale |
+| 6 | **value-only hover tooltip** — 라벨 hit 영역 수집(scale ×3) → core 취합(`chart.core.js` drawStaticLayer 후) → `onMouseMove` hit-test(`plugins.interaction.js:19`) → DOM tooltip(`plugins.tooltip.js`) | scale + core + interaction + tooltip |
+| - | 옵션 상수 추가 — `PLOT_LINE_LABEL_OPTION`, `PLOT_BAND_OPTION`(`helpers.constant.js:162, 183`) | constant |
+
+> #1~#5 는 `scale` 계열 + 상수 수준. **#6 만** interaction/tooltip 플러그인까지 범위가 확장된다.
+
+---
+
+## 6. 하위호환
+
+- 모든 신규 옵션의 기본값 = 기존 동작. **기존 코드는 한 줄도 안 고쳐도 동일하게 동작**한다.
+- 신규 키 미지정 시: 라벨은 `position:'outside'`(plot 밖 우측 여백) + `text` 그대로, 반응형/hover/배경 opacity/band border 모두 비활성.
+
+```js
+// 기존 코드 — 변경 없이 동일 동작
+plotLines: [{
+  color: '#FF0000', value: -50, segments: [6, 2],
+  label: { show: true, text: 'Y Plot Line' },  // showValue 기본 false → 'Y Plot Line' 그대로
+}]
+```
+
+---
+
+## 7. 예시
+
+```js
+axesY: [{
+  type: 'linear',
+  plotBands: [{
+    from: 70, to: 95,
+    color: 'rgba(255, 99, 99, 0.35)',
+    border: { color: '#FF0000', width: 1, segments: [2, 2] }, // 상/하단 빨간 점선
+    label: {
+      show: true, position: 'innerStart', showValue: true,    // from=70, to=95 (양끝)
+      fontColor: '#FF0000',
+    },
+  }],
+  plotLines: [
+    {
+      value: 90, color: '#E53935', segments: [2, 2],
+      label: {
+        show: true, position: 'innerStart', text: '심각', showValue: true, // "심각 90"
+        fontColor: '#FFFFFF',
+        fillColor: 'rgba(229, 57, 53, 0.9)',  // 박스 배경 + opacity (rgba)
+      },
+    },
+    {
+      value: 67, color: '#8E24AA', segments: [2, 2],
+      label: {
+        show: true, position: 'innerEnd', text: 'Alias', showValue: true,
+        fontColor: '#FFFFFF',
+        fillColor: 'rgba(142, 36, 170, 0.9)', // 박스 배경 + opacity (rgba)
+        responsive: { valueOnlyBelow: 400, hideBelow: 200 }, // <400: "67", <200: 숨김
+        showTextOnHover: {                                   // value-only 시 hover → "Alias"
+          use: true,
+          backgroundColor: '#4C4C4C', fontColor: '#FFFFFF', borderRadius: 4, useShadow: true,
+        },
+      },
+    },
+  ],
+}],
+```
+
+---
+
+## 8. 제외 / 보류 항목
+
+- **alias / value 좌·우 분리 배치** — 제외. 묶어서 한쪽 끝에 표시.
+- **모바일 hover tooltip** — 데스크탑 전용. 모바일 탭 지원은 범위 외.
+
+---
+
+## 9. z-order: plot front 패스 (스펙 변경 반영)
+
+목표 노출 순서: **`maxTip` > `plot(line/band/label)` > `series`** (maxTip 이 가장 앞).
+
+### 구조
+한 버퍼에 **그리는 순서 = z-order**. plot 을 static(맨 뒤)에서 떼어내 series 위·tip 아래에 그린다.
+```
+drawStaticLayer  : grid/axis 만
+drawSeriesLayer  : series (또는 worker bitmap 합성)
+drawForeground(ctx):                 ← z-order 단일 제어점
+  drawPlotsFront(ctx) : plotLine/band/label    ← series 위
+  drawTip(ctx)        : maxTip/selectItem/tooltip  ← 가장 앞
+→ commit
+```
+> **순서 변경**: `chart.core.js`의 `drawForeground` 안 두 줄(`drawTip`/`drawPlotsFront`) 순서만 swap.
+> 단, 경로가 2곳(동기 `drawChart`-buffer / 워커 `commitWorkerFrame`-displayCtx)이라 `drawForeground(ctx)`를 양쪽이 공유해 제어점은 사실상 한 곳. overlayCanvas(heatmap hover)·DOM tooltip(hover 툴팁)은 별도 레이어라 무관.
+
+### 구현
+- **scale ×3**: `draw()`의 plot 블록을 `drawPlots()`로 분리. `draw()`는 grid/axis 만 그리고 plot geometry 를 `this._plotGeom`에 캐시. `drawPlots()`는 캐시 + `this.ctx`로 그림(로직 동일, 위치만 이동).
+- **chart.core**: `drawPlotsFront(ctx)`(axes 순회 `drawPlots` + hover hit 영역 취합) / `drawForeground(ctx)` 신설. `drawTip` 호출부(메인/워커 미전송/`commitWorkerFrame`)를 `drawForeground`로 치환, 워커 사망 폴백엔 `drawPlotsFront` 추가.
+- 워커 경로: `drawStaticLayer`(전송 프레임)에서 캐시한 `_plotGeom`을 `commitWorkerFrame`이 displayCtx(+pixelRatio transform)에 그림. epoch 가드로 stale 방지.
+
+### 검증
+- 단위: `Chart.drawPipeline.spec.js`(파이프라인 순서) 외 비-visual chart spec 107개 통과.
+- visual golden spec 은 plot 미사용 → 영향 없음.

--- a/docs/specs/plotline-plotband-label-spec.md
+++ b/docs/specs/plotline-plotband-label-spec.md
@@ -25,7 +25,7 @@
 
 | 주제 | 결정 |
 |---|---|
-| **z-order** | **`maxTip > plot(line/band/label) > series`** 로 확정(스펙 변경 반영). plot 을 static 에서 떼어 **front 패스(`drawPlotsFront`)** 로 분리, `drawForeground`(`drawPlotsFront`→`drawTip`)를 통해 series 위·maxTip 아래에 그린다. 옵션화는 하지 않음. **순서 변경 시 `drawForeground`의 두 줄 swap.** (자세히는 §9) |
+| **z-order** | 기본 **`maxTip > plot(line/band/label) > series`**. plot 을 static 에서 떼어 **front 패스(`drawPlotsFront`)** 로 분리, `drawForeground`(`drawPlotsFront`→`drawTip`)를 통해 series 위·maxTip 아래에 그린다. **차트 옵션 `plot.aboveSeries`(기본 true)로 plot 을 series 위/아래 전환 가능**(false면 plot 을 series 아래로). maxTip 은 항상 최상단. (자세히는 §9) |
 | **0값 표시** | falsy 가드를 명시적 null/유한성 검사로 교체해 `0` 값/인덱스도 표시. |
 | **라벨 가로 배치** | 단일 옵션(`position`)으로 좌/우 끝 배치. alias·value를 좌/우로 **분리 배치하는 방안은 제외** — 묶어서 한쪽 끝에 표시. |
 | **라벨 텍스트** | 기존 `text`를 라벨(=alias)로 사용 (`alias` 신설 안 함). `showValue`로 value 합성. |
@@ -33,7 +33,7 @@
 | **value 포맷** | 해당 축의 `getLabelFormat()`(축 formatter) 적용. |
 | **PlotBand value** | `showValue` 시 `from`·`to` 양끝에 각각 라벨 표시(2개). |
 | **반응형 축약** | 너비 기준 3단계: 풀(text+value) → value만 → 미노출. |
-| **value-only hover tooltip** | 데스크탑 전용 / series tooltip 우선 / `showTextOnHover` 옵션(`use` **기본 false**) + **tooltip 스타일 지정 가능**. |
+| **value-only hover tooltip** | 데스크탑 전용 / **커서가 라벨 박스 위면 라벨 tooltip 우선**(그 외 영역은 series tooltip) / `showTextOnHover` 옵션(`use` **기본 false**) + **tooltip 스타일 지정 가능**. |
 
 ---
 
@@ -81,9 +81,10 @@ label: {
     use: false,              // 활성 여부 (기본 false)
     backgroundColor: '#4C4C4C',
     fontColor: '#FFFFFF',
-    borderColor: '#666666',
+    borderColor: null,       // null이면 backgroundColor 와 동일 → 테두리 미표시
     borderRadius: 4,
     fontSize: 12,
+    fontWeight: 400,
     fontFamily: 'Roboto',
     useShadow: false,
     shadowOpacity: 0.25,
@@ -150,10 +151,10 @@ value-only 상태(`hideBelow ≤ 너비 < valueOnlyBelow`)에서는 alias(text)�
 
 - **활성 조건**: `showTextOnHover.use: true` **그리고** 현재 value-only 상태일 때만.
 - **데스크탑 전용**: 모바일(`isMobile`)은 동작하지 않음.
-- **우선순위**: `findHitItem` 의 series hit 이 있으면 series tooltip 이 우선. series hit 이 **없을 때만** 라벨 tooltip 표시.
+- **우선순위**: **커서가 라벨 박스(value-only) 안에 있으면 라벨 tooltip 우선** — 그 프레임의 series hit 을 무시해 series tooltip 을 끄고 라벨 tooltip 을 표시한다(z-order 상 plot 이 series 위라 직접 hover 한 라벨이 이김). 라벨 박스 밖에서는 기존대로 series tooltip. (`onMouseMove` 가 `findPlotLabelHitRegion` 으로 판정)
 - **내용**: 해당 라벨의 `text`.
 - **표시 방식**: 경량 전용 DOM tooltip (series 용 `tooltipDOM` 과 별개). 커서 이탈 시 숨김.
-- **스타일**: `showTextOnHover` 의 `backgroundColor` / `fontColor` / `borderColor` / `borderRadius` / `fontSize` / `fontFamily` / `useShadow` / `shadowOpacity` / `padding` 으로 지정. 기본값은 series `tooltip` 룩앤필과 동일 계열.
+- **스타일**: `showTextOnHover` 의 `backgroundColor` / `fontColor` / `borderColor`(null이면 배경색=테두리 미표시) / `borderRadius` / `fontSize` / `fontWeight` / `fontFamily` / `useShadow` / `shadowOpacity` / `padding` 으로 지정. 기본값은 series `tooltip` 룩앤필과 동일 계열.
 
 ---
 
@@ -237,26 +238,30 @@ axesY: [{
 
 ---
 
-## 9. z-order: plot front 패스 (스펙 변경 반영)
+## 9. z-order: plot front 패스 + `plot.aboveSeries` 옵션
 
-목표 노출 순서: **`maxTip` > `plot(line/band/label)` > `series`** (maxTip 이 가장 앞).
+기본 노출 순서: **`maxTip` > `plot(line/band/label)` > `series`** (maxTip 이 가장 앞).
+차트 옵션 **`plot.aboveSeries`(기본 true)** 로 plot 을 series 위/아래 전환. `false`면 **`maxTip > series > plot`**. maxTip 은 항상 최상단.
 
 ### 구조
 한 버퍼에 **그리는 순서 = z-order**. plot 을 static(맨 뒤)에서 떼어내 series 위·tip 아래에 그린다.
 ```
-drawStaticLayer  : grid/axis 만
+drawStaticLayer  : grid/axis (+ aboveSeries:false 면 여기서 plot → series 아래)
 drawSeriesLayer  : series (또는 worker bitmap 합성)
-drawForeground(ctx):                 ← z-order 단일 제어점
-  drawPlotsFront(ctx) : plotLine/band/label    ← series 위
-  drawTip(ctx)        : maxTip/selectItem/tooltip  ← 가장 앞
+drawForeground(ctx):                 ← z-order 제어점
+  drawPlotsFront(ctx) : plotLine/band/label    ← aboveSeries:true(기본)일 때만, series 위
+  drawTip(ctx)        : maxTip/selectItem/tooltip  ← 항상 가장 앞
 → commit
 ```
-> **순서 변경**: `chart.core.js`의 `drawForeground` 안 두 줄(`drawTip`/`drawPlotsFront`) 순서만 swap.
-> 단, 경로가 2곳(동기 `drawChart`-buffer / 워커 `commitWorkerFrame`-displayCtx)이라 `drawForeground(ctx)`를 양쪽이 공유해 제어점은 사실상 한 곳. overlayCanvas(heatmap hover)·DOM tooltip(hover 툴팁)은 별도 레이어라 무관.
+> **위/아래 전환**: `plot.aboveSeries`. true면 `drawForeground`에서 plot 을 series 위에, false면 `drawStaticLayer` 끝에서 plot 을 series 아래(static)에 그린다(워커 경로는 buffer 위에 series bitmap 이 덮어 자동으로 아래에 깔림).
+> 경로가 2곳(동기 `drawChart`-buffer / 워커 `commitWorkerFrame`-displayCtx)이라 `drawForeground(ctx)`를 양쪽이 공유. 워커 사망 폴백(`drawSeriesLayerFallback`)도 동일 분기. overlayCanvas(heatmap hover)·DOM tooltip(hover 툴팁)은 별도 레이어라 무관.
 
 ### 구현
 - **scale ×3**: `draw()`의 plot 블록을 `drawPlots()`로 분리. `draw()`는 grid/axis 만 그리고 plot geometry 를 `this._plotGeom`에 캐시. `drawPlots()`는 캐시 + `this.ctx`로 그림(로직 동일, 위치만 이동).
-- **chart.core**: `drawPlotsFront(ctx)`(axes 순회 `drawPlots` + hover hit 영역 취합) / `drawForeground(ctx)` 신설. `drawTip` 호출부(메인/워커 미전송/`commitWorkerFrame`)를 `drawForeground`로 치환, 워커 사망 폴백엔 `drawPlotsFront` 추가.
+- **chart.core**: `drawPlotsFront(ctx)`(axes 순회 `drawPlots` + hover hit 영역 취합) / `drawForeground(ctx)` 신설. `drawTip` 호출부(메인/워커 미전송/`commitWorkerFrame`)를 `drawForeground`로 치환.
+- **`plot.aboveSeries` 분기**(기본값 `uses.js`의 `plot: { aboveSeries: true }`):
+  - `true`: `drawForeground`가 `drawPlotsFront`→`drawTip` (plot 이 series 위).
+  - `false`: `drawStaticLayer` 끝에서 `drawPlotsFront`(plot 이 series 아래) + `drawForeground`는 tip 만. 워커 사망 폴백도 동일 조건 분기.
 - 워커 경로: `drawStaticLayer`(전송 프레임)에서 캐시한 `_plotGeom`을 `commitWorkerFrame`이 displayCtx(+pixelRatio transform)에 그림. epoch 가드로 stale 방지.
 
 ### 검증

--- a/docs/specs/plotline-plotband-label-spec.md
+++ b/docs/specs/plotline-plotband-label-spec.md
@@ -60,6 +60,7 @@ label: {
 
   // ── 신규 ──
   borderRadius: 0,           // 라벨 박스 모서리 반경(px). 0이면 사각
+  gap: null,                 // 임계선/임계영역↔라벨 박스 간격(px). null이면 자동(fontSize 기준, X축 상단은 2)
   padding: null,             // 라벨 박스 안쪽 여백. number(단축) 또는 { top, right, bottom, left }
                              //   (차트 padding·tooltip rowPadding 과 동일 형식). null이면 fontSize/4
   pointer: {                 // 말풍선 꼬리. 방향은 배치 기준 자동, 크기 고정

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -277,31 +277,95 @@ const chartData = {
 | lineWidth | Number                             | 1         | 선 굵기                        |                                                                      |
 | label     | Object                             | null      | 표시할 label의 스타일을 정의   | ([상세](#plotlabel))                                                 |
 
+> `value`가 `0`이어도 선·라벨이 표시됩니다.
+
 ##### plotBand
 
-| 이름  | 타입                               | 디폴트    | 설명                                  | 종류(예시)                                                           |
-| ----- | ---------------------------------- | --------- | ------------------------------------- | -------------------------------------------------------------------- |
-| from  | Number(value), Date, Number(Index) | null      | 박스를 표시할 시작 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
-| to    | Number(value), Date, Number(Index) | null      | 박스를 표시할 종료 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
-| color | Hex, RGB, RGBA Code(String)        | '#FF0000' | 선 색상                               |                                                                      |
-| label | Object                             | null      | 표시할 label의 스타일을 정의          | ([상세](#plotlabel))                                                 |
+| 이름   | 타입                               | 디폴트    | 설명                                  | 종류(예시)                                                           |
+| ------ | ---------------------------------- | --------- | ------------------------------------- | -------------------------------------------------------------------- |
+| from   | Number(value), Date, Number(Index) | null      | 박스를 표시할 시작 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
+| to     | Number(value), Date, Number(Index) | null      | 박스를 표시할 종료 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
+| color  | Hex, RGB, RGBA Code(String)        | '#FF0000' | 박스(면) 배경 색상. `rgba(...)`로 투명도 지정 |                                                              |
+| border | Object \| null                     | null      | 밴드 start/end 모서리 stroke          | ([상세](#plotbandborder))                                            |
+| label  | Object                             | null      | 표시할 label의 스타일을 정의          | ([상세](#plotlabel))                                                 |
+
+> - `from`/`to`가 `0`이어도 표시됩니다.
+> - `label.showValue: true`이면 `from`·`to` 양 끝에 각각 값 라벨이 자동 바깥배치로 표시됩니다.
+
+###### plotBandBorder
+
+| 이름     | 타입                        | 디폴트 | 설명             | 종류(예시) |
+| -------- | --------------------------- | ------ | ---------------- | ---------- |
+| color    | Hex, RGB, RGBA Code(String) | -      | 모서리 선 색상   |            |
+| width    | Number                      | -      | 모서리 선 굵기   |            |
+| segments | Array\<number>              | -      | dash 간격(점선)  | [2, 2]     |
 
 ##### plotLabel
 
-| 이름          | 타입                        | 디폴트    | 설명                                                               | 종류(예시)                |
-| ------------- | --------------------------- | --------- | ------------------------------------------------------------------ | ------------------------- |
-| show          | Boolean                     | false     | label 표시 여부                                                    | true / false              |
-| fontSize      | Number                      | 12        | 폰트 크기                                                          |                           |
-| fontColor     | Hex, RGB, RGBA Code(String) | '#FF0000' | 폰트 색상                                                          |                           |
-| fillColor     | Hex, RGB, RGBA Code(String) | '#FFFFFF' | 박스 배경 색상                                                     |                           |
-| lineColor     | Hex, RGB, RGBA Code(String) | '#FF0000' | 박스 테두리 선 색상                                                |                           |
-| lineWidth     | Number                      | 0         | 테두리 선 굵기                                                     | 1 ~                       |
-| fontWeight    | Number                      | 400       | 폰트 굵기                                                          |                           |
-| fontFamily    | String                      | 'Roboto'  | 폰트 스타일                                                        |                           |
-| textAlign     | String                      | 'center'  | 수평 정렬                                                          | 'left', 'center', 'right' |
-| verticalAlign | String                      | 'middle'  | 수직 정렬                                                          | 'top', 'middle', 'bottom' |
-| textOverflow  | String                      | 'none'    | 라벨을 넣을 수 있는 여백 혹은 maxWidth 값을 넘었을 경우의 처리방안 | 'none', 'ellipsis'        |
-| maxWidth      | Number                      | null      | 라벨의 최대 너비                                                   |                           |
+| 이름            | 타입                        | 디폴트    | 설명                                                               | 종류(예시)                            |
+| --------------- | --------------------------- | --------- | ------------------------------------------------------------------ | ------------------------------------- |
+| show            | Boolean                     | false     | label 표시 여부                                                    | true / false                          |
+| text            | String \| null              | null      | 라벨 텍스트(=alias). `showValue: false`면 이 값을 그대로 표시       |                                       |
+| showValue       | Boolean                     | false     | `true` → `"{text} {value}"` 합성(value는 해당 축 formatter 적용)   | true / false                          |
+| fontSize        | Number                      | 12        | 폰트 크기                                                          |                                       |
+| fontColor       | Hex, RGB, RGBA Code(String) | '#FF0000' | 폰트 색상                                                          |                                       |
+| fillColor       | Hex, RGB, RGBA Code(String) | '#FFFFFF' | 박스 배경 색상. `rgba(...)`로 투명도 지정 가능                      |                                       |
+| lineColor       | Hex, RGB, RGBA Code(String) | '#FF0000' | 박스 테두리 선 색상                                                |                                       |
+| lineWidth       | Number                      | 0         | 테두리 선 굵기                                                     | 1 ~                                   |
+| fontWeight      | Number                      | 400       | 폰트 굵기                                                          |                                       |
+| fontFamily      | String                      | 'Roboto'  | 폰트 스타일                                                        |                                       |
+| position        | String                      | 'outside' | (Y축) 가로 배치. plot 밖 우측 / 안쪽 좌·우                         | 'outside', 'innerStart', 'innerEnd'   |
+| textAlign       | String                      | 'center'  | 수평 정렬                                                          | 'left', 'center', 'right'             |
+| verticalAlign   | String                      | 'middle'  | 수직 정렬                                                          | 'top', 'middle', 'bottom'             |
+| borderRadius    | Number                      | 0         | 라벨 박스 모서리 반경(px)                                          |                                       |
+| padding         | Number \| Object            | null      | 박스 안쪽 여백. 숫자 또는 `{ top, right, bottom, left }`. `null`이면 `fontSize/4` | 6, <br> { top: 4, bottom: 2 } |
+| pointer         | Object                      | ([상세](#pointer)) | 말풍선 꼬리                                              |                                       |
+| responsive      | Object                      | ([상세](#responsive)) | plot 너비 기준 단계 축약                              |                                       |
+| showTextOnHover | Object                      | ([상세](#showtextonhover)) | value-only 상태에서 hover 시 text tooltip       |                                       |
+| textOverflow    | String                      | 'none'    | 라벨을 넣을 수 있는 여백 혹은 maxWidth 값을 넘었을 경우의 처리방안 | 'none', 'ellipsis'                    |
+| maxWidth        | Number                      | null      | 라벨의 최대 너비                                                   |                                       |
+
+> - 배경 opacity는 별도 옵션 없이 `fillColor`에 `rgba(...)`를 주면 적용됩니다.
+> - X축(세로선/세로밴드) 라벨은 `position`·`verticalAlign`을 무시하고 **항상 plot 상단(top) 고정**, `textAlign`으로만 정렬됩니다.
+
+###### pointer
+
+| 이름  | 타입                                | 디폴트 | 설명                                          | 종류(예시) |
+| ----- | ----------------------------------- | ------ | --------------------------------------------- | ---------- |
+| show  | Boolean                             | false  | 말풍선 꼬리 표시 여부(방향은 배치 기준 자동)  | true / false |
+| color | Hex, RGB, RGBA Code(String) \| null | null   | 꼬리 색상. `null`이면 박스 배경색(`fillColor`) |            |
+
+###### responsive
+
+plot 너비(넓음→좁음) 기준 단계 축약. 둘 다 `null`이면 항상 풀(text+value) 표시.
+
+| 이름           | 타입           | 디폴트 | 설명                                             | 종류(예시) |
+| -------------- | -------------- | ------ | ------------------------------------------------ | ---------- |
+| valueOnlyBelow | Number \| null | null   | plot 너비 < 이 값 → **value만** 표시             | 400        |
+| hideBelow      | Number \| null | null   | plot 너비 < 이 값 → **라벨 미노출**(본체는 유지) | 200        |
+
+| 구간                                  | 표시         |
+| ------------------------------------- | ------------ |
+| 너비 ≥ `valueOnlyBelow`               | text + value |
+| `hideBelow` ≤ 너비 < `valueOnlyBelow` | value 만     |
+| 너비 < `hideBelow`                    | 라벨 미노출  |
+
+###### showTextOnHover
+
+value-only 상태에서 alias(text)가 가려지므로 hover로 보완(데스크탑 전용).
+
+| 이름            | 타입    | 디폴트                                 | 설명          | 종류(예시) |
+| --------------- | ------- | -------------------------------------- | ------------- | ---------- |
+| use             | Boolean | false                                  | 활성 여부     | true / false |
+| backgroundColor | String  | '#4C4C4C'                              | 배경 색상     |            |
+| fontColor       | String  | '#FFFFFF'                              | 폰트 색상     |            |
+| borderColor     | String  | '#666666'                              | 테두리 색상   |            |
+| borderRadius    | Number  | 4                                      | 모서리 반경   |            |
+| fontSize        | Number  | 12                                     | 폰트 크기     |            |
+| fontFamily      | String  | 'Roboto'                               | 폰트 패밀리   |            |
+| useShadow       | Boolean | false                                  | 그림자 사용   | true / false |
+| shadowOpacity   | Number  | 0.25                                   | 그림자 투명도 |            |
+| padding         | Object  | { top: 4, right: 8, bottom: 4, left: 8 } | 안쪽 여백   |            |
 
 ##### axes scrollbar
 

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -146,6 +146,7 @@ const chartData = {
 | tooltip      | Object                    | ([상세](#tooltip))                        | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성                                                                                                                                       |                                 |
 | indicator    | Object                    | ([상세](#indicator))                      | 지표선                                                                                                                                                                                 |                                 |
 | maxTip       | Object                    | ([상세](#maxtip))                         | 최대값에 tip 표시(값 표시) 여부 및 속성                                                                                                                                                |                                 |
+| plot         | Object                    | ([상세](#plot))                           | plotLines/plotBands(임계선·밴드)의 표시 z-order 전역 설정                                                                                                                              |                                 |
 | displayOverflow | Boolean                | false                                     | 값 축(세로 모드=Y, 가로 모드=X)의 range로 제한한 범위를 초과한 막대를 경계까지 표시할지 여부. false면 range 밖 데이터는 숨겨집니다.                                                     | true, false                     |
 | selectItem   | Object                    | ([상세](#selectitem))                     | 차트 아이템 선택 기능 활성화 여부 및 속성                                                                                                                                              |                                 |
 | selectLabel  | Object                    | ([상세](#selectlabel))                    | 차트 라벨 선택 기능 활성화 여부 및 속성                                                                                                                                                |                                 |
@@ -360,9 +361,10 @@ value-only 상태에서 alias(text)가 가려지므로 hover로 보완(데스크
 | use             | Boolean | false                                  | 활성 여부     | true / false |
 | backgroundColor | String  | '#4C4C4C'                              | 배경 색상     |            |
 | fontColor       | String  | '#FFFFFF'                              | 폰트 색상     |            |
-| borderColor     | String  | '#666666'                              | 테두리 색상   |            |
+| borderColor     | String \| null | null                            | 테두리 색상. `null`이면 `backgroundColor`와 동일 → 테두리 미표시 | |
 | borderRadius    | Number  | 4                                      | 모서리 반경   |            |
 | fontSize        | Number  | 12                                     | 폰트 크기     |            |
+| fontWeight      | Number  | 400                                    | 폰트 굵기     |            |
 | fontFamily      | String  | 'Roboto'                               | 폰트 패밀리   |            |
 | useShadow       | Boolean | false                                  | 그림자 사용   | true / false |
 | shadowOpacity   | Number  | 0.25                                   | 그림자 투명도 |            |
@@ -507,6 +509,17 @@ const chartOptions = {
     | name | String | 시리즈 이름 | 'Series 1' |
     | dataId | String | 데이터 ID | 'data_1' |
     | index | Number | 데이터 인덱스 | 0 |
+
+#### plot
+
+plotLines/plotBands(임계선·밴드)의 표시 순서(z-order) 전역 설정. maxTip 은 항상 최상단입니다.
+
+| 이름        | 타입    | 디폴트 | 설명                                                        | 종류(예시)   |
+| ----------- | ------- | ------ | ----------------------------------------------------------- | ------------ |
+| aboveSeries | Boolean | true   | 임계선/밴드를 series 위(true)에 그릴지, 아래(false)에 그릴지 | true / false |
+
+- `true`(기본): `maxTip > plot > series`
+- `false`: `maxTip > series > plot` (임계선/밴드가 데이터 시리즈 뒤로 깔림)
 
 #### indicator
 

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -318,6 +318,7 @@ const chartData = {
 | textAlign       | String                      | 'center'  | 수평 정렬                                                          | 'left', 'center', 'right'             |
 | verticalAlign   | String                      | 'middle'  | 수직 정렬                                                          | 'top', 'middle', 'bottom'             |
 | borderRadius    | Number                      | 0         | 라벨 박스 모서리 반경(px)                                          |                                       |
+| gap             | Number \| null              | null      | 임계선/임계영역과 라벨 박스 사이 간격(px). `null`이면 자동(fontSize 기준)          |                                       |
 | padding         | Number \| Object            | null      | 박스 안쪽 여백. 숫자 또는 `{ top, right, bottom, left }`. `null`이면 `fontSize/4` | 6, <br> { top: 4, bottom: 2 } |
 | pointer         | Object                      | ([상세](#pointer)) | 말풍선 꼬리                                              |                                       |
 | responsive      | Object                      | ([상세](#responsive)) | plot 너비 기준 단계 축약                              |                                       |

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -223,31 +223,95 @@ const chartData =
 | lineWidth | Number                             | 1         | 선 굵기                        |                                                                      |
 | label     | Object                             | null      | 표시할 label의 스타일을 정의   | ([상세](#plotlabel))                                                 |
 
+> `value`가 `0`이어도 선·라벨이 표시됩니다.
+
 ##### plotBand
 
-| 이름  | 타입                               | 디폴트    | 설명                                  | 종류(예시)                                                           |
-| ----- | ---------------------------------- | --------- | ------------------------------------- | -------------------------------------------------------------------- |
-| from  | Number(value), Date, Number(Index) | null      | 박스를 표시할 시작 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
-| to    | Number(value), Date, Number(Index) | null      | 박스를 표시할 종료 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
-| color | Hex, RGB, RGBA Code(String)        | '#FF0000' | 선 색상                               |                                                                      |
-| label | Object                             | null      | 표시할 label의 스타일을 정의          | ([상세](#plotlabel))                                                 |
+| 이름   | 타입                               | 디폴트    | 설명                                  | 종류(예시)                                                           |
+| ------ | ---------------------------------- | --------- | ------------------------------------- | -------------------------------------------------------------------- |
+| from   | Number(value), Date, Number(Index) | null      | 박스를 표시할 시작 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
+| to     | Number(value), Date, Number(Index) | null      | 박스를 표시할 종료 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
+| color  | Hex, RGB, RGBA Code(String)        | '#FF0000' | 박스(면) 배경 색상. `rgba(...)`로 투명도 지정 |                                                              |
+| border | Object \| null                     | null      | 밴드 start/end 모서리 stroke          | ([상세](#plotbandborder))                                            |
+| label  | Object                             | null      | 표시할 label의 스타일을 정의          | ([상세](#plotlabel))                                                 |
+
+> - `from`/`to`가 `0`이어도 표시됩니다.
+> - `label.showValue: true`이면 `from`·`to` 양 끝에 각각 값 라벨이 자동 바깥배치로 표시됩니다.
+
+###### plotBandBorder
+
+| 이름     | 타입                        | 디폴트 | 설명             | 종류(예시) |
+| -------- | --------------------------- | ------ | ---------------- | ---------- |
+| color    | Hex, RGB, RGBA Code(String) | -      | 모서리 선 색상   |            |
+| width    | Number                      | -      | 모서리 선 굵기   |            |
+| segments | Array\<number>              | -      | dash 간격(점선)  | [2, 2]     |
 
 ##### plotLabel
 
-| 이름          | 타입                        | 디폴트    | 설명                                                               | 종류(예시)                |
-| ------------- | --------------------------- | --------- | ------------------------------------------------------------------ | ------------------------- |
-| show          | Boolean                     | false     | label 표시 여부                                                    | true / false              |
-| fontSize      | Number                      | 12        | 폰트 크기                                                          |                           |
-| fontColor     | Hex, RGB, RGBA Code(String) | '#FF0000' | 폰트 색상                                                          |                           |
-| fillColor     | Hex, RGB, RGBA Code(String) | '#FFFFFF' | 박스 배경 색상                                                     |                           |
-| lineColor     | Hex, RGB, RGBA Code(String) | '#FF0000' | 박스 테두리 선 색상                                                |                           |
-| lineWidth     | Number                      | 0         | 테두리 선 굵기                                                     | 1 ~                       |
-| fontWeight    | Number                      | 400       | 폰트 굵기                                                          |                           |
-| fontFamily    | String                      | 'Roboto'  | 폰트 스타일                                                        |                           |
-| textAlign     | String                      | 'center'  | 수평 정렬                                                          | 'left', 'center', 'right' |
-| verticalAlign | String                      | 'middle'  | 수직 정렬                                                          | 'top', 'middle', 'bottom' |
-| textOverflow  | String                      | 'none'    | 라벨을 넣을 수 있는 여백 혹은 maxWidth 값을 넘었을 경우의 처리방안 | 'none', 'ellipsis'        |
-| maxWidth      | Number                      | null      | 라벨의 최대 너비                                                   |                           |
+| 이름            | 타입                        | 디폴트    | 설명                                                               | 종류(예시)                            |
+| --------------- | --------------------------- | --------- | ------------------------------------------------------------------ | ------------------------------------- |
+| show            | Boolean                     | false     | label 표시 여부                                                    | true / false                          |
+| text            | String \| null              | null      | 라벨 텍스트(=alias). `showValue: false`면 이 값을 그대로 표시       |                                       |
+| showValue       | Boolean                     | false     | `true` → `"{text} {value}"` 합성(value는 해당 축 formatter 적용)   | true / false                          |
+| fontSize        | Number                      | 12        | 폰트 크기                                                          |                                       |
+| fontColor       | Hex, RGB, RGBA Code(String) | '#FF0000' | 폰트 색상                                                          |                                       |
+| fillColor       | Hex, RGB, RGBA Code(String) | '#FFFFFF' | 박스 배경 색상. `rgba(...)`로 투명도 지정 가능                      |                                       |
+| lineColor       | Hex, RGB, RGBA Code(String) | '#FF0000' | 박스 테두리 선 색상                                                |                                       |
+| lineWidth       | Number                      | 0         | 테두리 선 굵기                                                     | 1 ~                                   |
+| fontWeight      | Number                      | 400       | 폰트 굵기                                                          |                                       |
+| fontFamily      | String                      | 'Roboto'  | 폰트 스타일                                                        |                                       |
+| position        | String                      | 'outside' | (Y축) 가로 배치. plot 밖 우측 / 안쪽 좌·우                         | 'outside', 'innerStart', 'innerEnd'   |
+| textAlign       | String                      | 'center'  | 수평 정렬                                                          | 'left', 'center', 'right'             |
+| verticalAlign   | String                      | 'middle'  | 수직 정렬                                                          | 'top', 'middle', 'bottom'             |
+| borderRadius    | Number                      | 0         | 라벨 박스 모서리 반경(px)                                          |                                       |
+| padding         | Number \| Object            | null      | 박스 안쪽 여백. 숫자 또는 `{ top, right, bottom, left }`. `null`이면 `fontSize/4` | 6, <br> { top: 4, bottom: 2 } |
+| pointer         | Object                      | ([상세](#pointer)) | 말풍선 꼬리                                              |                                       |
+| responsive      | Object                      | ([상세](#responsive)) | plot 너비 기준 단계 축약                              |                                       |
+| showTextOnHover | Object                      | ([상세](#showtextonhover)) | value-only 상태에서 hover 시 text tooltip       |                                       |
+| textOverflow    | String                      | 'none'    | 라벨을 넣을 수 있는 여백 혹은 maxWidth 값을 넘었을 경우의 처리방안 | 'none', 'ellipsis'                    |
+| maxWidth        | Number                      | null      | 라벨의 최대 너비                                                   |                                       |
+
+> - 배경 opacity는 별도 옵션 없이 `fillColor`에 `rgba(...)`를 주면 적용됩니다.
+> - X축(세로선/세로밴드) 라벨은 `position`·`verticalAlign`을 무시하고 **항상 plot 상단(top) 고정**, `textAlign`으로만 정렬됩니다.
+
+###### pointer
+
+| 이름  | 타입                                | 디폴트 | 설명                                          | 종류(예시) |
+| ----- | ----------------------------------- | ------ | --------------------------------------------- | ---------- |
+| show  | Boolean                             | false  | 말풍선 꼬리 표시 여부(방향은 배치 기준 자동)  | true / false |
+| color | Hex, RGB, RGBA Code(String) \| null | null   | 꼬리 색상. `null`이면 박스 배경색(`fillColor`) |            |
+
+###### responsive
+
+plot 너비(넓음→좁음) 기준 단계 축약. 둘 다 `null`이면 항상 풀(text+value) 표시.
+
+| 이름           | 타입           | 디폴트 | 설명                                             | 종류(예시) |
+| -------------- | -------------- | ------ | ------------------------------------------------ | ---------- |
+| valueOnlyBelow | Number \| null | null   | plot 너비 < 이 값 → **value만** 표시             | 400        |
+| hideBelow      | Number \| null | null   | plot 너비 < 이 값 → **라벨 미노출**(본체는 유지) | 200        |
+
+| 구간                                  | 표시         |
+| ------------------------------------- | ------------ |
+| 너비 ≥ `valueOnlyBelow`               | text + value |
+| `hideBelow` ≤ 너비 < `valueOnlyBelow` | value 만     |
+| 너비 < `hideBelow`                    | 라벨 미노출  |
+
+###### showTextOnHover
+
+value-only 상태에서 alias(text)가 가려지므로 hover로 보완(데스크탑 전용).
+
+| 이름            | 타입    | 디폴트                                 | 설명          | 종류(예시) |
+| --------------- | ------- | -------------------------------------- | ------------- | ---------- |
+| use             | Boolean | false                                  | 활성 여부     | true / false |
+| backgroundColor | String  | '#4C4C4C'                              | 배경 색상     |            |
+| fontColor       | String  | '#FFFFFF'                              | 폰트 색상     |            |
+| borderColor     | String  | '#666666'                              | 테두리 색상   |            |
+| borderRadius    | Number  | 4                                      | 모서리 반경   |            |
+| fontSize        | Number  | 12                                     | 폰트 크기     |            |
+| fontFamily      | String  | 'Roboto'                               | 폰트 패밀리   |            |
+| useShadow       | Boolean | false                                  | 그림자 사용   | true / false |
+| shadowOpacity   | Number  | 0.25                                   | 그림자 투명도 |            |
+| padding         | Object  | { top: 4, right: 8, bottom: 4, left: 8 } | 안쪽 여백   |            |
 
 #### title
 

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -264,6 +264,7 @@ const chartData =
 | textAlign       | String                      | 'center'  | 수평 정렬                                                          | 'left', 'center', 'right'             |
 | verticalAlign   | String                      | 'middle'  | 수직 정렬                                                          | 'top', 'middle', 'bottom'             |
 | borderRadius    | Number                      | 0         | 라벨 박스 모서리 반경(px)                                          |                                       |
+| gap             | Number \| null              | null      | 임계선/임계영역과 라벨 박스 사이 간격(px). `null`이면 자동(fontSize 기준)          |                                       |
 | padding         | Number \| Object            | null      | 박스 안쪽 여백. 숫자 또는 `{ top, right, bottom, left }`. `null`이면 `fontSize/4` | 6, <br> { top: 4, bottom: 2 } |
 | pointer         | Object                      | ([상세](#pointer)) | 말풍선 꼬리                                              |                                       |
 | responsive      | Object                      | ([상세](#responsive)) | plot 너비 기준 단계 축약                              |                                       |

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -143,6 +143,7 @@ const chartData =
 | tooltip    | Object          | ([상세](#tooltip))                        | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성                                                                                                                                       |                                 |
 | indicator  | Object          | ([상세](#indicator))                      | 지표선                                                                                                                                                                                 |                                 |
 | maxTip     | Object          | ([상세](#maxtip))                         | 최대값에 tip 표시(값 표시) 여부 및 속성                                                                                                                                                |                                 |
+| plot       | Object          | ([상세](#plot))                           | plotLines/plotBands(임계선·밴드)의 표시 z-order 전역 설정                                                                                                                              |                                 |
 | displayOverflow | Boolean    | false                                     | 값 축(Y)의 range로 제한한 범위를 초과한 데이터를 경계에 모아 표시할지 여부. false면 range 밖 데이터는 숨겨집니다.                                                                       | true, false                     |
 | selectItem | Object          | ([상세](#selectitem))                     | 차트 아이템 선택 기능 활성화 여부 및 속성                                                                                                                                              |                                 |
 | padding    | Object          | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값                                                                                                                                                                   |
@@ -306,9 +307,10 @@ value-only 상태에서 alias(text)가 가려지므로 hover로 보완(데스크
 | use             | Boolean | false                                  | 활성 여부     | true / false |
 | backgroundColor | String  | '#4C4C4C'                              | 배경 색상     |            |
 | fontColor       | String  | '#FFFFFF'                              | 폰트 색상     |            |
-| borderColor     | String  | '#666666'                              | 테두리 색상   |            |
+| borderColor     | String \| null | null                            | 테두리 색상. `null`이면 `backgroundColor`와 동일 → 테두리 미표시 | |
 | borderRadius    | Number  | 4                                      | 모서리 반경   |            |
 | fontSize        | Number  | 12                                     | 폰트 크기     |            |
+| fontWeight      | Number  | 400                                    | 폰트 굵기     |            |
 | fontFamily      | String  | 'Roboto'                               | 폰트 패밀리   |            |
 | useShadow       | Boolean | false                                  | 그림자 사용   | true / false |
 | shadowOpacity   | Number  | 0.25                                   | 그림자 투명도 |            |
@@ -441,6 +443,17 @@ const chartOptions = {
     | name | String | 시리즈 이름 | 'Series 1' |
     | dataId | String | 데이터 ID | 'data_1' |
     | index | Number | 데이터 인덱스 | 0 |
+
+#### plot
+
+plotLines/plotBands(임계선·밴드)의 표시 순서(z-order) 전역 설정. maxTip 은 항상 최상단입니다.
+
+| 이름        | 타입    | 디폴트 | 설명                                                            | 종류(예시)    |
+| ----------- | ------- | ------ | --------------------------------------------------------------- | ------------- |
+| aboveSeries | Boolean | true   | 임계선/밴드를 series 위(true)에 그릴지, 아래(false)에 그릴지     | true / false  |
+
+- `true`(기본): `maxTip > plot > series`
+- `false`: `maxTip > series > plot` (임계선/밴드가 데이터 시리즈 뒤로 깔림)
 
 #### indicator
 

--- a/docs/views/lineChart/example/PlotLine.vue
+++ b/docs/views/lineChart/example/PlotLine.vue
@@ -239,7 +239,7 @@ export default {
       },
     });
 
-    const time = dayjs().format('YYYY-MM-DD HH:mm:ss');
+    const time = dayjs().format('YYYY-MM-DD 00:00:00');
     const chartData = {
       series: {
         series1: { name: 'series#1', fill: true },
@@ -255,7 +255,7 @@ export default {
         dayjs(time).add(6, 'day'),
       ],
       data: {
-        series1: [-50, 25, 36, 47, 0, 50, 100],
+        series1: [-50, 25, 36, 47, 0, 50, 90],
         series2: [80, 36, 25, 47, 15, 90, 0],
       },
     };
@@ -341,9 +341,6 @@ export default {
       title: {
         text: 'Chart Title',
         show: false,
-      },
-      tooltip: {
-        use: false,
       },
       legend: {
         show: false,

--- a/docs/views/lineChart/example/PlotLine.vue
+++ b/docs/views/lineChart/example/PlotLine.vue
@@ -1,18 +1,248 @@
 <template>
-  <resizable-wrapper>
-    <ev-chart :data="chartData" :options="chartOptions" />
-  </resizable-wrapper>
+  <div class="case">
+    <resizable-wrapper>
+      <ev-chart :data="chartData" :options="chartOptions" />
+    </resizable-wrapper>
+  </div>
+
+  <div class="plot-controls">
+    <div class="group-title">추가된 Plot 목록 ({{ plots.length }})</div>
+    <ul class="plot-list">
+      <li v-for="p in plots" :key="p.id" class="plot-item">
+        <span class="swatch" :style="{ background: swatchColor(p) }" />
+        <span class="summary">{{ summary(p) }}</span>
+        <ev-button shape="radius" @click="removePlot(p.id)"> 삭제 </ev-button>
+      </li>
+      <li v-if="!plots.length" class="empty">아직 추가된 plot이 없습니다.</li>
+    </ul>
+
+    <div class="group-title builder-title">새 Plot 만들기</div>
+    <div class="grid">
+      <div class="field">
+        <span class="label">축(axis)</span>
+        <ev-select v-model="draft.axis" :items="axisList" />
+      </div>
+      <div class="field">
+        <span class="label">종류(type)</span>
+        <ev-select v-model="draft.kind" :items="kindList" />
+      </div>
+
+      <!-- Line -->
+      <template v-if="draft.kind === 'line'">
+        <div v-if="draft.axis === 'y'" class="field">
+          <span class="label">value</span>
+          <ev-input-number v-model="draft.value" :step="5" :min="-100" :max="150" />
+        </div>
+        <div v-else class="field">
+          <span class="label">위치(라벨 index)</span>
+          <ev-input-number v-model="draft.lineIdx" :step="1" :min="0" :max="6" />
+        </div>
+        <div class="field">
+          <span class="label">색상</span>
+          <color-field v-model="draft.color" />
+        </div>
+        <div class="field">
+          <span class="label">선 굵기</span>
+          <ev-input-number v-model="draft.lineWidth" :step="1" :min="0" :max="10" />
+        </div>
+        <div class="field">
+          <span class="label">선 스타일</span>
+          <ev-select v-model="draft.dash" :items="dashList" />
+        </div>
+      </template>
+
+      <!-- Band -->
+      <template v-else>
+        <template v-if="draft.axis === 'y'">
+          <div class="field">
+            <span class="label">from</span>
+            <ev-input-number v-model="draft.from" :step="5" :min="-100" :max="150" />
+          </div>
+          <div class="field">
+            <span class="label">to</span>
+            <ev-input-number v-model="draft.to" :step="5" :min="-100" :max="150" />
+          </div>
+        </template>
+        <template v-else>
+          <div class="field">
+            <span class="label">from(index)</span>
+            <ev-input-number v-model="draft.fromIdx" :step="1" :min="0" :max="6" />
+          </div>
+          <div class="field">
+            <span class="label">to(index)</span>
+            <ev-input-number v-model="draft.toIdx" :step="1" :min="0" :max="6" />
+          </div>
+        </template>
+        <div class="field">
+          <span class="label">색상(+투명도)</span>
+          <color-field v-model="draft.bandColor" with-alpha />
+        </div>
+        <div class="field">
+          <span class="label">border 사용</span>
+          <ev-toggle v-model="draft.borderUse" />
+        </div>
+        <div class="field">
+          <span class="label">border 색상</span>
+          <color-field v-model="draft.borderColor" />
+        </div>
+        <div class="field">
+          <span class="label">border 굵기</span>
+          <ev-input-number v-model="draft.borderWidth" :step="1" :min="0" :max="10" />
+        </div>
+        <div class="field">
+          <span class="label">border 스타일</span>
+          <ev-select v-model="draft.borderDash" :items="dashList" />
+        </div>
+      </template>
+    </div>
+
+    <div class="group-subtitle">Label</div>
+    <plot-label-controls :label="draft.label" :axis="draft.axis" />
+
+    <div class="actions">
+      <ev-button type="primary" shape="radius" @click="addPlot"> + 추가 </ev-button>
+    </div>
+
+  </div>
 </template>
 
 <script>
+import { reactive, computed } from 'vue';
 import dayjs from 'dayjs';
+import PlotLabelControls from './controlsUI/PlotLabelControls.vue';
+import ColorField from './controlsUI/ColorField.vue';
 
 export default {
+  components: { PlotLabelControls, ColorField },
   setup() {
+    const axisList = [
+      { name: 'Y축', value: 'y' },
+      { name: 'X축', value: 'x' },
+    ];
+    const kindList = [
+      { name: 'PlotLine', value: 'line' },
+      { name: 'PlotBand', value: 'band' },
+    ];
+    const dashList = [
+      { name: 'solid', value: 'solid' },
+      { name: 'dashed', value: 'dashed' },
+      { name: 'dotted', value: 'dotted' },
+    ];
+    const dashToSegments = (s) => {
+      if (s === 'dashed') {
+        return [4, 4];
+      }
+      if (s === 'dotted') {
+        return [2, 2];
+      }
+      return null;
+    };
+
+    // 라벨 옵션 전체 기본값(누락 방지). over 로 덮어쓰기
+    const makeLabel = (over = {}) => ({
+      show: true,
+      text: '',
+      showValue: false,
+      position: 'innerStart',
+      verticalAlign: 'top',
+      textAlign: 'center',
+      fontColor: '#FFFFFF',
+      fontSize: 12,
+      fontWeight: 400,
+      fontFamily: 'Roboto',
+      fillColor: 'rgba(0, 0, 0, 0.75)',
+      lineColor: '#000000',
+      lineWidth: 0,
+      borderRadius: 2,
+      paddingTop: 4,
+      paddingRight: 4,
+      paddingBottom: 4,
+      paddingLeft: 4,
+      textOverflow: 'none',
+      maxWidth: 0,
+      // 컨트롤러에선 빼고 기본값으로 동작시킴(반응형 3단계: 풀→value만→숨김)
+      valueOnlyBelow: 500,
+      hideBelow: 250,
+      pointerShow: false,
+      pointerColor: '',
+      hoverUse: true,
+      hoverBg: '#4C4C4C',
+      hoverFontColor: '#FFFFFF',
+      hoverBorderColor: '', // 빈값이면 배경색과 동일 → 테두리 미표시
+
+      hoverBorderRadius: 4,
+      hoverFontSize: 12,
+      hoverUseShadow: true,
+      hoverShadowOpacity: 0.25,
+      ...over,
+    });
+
+    // 현재 작성 중인 plot(폼). [추가] 시 스냅샷이 plots 로 들어간다.
+    const draft = reactive({
+      axis: 'y',
+      kind: 'line',
+      value: 80,
+      lineIdx: 2,
+      from: 0,
+      to: 120,
+      fromIdx: 4,
+      toIdx: 6,
+      color: '#E53935',
+      lineWidth: 1,
+      dash: 'dashed',
+      bandColor: 'rgba(250, 222, 76, 0.4)',
+      borderUse: true,
+      borderColor: '#FFA500',
+      borderWidth: 1,
+      borderDash: 'dotted',
+      label: makeLabel({ text: '경고', showValue: true, pointerShow: true }),
+    });
+
+    // ui 라벨 상태 → 차트 label 옵션
+    const buildLabel = (l) => ({
+      show: l.show,
+      text: l.text,
+      showValue: l.showValue,
+      position: l.position,
+      verticalAlign: l.verticalAlign,
+      textAlign: l.textAlign,
+      fontColor: l.fontColor,
+      fontSize: l.fontSize,
+      fontWeight: l.fontWeight,
+      fontFamily: l.fontFamily,
+      fillColor: l.fillColor,
+      lineColor: l.lineColor,
+      lineWidth: l.lineWidth,
+      borderRadius: l.borderRadius,
+      padding: {
+        top: l.paddingTop,
+        right: l.paddingRight,
+        bottom: l.paddingBottom,
+        left: l.paddingLeft,
+      },
+      textOverflow: l.textOverflow,
+      maxWidth: l.maxWidth || null,
+      responsive: {
+        valueOnlyBelow: l.valueOnlyBelow || null,
+        hideBelow: l.hideBelow || null,
+      },
+      pointer: { show: l.pointerShow, color: l.pointerColor || null },
+      showTextOnHover: {
+        use: l.hoverUse,
+        backgroundColor: l.hoverBg,
+        fontColor: l.hoverFontColor,
+        borderColor: l.hoverBorderColor || null,
+        borderRadius: l.hoverBorderRadius,
+        fontSize: l.hoverFontSize,
+        useShadow: l.hoverUseShadow,
+        shadowOpacity: l.hoverShadowOpacity,
+      },
+    });
+
     const time = dayjs().format('YYYY-MM-DD HH:mm:ss');
     const chartData = {
       series: {
-        series1: { name: 'series#1' },
+        series1: { name: 'series#1', fill: true },
         series2: { name: 'series#2' },
       },
       labels: [
@@ -25,12 +255,83 @@ export default {
         dayjs(time).add(6, 'day'),
       ],
       data: {
-        series1: [-50, 25, 36, 47, 0, 50, 80],
-        series2: [80, 36, 25, 47, 15, 100, 0],
+        series1: [-50, 25, 36, 47, 0, 50, 100],
+        series2: [80, 36, 25, 47, 15, 90, 0],
       },
     };
+    const labelTs = (idx) => chartData.labels[idx]?.valueOf();
 
-    const chartOptions = {
+    // 추가된 plot 목록
+    let nextId = 1;
+    const plots = reactive([]);
+    const addPlot = () => {
+      plots.push({
+        id: nextId,
+        axis: draft.axis,
+        kind: draft.kind,
+        value: draft.value,
+        lineIdx: draft.lineIdx,
+        from: draft.from,
+        to: draft.to,
+        fromIdx: draft.fromIdx,
+        toIdx: draft.toIdx,
+        color: draft.color,
+        lineWidth: draft.lineWidth,
+        dash: draft.dash,
+        bandColor: draft.bandColor,
+        borderUse: draft.borderUse,
+        borderColor: draft.borderColor,
+        borderWidth: draft.borderWidth,
+        borderDash: draft.borderDash,
+        label: { ...draft.label },
+      });
+      nextId += 1;
+    };
+    const removePlot = (id) => {
+      const i = plots.findIndex((p) => p.id === id);
+      if (i >= 0) {
+        plots.splice(i, 1);
+      }
+    };
+
+    // plot 항목(p) → 차트 옵션
+    const toLine = (p) => ({
+      value: p.axis === 'x' ? labelTs(p.lineIdx) : p.value,
+      color: p.color,
+      lineWidth: p.lineWidth,
+      segments: dashToSegments(p.dash),
+      label: buildLabel(p.label),
+    });
+    const toBand = (p) => ({
+      from: p.axis === 'x' ? labelTs(p.fromIdx) : p.from,
+      to: p.axis === 'x' ? labelTs(p.toIdx) : p.to,
+      color: p.bandColor,
+      border: p.borderUse
+        ? { color: p.borderColor, width: p.borderWidth, segments: dashToSegments(p.borderDash) }
+        : null,
+      label: buildLabel(p.label),
+    });
+    const pick = (axis, kind) => plots.filter((p) => p.axis === axis && p.kind === kind);
+
+    const plotLines = computed(() => pick('y', 'line').map(toLine));
+    const plotBands = computed(() => pick('y', 'band').map(toBand));
+    const xPlotLines = computed(() => pick('x', 'line').map(toLine));
+    const xPlotBands = computed(() => pick('x', 'band').map(toBand));
+
+    // 목록 표시용
+    const swatchColor = (p) => (p.kind === 'band' ? p.bandColor : p.color);
+    const summary = (p) => {
+      const axis = p.axis === 'x' ? 'X' : 'Y';
+      const text = p.label?.text ? ` · "${p.label.text}"` : '';
+      if (p.kind === 'line') {
+        const pos = p.axis === 'x' ? `idx ${p.lineIdx}` : `value ${p.value}`;
+        return `${axis} · Line · ${pos}${text}`;
+      }
+      const range = p.axis === 'x' ? `idx ${p.fromIdx}~${p.toIdx}` : `${p.from}~${p.to}`;
+      return `${axis} · Band · ${range}${text}`;
+    };
+
+    const chartOptions = reactive({
       type: 'line',
       width: '100%',
       height: '100%',
@@ -39,11 +340,13 @@ export default {
       },
       title: {
         text: 'Chart Title',
-        show: true,
+        show: false,
+      },
+      tooltip: {
+        use: false,
       },
       legend: {
-        show: true,
-        position: 'right',
+        show: false,
       },
       axesX: [
         {
@@ -51,31 +354,8 @@ export default {
           showGrid: false,
           timeFormat: 'MM/DD',
           interval: 'day',
-          plotLines: [
-            {
-              color: '#FF0000',
-              value: chartData.labels[5],
-              segments: [6, 2],
-              lineWidth: 1,
-              label: {
-                show: true,
-                text: 'X Plot Line',
-                textAlign: 'right',
-              },
-            },
-          ],
-          plotBands: [
-            {
-              color: 'rgba(250, 222, 76, 0.8)',
-              from: chartData.labels[2],
-              to: chartData.labels[3],
-              label: {
-                show: true,
-                text: 'X Plot Band ZONE',
-                fontColor: '#FFA500',
-              },
-            },
-          ],
+          plotLines: xPlotLines,
+          plotBands: xPlotBands,
         },
       ],
       axesY: [
@@ -84,41 +364,141 @@ export default {
           showGrid: true,
           startToZero: true,
           autoScaleRatio: 0.1,
-          plotLines: [
-            {
-              color: '#FF0000',
-              value: -50,
-              segments: [6, 2],
-              lineWidth: 1,
-              label: {
-                show: true,
-                text: 'Y Plot Line',
-              },
-            },
-          ],
-          plotBands: [
-            {
-              color: 'rgba(250, 222, 76, 0.8)',
-              from: 0,
-              to: 40,
-              label: {
-                show: true,
-                text: 'Y Plot Band',
-                fontColor: '#FFA500',
-                verticalAlign: 'bottom',
-              },
-            },
-          ],
+          plotLines,
+          plotBands,
         },
       ],
-    };
+      maxTip: {
+        use: true,
+      },
+    });
+
+    // 초기 예시 plot 2개
+    addPlot();
+    draft.kind = 'band';
+    draft.label.text = '';
+    draft.label.position = 'innerEnd';
+    addPlot();
+    // 폼을 line 기본으로 되돌림
+    draft.kind = 'line';
+    draft.label.text = '경고';
+    draft.label.position = 'innerStart';
 
     return {
       chartData,
       chartOptions,
+      draft,
+      plots,
+      axisList,
+      kindList,
+      dashList,
+      addPlot,
+      removePlot,
+      swatchColor,
+      summary,
     };
   },
 };
 </script>
 
-<style lang="scss"></style>
+<style lang="scss" scoped>
+.plot-controls {
+  margin-top: 16px;
+}
+
+.group-title {
+  margin: 24px 0 12px;
+  font-size: 14px;
+  font-weight: 700;
+  color: #2b2f36;
+
+  &:first-child {
+    margin-top: 0;
+  }
+
+  &.builder-title {
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid #e3e6eb;
+  }
+}
+
+.group-subtitle {
+  margin: 16px 0 10px;
+  padding-top: 12px;
+  border-top: 1px dashed #e3e6eb;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #8a8f98;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: 14px 18px;
+  align-items: end;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+
+  .label {
+    font-size: 12px;
+    color: #6b7280;
+    white-space: nowrap;
+  }
+
+  .ev-text-field,
+  .ev-input-number,
+  .ev-select {
+    width: 100%;
+  }
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+
+.plot-list {
+  margin: 0;
+  padding: 0 8px 0 0;
+  list-style: none;
+  max-height: 176px; // 약 3~4개 노출 후 스크롤
+  overflow-y: auto;
+}
+
+.plot-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid #f0f1f4;
+
+  .swatch {
+    flex: 0 0 auto;
+    width: 16px;
+    height: 16px;
+    border: 1px solid #d0d3d9;
+    border-radius: 3px;
+  }
+
+  .summary {
+    flex: 1 1 auto;
+    font-size: 13px;
+    color: #2b2f36;
+  }
+}
+
+.empty {
+  padding: 12px 0;
+  font-size: 13px;
+  color: #8a8f98;
+}
+</style>

--- a/docs/views/lineChart/example/controlsUI/ColorField.vue
+++ b/docs/views/lineChart/example/controlsUI/ColorField.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="color-field">
+    <input type="color" class="color-swatch" :value="hex" @input="onHex($event.target.value)" />
+    <ev-input-number
+      v-if="withAlpha"
+      v-model="alpha"
+      class="alpha"
+      :step="0.05"
+      :precision="2"
+      :min="0"
+      :max="1"
+    />
+  </div>
+</template>
+
+<script>
+import { ref, watch } from 'vue';
+
+// EVUI엔 colorPicker 컴포넌트가 없어 네이티브 <input type="color">로 대체.
+// 네이티브는 hex만 지원하므로 withAlpha일 때 alpha 슬라이더를 더해 rgba를 합성한다.
+export default {
+  name: 'ColorField',
+  props: {
+    modelValue: {
+      type: String,
+      default: '#000000',
+    },
+    withAlpha: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const toHex2 = (n) => Math.max(0, Math.min(255, Number(n))).toString(16).padStart(2, '0');
+
+    const parse = (v) => {
+      const s = String(v || '').trim();
+      const m = s.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)/i);
+      if (m) {
+        return {
+          hex: `#${toHex2(m[1])}${toHex2(m[2])}${toHex2(m[3])}`,
+          alpha: m[4] !== undefined ? Number(m[4]) : 1,
+        };
+      }
+      if (/^#[0-9a-f]{6}$/i.test(s)) {
+        return { hex: s.toLowerCase(), alpha: 1 };
+      }
+      if (/^#[0-9a-f]{3}$/i.test(s)) {
+        const h = s.slice(1);
+        return { hex: `#${h[0]}${h[0]}${h[1]}${h[1]}${h[2]}${h[2]}`.toLowerCase(), alpha: 1 };
+      }
+      return { hex: '#000000', alpha: 1 };
+    };
+
+    const initial = parse(props.modelValue);
+    const hex = ref(initial.hex);
+    const alpha = ref(initial.alpha);
+
+    watch(
+      () => props.modelValue,
+      (v) => {
+        const p = parse(v);
+        hex.value = p.hex;
+        alpha.value = p.alpha;
+      },
+    );
+
+    const compose = () => {
+      if (!props.withAlpha || alpha.value >= 1) {
+        emit('update:modelValue', hex.value);
+        return;
+      }
+      const r = parseInt(hex.value.slice(1, 3), 16);
+      const g = parseInt(hex.value.slice(3, 5), 16);
+      const b = parseInt(hex.value.slice(5, 7), 16);
+      emit('update:modelValue', `rgba(${r}, ${g}, ${b}, ${alpha.value})`);
+    };
+
+    const onHex = (v) => {
+      hex.value = v;
+      compose();
+    };
+    watch(alpha, compose);
+
+    return { hex, alpha, onHex };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.color-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.color-swatch {
+  width: 44px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid #d0d4da;
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+}
+
+.alpha {
+  flex: 1 1 auto;
+  min-width: 84px;
+}
+</style>

--- a/docs/views/lineChart/example/controlsUI/PlotLabelControls.vue
+++ b/docs/views/lineChart/example/controlsUI/PlotLabelControls.vue
@@ -1,0 +1,107 @@
+<template>
+  <div class="grid">
+    <div class="field">
+      <span class="label">라벨 표시</span>
+      <ev-toggle v-model="label.show" />
+    </div>
+    <div class="field">
+      <span class="label">텍스트(alias)</span>
+      <ev-text-field v-model="label.text" />
+    </div>
+    <div class="field">
+      <span class="label">value 표시</span>
+      <ev-toggle v-model="label.showValue" />
+    </div>
+    <div v-if="axis === 'y'" class="field">
+      <span class="label">위치(position)</span>
+      <ev-select v-model="label.position" :items="positionList" />
+    </div>
+    <div v-if="axis === 'y'" class="field">
+      <span class="label">세로 정렬</span>
+      <ev-select v-model="label.verticalAlign" :items="vAlignList" />
+    </div>
+    <div class="field">
+      <span class="label">가로 정렬(textAlign)</span>
+      <ev-select v-model="label.textAlign" :items="textAlignList" />
+    </div>
+    <div class="field">
+      <span class="label">말풍선 꼬리 표시</span>
+      <ev-toggle v-model="label.pointerShow" />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'PlotLabelControls',
+  props: {
+    // 부모의 reactive 라벨 상태(직접 v-model로 양방향)
+    label: {
+      type: Object,
+      required: true,
+    },
+    // 'y' | 'x' — x축은 position/verticalAlign 무시(항상 top), textAlign 만 사용
+    axis: {
+      type: String,
+      default: 'y',
+    },
+  },
+  setup() {
+    const positionList = [
+      { name: 'outside', value: 'outside' },
+      { name: 'innerStart', value: 'innerStart' },
+      { name: 'innerEnd', value: 'innerEnd' },
+    ];
+    const vAlignList = [
+      { name: 'top', value: 'top' },
+      { name: 'middle', value: 'middle' },
+      { name: 'bottom', value: 'bottom' },
+    ];
+    const textAlignList = [
+      { name: 'left', value: 'left' },
+      { name: 'center', value: 'center' },
+      { name: 'right', value: 'right' },
+    ];
+    return { positionList, vAlignList, textAlignList };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: 14px 18px;
+  align-items: end;
+}
+
+.group-subtitle {
+  margin: 16px 0 10px;
+  padding-top: 12px;
+  border-top: 1px dashed #e3e6eb;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #8a8f98;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+
+  .label {
+    font-size: 12px;
+    color: #6b7280;
+    white-space: nowrap;
+  }
+
+  .ev-text-field,
+  .ev-input-number,
+  .ev-select {
+    width: 100%;
+  }
+}
+</style>

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -187,31 +187,95 @@ const chartData =
 | lineWidth | Number | 1 | 선 굵기 |  |
 | label | Object | null | 표시할 label의 스타일을 정의 | ([상세](#plotlabel)) |
 
+> `value`가 `0`이어도 선·라벨이 표시됩니다.
+
 ##### plotBand
 
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 |-----|------|-------|-----|-----|
 | from | Number(value), Date, Number(Index) | null | 박스를 표시할 시작 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
 | to | Number(value), Date, Number(Index) | null | 박스를 표시할 종료 위치에 해당하는 값 | 3000, <br> new Date(), <br> 1 (축의 타입이 'step'인 경우 1번째 요소) |
-| color | Hex, RGB, RGBA Code(String) | '#FF0000' | 선 색상 | |
+| color | Hex, RGB, RGBA Code(String) | '#FF0000' | 박스(면) 배경 색상. `rgba(...)`로 투명도 지정 | |
+| border | Object \| null | null | 밴드 start/end 모서리 stroke | ([상세](#plotbandborder)) |
 | label | Object | null | 표시할 label의 스타일을 정의 | ([상세](#plotlabel)) |
+
+> - `from`/`to`가 `0`이어도 표시됩니다.
+> - `label.showValue: true`이면 `from`·`to` 양 끝에 각각 값 라벨이 자동 바깥배치로 표시됩니다.
+
+###### plotBandBorder
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+|-----|------|-------|-----|-----|
+| color | Hex, RGB, RGBA Code(String) | - | 모서리 선 색상 | |
+| width | Number | - | 모서리 선 굵기 | |
+| segments | Array\<number> | - | dash 간격(점선) | [2, 2] |
 
 ##### plotLabel
 
 | 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
 |-----|------|-------|-----|-----|
 | show | Boolean | false | label 표시 여부 | true / false |
+| text | String \| null | null | 라벨 텍스트(=alias). `showValue: false`면 이 값을 그대로 표시 | |
+| showValue | Boolean | false | `true` → `"{text} {value}"` 합성(value는 해당 축 formatter 적용) | true / false |
 | fontSize | Number | 12 | 폰트 크기 | |
 | fontColor | Hex, RGB, RGBA Code(String) | '#FF0000' | 폰트 색상 | |
-| fillColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | 박스 배경 색상 | |
+| fillColor | Hex, RGB, RGBA Code(String) | '#FFFFFF' | 박스 배경 색상. `rgba(...)`로 투명도 지정 가능 | |
 | lineColor | Hex, RGB, RGBA Code(String) | '#FF0000' | 박스 테두리 선 색상 | |
 | lineWidth | Number | 0 | 테두리 선 굵기 | 1 ~ |
 | fontWeight | Number | 400 | 폰트 굵기 |  |
 | fontFamily | String | 'Roboto' | 폰트 스타일 |  |
+| position | String | 'outside' | (Y축) 가로 배치. plot 밖 우측 / 안쪽 좌·우 | 'outside', 'innerStart', 'innerEnd' |
 | textAlign | String | 'center' | 수평 정렬 | 'left', 'center', 'right' |
 | verticalAlign | String | 'middle' | 수직 정렬 | 'top', 'middle', 'bottom' |
+| borderRadius | Number | 0 | 라벨 박스 모서리 반경(px) | |
+| padding | Number \| Object | null | 박스 안쪽 여백. 숫자 또는 `{ top, right, bottom, left }`. `null`이면 `fontSize/4` | 6, <br> { top: 4, bottom: 2 } |
+| pointer | Object | ([상세](#pointer)) | 말풍선 꼬리 | |
+| responsive | Object | ([상세](#responsive)) | plot 너비 기준 단계 축약 | |
+| showTextOnHover | Object | ([상세](#showtextonhover)) | value-only 상태에서 hover 시 text tooltip | |
 | textOverflow | String | 'none' | 라벨을 넣을 수 있는 여백 혹은 maxWidth 값을 넘었을 경우의 처리방안  | 'none', 'ellipsis' |
 | maxWidth | Number | null | 라벨의 최대 너비  |  |
+
+> - 배경 opacity는 별도 옵션 없이 `fillColor`에 `rgba(...)`를 주면 적용됩니다.
+> - X축(세로선/세로밴드) 라벨은 `position`·`verticalAlign`을 무시하고 **항상 plot 상단(top) 고정**, `textAlign`으로만 정렬됩니다.
+
+###### pointer
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+|-----|------|-------|-----|-----|
+| show | Boolean | false | 말풍선 꼬리 표시 여부(방향은 배치 기준 자동) | true / false |
+| color | Hex, RGB, RGBA Code(String) \| null | null | 꼬리 색상. `null`이면 박스 배경색(`fillColor`) | |
+
+###### responsive
+
+plot 너비(넓음→좁음) 기준 단계 축약. 둘 다 `null`이면 항상 풀(text+value) 표시.
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+|-----|------|-------|-----|-----|
+| valueOnlyBelow | Number \| null | null | plot 너비 < 이 값 → **value만** 표시 | 400 |
+| hideBelow | Number \| null | null | plot 너비 < 이 값 → **라벨 미노출**(본체는 유지) | 200 |
+
+| 구간 | 표시 |
+|-----|-----|
+| 너비 ≥ `valueOnlyBelow` | text + value |
+| `hideBelow` ≤ 너비 < `valueOnlyBelow` | value 만 |
+| 너비 < `hideBelow` | 라벨 미노출 |
+
+###### showTextOnHover
+
+value-only 상태에서 alias(text)가 가려지므로 hover로 보완(데스크탑 전용).
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+|-----|------|-------|-----|-----|
+| use | Boolean | false | 활성 여부 | true / false |
+| backgroundColor | String | '#4C4C4C' | 배경 색상 | |
+| fontColor | String | '#FFFFFF' | 폰트 색상 | |
+| borderColor | String | '#666666' | 테두리 색상 | |
+| borderRadius | Number | 4 | 모서리 반경 | |
+| fontSize | Number | 12 | 폰트 크기 | |
+| fontFamily | String | 'Roboto' | 폰트 패밀리 | |
+| useShadow | Boolean | false | 그림자 사용 | true / false |
+| shadowOpacity | Number | 0.25 | 그림자 투명도 | |
+| padding | Object | { top: 4, right: 8, bottom: 4, left: 8 } | 안쪽 여백 | |
 
 #### title
 

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -228,6 +228,7 @@ const chartData =
 | textAlign | String | 'center' | 수평 정렬 | 'left', 'center', 'right' |
 | verticalAlign | String | 'middle' | 수직 정렬 | 'top', 'middle', 'bottom' |
 | borderRadius | Number | 0 | 라벨 박스 모서리 반경(px) | |
+| gap | Number \| null | null | 임계선/임계영역과 라벨 박스 사이 간격(px). `null`이면 자동(fontSize 기준) | |
 | padding | Number \| Object | null | 박스 안쪽 여백. 숫자 또는 `{ top, right, bottom, left }`. `null`이면 `fontSize/4` | 6, <br> { top: 4, bottom: 2 } |
 | pointer | Object | ([상세](#pointer)) | 말풍선 꼬리 | |
 | responsive | Object | ([상세](#responsive)) | plot 너비 기준 단계 축약 | |

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -95,6 +95,7 @@ const chartData =
   | dragSelection | Object | ([상세](#dragselection)) | drag-select의 사용 여부 | |
   | padding | Object | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값 |
   | tooltip | Object | ([상세](#tooltip)) | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성 | |
+  | plot | Object | ([상세](#plot)) | plotLines/plotBands(임계선·밴드)의 표시 z-order 전역 설정 | |
   | selectItem | Object | ([상세](#selectitem)) | 차트 아이템 선택 기능 활성화 여부 및 속성 | |
   | displayOverflow | Boolean | false | range로 설정한 y축 범위 이상의 값 표시 여부 | |
   | realTimeScatter | Object | ([상세](#realtimescatter)) | 실시간으로 데이터를 처리하는 real time scatter로 변경 여부 및 속성 | |
@@ -270,9 +271,10 @@ value-only 상태에서 alias(text)가 가려지므로 hover로 보완(데스크
 | use | Boolean | false | 활성 여부 | true / false |
 | backgroundColor | String | '#4C4C4C' | 배경 색상 | |
 | fontColor | String | '#FFFFFF' | 폰트 색상 | |
-| borderColor | String | '#666666' | 테두리 색상 | |
+| borderColor | String \| null | null | 테두리 색상. `null`이면 `backgroundColor`와 동일 → 테두리 미표시 | |
 | borderRadius | Number | 4 | 모서리 반경 | |
 | fontSize | Number | 12 | 폰트 크기 | |
+| fontWeight | Number | 400 | 폰트 굵기 | |
 | fontFamily | String | 'Roboto' | 폰트 패밀리 | |
 | useShadow | Boolean | false | 그림자 사용 | true / false |
 | shadowOpacity | Number | 0.25 | 그림자 투명도 | |
@@ -401,6 +403,17 @@ const chartOptions = {
     | name | String | 시리즈 이름 | 'Series 1' |
     | dataId | String | 데이터 ID | 'data_1' |
     | index | Number | 데이터 인덱스 | 0 |
+
+#### plot
+
+plotLines/plotBands(임계선·밴드)의 표시 순서(z-order) 전역 설정. maxTip 은 항상 최상단입니다.
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+|-----|------|-------|-----|-----|
+| aboveSeries | Boolean | true | 임계선/밴드를 series 위(true)에 그릴지, 아래(false)에 그릴지 | true / false |
+
+- `true`(기본): `maxTip > plot > series`
+- `false`: `maxTip > series > plot` (임계선/밴드가 데이터 시리즈 뒤로 깔림)
 
 #### selectItem
 

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -488,7 +488,7 @@ class EvChart {
     }
     this.drawSeriesOverlay();
 
-    this.drawTip();
+    this.drawForeground(this.bufferCtx);
 
     this.commitToDisplay(this.displayCtx, this.bufferCanvas);
   }
@@ -532,7 +532,7 @@ class EvChart {
       // series→overlay→tip→commit).
       this.drawSeriesLayer(this.bufferCtx, hitInfo);
       this.drawSeriesOverlay();
-      this.drawTip();
+      this.drawForeground(this.bufferCtx);
       this.commitToDisplay(this.displayCtx, this.bufferCanvas);
     } else {
       // 전송 프레임: overlay(별도 canvas)만 그린다. series 는 worker, tip(maxTip/selectItem/selectLabel)은
@@ -616,7 +616,7 @@ class EvChart {
     // 어긋나지 않도록 동일 transform 을 걸고 그린다.
     ctx.save();
     ctx.setTransform(this.pixelRatio, 0, 0, this.pixelRatio, 0, 0);
-    this.drawTip(ctx);
+    this.drawForeground(ctx);
     ctx.restore();
   }
 
@@ -636,6 +636,7 @@ class EvChart {
       return;
     }
     this.drawSeriesLayer(this.bufferCtx, undefined);
+    this.drawPlotsFront(this.bufferCtx);
     this.commitToDisplay(this.displayCtx, this.bufferCanvas);
   }
 
@@ -1204,6 +1205,7 @@ class EvChart {
    * @returns {undefined}
    */
   drawStaticLayer(bufferCtx, hitInfo) {
+    // grid/axis 만 그린다. plot(line/band/label)은 drawPlotsFront(front 패스)에서 그린다.
     this.axesX.forEach((axis, index) => {
       axis.ctx = bufferCtx;
       axis.draw(
@@ -1226,6 +1228,37 @@ class EvChart {
         this.defaultSelectInfo,
       );
     });
+  }
+
+  /**
+   * plot(line/band/label) front 패스. series 위(maxTip 아래)에 그린다.
+   * draw()가 캐시한 _plotGeom 으로 각 axis.drawPlots()를 ctx 에 그리고 hover hit 영역을 취합한다.
+   * @param {CanvasRenderingContext2D} [ctx]  그릴 ctx (main=bufferCtx, worker=displayCtx). 미전달 시 bufferCtx
+   *
+   * @returns {undefined}
+   */
+  drawPlotsFront(ctx = this.bufferCtx) {
+    this.plotLabelHitRegions = [];
+    [...(this.axesX ?? []), ...(this.axesY ?? [])].forEach((axis) => {
+      axis.ctx = ctx;
+      axis.drawPlots?.();
+      // value-only plot 라벨의 hover hit 영역 취합 (#6 showTextOnHover)
+      if (axis.plotLabelHitRegions?.length) {
+        this.plotLabelHitRegions.push(...axis.plotLabelHitRegions);
+      }
+    });
+  }
+
+  /**
+   * series 위에 그리는 전경(foreground) 레이어. z-order(뒤→앞) = 아래 호출 순서.
+   * **노출 순서를 바꾸려면 이 두 줄만 swap** (현재: maxTip 이 plot 위 → maxTip > plot > series).
+   * @param {CanvasRenderingContext2D} [ctx]  그릴 ctx (main=bufferCtx, worker=displayCtx)
+   *
+   * @returns {undefined}
+   */
+  drawForeground(ctx = this.bufferCtx) {
+    this.drawPlotsFront(ctx);
+    this.drawTip(ctx);
   }
 
   /**

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -636,7 +636,10 @@ class EvChart {
       return;
     }
     this.drawSeriesLayer(this.bufferCtx, undefined);
-    this.drawPlotsFront(this.bufferCtx);
+    // aboveSeries:false 면 plot 은 이미 static(series 아래)에 그려졌으므로 위에 다시 그리지 않는다.
+    if (this.options.plot?.aboveSeries !== false) {
+      this.drawPlotsFront(this.bufferCtx);
+    }
     this.commitToDisplay(this.displayCtx, this.bufferCanvas);
   }
 
@@ -1228,6 +1231,12 @@ class EvChart {
         this.defaultSelectInfo,
       );
     });
+
+    // plot.aboveSeries:false → plot(임계선/밴드/라벨)을 series 아래에 두기 위해 static 단계(=series 직전)에
+    // 그린다. 기본(true)이면 여기서 그리지 않고 drawForeground 가 series 위에 그린다.
+    if (this.options.plot?.aboveSeries === false) {
+      this.drawPlotsFront(bufferCtx);
+    }
   }
 
   /**
@@ -1251,13 +1260,16 @@ class EvChart {
 
   /**
    * series 위에 그리는 전경(foreground) 레이어. z-order(뒤→앞) = 아래 호출 순서.
-   * **노출 순서를 바꾸려면 이 두 줄만 swap** (현재: maxTip 이 plot 위 → maxTip > plot > series).
+   * 기본 노출 순서: maxTip > plot > series. plot.aboveSeries:false 면 plot 은 drawStaticLayer 에서
+   * series 아래로 그려지므로 여기서는 tip 만 그린다(maxTip > series > plot).
    * @param {CanvasRenderingContext2D} [ctx]  그릴 ctx (main=bufferCtx, worker=displayCtx)
    *
    * @returns {undefined}
    */
   drawForeground(ctx = this.bufferCtx) {
-    this.drawPlotsFront(ctx);
+    if (this.options.plot?.aboveSeries !== false) {
+      this.drawPlotsFront(ctx);
+    }
     this.drawTip(ctx);
   }
 

--- a/src/components/chart/helpers/helpers.constant.js
+++ b/src/components/chart/helpers/helpers.constant.js
@@ -159,11 +159,25 @@ export const AXIS_OPTION = {
   },
 };
 
+export const PLOT_LABEL_HOVER_TIP_OPTION = {
+  use: false,
+  backgroundColor: '#4C4C4C',
+  fontColor: '#FFFFFF',
+  borderColor: null, // null이면 backgroundColor 와 동일 → 테두리 미표시
+  borderRadius: 4,
+  fontSize: 12,
+  fontWeight: 400,
+  fontFamily: 'Roboto',
+  useShadow: false,
+  shadowOpacity: 0.25,
+  padding: { top: 4, right: 8, bottom: 4, left: 8 },
+};
+
 export const PLOT_LINE_LABEL_OPTION = {
   show: false,
   fontSize: 12,
   fontColor: '#FF0000',
-  fillColor: '#FFFFFF',
+  fillColor: '#FFFFFF', // 박스 배경. rgba 허용 → opacity 지원
   lineColor: '#FF0000',
   lineWidth: 0,
   fontWeight: 400,
@@ -172,6 +186,22 @@ export const PLOT_LINE_LABEL_OPTION = {
   textAlign: 'center',
   textOverflow: 'none', // 'none', 'ellipsis'
   maxWidth: null,
+  text: null, // 라벨 텍스트(=alias). showValue=false면 이 값을 그대로 표시
+  borderRadius: 0, // 라벨 박스 모서리 반경
+  gap: null, // 임계선↔라벨 박스 간격(px). null이면 자동(fontSize/4+2, X축 상단은 2)
+  padding: null, // 라벨 박스 안쪽 여백. number 또는 { top, right, bottom, left }. null이면 fontSize/4
+  pointer: {
+    // 말풍선 꼬리. 방향은 배치 기준 자동, 크기 고정
+    show: false,
+    color: null, // null이면 박스 배경색(fillColor) 사용
+  },
+  position: 'outside', // 'outside'(plot 밖 우측 여백) | 'innerStart'(plot 안 좌측) | 'innerEnd'(plot 안 우측)
+  showValue: false, // true → "text value" 합성 (value = 축 formatter)
+  responsive: {
+    valueOnlyBelow: null, // plot 너비 < 이 값 → value만
+    hideBelow: null, // plot 너비 < 이 값 → 라벨 미노출
+  },
+  showTextOnHover: PLOT_LABEL_HOVER_TIP_OPTION, // value-only 상태에서 hover 시 text tooltip
 };
 
 export const PLOT_LINE_OPTION = {
@@ -182,6 +212,7 @@ export const PLOT_LINE_OPTION = {
 
 export const PLOT_BAND_OPTION = {
   color: '#FAE59D',
+  border: null, // { color, width, segments } — start/end 모서리 stroke
 };
 
 export const HEAT_MAP_OPTION = {

--- a/src/components/chart/plugins/plugins.interaction.js
+++ b/src/components/chart/plugins/plugins.interaction.js
@@ -26,7 +26,16 @@ const modules = {
       const offset = this.getMousePosition(e);
       const hitInfo = this.findHitItem(offset);
 
-      if (tooltip?.showAllValueInRange && hitInfo?.items) {
+      // #6: 커서가 value-only 라벨 박스(plot 라벨, z-order 상 series 위) 안에 있으면 라벨 tooltip 을
+      // series tooltip 보다 우선한다. 해당 프레임의 series hit 을 비워 아래 파이프라인이 'no hit' 으로
+      // 동작하게 하고(series tooltip/highlight off), handlePlotLabelHover 가 라벨 tooltip 을 띄운다.
+      const plotLabelHit = this.findPlotLabelHitRegion(offset);
+      if (plotLabelHit) {
+        hitInfo.items = {};
+        hitInfo.hitId = null;
+      }
+
+      if (!plotLabelHit && tooltip?.showAllValueInRange && hitInfo?.items) {
         this.addNotHitInfo(hitInfo);
       }
 
@@ -121,6 +130,10 @@ const modules = {
         this.hideTooltipDOM();
       }
 
+      // value-only plot 라벨 hover → text tooltip (#6). 라벨 박스 위에선 위에서 series hit 을 비워
+      // 라벨을 우선한다.
+      this.handlePlotLabelHover(plotLabelHit, e);
+
       this._lastHoverSig = hoverSig;
 
       // 전용 드래그 캔버스를 쓰면 keepDisplay 영역이 그 캔버스에 그대로 남아 있어(매 hover의
@@ -180,6 +193,8 @@ const modules = {
       if (!dragSelection.use || !dragSelection.keepDisplay) {
         this.overlayClear();
       }
+
+      this.hidePlotLabelTooltip?.();
 
       if (tooltip.use && this.isInitTooltip) {
         if (typeof tooltip?.returnValue === 'function') {
@@ -1042,6 +1057,45 @@ const modules = {
     const e = evt.originalEvent || evt;
     const rect = this.getOverlayClientRect();
     return [e.clientX - rect.left, e.clientY - rect.top, rect.width, rect.height];
+  },
+
+  /**
+   * 커서 위치(offset)가 들어가는 value-only plot 라벨 hit 영역을 찾는다. (#6 showTextOnHover)
+   * @param {array} offset  getMousePosition() 결과 [x, y]
+   *
+   * @returns {object|null} 매칭된 라벨 hit 영역(text/style 포함) 또는 null
+   */
+  findPlotLabelHitRegion(offset) {
+    const regions = this.plotLabelHitRegions;
+
+    if (!regions?.length) {
+      return null;
+    }
+
+    const [x, y] = offset;
+    return (
+      regions.find(
+        (r) => x >= r.x && x <= r.x + r.width && y >= r.y && y <= r.y + r.height,
+      ) ?? null
+    );
+  },
+
+  /**
+   * value-only plot 라벨 hover 시 text tooltip 을 표시/숨김한다. (#6 showTextOnHover)
+   * 라벨 박스 위에선 라벨을 series tooltip 보다 우선하므로(onMouseMove 에서 series hit 을 비움),
+   * 여기서는 미리 구한 hit 영역만 받아 표시/숨김을 처리한다. (데스크탑 전용 — onMouseMove 가
+   * isMobile 에서 조기 반환)
+   * @param {object|null} hit  findPlotLabelHitRegion() 결과
+   * @param {MouseEvent} e     mousemove 이벤트
+   *
+   * @returns {undefined}
+   */
+  handlePlotLabelHover(hit, e) {
+    if (hit) {
+      this.showPlotLabelTooltip(hit, e.originalEvent || e);
+    } else {
+      this.hidePlotLabelTooltip?.();
+    }
   },
 
   /**

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -56,6 +56,69 @@ const modules = {
   },
 
   /**
+   * value-only plot 라벨 hover 시 표시할 경량 텍스트 tooltip DOM 을 생성한다(지연 생성).
+   * series tooltip(tooltipDOM)과 별개의 단일 텍스트 요소.
+   *
+   * @returns {undefined}
+   */
+  createPlotLabelTooltipDOM() {
+    this.plotLabelTooltipDOM = document.createElement('div');
+    this.plotLabelTooltipDOM.className = 'ev-chart-plot-label-tooltip';
+    this.plotLabelTooltipDOM.style.position = 'fixed';
+    this.plotLabelTooltipDOM.style.display = 'none';
+    this.plotLabelTooltipDOM.style.pointerEvents = 'none';
+    this.plotLabelTooltipDOM.style.zIndex = '1000';
+    this.plotLabelTooltipDOM.style.whiteSpace = 'nowrap';
+    document.body.appendChild(this.plotLabelTooltipDOM);
+  },
+
+  /**
+   * plot 라벨 hover tooltip 을 region.text 로 표시한다.
+   * @param {object} region   { text, style } hover hit 영역
+   * @param {MouseEvent} evt  커서 위치(clientX/Y)
+   *
+   * @returns {undefined}
+   */
+  showPlotLabelTooltip(region, evt) {
+    if (!this.plotLabelTooltipDOM) {
+      this.createPlotLabelTooltipDOM();
+    }
+
+    const dom = this.plotLabelTooltipDOM;
+    const style = region.style ?? {};
+    const padding = style.padding ?? { top: 4, right: 8, bottom: 4, left: 8 };
+
+    const backgroundColor = style.backgroundColor ?? '#4C4C4C';
+    dom.textContent = region.text;
+    dom.style.backgroundColor = backgroundColor;
+    dom.style.color = style.fontColor ?? '#FFFFFF';
+    // borderColor 미지정 시 배경색과 동일 → 테두리가 보이지 않음
+    dom.style.border = `1px solid ${style.borderColor ?? backgroundColor}`;
+    dom.style.borderRadius = `${style.borderRadius ?? 4}px`;
+    dom.style.fontSize = `${style.fontSize ?? 12}px`;
+    dom.style.fontWeight = `${style.fontWeight ?? 400}`;
+    dom.style.fontFamily = style.fontFamily ?? 'Roboto';
+    dom.style.padding = `${padding.top}px ${padding.right}px ${padding.bottom}px ${padding.left}px`;
+    dom.style.boxShadow = style.useShadow
+      ? `2px 2px 4px rgba(0, 0, 0, ${style.shadowOpacity ?? 0.25})`
+      : 'none';
+    dom.style.left = `${evt.clientX + 10}px`;
+    dom.style.top = `${evt.clientY + 10}px`;
+    dom.style.display = 'block';
+  },
+
+  /**
+   * plot 라벨 hover tooltip 을 숨긴다.
+   *
+   * @returns {undefined}
+   */
+  hidePlotLabelTooltip() {
+    if (this.plotLabelTooltipDOM) {
+      this.plotLabelTooltipDOM.style.display = 'none';
+    }
+  },
+
+  /**
    * get Tooltip's font style by Type ('title' | 'contents')
    * @param {string} type  'title' | 'contents'
    * @returns {string}
@@ -1157,6 +1220,10 @@ const modules = {
     if (this.tooltipDOM) {
       this.tooltipDOM.remove();
       this.tooltipDOM = null;
+    }
+    if (this.plotLabelTooltipDOM) {
+      this.plotLabelTooltipDOM.remove();
+      this.plotLabelTooltipDOM = null;
     }
     this.isInitTooltip = false;
   },

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -490,97 +490,108 @@ class Scale {
       }
     }
 
-    // Draw plot lines and plot bands
+    // plot(line/band/label)은 front 패스(drawPlots)로 분리 — 여기선 geometry 만 캐시한다.
+    // (z-order: series 위·maxTip 아래. chart.core.drawForeground 에서 drawTip 앞에 호출)
     if (this.plotBands?.length || this.plotLines?.length) {
-      const xArea = chartRect.chartWidth - (labelOffset.left + labelOffset.right);
-      const yArea = chartRect.chartHeight - (labelOffset.top + labelOffset.bottom);
-      const padding = aliasPixel + 1;
-      const minX = aPos.x1;
-      const maxX = aPos.x2 + padding;
-      const minY = aPos.y1 - padding; // top
-      const maxY = aPos.y2; // bottom
+      this._plotGeom = { aPos, axisMin, axisMax, aliasPixel, chartRect, labelOffset };
+    }
+  }
 
-      this.plotBands?.forEach((plotBand) => {
-        const mergedPlotBandOpt = defaultsDeep({}, plotBand, PLOT_BAND_OPTION);
-        const { from: userDefinedFrom, to: userDefinedTo, label: labelOpt } = mergedPlotBandOpt;
-        const from = !Util.isNullOrUndefined(userDefinedFrom)
-          ? Math.max(userDefinedFrom, axisMin)
-          : axisMin;
-        const to = !Util.isNullOrUndefined(userDefinedTo)
-          ? Math.min(userDefinedTo, axisMax)
-          : axisMax;
+  /**
+   * plotLine/plotBand/label 그리기 (front 패스). draw() 가 캐시한 _plotGeom 으로 그린다.
+   * ctx 는 호출부(chart.core.drawPlotsFront)가 axis.ctx 로 주입(main=buffer, worker=display).
+   *
+   * @returns {undefined}
+   */
+  drawPlots() {
+    if (!(this.plotBands?.length || this.plotLines?.length) || !this._plotGeom) {
+      return;
+    }
 
-        this.setPlotBandStyle(mergedPlotBandOpt);
+    const { aPos, axisMin, axisMax, aliasPixel, chartRect, labelOffset } = this._plotGeom;
+    const xArea = chartRect.chartWidth - (labelOffset.left + labelOffset.right);
+    const yArea = chartRect.chartHeight - (labelOffset.top + labelOffset.bottom);
+    const padding = aliasPixel + 1;
+    const minX = aPos.x1;
+    const maxX = aPos.x2 + padding;
+    const minY = aPos.y1 - padding; // top
+    const maxY = aPos.y2; // bottom
+    const bounds = { minX, maxX, minY, maxY };
+    this.plotLabelHitRegions = [];
 
-        let fromPos;
-        let toPos;
-        if (this.type === 'x') {
-          fromPos = Canvas.calculateX(from, axisMin, axisMax, xArea, minX);
-          toPos = Canvas.calculateX(to, axisMin, axisMax, xArea, minX);
+    this.plotBands?.forEach((plotBand) => {
+      const mergedPlotBandOpt = defaultsDeep({}, plotBand, PLOT_BAND_OPTION);
+      const {
+        from: userDefinedFrom,
+        to: userDefinedTo,
+        label: labelOpt,
+        border,
+      } = mergedPlotBandOpt;
+      const from = !Util.isNullOrUndefined(userDefinedFrom)
+        ? Math.max(userDefinedFrom, axisMin)
+        : axisMin;
+      const to = !Util.isNullOrUndefined(userDefinedTo)
+        ? Math.min(userDefinedTo, axisMax)
+        : axisMax;
 
-          if (fromPos === null || toPos === null) {
-            return;
-          }
+      let fromPos;
+      let toPos;
+      if (this.type === 'x') {
+        fromPos = Canvas.calculateX(from, axisMin, axisMax, xArea, minX);
+        toPos = Canvas.calculateX(to, axisMin, axisMax, xArea, minX);
 
-          this.drawXPlotBand(fromPos, toPos, minX, maxX, minY, maxY);
-        } else {
-          fromPos = Canvas.calculateY(from, axisMin, axisMax, yArea, maxY);
-          toPos = Canvas.calculateY(to, axisMin, axisMax, yArea, maxY);
-
-          if (fromPos === null || toPos === null) {
-            return;
-          }
-
-          this.drawYPlotBand(fromPos, toPos, minX, maxX, minY, maxY);
-        }
-
-        if (labelOpt.show) {
-          const labelOptions = this.getNormalizedLabelOptions(chartRect, labelOpt);
-          const textXY = this.getPlotBandLabelPosition(fromPos, toPos, labelOptions, maxX, minY);
-          this.drawPlotLabel(labelOptions, textXY);
-        }
-
-        ctx.restore();
-      });
-
-      this.plotLines?.forEach((plotLine) => {
-        if (typeof +plotLine.value !== 'number') {
+        if (fromPos === null || toPos === null) {
           return;
         }
 
-        const mergedPlotLineOpt = defaultsDeep({}, plotLine, PLOT_LINE_OPTION);
-        const { value, label: labelOpt } = mergedPlotLineOpt;
+        this.setPlotBandStyle(mergedPlotBandOpt);
+        this.drawXPlotBand(fromPos, toPos, minX, maxX, minY, maxY, border);
+      } else {
+        fromPos = Canvas.calculateY(from, axisMin, axisMax, yArea, maxY);
+        toPos = Canvas.calculateY(to, axisMin, axisMax, yArea, maxY);
 
-        let dataPos;
-        if (this.type === 'x') {
-          dataPos = Canvas.calculateX(value, axisMin, axisMax, xArea, minX);
-
-          if (dataPos === null) {
-            return;
-          }
-
-          this.setPlotLineStyle(mergedPlotLineOpt);
-          this.drawXPlotLine(dataPos, minX, maxX, minY, maxY);
-        } else {
-          dataPos = Canvas.calculateY(value, axisMin, axisMax, yArea, maxY);
-
-          if (dataPos === null) {
-            return;
-          }
-
-          this.setPlotLineStyle(mergedPlotLineOpt);
-          this.drawYPlotLine(dataPos, minX, maxX, minY, maxY);
+        if (fromPos === null || toPos === null) {
+          return;
         }
 
-        if (labelOpt.show) {
-          const labelOptions = this.getNormalizedLabelOptions(chartRect, labelOpt);
-          const textXY = this.getPlotLineLabelPosition(dataPos, labelOptions, maxX, minY);
-          this.drawPlotLabel(labelOptions, textXY);
+        this.setPlotBandStyle(mergedPlotBandOpt);
+        this.drawYPlotBand(fromPos, toPos, minX, maxX, minY, maxY, border);
+      }
+
+      this.drawPlotBandLabel(fromPos, toPos, labelOpt, bounds, chartRect, from, to);
+    });
+
+    this.plotLines?.forEach((plotLine) => {
+      if (!Number.isFinite(+plotLine.value)) {
+        return;
+      }
+
+      const mergedPlotLineOpt = defaultsDeep({}, plotLine, PLOT_LINE_OPTION);
+      const { value, label: labelOpt } = mergedPlotLineOpt;
+
+      let dataPos;
+      if (this.type === 'x') {
+        dataPos = Canvas.calculateX(value, axisMin, axisMax, xArea, minX);
+
+        if (dataPos === null) {
+          return;
         }
 
-        ctx.restore();
-      });
-    }
+        this.setPlotLineStyle(mergedPlotLineOpt);
+        this.drawXPlotLine(dataPos, minX, maxX, minY, maxY);
+      } else {
+        dataPos = Canvas.calculateY(value, axisMin, axisMax, yArea, maxY);
+
+        if (dataPos === null) {
+          return;
+        }
+
+        this.setPlotLineStyle(mergedPlotLineOpt);
+        this.drawYPlotLine(dataPos, minX, maxX, minY, maxY);
+      }
+
+      this.drawPlotLineLabel(dataPos, labelOpt, bounds, chartRect, value);
+    });
   }
 
   /**
@@ -597,10 +608,7 @@ class Scale {
     ctx.save();
     ctx.lineWidth = lineWidth;
     ctx.strokeStyle = color;
-
-    if (plotLine.segments) {
-      ctx.setLineDash(plotLine.segments);
-    }
+    ctx.setLineDash(plotLine.segments ?? []);
   }
 
   /**
@@ -629,12 +637,10 @@ class Scale {
    *
    * @returns {undefined}
    */
-  drawXPlotBand(fromDataX, toDataX, minX, maxX, minY, maxY) {
+  drawXPlotBand(fromDataX, toDataX, minX, maxX, minY, maxY, border) {
     const ctx = this.ctx;
 
-    const checkValidPosition = (x) => x || x > minX || x < maxX;
-
-    if (!checkValidPosition(fromDataX) || !checkValidPosition(toDataX)) {
+    if (!Number.isFinite(fromDataX) || !Number.isFinite(toDataX)) {
       ctx.closePath();
       ctx.restore();
       return;
@@ -646,8 +652,13 @@ class Scale {
     ctx.lineTo(toDataX, minY);
     ctx.lineTo(fromDataX, minY);
 
-    ctx.stroke();
     ctx.fill();
+
+    this.drawPlotBandBorder(border, [
+      [fromDataX, minY, fromDataX, maxY],
+      [toDataX, minY, toDataX, maxY],
+    ]);
+
     ctx.restore();
     ctx.closePath();
   }
@@ -665,7 +676,7 @@ class Scale {
   drawXPlotLine(dataX, minX, maxX, minY, maxY) {
     const ctx = this.ctx;
 
-    if (!dataX || dataX < minX || dataX > maxX) {
+    if (!Number.isFinite(dataX) || dataX < minX || dataX > maxX) {
       ctx.closePath();
       ctx.restore();
       return;
@@ -695,7 +706,7 @@ class Scale {
   drawYPlotLine(dataY, minX, maxX, minY, maxY) {
     const ctx = this.ctx;
 
-    if (!dataY || dataY > maxY || dataY < minY) {
+    if (!Number.isFinite(dataY) || dataY > maxY || dataY < minY) {
       ctx.closePath();
       ctx.restore();
       return;
@@ -723,12 +734,10 @@ class Scale {
    *
    * @returns {undefined}
    */
-  drawYPlotBand(fromDataY, toDataY, minX, maxX, minY, maxY) {
+  drawYPlotBand(fromDataY, toDataY, minX, maxX, minY, maxY, border) {
     const ctx = this.ctx;
 
-    const checkValidPosition = (y) => y || y > minY || y < maxY;
-
-    if (!checkValidPosition(fromDataY) || !checkValidPosition(toDataY)) {
+    if (!Number.isFinite(fromDataY) || !Number.isFinite(toDataY)) {
       ctx.closePath();
       ctx.restore();
       return;
@@ -741,45 +750,133 @@ class Scale {
     ctx.lineTo(minX, fromDataY);
 
     ctx.fill();
+
+    this.drawPlotBandBorder(border, [
+      [minX, fromDataY, maxX, fromDataY],
+      [minX, toDataY, maxX, toDataY],
+    ]);
+
     ctx.restore();
     ctx.closePath();
   }
 
   /**
+   * Stroke plot band's start/end edges with the given border style
+   * @param {object|null} border   { color, width, segments }
+   * @param {Array<number[]>} edges  각 edge 의 [x1, y1, x2, y2]
+   *
+   * @returns {undefined}
+   */
+  drawPlotBandBorder(border, edges) {
+    if (!border || !(border.width > 0)) {
+      return;
+    }
+
+    const ctx = this.ctx;
+    ctx.save();
+    ctx.beginPath();
+    ctx.strokeStyle = border.color ?? '#000000';
+    ctx.lineWidth = border.width;
+    ctx.setLineDash(border.segments ?? []);
+
+    edges.forEach(([x1, y1, x2, y2]) => {
+      ctx.moveTo(x1, y1);
+      ctx.lineTo(x2, y2);
+    });
+
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  /**
    * get normalized options for plot label
    * @param {object} chartRect     chartRect
-   * @param {object} labelOpt      plotLine Options
+   * @param {object} labelOpt      plotLine label Options
+   * @param {number} [value]       표시할 임계값(축 formatter 적용). null 이면 value 미표기
    *
    * @returns {object}
    */
-  getNormalizedLabelOptions(chartRect, labelOpt) {
-    const mergedLabelOpt = defaultsDeep({}, labelOpt, PLOT_LINE_LABEL_OPTION);
+  getNormalizedLabelOptions(chartRect, labelOpt, value = null) {
+    const merged = defaultsDeep({}, labelOpt, PLOT_LINE_LABEL_OPTION);
 
     const ctx = this.ctx;
-    const { maxWidth } = mergedLabelOpt;
-    const fontSize = mergedLabelOpt.fontSize > 20 ? 20 : mergedLabelOpt.fontSize;
-    let label = mergedLabelOpt.text;
-    let labelWidth = maxWidth ?? ctx.measureText(label).width;
+    const { maxWidth, responsive } = merged;
+    const fontSize = merged.fontSize > 20 ? 20 : merged.fontSize;
+
+    // 반응형 3단계 판정 (plot 너비 기준)
+    const plotWidth = chartRect.chartWidth;
+    const valueOnlyBelow = responsive?.valueOnlyBelow;
+    const hideBelow = responsive?.hideBelow;
+    const hidden = !Util.isNullOrUndefined(hideBelow) && plotWidth < hideBelow;
+    const valueOnly =
+      !hidden && !Util.isNullOrUndefined(valueOnlyBelow) && plotWidth < valueOnlyBelow;
+
+    // 텍스트 결정 (alias=text, value=축 formatter)
+    const aliasText = merged.text != null ? String(merged.text) : '';
+    const hasValue = !Util.isNullOrUndefined(value) && Number.isFinite(+value);
+    const formattedValue = merged.showValue && hasValue ? String(this.getLabelFormat(value)) : '';
+
+    let label;
+    if (merged.showValue) {
+      label = valueOnly ? formattedValue : [aliasText, formattedValue].filter((t) => t).join(' ');
+    } else {
+      label = aliasText;
+    }
+
+    // 정확한 폭 측정을 위해 라벨 폰트를 먼저 적용 (save/restore 로 부수효과 차단)
+    ctx.save();
+    ctx.font = Util.getLabelStyle({ ...merged, fontSize });
+    let displayLabel = label;
+    let labelWidth = maxWidth ?? ctx.measureText(displayLabel).width;
 
     const plotLabelAreaWidth =
       this.type === 'y' ? chartRect.width - chartRect.chartWidth : (maxWidth ?? chartRect.width);
 
     if (
-      plotLabelAreaWidth < ctx.measureText(label).width &&
-      mergedLabelOpt.textOverflow === 'ellipsis'
+      merged.position === 'outside' &&
+      plotLabelAreaWidth < ctx.measureText(displayLabel).width &&
+      merged.textOverflow === 'ellipsis'
     ) {
-      label = Util.truncateLabelWithEllipsis(mergedLabelOpt.text, plotLabelAreaWidth, ctx);
-      labelWidth = ctx.measureText(label).width;
+      displayLabel = Util.truncateLabelWithEllipsis(label, plotLabelAreaWidth, ctx);
+      labelWidth = ctx.measureText(displayLabel).width;
+    }
+    ctx.restore();
+
+    // padding: number(단축) 또는 { top, right, bottom, left }(차트 padding·tooltip rowPadding 과 동일 형식)
+    const defaultPad = fontSize / 4;
+    const padOpt = merged.padding;
+    let padTop = defaultPad;
+    let padRight = defaultPad;
+    let padBottom = defaultPad;
+    let padLeft = defaultPad;
+    if (typeof padOpt === 'number') {
+      padTop = padOpt;
+      padRight = padOpt;
+      padBottom = padOpt;
+      padLeft = padOpt;
+    } else if (padOpt && typeof padOpt === 'object') {
+      padTop = padOpt.top ?? defaultPad;
+      padRight = padOpt.right ?? defaultPad;
+      padBottom = padOpt.bottom ?? defaultPad;
+      padLeft = padOpt.left ?? defaultPad;
     }
 
     return {
-      label,
+      ...merged,
+      label: displayLabel,
       fontSize,
       labelWidth,
-      labelBoxPadding: fontSize / 4,
+      padTop,
+      padRight,
+      padBottom,
+      padLeft,
+      lineGap: merged.gap != null ? merged.gap : defaultPad + 2, // 임계선↔박스 간격(gap 옵션 우선)
       labelHalfWidth: labelWidth / 2,
       labelHalfHeight: fontSize / 2,
-      ...mergedLabelOpt,
+      borderRadius: Math.max(0, merged.borderRadius ?? 0),
+      hidden,
+      valueOnly,
+      hoverText: aliasText, // value-only hover tooltip 에 표시할 원본 텍스트
     };
   }
 
@@ -793,61 +890,55 @@ class Scale {
    *
    * @returns {object}
    */
-  getPlotBandLabelPosition(fromPos, toPos, labelOpt, maxX, minY) {
-    const {
-      fontSize,
-      labelWidth,
-      labelHalfWidth,
-      labelHalfHeight,
-      labelBoxPadding,
-      textAlign,
-      verticalAlign,
-    } = labelOpt;
+  getPlotBandLabelPosition(fromPos, toPos, labelOpt, bounds) {
+    const { fontSize, labelWidth, padTop, padRight, padBottom, padLeft, position } = labelOpt;
+    const { maxX } = bounds;
 
     if (fontSize <= 0) {
-      return { textX: 0, textY: 0 };
+      return null;
     }
 
-    let textX;
-    let textY;
+    const center = (fromPos + toPos) / 2;
 
+    // X축(세로 밴드): 단일 라벨은 항상 plot 위(top), 밴드 중앙 기준 textAlign
     if (this.type === 'x') {
-      textY = minY - labelBoxPadding - fontSize;
-
-      switch (textAlign) {
-        case 'left':
-          textX = fromPos + labelHalfWidth + labelBoxPadding;
-          break;
-
-        case 'right':
-          textX = toPos - labelHalfWidth - labelBoxPadding;
-          break;
-
-        case 'center':
-        default:
-          textX = (toPos - fromPos) / 2 + fromPos;
-          break;
-      }
-    } else {
-      textX = maxX + labelWidth + labelBoxPadding;
-
-      switch (verticalAlign) {
-        case 'top':
-          textY = toPos + labelHalfHeight + labelBoxPadding;
-          break;
-
-        case 'bottom':
-          textY = fromPos - labelHalfHeight - labelBoxPadding;
-          break;
-
-        case 'middle':
-        default:
-          textY = (fromPos - toPos) / 2 + toPos;
-          break;
-      }
+      return this.computeTopLabelBox(center, labelOpt, bounds);
     }
 
-    return { textX, textY };
+    // Y축 plot 안 배치: 밴드 중앙을 선처럼 취급
+    if (position === 'innerStart' || position === 'innerEnd') {
+      return this.computeInnerLabelBox(center, labelOpt, bounds);
+    }
+
+    // Y축 기존 바깥(우측 여백): plot 우측 끝(maxX) 바로 바깥에 박스를 두고 텍스트는 박스 안 중앙 정렬.
+    const boxWidth = labelWidth + padLeft + padRight;
+    const boxHeight = fontSize + padTop + padBottom;
+    const left = maxX + padLeft;
+    const right = left + boxWidth;
+    let anchorY;
+    switch (labelOpt.verticalAlign) {
+      case 'top':
+        anchorY = toPos;
+        break;
+      case 'bottom':
+        anchorY = fromPos;
+        break;
+      case 'middle':
+      default:
+        anchorY = (fromPos + toPos) / 2;
+        break;
+    }
+    const top = anchorY - boxHeight / 2;
+    const bottom = anchorY + boxHeight / 2;
+
+    return {
+      textX: left + padLeft + labelWidth / 2,
+      textY: top + padTop + fontSize / 2,
+      textAlign: 'center',
+      textBaseline: 'middle',
+      box: { left, top, right, bottom },
+      pointerEdge: 'left',
+    };
   }
 
   /**
@@ -859,53 +950,212 @@ class Scale {
    *
    * @returns {undefined}
    */
-  getPlotLineLabelPosition(dataPos, labelOpt, maxX, minY) {
-    const { fontSize, labelWidth, labelHalfWidth, labelHalfHeight, labelBoxPadding } = labelOpt;
+  getPlotLineLabelPosition(dataPos, labelOpt, bounds) {
+    const { fontSize, labelWidth, padTop, padRight, padBottom, padLeft, position } = labelOpt;
+    const { maxX } = bounds;
 
     if (fontSize <= 0) {
-      return { textX: 0, textY: 0 };
+      return null;
     }
 
-    let textX;
-    let textY;
+    // X축(세로선): 항상 plot 위(top) + textAlign(좌/센터/우). position/verticalAlign 무시
+    if (this.type === 'x') {
+      return this.computeTopLabelBox(dataPos, labelOpt, bounds);
+    }
+
+    // Y축 plot 안 배치
+    if (position === 'innerStart' || position === 'innerEnd') {
+      return this.computeInnerLabelBox(dataPos, labelOpt, bounds);
+    }
+
+    // Y축 기존 바깥(우측 여백): plot 우측 끝(maxX) 바로 바깥에 박스를 두고 텍스트는 박스 안 중앙 정렬.
+    // (textAlign:'left' + textX=maxX+labelWidth 는 텍스트가 박스를 넘어 우측 여백 밖으로 나가 안 보였음)
+    const boxWidth = labelWidth + padLeft + padRight;
+    const boxHeight = fontSize + padTop + padBottom;
+    const left = maxX + padLeft;
+    const right = left + boxWidth;
+    let top;
+    let bottom;
+    switch (labelOpt.verticalAlign) {
+      case 'top': // 선 위
+        bottom = dataPos;
+        top = bottom - boxHeight;
+        break;
+      case 'bottom': // 선 아래
+        top = dataPos;
+        bottom = top + boxHeight;
+        break;
+      case 'middle':
+      default:
+        top = dataPos - boxHeight / 2;
+        bottom = dataPos + boxHeight / 2;
+        break;
+    }
+
+    return {
+      textX: left + padLeft + labelWidth / 2,
+      textY: top + padTop + fontSize / 2,
+      textAlign: 'center',
+      textBaseline: 'middle',
+      box: { left, top, right, bottom },
+      pointerEdge: 'left',
+    };
+  }
+
+  /**
+   * X축 plot 라벨 박스 레이아웃 계산 — 항상 plot 위(top)에 배치하고 세로선(lineX) 기준
+   * textAlign(좌/센터/우)으로 가로 정렬한다. 꼬리(pointer)는 아래로, 끝은 선(lineX)을 가리킨다.
+   * @param {number} lineX     세로 임계선 x 좌표
+   * @param {object} labelOpt  정규화된 라벨 옵션
+   * @param {object} bounds    { minX, maxX, minY, maxY }
+   *
+   * @returns {object}
+   */
+  computeTopLabelBox(lineX, labelOpt, bounds) {
+    const { labelWidth, fontSize, padTop, padRight, padBottom, padLeft, textAlign } = labelOpt;
+    const { minY } = bounds;
+    const boxWidth = labelWidth + padLeft + padRight;
+    const boxHeight = fontSize + padTop + padBottom;
+    // 박스 하단을 plot 상단 위로 띄워 꼬리 공간 확보. X축 라벨은 선에 조금 더 가깝게 내림.
+    // gap 옵션 지정 시 그 값을, 아니면 기본 2px.
+    const topGap = labelOpt.gap != null ? labelOpt.gap : 2;
+    const bottom = minY - topGap;
+    const top = bottom - boxHeight;
+
+    // 좌/우 정렬 시 박스 모서리를 세로선에 바로 붙여 꼬리가 짧고 곧게 떨어지도록 한다.
+    // (gap 만큼 띄우면 꼬리 밑변이 borderRadius+halfBase 인셋까지 밀려 길고 가늘게 슬랜트됨)
+    const sideGap = 0;
+
+    let left;
+    let right;
+    switch (textAlign) {
+      case 'left': // 선 왼쪽
+        right = lineX - sideGap;
+        left = right - boxWidth;
+        break;
+      case 'right': // 선 오른쪽
+        left = lineX + sideGap;
+        right = left + boxWidth;
+        break;
+      default: // center
+        left = lineX - boxWidth / 2;
+        right = lineX + boxWidth / 2;
+        break;
+    }
+
+    return {
+      textX: left + padLeft + labelWidth / 2,
+      textY: top + padTop + fontSize / 2,
+      textAlign: 'center',
+      textBaseline: 'middle',
+      box: { left, top, right, bottom },
+      pointerEdge: 'bottom',
+      pointerTipX: lineX, // 꼬리 끝이 세로선을 가리킴
+    };
+  }
+
+  /**
+   * plot 안(좌/우 끝) 라벨 박스 레이아웃 계산.
+   * 임계선(가로 또는 세로)을 기준으로 박스를 plot 안쪽 좌/우 끝에 배치하고 텍스트를 중앙 정렬한다.
+   * @param {number} linePos   임계선 위치(type y → y좌표, type x → x좌표)
+   * @param {object} labelOpt  정규화된 라벨 옵션
+   * @param {object} bounds    { minX, maxX, minY, maxY }
+   *
+   * @returns {object}
+   */
+  computeInnerLabelBox(linePos, labelOpt, bounds) {
+    const {
+      labelWidth,
+      fontSize,
+      padTop,
+      padRight,
+      padBottom,
+      padLeft,
+      lineGap: gap,
+      position,
+      verticalAlign,
+      textAlign,
+    } = labelOpt;
+    const { minX, maxX, minY, maxY } = bounds;
+    const boxWidth = labelWidth + padLeft + padRight;
+    const boxHeight = fontSize + padTop + padBottom;
+
+    let left;
+    let top;
+    let right;
+    let bottom;
 
     if (this.type === 'x') {
-      textY = minY - labelBoxPadding - fontSize;
+      // 세로 임계선: innerStart=상단, innerEnd=하단
+      if (position === 'innerEnd') {
+        bottom = maxY - gap;
+        top = bottom - boxHeight;
+      } else {
+        top = minY + gap;
+        bottom = top + boxHeight;
+      }
 
-      switch (labelOpt.textAlign) {
+      switch (textAlign) {
         case 'left':
-          textX = dataPos - labelHalfWidth - labelBoxPadding;
+          left = linePos + gap;
+          right = left + boxWidth;
           break;
-
         case 'right':
-          textX = dataPos + labelHalfWidth + labelBoxPadding;
+          right = linePos - gap;
+          left = right - boxWidth;
           break;
-
-        case 'center':
         default:
-          textX = dataPos;
+          left = linePos - boxWidth / 2;
+          right = linePos + boxWidth / 2;
           break;
       }
     } else {
-      textX = maxX + labelWidth + labelBoxPadding;
+      // 가로 임계선: innerStart=좌측, innerEnd=우측
+      if (position === 'innerEnd') {
+        right = maxX - gap;
+        left = right - boxWidth;
+      } else {
+        left = minX + gap;
+        right = left + boxWidth;
+      }
 
-      switch (labelOpt.verticalAlign) {
+      switch (verticalAlign) {
         case 'top':
-          textY = dataPos - labelHalfHeight - labelBoxPadding;
+          bottom = linePos - gap;
+          top = bottom - boxHeight;
           break;
-
         case 'bottom':
-          textY = dataPos + labelHalfHeight + labelBoxPadding;
+          top = linePos + gap;
+          bottom = top + boxHeight;
           break;
-
-        case 'middle':
         default:
-          textY = dataPos;
+          top = linePos - boxHeight / 2;
+          bottom = linePos + boxHeight / 2;
           break;
       }
     }
 
-    return { textX, textY };
+    // 말풍선 꼬리 방향(자동): 선의 반대편 박스 변에서 선을 향해
+    let pointerEdge;
+    if (this.type === 'x') {
+      pointerEdge = position === 'innerEnd' ? 'top' : 'bottom';
+    } else if (verticalAlign === 'top') {
+      pointerEdge = 'bottom';
+    } else if (verticalAlign === 'bottom') {
+      pointerEdge = 'top';
+    } else {
+      pointerEdge = null; // middle: 박스가 선 위에 걸침 → 꼬리 없음
+    }
+
+    return {
+      // 텍스트는 padding 을 제외한 content 영역 중앙에 정렬
+      textX: left + padLeft + labelWidth / 2,
+      textY: top + padTop + fontSize / 2,
+      textAlign: 'center',
+      textBaseline: 'middle',
+      box: { left, top, right, bottom },
+      pointerEdge,
+    };
   }
 
   /**
@@ -920,7 +1170,7 @@ class Scale {
       return;
     }
 
-    const { textX, textY } = positions;
+    const { textX, textY, textAlign = 'left', textBaseline = 'alphabetic', box } = positions;
     const {
       label,
       fontSize,
@@ -928,56 +1178,238 @@ class Scale {
       fillColor,
       lineColor,
       lineWidth,
-      labelBoxPadding,
-      labelWidth,
-      labelHalfWidth,
-      labelHalfHeight,
+      borderRadius = 0,
     } = labelOptions;
 
-    if (fontSize <= 0) {
+    if (fontSize <= 0 || !box) {
       return;
     }
 
+    const { left, top, right, bottom } = box;
     const ctx = this.ctx;
     ctx.save();
     ctx.beginPath();
     ctx.font = Util.getLabelStyle(labelOptions);
-
-    let top = 0;
-    let bottom = 0;
-    let left = 0;
-    let right = 0;
-
-    if (this.type === 'x') {
-      top = textY - labelBoxPadding;
-      bottom = textY + fontSize;
-      left = textX - labelHalfWidth - labelBoxPadding;
-      right = textX + labelHalfWidth + labelBoxPadding;
-    } else {
-      top = textY - labelHalfHeight - labelBoxPadding;
-      bottom = textY + labelHalfHeight + labelBoxPadding;
-      left = textX - labelWidth;
-      right = textX + labelBoxPadding;
-    }
+    ctx.setLineDash([]);
 
     ctx.fillStyle = fillColor;
     ctx.strokeStyle = lineColor;
     ctx.lineWidth = lineWidth;
-    ctx.moveTo(left, bottom);
-    ctx.lineTo(left, top);
-    ctx.lineTo(right, top);
-    ctx.lineTo(right, bottom);
-    ctx.lineTo(left, bottom);
+
+    const radius = Math.min(borderRadius, Math.abs(right - left) / 2, Math.abs(bottom - top) / 2);
+    if (radius > 0) {
+      ctx.moveTo(left + radius, top);
+      ctx.lineTo(right - radius, top);
+      ctx.arcTo(right, top, right, top + radius, radius);
+      ctx.lineTo(right, bottom - radius);
+      ctx.arcTo(right, bottom, right - radius, bottom, radius);
+      ctx.lineTo(left + radius, bottom);
+      ctx.arcTo(left, bottom, left, bottom - radius, radius);
+      ctx.lineTo(left, top + radius);
+      ctx.arcTo(left, top, left + radius, top, radius);
+      ctx.closePath();
+    } else {
+      ctx.moveTo(left, bottom);
+      ctx.lineTo(left, top);
+      ctx.lineTo(right, top);
+      ctx.lineTo(right, bottom);
+      ctx.lineTo(left, bottom);
+    }
     ctx.fill();
 
     if (lineWidth > 0) {
       ctx.stroke();
     }
 
-    ctx.fillStyle = fontColor;
+    // 말풍선 꼬리(pointer): positions.pointerEdge 방향으로 박스와 이어 그린다 (색=pointer.color ?? fillColor)
+    if (labelOptions.pointer?.show && positions.pointerEdge) {
+      this.drawLabelPointer(
+        box,
+        positions.pointerEdge,
+        labelOptions.pointer.color ?? fillColor,
+        lineColor,
+        lineWidth,
+        positions.pointerTipX,
+        radius,
+      );
+    }
 
+    ctx.fillStyle = fontColor;
+    ctx.textAlign = textAlign;
+    ctx.textBaseline = textBaseline;
     ctx.fillText(label, textX, textY);
     ctx.closePath();
+    ctx.restore();
+
+    // #6 value-only 상태 + showTextOnHover.use + 원본 텍스트가 있을 때 hover hit 영역 수집
+    if (labelOptions.valueOnly && labelOptions.showTextOnHover?.use && labelOptions.hoverText) {
+      if (!this.plotLabelHitRegions) {
+        this.plotLabelHitRegions = [];
+      }
+      this.plotLabelHitRegions.push({
+        x: Math.min(left, right),
+        y: Math.min(top, bottom),
+        width: Math.abs(right - left),
+        height: Math.abs(bottom - top),
+        text: labelOptions.hoverText,
+        style: labelOptions.showTextOnHover,
+      });
+    }
+  }
+
+  /**
+   * 라벨 박스 말풍선 꼬리(삼각형)를 edge 방향으로 그린다. 밑변은 박스 변과 겹쳐 같은 색으로 합쳐지고,
+   * 테두리(lineWidth>0)가 있으면 두 빗변만 stroke 한다. 크기는 고정.
+   * @param {object} box        { left, top, right, bottom }
+   * @param {string} edge       'top' | 'bottom' | 'left' | 'right'
+   * @param {string} fillColor  꼬리 채움색
+   * @param {string} lineColor  테두리색
+   * @param {number} lineWidth  테두리 두께
+   * @param {number} [aimX]     top/bottom 꼬리가 가리킬 x(선 위치). 미지정 시 박스 중앙
+   *
+   * @returns {undefined}
+   */
+  drawLabelPointer(box, edge, fillColor, lineColor, lineWidth, aimX, radius = 0) {
+    const ctx = this.ctx;
+    // maxTip 화살표(arrowSize=4, element.tip.js)와 동일한 크기로 맞춤
+    const height = 4; // 꼬리 높이(고정, = maxTip arrowSize)
+    const halfBase = 4; // 꼬리 밑변 절반(고정, = maxTip arrowSize)
+    const cx = (box.left + box.right) / 2;
+    const cy = (box.top + box.bottom) / 2;
+    // 둥근 모서리(borderRadius)를 침범하지 않도록 밑변 중심을 radius+halfBase 만큼 모서리에서 띄운다(maxTip 방식)
+    const insetX = Math.min(radius + halfBase, (box.right - box.left) / 2);
+    const insetY = Math.min(radius + halfBase, (box.bottom - box.top) / 2);
+    const aim = aimX != null ? aimX : cx;
+    const baseCx = Math.max(box.left + insetX, Math.min(box.right - insetX, aim));
+    const baseCy = Math.max(box.top + insetY, Math.min(box.bottom - insetY, cy));
+
+    let ax;
+    let ay;
+    let bx;
+    let by;
+    let tipX;
+    let tipY;
+    switch (edge) {
+      case 'top':
+        ax = baseCx - halfBase;
+        ay = box.top;
+        bx = baseCx + halfBase;
+        by = box.top;
+        tipX = aim;
+        tipY = box.top - height;
+        break;
+      case 'left':
+        ax = box.left;
+        ay = baseCy - halfBase;
+        bx = box.left;
+        by = baseCy + halfBase;
+        tipX = box.left - height;
+        tipY = baseCy;
+        break;
+      case 'right':
+        ax = box.right;
+        ay = baseCy - halfBase;
+        bx = box.right;
+        by = baseCy + halfBase;
+        tipX = box.right + height;
+        tipY = baseCy;
+        break;
+      case 'bottom':
+      default:
+        ax = baseCx - halfBase;
+        ay = box.bottom;
+        bx = baseCx + halfBase;
+        by = box.bottom;
+        tipX = aim;
+        tipY = box.bottom + height;
+        break;
+    }
+
+    ctx.beginPath();
+    ctx.moveTo(ax, ay);
+    ctx.lineTo(tipX, tipY);
+    ctx.lineTo(bx, by);
+    ctx.closePath();
+    ctx.fillStyle = fillColor;
+    ctx.fill();
+
+    if (lineWidth > 0) {
+      // 밑변(박스와 겹침)은 제외하고 두 빗변만 stroke
+      ctx.beginPath();
+      ctx.moveTo(ax, ay);
+      ctx.lineTo(tipX, tipY);
+      ctx.lineTo(bx, by);
+      ctx.strokeStyle = lineColor;
+      ctx.lineWidth = lineWidth;
+      ctx.stroke();
+    }
+  }
+
+  /**
+   * plotLine 라벨 1개 렌더 (정규화 → 위치 계산 → 그리기). 밴드 모서리에도 재사용된다.
+   * @param {number} dataPos   임계선 위치(px)
+   * @param {object} labelOpt  라벨 옵션
+   * @param {object} bounds    { minX, maxX, minY, maxY }
+   * @param {object} chartRect chartRect
+   * @param {number} [value]   표시할 값(축 formatter 적용)
+   *
+   * @returns {undefined}
+   */
+  drawPlotLineLabel(dataPos, labelOpt, bounds, chartRect, value = null) {
+    if (!labelOpt?.show) {
+      return;
+    }
+
+    const opts = this.getNormalizedLabelOptions(chartRect, labelOpt, value);
+    if (opts.hidden) {
+      return;
+    }
+
+    const positions = this.getPlotLineLabelPosition(dataPos, opts, bounds);
+    this.drawPlotLabel(opts, positions);
+  }
+
+  /**
+   * plotBand 라벨 렌더. showValue 면 from·to 양 끝에 각각, 아니면 단일 라벨.
+   * @param {number} fromPos    from edge 위치(px)
+   * @param {number} toPos      to edge 위치(px)
+   * @param {object} labelOpt   라벨 옵션
+   * @param {object} bounds     { minX, maxX, minY, maxY }
+   * @param {object} chartRect  chartRect
+   * @param {number} fromValue  from edge 값
+   * @param {number} toValue    to edge 값
+   *
+   * @returns {undefined}
+   */
+  drawPlotBandLabel(fromPos, toPos, labelOpt, bounds, chartRect, fromValue, toValue) {
+    if (!labelOpt?.show) {
+      return;
+    }
+
+    if (labelOpt.showValue) {
+      // 밴드 두 모서리 라벨은 자동 바깥쪽 배치.
+      // Y축: 작은 값=선 아래(bottom)/큰 값=선 위(top). X축: 작은 값(좌 edge)=좌/큰 값(우 edge)=우.
+      const fromLower = fromValue <= toValue;
+      const fromOverride =
+        this.type === 'x'
+          ? { textAlign: fromLower ? 'left' : 'right' }
+          : { verticalAlign: fromLower ? 'bottom' : 'top' };
+      const toOverride =
+        this.type === 'x'
+          ? { textAlign: fromLower ? 'right' : 'left' }
+          : { verticalAlign: fromLower ? 'top' : 'bottom' };
+      this.drawPlotLineLabel(fromPos, { ...labelOpt, ...fromOverride }, bounds, chartRect, fromValue);
+      this.drawPlotLineLabel(toPos, { ...labelOpt, ...toOverride }, bounds, chartRect, toValue);
+      return;
+    }
+
+    const opts = this.getNormalizedLabelOptions(chartRect, labelOpt, null);
+    if (opts.hidden) {
+      return;
+    }
+
+    const positions = this.getPlotBandLabelPosition(fromPos, toPos, opts, bounds);
+    this.drawPlotLabel(opts, positions);
   }
 
   /**

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -871,8 +871,6 @@ class Scale {
       padBottom,
       padLeft,
       lineGap: merged.gap != null ? merged.gap : defaultPad + 2, // 임계선↔박스 간격(gap 옵션 우선)
-      labelHalfWidth: labelWidth / 2,
-      labelHalfHeight: fontSize / 2,
       borderRadius: Math.max(0, merged.borderRadius ?? 0),
       hidden,
       valueOnly,

--- a/src/components/chart/scale/scale.step.js
+++ b/src/components/chart/scale/scale.step.js
@@ -428,68 +428,80 @@ class StepScale extends Scale {
       ctx.closePath();
     }
 
-    // draw plot lines and plot bands
+    // plot 은 front 패스(drawPlots)로 분리 — geometry 만 캐시 (z-order: series 위·maxTip 아래)
     if (this.plotBands?.length || this.plotLines?.length) {
-      const padding = Util.aliasPixel(ctx.lineWidth) + 1;
-      const minX = aPos.x1 + padding;
-      const maxX = aPos.x2;
-      const minY = aPos.y1 + padding;
-      const maxY = aPos.y2;
-      const labelGap = (endPoint - startPoint) / (this.labelStyle.show ? labels.length : 1);
-
-      this.plotBands?.forEach((plotBand) => {
-        if (!plotBand.from && !plotBand.to) {
-          return;
-        }
-
-        const mergedPlotBandOpt = defaultsDeep({}, plotBand, PLOT_BAND_OPTION);
-        const { from = 0, to = labels.length, label: labelOpt } = mergedPlotBandOpt;
-        const fromPos = Math.round(startPoint + labelGap * from);
-        const toPos = Math.round(startPoint + labelGap * to);
-
-        this.setPlotBandStyle(mergedPlotBandOpt);
-
-        if (this.type === 'x') {
-          this.drawXPlotBand(fromPos, toPos, minX, maxX, minY, maxY);
-        } else {
-          this.drawYPlotBand(fromPos, toPos, minX, maxX, minY, maxY);
-        }
-
-        if (labelOpt.show) {
-          const labelOptions = this.getNormalizedLabelOptions(chartRect, labelOpt);
-          const textXY = this.getPlotBandLabelPosition(fromPos, toPos, labelOptions, maxX, minY);
-          this.drawPlotLabel(labelOptions, textXY);
-        }
-
-        ctx.restore();
-      });
-
-      this.plotLines?.forEach((plotLine) => {
-        if (!plotLine.value) {
-          return;
-        }
-
-        const mergedPlotLineOpt = defaultsDeep({}, plotLine, PLOT_LINE_OPTION);
-        const { value, label: labelOpt } = mergedPlotLineOpt;
-        const dataPos = Math.round(startPoint + labelGap * value) + labelGap / 2;
-
-        this.setPlotLineStyle(mergedPlotLineOpt);
-
-        if (this.type === 'x') {
-          this.drawXPlotLine(dataPos, minX, maxX, minY, maxY);
-        } else {
-          this.drawYPlotLine(dataPos, minX, maxX, minY, maxY);
-        }
-
-        if (labelOpt.show) {
-          const labelOptions = this.getNormalizedLabelOptions(chartRect, labelOpt);
-          const textXY = this.getPlotLineLabelPosition(dataPos, labelOptions, maxX, minY);
-          this.drawPlotLabel(labelOptions, textXY);
-        }
-
-        ctx.restore();
-      });
+      this._plotGeom = {
+        aPos,
+        startPoint,
+        endPoint,
+        chartRect,
+        aliasPixel: Util.aliasPixel(ctx.lineWidth),
+      };
     }
+  }
+
+  /**
+   * plotLine/plotBand/label 그리기 (front 패스). draw() 가 캐시한 _plotGeom 으로 그린다.
+   * ctx 는 호출부(chart.core.drawPlotsFront)가 axis.ctx 로 주입(main=buffer, worker=display).
+   *
+   * @returns {undefined}
+   */
+  drawPlots() {
+    if (!(this.plotBands?.length || this.plotLines?.length) || !this._plotGeom) {
+      return;
+    }
+
+    const labels = this.labels;
+    const { aPos, startPoint, endPoint, chartRect, aliasPixel } = this._plotGeom;
+    const padding = aliasPixel + 1;
+    const minX = aPos.x1 + padding;
+    const maxX = aPos.x2;
+    const minY = aPos.y1 + padding;
+    const maxY = aPos.y2;
+    const labelGap = (endPoint - startPoint) / (this.labelStyle.show ? labels.length : 1);
+    const bounds = { minX, maxX, minY, maxY };
+    this.plotLabelHitRegions = [];
+
+    this.plotBands?.forEach((plotBand) => {
+      if (Util.isNullOrUndefined(plotBand.from) && Util.isNullOrUndefined(plotBand.to)) {
+        return;
+      }
+
+      const mergedPlotBandOpt = defaultsDeep({}, plotBand, PLOT_BAND_OPTION);
+      const { from = 0, to = labels.length, label: labelOpt, border } = mergedPlotBandOpt;
+      const fromPos = Math.round(startPoint + labelGap * from);
+      const toPos = Math.round(startPoint + labelGap * to);
+
+      this.setPlotBandStyle(mergedPlotBandOpt);
+
+      if (this.type === 'x') {
+        this.drawXPlotBand(fromPos, toPos, minX, maxX, minY, maxY, border);
+      } else {
+        this.drawYPlotBand(fromPos, toPos, minX, maxX, minY, maxY, border);
+      }
+
+      this.drawPlotBandLabel(fromPos, toPos, labelOpt, bounds, chartRect, from, to);
+    });
+
+    this.plotLines?.forEach((plotLine) => {
+      if (Util.isNullOrUndefined(plotLine.value)) {
+        return;
+      }
+
+      const mergedPlotLineOpt = defaultsDeep({}, plotLine, PLOT_LINE_OPTION);
+      const { value, label: labelOpt } = mergedPlotLineOpt;
+      const dataPos = Math.round(startPoint + labelGap * value) + labelGap / 2;
+
+      this.setPlotLineStyle(mergedPlotLineOpt);
+
+      if (this.type === 'x') {
+        this.drawXPlotLine(dataPos, minX, maxX, minY, maxY);
+      } else {
+        this.drawYPlotLine(dataPos, minX, maxX, minY, maxY);
+      }
+
+      this.drawPlotLineLabel(dataPos, labelOpt, bounds, chartRect, value);
+    });
   }
 
   /**

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -777,105 +777,108 @@ class TimeScale extends Scale {
       }
     }
 
-    // plotBand / plotLine은 axisMin/axisMax 기준으로 위치를 계산하는 기존 구조를 유지
+    // plot 은 front 패스(drawPlots)로 분리 — geometry 만 캐시 (z-order: series 위·maxTip 아래)
+    // (plotBand/plotLine 은 axisMin/axisMax 기준 위치 계산 구조 유지)
     if (this.plotBands?.length || this.plotLines?.length) {
-      const xArea = chartRect.chartWidth - (labelOffset.left + labelOffset.right);
-      const yArea = chartRect.chartHeight - (labelOffset.top + labelOffset.bottom);
-      const padding = aliasPixel + 1;
-      const minX = aPos.x1;
-      const maxX = aPos.x2 + padding;
-      const minY = aPos.y1 - padding;
-      const maxY = aPos.y2;
+      this._plotGeom = { aPos, axisMin, axisMax, aliasPixel, chartRect, labelOffset };
+    }
+  }
 
-      this.plotBands?.forEach((plotBand) => {
-        const mergedPlotBandOpt = defaultsDeep({}, plotBand, PLOT_BAND_OPTION);
-        const {
-          from: userDefinedFrom,
-          to: userDefinedTo,
-          label: labelOpt,
-        } = mergedPlotBandOpt;
-        const from = !Util.isNullOrUndefined(userDefinedFrom)
-          ? Math.max(userDefinedFrom, axisMin)
-          : axisMin;
-        const to = !Util.isNullOrUndefined(userDefinedTo)
-          ? Math.min(userDefinedTo, axisMax)
-          : axisMax;
+  /**
+   * plotLine/plotBand/label 그리기 (front 패스). draw() 가 캐시한 _plotGeom 으로 그린다.
+   * ctx 는 호출부(chart.core.drawPlotsFront)가 axis.ctx 로 주입(main=buffer, worker=display).
+   *
+   * @returns {undefined}
+   */
+  drawPlots() {
+    if (!(this.plotBands?.length || this.plotLines?.length) || !this._plotGeom) {
+      return;
+    }
 
-        this.setPlotBandStyle(mergedPlotBandOpt);
+    const { aPos, axisMin, axisMax, aliasPixel, chartRect, labelOffset } = this._plotGeom;
+    const xArea = chartRect.chartWidth - (labelOffset.left + labelOffset.right);
+    const yArea = chartRect.chartHeight - (labelOffset.top + labelOffset.bottom);
+    const padding = aliasPixel + 1;
+    const minX = aPos.x1;
+    const maxX = aPos.x2 + padding;
+    const minY = aPos.y1 - padding;
+    const maxY = aPos.y2;
+    const bounds = { minX, maxX, minY, maxY };
+    this.plotLabelHitRegions = [];
 
-        let fromPos;
-        let toPos;
-        if (this.type === 'x') {
-          fromPos = Canvas.calculateX(from, axisMin, axisMax, xArea, minX);
-          toPos = Canvas.calculateX(to, axisMin, axisMax, xArea, minX);
+    this.plotBands?.forEach((plotBand) => {
+      const mergedPlotBandOpt = defaultsDeep({}, plotBand, PLOT_BAND_OPTION);
+      const {
+        from: userDefinedFrom,
+        to: userDefinedTo,
+        label: labelOpt,
+        border,
+      } = mergedPlotBandOpt;
+      const from = !Util.isNullOrUndefined(userDefinedFrom)
+        ? Math.max(userDefinedFrom, axisMin)
+        : axisMin;
+      const to = !Util.isNullOrUndefined(userDefinedTo)
+        ? Math.min(userDefinedTo, axisMax)
+        : axisMax;
 
-          if (fromPos === null || toPos === null) {
-            return;
-          }
+      let fromPos;
+      let toPos;
+      if (this.type === 'x') {
+        fromPos = Canvas.calculateX(from, axisMin, axisMax, xArea, minX);
+        toPos = Canvas.calculateX(to, axisMin, axisMax, xArea, minX);
 
-          this.drawXPlotBand(fromPos, toPos, minX, maxX, minY, maxY);
-        } else {
-          fromPos = Canvas.calculateY(from, axisMin, axisMax, yArea, maxY);
-          toPos = Canvas.calculateY(to, axisMin, axisMax, yArea, maxY);
-
-          if (fromPos === null || toPos === null) {
-            return;
-          }
-
-          this.drawYPlotBand(fromPos, toPos, minX, maxX, minY, maxY);
-        }
-
-        if (labelOpt.show) {
-          const labelOptions = this.getNormalizedLabelOptions(chartRect, labelOpt);
-          const textXY = this.getPlotBandLabelPosition(
-            fromPos, toPos, labelOptions, maxX, minY,
-          );
-          this.drawPlotLabel(labelOptions, textXY);
-        }
-
-        ctx.restore();
-      });
-
-      this.plotLines?.forEach((plotLine) => {
-        if (!Number.isFinite(+plotLine.value)) {
+        if (fromPos === null || toPos === null) {
           return;
         }
 
-        const mergedPlotLineOpt = defaultsDeep({}, plotLine, PLOT_LINE_OPTION);
-        const { value, label: labelOpt } = mergedPlotLineOpt;
+        this.setPlotBandStyle(mergedPlotBandOpt);
+        this.drawXPlotBand(fromPos, toPos, minX, maxX, minY, maxY, border);
+      } else {
+        fromPos = Canvas.calculateY(from, axisMin, axisMax, yArea, maxY);
+        toPos = Canvas.calculateY(to, axisMin, axisMax, yArea, maxY);
 
-        let dataPos;
-        if (this.type === 'x') {
-          dataPos = Canvas.calculateX(value, axisMin, axisMax, xArea, minX);
-
-          if (dataPos === null) {
-            return;
-          }
-
-          this.setPlotLineStyle(mergedPlotLineOpt);
-          this.drawXPlotLine(dataPos, minX, maxX, minY, maxY);
-        } else {
-          dataPos = Canvas.calculateY(value, axisMin, axisMax, yArea, maxY);
-
-          if (dataPos === null) {
-            return;
-          }
-
-          this.setPlotLineStyle(mergedPlotLineOpt);
-          this.drawYPlotLine(dataPos, minX, maxX, minY, maxY);
+        if (fromPos === null || toPos === null) {
+          return;
         }
 
-        if (labelOpt.show) {
-          const labelOptions = this.getNormalizedLabelOptions(chartRect, labelOpt);
-          const textXY = this.getPlotLineLabelPosition(
-            dataPos, labelOptions, maxX, minY,
-          );
-          this.drawPlotLabel(labelOptions, textXY);
+        this.setPlotBandStyle(mergedPlotBandOpt);
+        this.drawYPlotBand(fromPos, toPos, minX, maxX, minY, maxY, border);
+      }
+
+      this.drawPlotBandLabel(fromPos, toPos, labelOpt, bounds, chartRect, from, to);
+    });
+
+    this.plotLines?.forEach((plotLine) => {
+      if (!Number.isFinite(+plotLine.value)) {
+        return;
+      }
+
+      const mergedPlotLineOpt = defaultsDeep({}, plotLine, PLOT_LINE_OPTION);
+      const { value, label: labelOpt } = mergedPlotLineOpt;
+
+      let dataPos;
+      if (this.type === 'x') {
+        dataPos = Canvas.calculateX(value, axisMin, axisMax, xArea, minX);
+
+        if (dataPos === null) {
+          return;
         }
 
-        ctx.restore();
-      });
-    }
+        this.setPlotLineStyle(mergedPlotLineOpt);
+        this.drawXPlotLine(dataPos, minX, maxX, minY, maxY);
+      } else {
+        dataPos = Canvas.calculateY(value, axisMin, axisMax, yArea, maxY);
+
+        if (dataPos === null) {
+          return;
+        }
+
+        this.setPlotLineStyle(mergedPlotLineOpt);
+        this.drawYPlotLine(dataPos, minX, maxX, minY, maxY);
+      }
+
+      this.drawPlotLineLabel(dataPos, labelOpt, bounds, chartRect, value);
+    });
   }
 }
 

--- a/src/components/chart/uses.js
+++ b/src/components/chart/uses.js
@@ -135,6 +135,10 @@ const DEFAULT_OPTIONS = {
     color: '#EE7F44',
     segments: null,
   },
+  plot: {
+    // 임계선/밴드(plotLines·plotBands)를 series 위(true)/아래(false)에 그릴지. maxTip 은 항상 최상단.
+    aboveSeries: true,
+  },
   maxTip: {
     use: false,
     fixedPosTop: false,


### PR DESCRIPTION
## 개요
- 차트의 임계선(PlotLine), 임계범위(PlotBand)에 대한 신규 옵션을 추가하고 렌더링을 개선함
- 모든 신규 옵션의 기본값은 기존 동작이라 기존 설정은 수정없이 그대로 동작함

## 변경 사항
### PlotBand
1. `border` 옵션 추가 -- 영역의 start/end 모서리 stroke (color, width, segments)
2. `from` / `to` 가 0이 아니어도 표시 
3. `label.showValue: true` from & to 양 끝 값 자동 바깥배치 

### PlotLine
1. value가 0이어도 표시 (기존 로직 변경)

### 공통 Label 
1. 신규 옵션 
   - text(alias), showValue("{text} {value}" 합성)
   - position(outside/innerStart/innerEnd)
   - borderRadius, padding(number | {top,right,bottom,left})
   - pointer(말풍선 꼬리), responsive(plot 너비 기준 단계 축약: value-only/hide)
   - showTextOnHover(value-only 상태에서 hover 시 alias tooltip)
2. 배경 opacity: fillColor에 rgba(...) 지정 시 적용
3. X축(세로선/세로밴드) 라벨: position·verticalAlign 무시, 항상 plot 상단 고정 + textAlign 정렬

### 기타 
- 표시 우선순위 변경  z-order: maxTip > plot(line/band/label) > series

### 문서/예제
1. lineChart / barChart / scatterChart API 문서에 신규 옵션·동작 변경 반영
2. lineChart PlotLine 예제에 옵션 제어 UI(PlotLabelControls, ColorField) 추가
3. 라벨 동작 스펙 문서 추가 (docs/specs/plotline-plotband-label-spec.md)


## 동작 예시 
<img width="1178" height="892" alt="260622_plot_example" src="https://github.com/user-attachments/assets/7a3759ee-bb35-4c3a-a5bd-901c16abd10e" />

