### PR TITLE
fix(chart): 슬라이딩 윈도우 시간축 라벨 점프 현상 수정

### DIFF
--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -278,6 +278,19 @@ function expandByInteger(baseMeta, span, maxSteps) {
  * base의 정수배로 확장한다. number/auto interval은 epoch(0) 기준 정렬이라 본래
  * 자정 점프가 없고, day 이상 단위는 startOf('year') 등 별도 anchor를 사용한다.
  *
+ * [알려진 한계 — DST/연말 경계]
+ * 위 "자정마다 anchor가 24h 이동" 전제는 "하루 = 86,400,000ms"가 항상 참일 때만
+ * 성립한다. 다음 두 경계에서는 anchor 이동폭이 24h가 아니라 라벨이 일회성으로
+ * 점프할 수 있다(드물고 작아 수용한 예외):
+ *   - DST 전환일: 하루가 23h(봄)/25h(가을)이라, sub-day 격자가 DST일 자정을
+ *     넘는 순간 23h%interval / 25h%interval 만큼(예: 4h interval이면 3h/1h) 밀린다.
+ *     한국(KST)은 DST 미시행이라 영향 없음. US/EU 등 DST 타임존을 사용처가 주입한
+ *     경우에만, 연 1~2회 발생.
+ *   - 연말: day 이상 단위가 다일(2·3일 등)로 확장되면 startOf('year') anchor 교체로
+ *     연 1회 다일 간격이 어긋날 수 있다.
+ * wall-clock 라벨을 유지하는 한 DST일의 불연속은 원리적으로 제거 불가하며(그날은
+ * 실시간 간격 자체가 23h/25h), 완전 제거하려면 타임존 인식 tick 재구성이 필요하다.
+ *
  * @param {{ ms: number, unit: string|null, time: number|null }} baseMeta base interval
  * @param {number} span graphMax - graphMin
  * @param {number} maxSteps 최대 tick 수

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -206,6 +206,116 @@ function generateVisibleTicks(graphMin, graphMax, meta) {
   return ticks;
 }
 
+const DAY_MS = 86400000;
+const SUB_DAY_UNITS = ['millisecond', 'second', 'minute', 'hour'];
+const divisorCache = new Map();
+
+/**
+ * n의 모든 약수를 오름차순으로 반환한다(결과 캐시).
+ *
+ * @param {number} n 양의 정수
+ * @returns {number[]} 오름차순 약수 배열
+ */
+function divisorsAsc(n) {
+  if (divisorCache.has(n)) {
+    return divisorCache.get(n);
+  }
+  const small = [];
+  const large = [];
+  for (let i = 1; i * i <= n; i += 1) {
+    if (n % i === 0) {
+      small.push(i);
+      if (i !== n / i) {
+        large.push(n / i);
+      }
+    }
+  }
+  const result = small.concat(large.reverse());
+  divisorCache.set(n, result);
+  return result;
+}
+
+/**
+ * base interval을 maxSteps에 맞춰 "정수배"로 확장한다(boundary 정렬 제약 없음).
+ *
+ * 위상(phase) 독립적인 worst-case tick 수 floor(span / M) + 1 이 maxSteps 이하가
+ * 되는 최소 배수를 선택한다.
+ *
+ * @param {{ ms: number, unit: string|null, time: number|null }} baseMeta base interval
+ * @param {number} span graphMax - graphMin
+ * @param {number} maxSteps 최대 tick 수
+ * @returns {{ ms: number, unit: string|null, time: number|null }} 확장된 meta
+ */
+function expandByInteger(baseMeta, span, maxSteps) {
+  const estimated = Math.ceil(span / baseMeta.ms);
+  let multiplier = estimated > maxSteps
+    ? Math.max(1, Math.floor(estimated / maxSteps))
+    : 1;
+  let ms = baseMeta.ms * multiplier;
+  const MAX_MULTIPLIER = multiplier + 10000;
+  while (
+    multiplier <= MAX_MULTIPLIER
+    && Math.floor(span / ms) + 1 > maxSteps
+  ) {
+    multiplier += 1;
+    ms = baseMeta.ms * multiplier;
+  }
+  return baseMeta.unit
+    ? { ms, unit: baseMeta.unit, time: (baseMeta.time || 1) * multiplier }
+    : { ms, unit: null, time: null };
+}
+
+/**
+ * base interval을 maxSteps에 맞춰 확장한 meta를 반환한다.
+ *
+ * sub-day 단위(ms/s/m/h)이고 base가 하루(24h)를 나누어떨어지면, 확장 후보를
+ * "하루를 나누어떨어지는 base의 배수"로 제한한다. 확장 interval이 항상 하루의
+ * 약수가 되므로 startOf('day') 기준 격자가 자정마다 동일해진다. 따라서 실시간
+ * 슬라이딩 윈도우가 자정을 넘어 기준점(anchor)이 24h 이동해도 라벨이 점프하지
+ * 않는다(예: 24를 못 나누는 20h를 피하고 24h를 선택).
+ *
+ * 그 외(number/auto interval, day 이상 단위, 하루를 못 나누는 base)는 기존처럼
+ * base의 정수배로 확장한다. number/auto interval은 epoch(0) 기준 정렬이라 본래
+ * 자정 점프가 없고, day 이상 단위는 startOf('year') 등 별도 anchor를 사용한다.
+ *
+ * @param {{ ms: number, unit: string|null, time: number|null }} baseMeta base interval
+ * @param {number} span graphMax - graphMin
+ * @param {number} maxSteps 최대 tick 수
+ * @returns {{ ms: number, unit: string|null, time: number|null }} 확장된 meta
+ */
+function expandIntervalMeta(baseMeta, span, maxSteps) {
+  const fits = (ms) => Math.floor(span / ms) + 1 <= maxSteps;
+
+  // base 자체가 maxSteps를 만족하면 확장 불필요
+  if (fits(baseMeta.ms)) {
+    return baseMeta;
+  }
+
+  // sub-day 단위 + base가 하루의 약수 → 하루의 약수 범위 안에서만 확장
+  if (
+    baseMeta.unit
+    && SUB_DAY_UNITS.includes(baseMeta.unit)
+    && DAY_MS % baseMeta.ms === 0
+  ) {
+    // k가 (DAY_MS / baseMs)의 약수면 k * baseMs 가 하루를 나누어떨어진다
+    const ks = divisorsAsc(DAY_MS / baseMeta.ms);
+    for (let i = 0; i < ks.length; i += 1) {
+      const candidateMs = baseMeta.ms * ks[i];
+      if (fits(candidateMs)) {
+        return {
+          ms: candidateMs,
+          unit: baseMeta.unit,
+          time: (baseMeta.time || 1) * ks[i],
+        };
+      }
+    }
+    // 하루(24h)로도 부족 → day 단위로 승격하여 정수배 확장
+    return expandByInteger({ ms: DAY_MS, unit: 'day', time: 1 }, span, maxSteps);
+  }
+
+  return expandByInteger(baseMeta, span, maxSteps);
+}
+
 /**
  * 임의의 값을 숫자(타임스탬프)로 정규화한다.
  * null/undefined → null, 유한한 숫자 → 그대로, 그 외 → dayjs로 파싱 후 valueOf()
@@ -401,38 +511,17 @@ class TimeScale extends Scale {
       baseMeta = { ms: autoMs, unit: null, time: null };
     }
 
-    // tick 생성 + maxSteps 초과 시 interval을 strict 배수로 확장
-    // 예상 tick 수에서 초기 multiplier를 추정하여 불필요한 반복을 줄인다
-    // fixedSteps인 경우 interval 확장을 하지 않으므로 multiplier는 항상 1
-    const estimatedTicks = Math.ceil((graphMax - graphMin) / baseMeta.ms);
-    let multiplier = (!this.fixedSteps && estimatedTicks > maxSteps)
-      ? Math.max(1, Math.floor(estimatedTicks / maxSteps))
-      : 1;
-    let ticks;
-    let currentMs;
+    // base interval을 maxSteps에 맞춰 확장한다.
+    // sub-day 단위는 "하루의 약수"로만 확장되어 자정 경계에서 격자가 점프하지
+    // 않고(예: 20h 회피 → 24h), 그 외는 정수배로 확장된다. fixedSteps면 확장하지
+    // 않고 base를 그대로 쓴다. 상세는 expandIntervalMeta 주석 참고.
+    const span = graphMax - graphMin;
+    const finalMeta = this.fixedSteps
+      ? baseMeta
+      : expandIntervalMeta(baseMeta, span, maxSteps);
+    const currentMs = finalMeta.ms;
 
-    const MAX_MULTIPLIER = multiplier + 10000;
-    while (multiplier <= MAX_MULTIPLIER) {
-      const currentMeta = baseMeta.unit
-        ? {
-            ms: baseMeta.ms * multiplier,
-            unit: baseMeta.unit,
-            time: (baseMeta.time || 1) * multiplier,
-          }
-        : {
-            ms: baseMeta.ms * multiplier,
-            unit: null,
-            time: null,
-          };
-
-      currentMs = currentMeta.ms;
-      ticks = generateVisibleTicks(graphMin, graphMax, currentMeta);
-
-      if (ticks.length <= maxSteps || this.fixedSteps) {
-        break;
-      }
-      multiplier++;
-    }
+    const ticks = generateVisibleTicks(graphMin, graphMax, finalMeta);
 
     return {
       steps: Math.max(0, ticks.length - 1),

--- a/src/components/chart/scale/scale.time.spec.js
+++ b/src/components/chart/scale/scale.time.spec.js
@@ -390,9 +390,11 @@ describe('TimeScale', () => {
 
     describe('maxSteps 확장 시 boundary 정렬', () => {
       it('interval: "minute" + maxSteps 초과 시 첫 tick은 확장된 interval boundary에 정렬된다', () => {
-        // graphMin(12:52)은 1분 boundary에 정렬되어 있으나,
-        // maxSteps 초과로 interval이 10분으로 확장되므로
-        // 첫 tick은 확장 interval boundary인 13:00부터 시작해야 한다.
+        // graphMin(12:52)은 1분 boundary에 정렬되어 있으나, maxSteps 초과로
+        // interval이 확장된다. 확장 후보는 "하루를 나누어떨어지는 base의 배수"로
+        // 제한되어(위상 독립 + 자정 경계 점프 없음) worst-case tick 수가 maxSteps를
+        // 넘지 않는 최소 약수가 선택된다. W=60분, maxSteps=6에서는 12분(1440의 약수,
+        // floor(60/12)+1=6)이 선택된다(11분은 하루를 못 나누므로 제외).
         const scale = createScale({ interval: 'minute' });
 
         const result = scale.calculateSteps({
@@ -403,13 +405,15 @@ describe('TimeScale', () => {
 
         expect(result.ticks).toEqual([
           ts('2026-04-23 13:00:00'),
-          ts('2026-04-23 13:10:00'),
-          ts('2026-04-23 13:20:00'),
-          ts('2026-04-23 13:30:00'),
-          ts('2026-04-23 13:40:00'),
-          ts('2026-04-23 13:50:00'),
+          ts('2026-04-23 13:12:00'),
+          ts('2026-04-23 13:24:00'),
+          ts('2026-04-23 13:36:00'),
+          ts('2026-04-23 13:48:00'),
         ]);
-        expect(result.interval).toBe(10 * 60 * 1000);
+        expect(result.interval).toBe(12 * 60 * 1000);
+        expect(result.ticks.length).toBeLessThanOrEqual(6);
+        // 확장 interval은 하루를 나누어떨어져야 한다(자정 점프 방지)
+        expect((24 * 60 * 60 * 1000) % result.interval).toBe(0);
 
         // 모든 tick은 확장 interval 간격으로 균등 배치
         for (let i = 1; i < result.ticks.length; i++) {
@@ -440,6 +444,73 @@ describe('TimeScale', () => {
         const dayStart = dayjs(result.graphMin).startOf('day').valueOf();
         result.ticks.forEach((tick) => {
           expect((tick - dayStart) % result.interval).toBe(0);
+        });
+      });
+
+      it('슬라이딩 윈도우: 폭/maxSteps가 같으면 위치가 달라도 interval/정렬이 유지된다', () => {
+        // 실시간 차트(5초마다 데이터 유입)에서 동일한 폭(10분)의 윈도우가 흐를 때,
+        // 윈도우 위치(phase)에 따라 interval이나 tick 정렬이 바뀌면 안 된다.
+        // (예: 0/4/8 → 3/6/9 로 라벨이 통째로 바뀌는 현상 방지)
+        const scale = createScale({ interval: 'minute' });
+        const WINDOW = 10 * 60 * 1000; // 10분
+        const STEP = 5 * 1000; // 5초
+
+        const base = ts('2026-04-23 12:00:00');
+        const results = [];
+        for (let i = 0; i < 24; i++) {
+          const min = base + i * STEP;
+          results.push(scale.calculateSteps({
+            minValue: min,
+            maxValue: min + WINDOW,
+            maxSteps: 3,
+          }));
+        }
+
+        const dayStart = dayjs(base).startOf('day').valueOf();
+        results.forEach((result) => {
+          // interval은 위치와 무관하게 동일해야 한다.
+          expect(result.interval).toBe(results[0].interval);
+          // 모든 tick은 동일한 절대 boundary 격자(day 시작 기준 interval 배수)에 정렬.
+          result.ticks.forEach((tick) => {
+            expect((tick - dayStart) % result.interval).toBe(0);
+          });
+          // 계약: tick 수는 maxSteps 이하.
+          expect(result.ticks.length).toBeLessThanOrEqual(3);
+        });
+      });
+
+      it('확장 interval은 하루를 나누어떨어진다: 자정을 넘어도 라벨이 점프하지 않는다', () => {
+        // 버그 재현 시나리오: interval=1h, 폭≈59h, maxSteps=3에서 기존 로직은
+        // 20h(=24를 못 나눔)로 확장되어, 윈도우가 자정을 넘는 순간 anchor가 24h
+        // 이동하며 모든 라벨이 4h씩 점프했다. 이제 하루의 약수(24h)로 확장되어
+        // 자정 기준점이 바뀌어도 동일한 절대 격자에 머문다.
+        const scale = createScale({ interval: { time: 1, unit: 'hour' } });
+        const WINDOW = 59 * 60 * 60 * 1000;
+        const STEP = 60 * 60 * 1000; // 1시간씩 이동(자정 횡단 포함)
+
+        const base = ts('2026-04-23 23:37:00');
+        const results = [];
+        for (let i = 0; i < 6; i++) {
+          const min = base + i * STEP;
+          results.push(scale.calculateSteps({
+            minValue: min,
+            maxValue: min + WINDOW,
+            maxSteps: 3,
+          }));
+        }
+
+        const DAY = 24 * 60 * 60 * 1000;
+        // 모든 윈도우 위치가 공유하는 단일 고정 기준점.
+        const fixedAnchor = dayjs(base).startOf('day').valueOf();
+        results.forEach((result) => {
+          // 확장 interval은 위치와 무관하게 동일하고 하루를 나누어떨어진다.
+          expect(result.interval).toBe(results[0].interval);
+          expect(DAY % result.interval).toBe(0);
+          expect(result.ticks.length).toBeLessThanOrEqual(3);
+          // 모든 위치의 tick이 동일한 절대 격자에 정렬 → 자정 점프 없음.
+          result.ticks.forEach((tick) => {
+            expect((tick - fixedAnchor) % result.interval).toBe(0);
+          });
         });
       });
     });


### PR DESCRIPTION
### 이슈 개요
- <img width="615" height="116" alt="image" src="https://github.com/user-attachments/assets/4d6d83cb-9d29-49ea-b21f-d37eba0e8a1f" />
- 라벨이 부드럽게 이동하는 게 아니라, 전혀 다른 시각의 라벨 세트로 통째로 바뀌어 버리는 현상 발생

### 문제 원인 
- 차트는 라벨 간격(Interval)을 정할 때 "이 간격으로 라벨을 넣으면 몇개?" 를 원칙으로 결정 
   - 라벨 개수가 첫번재 라벨 위치에 따라 `1개의 오차범위 발생 `
   - exemple
      - `00:00~00:10` 범위에 대해 
         - `00:00`, `00:04`, `00:08`  === **3개**
      - 5초뒤, 00:00 이 축에서 빠져나가면서 `00:01~00:11`  범위에 대해 
         - `00:04`, `00:08` === **2개** 

### 수정 내용
- "실제로 몇 개 나오는지" 대신 "이 폭에서 최대 몇 개까지 나올 수 있는지" 를 기준으로 함 

### 추가 수정 
- 자정을 넘는 순간 라벨이 몇 시간씩 밀리는 현상  
   - <img width="463" height="91" alt="image" src="https://github.com/user-attachments/assets/9ef149d4-07f8-4a12-a398-1abb323fff98" />

- 원인 
   - 시간축 라벨의 기준점은 "현재 x축 범위가 속한 날의 자정(00:00:00)" 
   - 예를들어 23일 안에 있으면 23일 00:00:00 이 기준, 24일로 넘어가면 24일 00:00:00 이 기준이 됨 

- 수정내용 
   - 간격을 자동으로 늘릴 때, 24시간의 약수인 값만 후보로 사용하도록 제한 

### 기존동작
- 첫번째 라벨이 차트에서 빠질 때, 뒤의 라벨이 다른 시간으로 옮겨짐 
- <img width="594" height="266" alt="260634_time_axis_before" src="https://github.com/user-attachments/assets/8cf9b82b-f705-4180-8e7f-71cc3860c5d9" />

 
### 현재동작
- 라벨이 빠지거나 기준이 변경되더라도 흔들림이 없음
- <img width="594" height="266" alt="260623_time_axis_after" src="https://github.com/user-attachments/assets/0c4f30fa-9f4b-4d0e-8e83-90b32898aca2" />

### 테스트 가이드 
- http://localhost:9999/EVUI/lineChart#default
- 데이터 자동업데이트 ON 을 한뒤 x축 시간을 감시