### PR TITLE
fix(chart): 커스텀 툴팁 위치 계산 시 offsetWidth undefined 크래시 수정

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -421,6 +421,11 @@ const chartOptions = {
 }
 ```
 
+> **`formatter.html` 마크업 안내**
+> - 반환하는 HTML의 **루트 element**가 툴팁 본문으로 부착되며, 위치/크기 계산도 이 루트를 기준으로 합니다. 루트 element는 1개여야 합니다.
+> - `ev-chart-tooltip-custom`(및 `__header`, `__body`) 클래스는 **선택**입니다. 사용하면 EVUI 기본 스타일과 휠 스크롤 기본 타겟(`htmlScrollTarget: '.ev-chart-tooltip-custom__body'`)이 자동 적용됩니다.
+> - 직접 마크업/클래스를 사용하는 경우, 스크롤이 필요하면 `htmlScrollTarget`을 해당 스크롤 요소의 셀렉터로 지정하세요.
+
 #### returnValue
 
 | 이름 | 타입 | 설명 | 종류(예시) |

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -303,6 +303,11 @@ const chartOptions = {
 }
 ```
 
+> **`formatter.html` 마크업 안내**
+> - 반환하는 HTML의 **루트 element**가 툴팁 본문으로 부착되며, 위치/크기 계산도 이 루트를 기준으로 합니다. 루트 element는 1개여야 합니다.
+> - `ev-chart-tooltip-custom`(및 `__header`, `__body`) 클래스는 **선택**입니다. 사용하면 EVUI 기본 스타일과 휠 스크롤 기본 타겟(`htmlScrollTarget: '.ev-chart-tooltip-custom__body'`)이 자동 적용됩니다.
+> - 직접 마크업/클래스를 사용하는 경우, 스크롤이 필요하면 `htmlScrollTarget`을 해당 스크롤 요소의 셀렉터로 지정하세요.
+
 #### returnValue
 
 | 이름 | 타입 | 설명 | 종류(예시) |

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -355,6 +355,11 @@ const chartOptions = {
 }
 ```
 
+> **`formatter.html` 마크업 안내**
+> - 반환하는 HTML의 **루트 element**가 툴팁 본문으로 부착되며, 위치/크기 계산도 이 루트를 기준으로 합니다. 루트 element는 1개여야 합니다.
+> - `ev-chart-tooltip-custom`(및 `__header`, `__body`) 클래스는 **선택**입니다. 사용하면 EVUI 기본 스타일과 휠 스크롤 기본 타겟(`htmlScrollTarget: '.ev-chart-tooltip-custom__body'`)이 자동 적용됩니다.
+> - 직접 마크업/클래스를 사용하는 경우, 스크롤이 필요하면 `htmlScrollTarget`을 해당 스크롤 요소의 셀렉터로 지정하세요.
+
 #### returnValue
 
 | 이름 | 타입 | 설명 | 종류(예시) |

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -206,6 +206,11 @@ const chartOptions = {
 }
 ```
 
+> **`formatter.html` 마크업 안내**
+> - 반환하는 HTML의 **루트 element**가 툴팁 본문으로 부착되며, 위치/크기 계산도 이 루트를 기준으로 합니다. 루트 element는 1개여야 합니다.
+> - `ev-chart-tooltip-custom`(및 `__header`, `__body`) 클래스는 **선택**입니다. 사용하면 EVUI 기본 스타일과 휠 스크롤 기본 타겟(`htmlScrollTarget: '.ev-chart-tooltip-custom__body'`)이 자동 적용됩니다.
+> - 직접 마크업/클래스를 사용하는 경우, 스크롤이 필요하면 `htmlScrollTarget`을 해당 스크롤 요소의 셀렉터로 지정하세요.
+
 #### returnValue
 
 | 이름 | 타입 | 설명 | 종류(예시) |

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -311,6 +311,11 @@ const chartOptions = {
 }
 ```
 
+> **`formatter.html` 마크업 안내**
+> - 반환하는 HTML의 **루트 element**가 툴팁 본문으로 부착되며, 위치/크기 계산도 이 루트를 기준으로 합니다. 루트 element는 1개여야 합니다.
+> - `ev-chart-tooltip-custom`(및 `__header`, `__body`) 클래스는 **선택**입니다. 사용하면 EVUI 기본 스타일과 휠 스크롤 기본 타겟(`htmlScrollTarget: '.ev-chart-tooltip-custom__body'`)이 자동 적용됩니다.
+> - 직접 마크업/클래스를 사용하는 경우, 스크롤이 필요하면 `htmlScrollTarget`을 해당 스크롤 요소의 셀렉터로 지정하세요.
+
 #### returnValue
 
 | 이름 | 타입 | 설명 | 종류(예시) |

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -706,15 +706,18 @@ const modules = {
       return;
     }
 
-    let customTooltipEl = this.tooltipDOM.getElementsByClassName('ev-chart-tooltip-custom')?.[0];
+    // drawCustomTooltip 은 사용자 formatter.html 의 루트 노드를 tooltipDOM 에 단독으로 붙이므로
+    // (htmlToElement 가 firstChild 하나만 반환) 커스텀 루트는 항상 firstElementChild 다.
+    // 특정 클래스명(ev-chart-tooltip-custom)에 의존하지 않아, 사용자가 임의 마크업을 써도 안전하다.
+    let customTooltipEl = this.tooltipDOM.firstElementChild;
     // skip-redraw fast path 등으로 커스텀 엘리먼트가 비어 있을 수 있다. 같은 데이터 포인트에
     // 머물러 fast path 가 계속 redraw 를 건너뛰는 경우, 여기서 한 번 그려 복구한다.
     // (엘리먼트가 이미 있는 일반 경로에서는 재draw 하지 않으므로 비용/부작용 없음)
     if (!customTooltipEl && hitInfo?.items && Object.keys(hitInfo.items).length) {
       this.drawCustomTooltip(hitInfo.items);
-      customTooltipEl = this.tooltipDOM.getElementsByClassName('ev-chart-tooltip-custom')?.[0];
+      customTooltipEl = this.tooltipDOM.firstElementChild;
     }
-    
+
     if (!customTooltipEl) {
       return;
     }

--- a/src/components/chart/plugins/plugins.tooltip.js
+++ b/src/components/chart/plugins/plugins.tooltip.js
@@ -702,8 +702,20 @@ const modules = {
     const mouseX = e.pageX;
     const mouseY = e.pageY;
 
-    const customTooltipEl = this.tooltipDOM.getElementsByClassName('ev-chart-tooltip-custom')?.[0];
-    if (!customTooltipEl && !this.tooltipDOM) {
+    if (!this.tooltipDOM) {
+      return;
+    }
+
+    let customTooltipEl = this.tooltipDOM.getElementsByClassName('ev-chart-tooltip-custom')?.[0];
+    // skip-redraw fast path 등으로 커스텀 엘리먼트가 비어 있을 수 있다. 같은 데이터 포인트에
+    // 머물러 fast path 가 계속 redraw 를 건너뛰는 경우, 여기서 한 번 그려 복구한다.
+    // (엘리먼트가 이미 있는 일반 경로에서는 재draw 하지 않으므로 비용/부작용 없음)
+    if (!customTooltipEl && hitInfo?.items && Object.keys(hitInfo.items).length) {
+      this.drawCustomTooltip(hitInfo.items);
+      customTooltipEl = this.tooltipDOM.getElementsByClassName('ev-chart-tooltip-custom')?.[0];
+    }
+    
+    if (!customTooltipEl) {
       return;
     }
 


### PR DESCRIPTION
## 문제
커스텀 툴팁(`tooltip.formatter.html`) 사용 중 마우스 이동 시 크래시 발생:
`Uncaught TypeError: Cannot read properties of undefined (reading 'offsetWidth') at setCustomTooltipLayoutPosition`

## 원인
`setCustomTooltipLayoutPosition`의 가드가 `!customTooltipEl && !tooltipDOM`(둘 다 없을 때만 return)로 되어 있어, tooltipDOM은 있지만 내부에 `.ev-chart-tooltip-custom` 엘리먼트가 없는 경우 `undefined.offsetWidth` 접근으로 크래시. 
또한 **skip-redraw 최적화로 같은 데이터 포인트에 머물면 엘리먼트가 비어도 redraw가 계속 스킵되어 복구되지 않는** 갭이 있었음.

## 수정
- tooltipDOM / customTooltipEl 가드를 분리해 각각 방어
- 엘리먼트가 비어 있고 hit 데이터가 있으면 해당 함수에서 한 번 그려 복구(self-heal). 정상 경로에선 재draw가 없어 기존 성능 최적화 유지.

## 테스트
- eslint 통과
- 사용처 런타임 동작 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
