### PR TITLE
feat(chart): EvChart 어노테이션/뱃지 모듈 추가

### DIFF
--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -663,7 +663,7 @@ plotLines/plotBands(임계선·밴드)의 표시 순서(z-order) 전역 설정. 
 | location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스('start'/'end'는 데이터 있는 non-null 첫/마지막). 파이는 무시 |
 
 - **이 차트의 `series` 기준점**: 막대의 값이 끝나는 변의 중앙(가로/세로 자동 판별)
-- **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정)
+- **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정). `xValue`와 `yValue`를 **모두** 지정해야 하며, 하나만 지정하면 표시되지 않습니다.
 - 기준점이 축 범위/줌 영역 밖이거나, 추적 `series`가 숨김 상태(`show: false`, 범례 토글 포함)이면 그리지 않습니다. `pixel`은 항상 표시됩니다.
 
 ##### annotation content

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -143,6 +143,7 @@ const chartData = {
 | axesY        | Object                    | 없음                                      | Y축에 대한 속성                                                                                                                                                                        | [상세](#axesx-axesy)            |
 | title        | Object                    | ([상세](#title))                          | 차트 상단에 위치할 차트 제목 표시 여부 및 속성                                                                                                                                         |                                 |
 | legend       | Object                    | ([상세](#legend))                         | 차트의 범례 표시 여부 및 속성                                                                                                                                                          |                                 |
+| annotations | Array | ([상세](#annotation)) | 차트 위에 표시할 어노테이션/뱃지 목록 | |
 | tooltip      | Object                    | ([상세](#tooltip))                        | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성                                                                                                                                       |                                 |
 | indicator    | Object                    | ([상세](#indicator))                      | 지표선                                                                                                                                                                                 |                                 |
 | maxTip       | Object                    | ([상세](#maxtip))                         | 최대값에 tip 표시(값 표시) 여부 및 속성                                                                                                                                                |                                 |
@@ -623,3 +624,104 @@ plotLines/plotBands(임계선·밴드)의 표시 순서(z-order) 전역 설정. 
 | axes-data-max-change | maxY | show 된 series 들의 **실제 데이터 y 최대값**(number)을 반환한다. axes-scale-change(라벨 스텝 개수)와 달리 데이터 값이다. 차트가 내부적으로 이미 계산한 series.minMax.maxY 를 재사용하므로 소비처가 동일 데이터를 따로 스캔해 max 를 구하지 않아도 된다. **차트 타입과 무관하게** 사용할 수 있으며, 이 이벤트를 바인딩한 경우에만 발생한다(바인딩 안 하면 집계 비용 0). 발생 시엔 렌더마다(같은 값이어도) 발생한다. 유효한(유한수) 데이터가 있는 show 된 series 가 하나도 없으면 — 보이는 series 가 없거나 모두 빈 데이터면 — null 을 emit 한다. 단, realTimeScatter 는 전 series 가 빈 데이터일 때 내부 minMax 가 0 으로 폴백되어 0 이 emit 된다. maxY 는 show 된 전 series 의 **통합 최대값(단일 y축·세로 차트 기준, 축 구분 없음)** 이라 다중 y축에서는 축별 구분이 되지 않는다. realTimeScatter autoScale 의 데이터 최대값 용도로 도입됐으나 line·bar 등 다른 차트에서도 동일하게 동작한다. |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환
+
+#### annotation
+
+차트 위에 어노테이션/뱃지를 표시합니다. `options.annotations`에 **배열**로 지정하며, 배열 순서가 그리는 순서(z-order, 뒤 항목이 위)입니다. 어노테이션은 전용 레이어에 그려져 hover 하이라이트 위에 표시됩니다.
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+|------|------|--------|------|-----------|
+| id | String | annotation-${index} | 식별/key 용도. 중복 시 콘솔 경고 | |
+| type | String | 'text' | 어노테이션 외형 종류 | 'text', 'badge', 'callout', 'circle' |
+| content | String \| Function | '' | 표시 텍스트(토큰/콜백 지원). circle은 무시 | [상세](#annotation-content) |
+| position | Object | ([상세](#annotation-position)) | 위치 지정 방식 | |
+| connector | Object | ([상세](#annotation-connector)) | 데이터 지점과 박스를 잇는 연결선(기본 비활성). callout은 무시 | |
+| style | Object | type별 기본값 | 외형/말풍선/도형 속성 | [상세](#annotation-style) |
+
+##### type 종류
+- `text` : 배경/테두리 없는 순수 텍스트(라벨)
+- `badge` : 배경 박스 + 라운딩을 가진 텍스트 뱃지
+- `callout` : 데이터 지점을 가리키는 꼬리가 달린 말풍선
+- `circle` : 텍스트 없는 강조용 원형 도형(`style.radius` 사용)
+
+##### annotation position
+
+위치 기준은 상호 배타적인 3가지 `type`으로 구분합니다.
+
+| 이름 | 적용 type | 타입 | 디폴트 | 설명 |
+|------|-----------|------|--------|------|
+| type | 공통 | String | 'pixel' | 'axis' \| 'pixel' \| 'series' |
+| offsetX | 공통 | Number | 0 | 기준점으로부터 X 오프셋(px) |
+| offsetY | 공통 | Number | 0 | 기준점으로부터 Y 오프셋(px) |
+| x | pixel | Number | 0 | canvas 좌상단(0,0) 기준 절대 X 좌표 |
+| y | pixel | Number | 0 | canvas 좌상단(0,0) 기준 절대 Y 좌표 |
+| xAxisIndex | axis | Number | 0 | 기준 X축 인덱스 |
+| yAxisIndex | axis | Number | 0 | 기준 Y축 인덱스 |
+| xValue | axis | Number \| String | null | X축 값(linear=숫자, time=숫자/날짜문자열, step=라벨/인덱스) |
+| yValue | axis | Number \| String | null | Y축 값 |
+| seriesId | series | String | null | 추적할 시리즈 id |
+| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스. 파이는 무시 |
+
+- **이 차트의 `series` 기준점**: 막대의 값이 끝나는 변의 중앙(가로/세로 자동 판별)
+- **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정)
+- 기준점이 축 범위/줌 영역 밖이거나, 추적 `series`가 숨김 상태(`show: false`, 범례 토글 포함)이면 그리지 않습니다. `pixel`은 항상 표시됩니다.
+
+##### annotation content
+
+- 문자열: 그대로 표시
+- 토큰 치환: `{xValue}` `{yValue}` `{seriesId}` `{seriesName}` `{dataIndex}` `{percentage}` (알 수 없는 토큰은 원문 유지)
+- 콜백 `(ctx) => string` : `ctx = { xValue, yValue, seriesId, seriesName, dataIndex, percentage }` (`percentage`는 파이 전용, 그 외 null)
+- `\n` 으로 멀티라인 지원
+
+##### annotation connector
+
+데이터 지점과 어노테이션 박스의 가장 가까운 경계를 잇는 선입니다.
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류 |
+|------|------|--------|------|------|
+| enabled | Boolean | false | 연결선 사용 여부 | |
+| type | String | 'straight' | 선 모양 | 'straight', 'elbow' |
+| style.stroke | String | '#9E9E9E' | 선 색상 | |
+| style.strokeWidth | Number | 1 | 선 두께 | |
+| style.dashStyle | String | 'solid' | 점선 스타일 | 'solid', 'dash', 'dot' |
+
+> `callout`은 꼬리가 connector 역할을 하므로 connector를 켜도 자동으로 비활성화됩니다.
+
+##### annotation style
+
+text/badge/callout 공통 텍스트 속성과 type별 전용 속성을 `style` 하나로 통합합니다.
+
+| 이름 | 타입 | 설명 | 적용 type |
+|------|------|------|-----------|
+| color | String | 글자 색 | text, badge, callout |
+| backgroundColor | String | 배경 색('transparent' 가능) | 전체 |
+| borderColor | String | 테두리 색 | 전체 |
+| borderWidth | Number | 테두리 두께 | 전체 |
+| borderRadius | Number | 모서리 둥글기 | text, badge, callout |
+| padding | Number \| Array | 안쪽 여백. n / [상하,좌우] / [상,우,하,좌] | text, badge, callout |
+| fontSize | String | 글자 크기(예: '11px') | text, badge, callout |
+| fontWeight | String | 글자 굵기 | text, badge, callout |
+| fontFamily | String | 글꼴 | text, badge, callout |
+| textAlign | String | 정렬 | text, badge, callout |
+| anchor | String | 꼬리 방향('auto'는 offset 방향으로 결정) | callout |
+| arrowSize | Number | 꼬리 크기 | callout |
+| radius | Number | 원 반지름 | circle |
+
+**type별 style 기본값**
+
+| 속성 | text | badge | callout | circle |
+|------|------|-------|---------|--------|
+| color | #212121 | #8B2323 | #212121 | - |
+| backgroundColor | transparent | #FDF0F0 | #FFFFFF | rgba(178,76,76,0.15) |
+| borderColor | transparent | #B24C4C | #B0B0B0 | #B24C4C |
+| borderWidth | 0 | 1 | 1 | 1 |
+| borderRadius | 0 | 6 | 4 | - |
+| padding | [0,0] | [6,10] | [4,8] | - |
+| fontSize | 11px | 11px | 11px | - |
+| fontWeight | normal | normal | normal | - |
+| textAlign | center | center | center | - |
+| anchor | - | - | auto | - |
+| arrowSize | - | - | 4 | - |
+| radius | - | - | - | 10 |
+
+> 실제 사용 예시는 상단의 **Annotations** 예제를 참고하세요.

--- a/docs/views/barChart/api/barChart.md
+++ b/docs/views/barChart/api/barChart.md
@@ -660,7 +660,7 @@ plotLines/plotBands(임계선·밴드)의 표시 순서(z-order) 전역 설정. 
 | xValue | axis | Number \| String | null | X축 값(linear=숫자, time=숫자/날짜문자열, step=라벨/인덱스) |
 | yValue | axis | Number \| String | null | Y축 값 |
 | seriesId | series | String | null | 추적할 시리즈 id |
-| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스. 파이는 무시 |
+| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스('start'/'end'는 데이터 있는 non-null 첫/마지막). 파이는 무시 |
 
 - **이 차트의 `series` 기준점**: 막대의 값이 끝나는 변의 중앙(가로/세로 자동 판별)
 - **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정)

--- a/docs/views/barChart/example/Annotations.vue
+++ b/docs/views/barChart/example/Annotations.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="case">
+    <resizable-wrapper>
+      <ev-chart :data="chartData" :options="chartOptions" />
+    </resizable-wrapper>
+  </div>
+  <div class="description">
+    <span class="toggle-label">Horizontal</span>
+    <ev-toggle v-model="isHorizontal" />
+  </div>
+</template>
+
+<script>
+import { computed, ref } from 'vue';
+
+export default {
+  setup() {
+    const isHorizontal = ref(false);
+
+    const chartData = {
+      series: {
+        sales: { name: 'Sales' },
+      },
+      labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+      data: {
+        sales: [40, 65, 30, 80, 55],
+      },
+    };
+
+    const peakIdx = 3; // 'Thu' = 80 (최댓값)
+    const lowIdx = 2; // 'Wed' = 30 (최솟값)
+
+    const chartOptions = computed(() => ({
+      type: 'bar',
+      width: '100%',
+      height: '100%',
+      thickness: 0.6,
+      horizontal: isHorizontal.value,
+      padding: { top: 80, right: 40, left: 10, bottom: 10 },
+      title: { text: 'Bar Annotations (center-anchored)', show: true },
+      legend: { show: false },
+      axesX: [
+        isHorizontal.value
+          ? { type: 'linear', startToZero: true, showGrid: true }
+          : { type: 'step', showAxisTick: true },
+      ],
+      axesY: [
+        isHorizontal.value
+          ? { type: 'step', showAxisTick: true }
+          : { type: 'linear', startToZero: true, showGrid: true },
+      ],
+      // ── series 위치 어노테이션이 막대의 '중심'에 정렬되는지 확인하는 데모 ──
+      annotations: [
+        // 1) callout: 최댓값 막대 중심을 가리킴(가로/세로 모두 중심 유지)
+        {
+          id: 'peak-callout',
+          type: 'callout',
+          content: ctx => `Peak ${typeof ctx.yValue === 'number' ? ctx.yValue : ctx.xValue}`,
+          position: {
+            type: 'series',
+            seriesId: 'sales',
+            location: peakIdx,
+            offsetX: isHorizontal.value ? 50 : 0,
+            offsetY: isHorizontal.value ? 0 : -44,
+          },
+          style: { backgroundColor: '#1F2937', color: '#FFFFFF', borderColor: '#1F2937' },
+        },
+        // 2) badge + connector(elbow): 최솟값 막대 중심에서 리더선으로 연결
+        {
+          id: 'low-badge',
+          type: 'badge',
+          content: 'Lowest',
+          position: {
+            type: 'series',
+            seriesId: 'sales',
+            location: lowIdx,
+            offsetX: 56,
+            offsetY: -44,
+          },
+          connector: { enabled: true, type: 'elbow', style: { stroke: '#B24C4C', dashStyle: 'dash' } },
+        },
+        // 3) circle: 막대 중심 강조(텍스트 없음)
+        {
+          id: 'mark-circle',
+          type: 'circle',
+          position: { type: 'series', seriesId: 'sales', location: 1 },
+          style: { radius: 10, borderColor: '#2563EB', backgroundColor: 'rgba(37,99,235,0.15)', borderWidth: 2 },
+        },
+        // 4) text: pixel(canvas 절대 좌표) 고정 워터마크
+        {
+          id: 'watermark',
+          type: 'text',
+          content: 'Pixel Position (120, 60)',
+          position: { type: 'pixel', x: 120, y: 60 },
+          style: { color: '#9CA3AF', fontSize: '12px' },
+        },
+      ],
+    }));
+
+    return { chartData, chartOptions, isHorizontal };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.toggle-label {
+  vertical-align: top;
+  margin-right: 7px;
+}
+</style>

--- a/docs/views/barChart/props.js
+++ b/docs/views/barChart/props.js
@@ -40,6 +40,8 @@ import ShowValue from './example/ShowValue';
 import ShowValueRaw from './example/ShowValue?raw';
 import DisplayOverflow from './example/DisplayOverflow';
 import DisplayOverflowRaw from './example/DisplayOverflow?raw';
+import Annotations from './example/Annotations';
+import AnnotationsRaw from './example/Annotations?raw';
 
 export default {
   mdText,
@@ -153,6 +155,13 @@ export default {
         'displayOverflow 옵션으로 값 축(세로=Y, 가로=X) range를 초과한 막대를 경계까지 기본 시리즈 색으로 표시할 수 있습니다(false 기본값이면 숨김). 가로 모드 토글로 값 축 전환 동작을 확인할 수 있습니다.',
       component: DisplayOverflow,
       parsedData: parse(DisplayOverflowRaw).descriptor,
+    },
+    Annotations: {
+      description:
+        'annotations 옵션으로 막대 위에 어노테이션/뱃지를 표시합니다. series 위치 어노테이션은 막대의 '
+        + '시각적 중심에 정렬되며, Horizontal 토글로 가로/세로 모두 중심 정렬이 유지되는지 확인할 수 있습니다.',
+      component: Annotations,
+      parsedData: parse(AnnotationsRaw).descriptor,
     },
   },
 };

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -443,7 +443,7 @@ const chartOptions = {
 | xValue | axis | Number \| String | null | X축 값(linear=숫자, time=숫자/날짜문자열, step=라벨/인덱스) |
 | yValue | axis | Number \| String | null | Y축 값 |
 | seriesId | series | String | null | 추적할 시리즈 id |
-| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스. 파이는 무시 |
+| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스('start'/'end'는 데이터 있는 non-null 첫/마지막). 파이는 무시 |
 
 - **이 차트의 `series` 기준점**: 셀 중심
 - **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정)

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -446,7 +446,7 @@ const chartOptions = {
 | location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스('start'/'end'는 데이터 있는 non-null 첫/마지막). 파이는 무시 |
 
 - **이 차트의 `series` 기준점**: 셀 중심
-- **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정)
+- **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정). `xValue`와 `yValue`를 **모두** 지정해야 하며, 하나만 지정하면 표시되지 않습니다.
 - 기준점이 축 범위/줌 영역 밖이거나, 추적 `series`가 숨김 상태(`show: false`, 범례 토글 포함)이면 그리지 않습니다. `pixel`은 항상 표시됩니다.
 
 ##### annotation content

--- a/docs/views/heatMap/api/heatMap.md
+++ b/docs/views/heatMap/api/heatMap.md
@@ -118,6 +118,7 @@ const chartData =
 | axesY         | Object          | 없음                                      | Y축에 대한 속성                                                 | [상세](#axesx-axesy)            |
 | title         | Object          | ([상세](#title))                          | 차트 상단에 위치할 차트 제목 표시 여부 및 속성                  |                                 |
 | legend        | Object          | ([상세](#legend))                         | 차트의 범례 표시 여부 및 속성                                   |                                 |
+| annotations | Array | ([상세](#annotation)) | 차트 위에 표시할 어노테이션/뱃지 목록 | |
 | dragSelection | Object          | ([상세](#dragselection))                  | drag-select의 사용 여부                                         |                                 |
 | padding       | Object          | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값                                            |
 | tooltip       | Object          | ([상세](#tooltip))                        | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성                |                                 |
@@ -406,3 +407,104 @@ const chartOptions = {
 
 - drag-select는 `dragSelection` 옵션의 `use`값이 `true` 일 때 이벤트를 발생 시킬 수 있다.
   그리고 선택영역은 그래프에 표시된 데이터의 중앙이 포함 되어야 선택영역 내 데이터로 인식 한다.
+
+#### annotation
+
+차트 위에 어노테이션/뱃지를 표시합니다. `options.annotations`에 **배열**로 지정하며, 배열 순서가 그리는 순서(z-order, 뒤 항목이 위)입니다. 어노테이션은 전용 레이어에 그려져 hover 하이라이트 위에 표시됩니다.
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+|------|------|--------|------|-----------|
+| id | String | annotation-${index} | 식별/key 용도. 중복 시 콘솔 경고 | |
+| type | String | 'text' | 어노테이션 외형 종류 | 'text', 'badge', 'callout', 'circle' |
+| content | String \| Function | '' | 표시 텍스트(토큰/콜백 지원). circle은 무시 | [상세](#annotation-content) |
+| position | Object | ([상세](#annotation-position)) | 위치 지정 방식 | |
+| connector | Object | ([상세](#annotation-connector)) | 데이터 지점과 박스를 잇는 연결선(기본 비활성). callout은 무시 | |
+| style | Object | type별 기본값 | 외형/말풍선/도형 속성 | [상세](#annotation-style) |
+
+##### type 종류
+- `text` : 배경/테두리 없는 순수 텍스트(라벨)
+- `badge` : 배경 박스 + 라운딩을 가진 텍스트 뱃지
+- `callout` : 데이터 지점을 가리키는 꼬리가 달린 말풍선
+- `circle` : 텍스트 없는 강조용 원형 도형(`style.radius` 사용)
+
+##### annotation position
+
+위치 기준은 상호 배타적인 3가지 `type`으로 구분합니다.
+
+| 이름 | 적용 type | 타입 | 디폴트 | 설명 |
+|------|-----------|------|--------|------|
+| type | 공통 | String | 'pixel' | 'axis' \| 'pixel' \| 'series' |
+| offsetX | 공통 | Number | 0 | 기준점으로부터 X 오프셋(px) |
+| offsetY | 공통 | Number | 0 | 기준점으로부터 Y 오프셋(px) |
+| x | pixel | Number | 0 | canvas 좌상단(0,0) 기준 절대 X 좌표 |
+| y | pixel | Number | 0 | canvas 좌상단(0,0) 기준 절대 Y 좌표 |
+| xAxisIndex | axis | Number | 0 | 기준 X축 인덱스 |
+| yAxisIndex | axis | Number | 0 | 기준 Y축 인덱스 |
+| xValue | axis | Number \| String | null | X축 값(linear=숫자, time=숫자/날짜문자열, step=라벨/인덱스) |
+| yValue | axis | Number \| String | null | Y축 값 |
+| seriesId | series | String | null | 추적할 시리즈 id |
+| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스. 파이는 무시 |
+
+- **이 차트의 `series` 기준점**: 셀 중심
+- **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정)
+- 기준점이 축 범위/줌 영역 밖이거나, 추적 `series`가 숨김 상태(`show: false`, 범례 토글 포함)이면 그리지 않습니다. `pixel`은 항상 표시됩니다.
+
+##### annotation content
+
+- 문자열: 그대로 표시
+- 토큰 치환: `{xValue}` `{yValue}` `{seriesId}` `{seriesName}` `{dataIndex}` `{percentage}` (알 수 없는 토큰은 원문 유지)
+- 콜백 `(ctx) => string` : `ctx = { xValue, yValue, seriesId, seriesName, dataIndex, percentage }` (`percentage`는 파이 전용, 그 외 null)
+- `\n` 으로 멀티라인 지원
+
+##### annotation connector
+
+데이터 지점과 어노테이션 박스의 가장 가까운 경계를 잇는 선입니다.
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류 |
+|------|------|--------|------|------|
+| enabled | Boolean | false | 연결선 사용 여부 | |
+| type | String | 'straight' | 선 모양 | 'straight', 'elbow' |
+| style.stroke | String | '#9E9E9E' | 선 색상 | |
+| style.strokeWidth | Number | 1 | 선 두께 | |
+| style.dashStyle | String | 'solid' | 점선 스타일 | 'solid', 'dash', 'dot' |
+
+> `callout`은 꼬리가 connector 역할을 하므로 connector를 켜도 자동으로 비활성화됩니다.
+
+##### annotation style
+
+text/badge/callout 공통 텍스트 속성과 type별 전용 속성을 `style` 하나로 통합합니다.
+
+| 이름 | 타입 | 설명 | 적용 type |
+|------|------|------|-----------|
+| color | String | 글자 색 | text, badge, callout |
+| backgroundColor | String | 배경 색('transparent' 가능) | 전체 |
+| borderColor | String | 테두리 색 | 전체 |
+| borderWidth | Number | 테두리 두께 | 전체 |
+| borderRadius | Number | 모서리 둥글기 | text, badge, callout |
+| padding | Number \| Array | 안쪽 여백. n / [상하,좌우] / [상,우,하,좌] | text, badge, callout |
+| fontSize | String | 글자 크기(예: '11px') | text, badge, callout |
+| fontWeight | String | 글자 굵기 | text, badge, callout |
+| fontFamily | String | 글꼴 | text, badge, callout |
+| textAlign | String | 정렬 | text, badge, callout |
+| anchor | String | 꼬리 방향('auto'는 offset 방향으로 결정) | callout |
+| arrowSize | Number | 꼬리 크기 | callout |
+| radius | Number | 원 반지름 | circle |
+
+**type별 style 기본값**
+
+| 속성 | text | badge | callout | circle |
+|------|------|-------|---------|--------|
+| color | #212121 | #8B2323 | #212121 | - |
+| backgroundColor | transparent | #FDF0F0 | #FFFFFF | rgba(178,76,76,0.15) |
+| borderColor | transparent | #B24C4C | #B0B0B0 | #B24C4C |
+| borderWidth | 0 | 1 | 1 | 1 |
+| borderRadius | 0 | 6 | 4 | - |
+| padding | [0,0] | [6,10] | [4,8] | - |
+| fontSize | 11px | 11px | 11px | - |
+| fontWeight | normal | normal | normal | - |
+| textAlign | center | center | center | - |
+| anchor | - | - | auto | - |
+| arrowSize | - | - | 4 | - |
+| radius | - | - | - | 10 |
+
+> 실제 사용 예시는 상단의 **Annotations** 예제를 참고하세요.

--- a/docs/views/heatMap/example/Annotations.vue
+++ b/docs/views/heatMap/example/Annotations.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="case">
+    <resizable-wrapper>
+      <ev-chart :data="chartData" :options="chartOptions" />
+    </resizable-wrapper>
+  </div>
+</template>
+
+<script>
+import { reactive } from 'vue';
+
+export default {
+  setup() {
+    const chartData = reactive({
+      series: {
+        load: { name: 'Load' },
+      },
+      labels: {
+        x: ['00:00', '06:00', '12:00', '18:00'],
+        y: ['1w', '2w', '3w'],
+      },
+      data: {
+        load: [
+          { x: '00:00', y: '1w', value: 100 },
+          { x: '00:00', y: '2w', value: 80 },
+          { x: '00:00', y: '3w', value: 130 },
+          { x: '06:00', y: '1w', value: 20 },
+          { x: '06:00', y: '2w', value: 150 },
+          { x: '06:00', y: '3w', value: 115 },
+          { x: '12:00', y: '1w', value: 150 },
+          { x: '12:00', y: '2w', value: 80 },
+          { x: '12:00', y: '3w', value: 120 },
+          { x: '18:00', y: '1w', value: 30 },
+          { x: '18:00', y: '2w', value: 150 },
+          { x: '18:00', y: '3w', value: 90 },
+        ],
+      },
+    });
+
+    const hotIdx = 4; // { x: '06:00', y: '2w', value: 150 }
+
+    const chartOptions = reactive({
+      type: 'heatMap',
+      width: '100%',
+      height: '100%',
+      padding: { top: 40, right: 40, left: 10, bottom: 10 },
+      title: { text: 'HeatMap Annotations', show: true },
+      axesX: [{ type: 'step' }],
+      axesY: [{ type: 'step' }],
+      heatMapColor: { min: '#FFC19E', max: '#CC3D3D', rangeCount: 5 },
+      tooltip: { use: true },
+      // ── series 위치는 셀 '중심', axis 위치는 step 라벨(x/y) 기준 ──
+      annotations: [
+        // 1) callout: 특정 셀 중심 추적
+        {
+          id: 'hot-callout',
+          type: 'callout',
+          content: 'Hotspot',
+          position: { type: 'series', seriesId: 'load', location: hotIdx, offsetY: -30 },
+          style: { backgroundColor: '#1F2937', color: '#FFFFFF', borderColor: '#1F2937' },
+        },
+        // 2) circle: 셀 중심 강조
+        {
+          id: 'mark-circle',
+          type: 'circle',
+          position: { type: 'series', seriesId: 'load', location: 6 },
+          style: { radius: 14, borderColor: '#2563EB', backgroundColor: 'rgba(37,99,235,0.12)', borderWidth: 2 },
+        },
+        // 3) badge: axis(step 라벨 x/y) 위치 + connector(elbow)
+        {
+          id: 'label-badge',
+          type: 'badge',
+          content: '12:00 / 3w',
+          position: { type: 'axis', xValue: '12:00', yValue: '3w', offsetX: 40, offsetY: -34 },
+          connector: { enabled: true, type: 'elbow', style: { stroke: '#B24C4C', dashStyle: 'dash' } },
+        },
+        // 4) text: pixel(canvas 절대 좌표) 워터마크
+        {
+          id: 'watermark',
+          type: 'text',
+          content: 'heatmap demo',
+          position: { type: 'pixel', x: 110, y: 60 },
+          style: { color: '#9CA3AF', fontSize: '12px' },
+        },
+      ],
+    });
+
+    return { chartData, chartOptions };
+  },
+};
+</script>

--- a/docs/views/heatMap/props.js
+++ b/docs/views/heatMap/props.js
@@ -24,6 +24,8 @@ import StepAxis from './example/StepAxis';
 import StepAxisRaw from './example/StepAxis?raw';
 import LegendClickMode from './example/LegendClickMode';
 import LegendClickModeRaw from './example/LegendClickMode?raw';
+import Annotations from './example/Annotations';
+import AnnotationsRaw from './example/Annotations?raw';
 
 export default {
   mdText,
@@ -87,6 +89,13 @@ export default {
       description: 'Legend Click Mode',
       component: LegendClickMode,
       parsedData: parse(LegendClickModeRaw).descriptor,
+    },
+    Annotations: {
+      description:
+        'annotations 옵션으로 히트맵 위에 어노테이션/뱃지를 표시합니다. series 위치 어노테이션은 셀 '
+        + '중심에 정렬되며, axis 위치는 step 축의 x/y 라벨로 지정합니다.',
+      component: Annotations,
+      parsedData: parse(AnnotationsRaw).descriptor,
     },
   },
 };

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -690,7 +690,7 @@ chartOptions.value = {
 | location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스('start'/'end'는 데이터 있는 non-null 첫/마지막). 파이는 무시 |
 
 - **이 차트의 `series` 기준점**: 데이터 포인트 중심
-- **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정)
+- **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정). `xValue`와 `yValue`를 **모두** 지정해야 하며, 하나만 지정하면 표시되지 않습니다.
 - 기준점이 축 범위/줌 영역 밖이거나, 추적 `series`가 숨김 상태(`show: false`, 범례 토글 포함)이면 그리지 않습니다. `pixel`은 항상 표시됩니다.
 
 ##### annotation content

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -687,7 +687,7 @@ chartOptions.value = {
 | xValue | axis | Number \| String | null | X축 값(linear=숫자, time=숫자/날짜문자열, step=라벨/인덱스) |
 | yValue | axis | Number \| String | null | Y축 값 |
 | seriesId | series | String | null | 추적할 시리즈 id |
-| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스. 파이는 무시 |
+| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스('start'/'end'는 데이터 있는 non-null 첫/마지막). 파이는 무시 |
 
 - **이 차트의 `series` 기준점**: 데이터 포인트 중심
 - **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정)

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -140,6 +140,7 @@ const chartData =
 | axesY      | Object          | 없음                                      | Y축에 대한 속성                                                                                                                                                                        | [상세](#axesx-axesy)            |
 | title      | Object          | ([상세](#title))                          | 차트 상단에 위치할 차트 제목 표시 여부 및 속성                                                                                                                                         |                                 |
 | legend     | Object          | ([상세](#legend))                         | 차트의 범례 표시 여부 및 속성                                                                                                                                                          |                                 |
+| annotations | Array | ([상세](#annotation)) | 차트 위에 표시할 어노테이션/뱃지 목록 | |
 | tooltip    | Object          | ([상세](#tooltip))                        | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성                                                                                                                                       |                                 |
 | indicator  | Object          | ([상세](#indicator))                      | 지표선                                                                                                                                                                                 |                                 |
 | maxTip     | Object          | ([상세](#maxtip))                         | 최대값에 tip 표시(값 표시) 여부 및 속성                                                                                                                                                |                                 |
@@ -650,3 +651,104 @@ chartOptions.value = {
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환
 
 
+
+#### annotation
+
+차트 위에 어노테이션/뱃지를 표시합니다. `options.annotations`에 **배열**로 지정하며, 배열 순서가 그리는 순서(z-order, 뒤 항목이 위)입니다. 어노테이션은 전용 레이어에 그려져 hover 하이라이트 위에 표시됩니다.
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+|------|------|--------|------|-----------|
+| id | String | annotation-${index} | 식별/key 용도. 중복 시 콘솔 경고 | |
+| type | String | 'text' | 어노테이션 외형 종류 | 'text', 'badge', 'callout', 'circle' |
+| content | String \| Function | '' | 표시 텍스트(토큰/콜백 지원). circle은 무시 | [상세](#annotation-content) |
+| position | Object | ([상세](#annotation-position)) | 위치 지정 방식 | |
+| connector | Object | ([상세](#annotation-connector)) | 데이터 지점과 박스를 잇는 연결선(기본 비활성). callout은 무시 | |
+| style | Object | type별 기본값 | 외형/말풍선/도형 속성 | [상세](#annotation-style) |
+
+##### type 종류
+- `text` : 배경/테두리 없는 순수 텍스트(라벨)
+- `badge` : 배경 박스 + 라운딩을 가진 텍스트 뱃지
+- `callout` : 데이터 지점을 가리키는 꼬리가 달린 말풍선
+- `circle` : 텍스트 없는 강조용 원형 도형(`style.radius` 사용)
+
+##### annotation position
+
+위치 기준은 상호 배타적인 3가지 `type`으로 구분합니다.
+
+| 이름 | 적용 type | 타입 | 디폴트 | 설명 |
+|------|-----------|------|--------|------|
+| type | 공통 | String | 'pixel' | 'axis' \| 'pixel' \| 'series' |
+| offsetX | 공통 | Number | 0 | 기준점으로부터 X 오프셋(px) |
+| offsetY | 공통 | Number | 0 | 기준점으로부터 Y 오프셋(px) |
+| x | pixel | Number | 0 | canvas 좌상단(0,0) 기준 절대 X 좌표 |
+| y | pixel | Number | 0 | canvas 좌상단(0,0) 기준 절대 Y 좌표 |
+| xAxisIndex | axis | Number | 0 | 기준 X축 인덱스 |
+| yAxisIndex | axis | Number | 0 | 기준 Y축 인덱스 |
+| xValue | axis | Number \| String | null | X축 값(linear=숫자, time=숫자/날짜문자열, step=라벨/인덱스) |
+| yValue | axis | Number \| String | null | Y축 값 |
+| seriesId | series | String | null | 추적할 시리즈 id |
+| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스. 파이는 무시 |
+
+- **이 차트의 `series` 기준점**: 데이터 포인트 중심
+- **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정)
+- 기준점이 축 범위/줌 영역 밖이거나, 추적 `series`가 숨김 상태(`show: false`, 범례 토글 포함)이면 그리지 않습니다. `pixel`은 항상 표시됩니다.
+
+##### annotation content
+
+- 문자열: 그대로 표시
+- 토큰 치환: `{xValue}` `{yValue}` `{seriesId}` `{seriesName}` `{dataIndex}` `{percentage}` (알 수 없는 토큰은 원문 유지)
+- 콜백 `(ctx) => string` : `ctx = { xValue, yValue, seriesId, seriesName, dataIndex, percentage }` (`percentage`는 파이 전용, 그 외 null)
+- `\n` 으로 멀티라인 지원
+
+##### annotation connector
+
+데이터 지점과 어노테이션 박스의 가장 가까운 경계를 잇는 선입니다.
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류 |
+|------|------|--------|------|------|
+| enabled | Boolean | false | 연결선 사용 여부 | |
+| type | String | 'straight' | 선 모양 | 'straight', 'elbow' |
+| style.stroke | String | '#9E9E9E' | 선 색상 | |
+| style.strokeWidth | Number | 1 | 선 두께 | |
+| style.dashStyle | String | 'solid' | 점선 스타일 | 'solid', 'dash', 'dot' |
+
+> `callout`은 꼬리가 connector 역할을 하므로 connector를 켜도 자동으로 비활성화됩니다.
+
+##### annotation style
+
+text/badge/callout 공통 텍스트 속성과 type별 전용 속성을 `style` 하나로 통합합니다.
+
+| 이름 | 타입 | 설명 | 적용 type |
+|------|------|------|-----------|
+| color | String | 글자 색 | text, badge, callout |
+| backgroundColor | String | 배경 색('transparent' 가능) | 전체 |
+| borderColor | String | 테두리 색 | 전체 |
+| borderWidth | Number | 테두리 두께 | 전체 |
+| borderRadius | Number | 모서리 둥글기 | text, badge, callout |
+| padding | Number \| Array | 안쪽 여백. n / [상하,좌우] / [상,우,하,좌] | text, badge, callout |
+| fontSize | String | 글자 크기(예: '11px') | text, badge, callout |
+| fontWeight | String | 글자 굵기 | text, badge, callout |
+| fontFamily | String | 글꼴 | text, badge, callout |
+| textAlign | String | 정렬 | text, badge, callout |
+| anchor | String | 꼬리 방향('auto'는 offset 방향으로 결정) | callout |
+| arrowSize | Number | 꼬리 크기 | callout |
+| radius | Number | 원 반지름 | circle |
+
+**type별 style 기본값**
+
+| 속성 | text | badge | callout | circle |
+|------|------|-------|---------|--------|
+| color | #212121 | #8B2323 | #212121 | - |
+| backgroundColor | transparent | #FDF0F0 | #FFFFFF | rgba(178,76,76,0.15) |
+| borderColor | transparent | #B24C4C | #B0B0B0 | #B24C4C |
+| borderWidth | 0 | 1 | 1 | 1 |
+| borderRadius | 0 | 6 | 4 | - |
+| padding | [0,0] | [6,10] | [4,8] | - |
+| fontSize | 11px | 11px | 11px | - |
+| fontWeight | normal | normal | normal | - |
+| textAlign | center | center | center | - |
+| anchor | - | - | auto | - |
+| arrowSize | - | - | 4 | - |
+| radius | - | - | - | 10 |
+
+> 실제 사용 예시는 상단의 **Annotations** 예제를 참고하세요.

--- a/docs/views/lineChart/example/Annotations.vue
+++ b/docs/views/lineChart/example/Annotations.vue
@@ -1,0 +1,162 @@
+<template>
+  <div class="case">
+    <resizable-wrapper>
+      <ev-chart :data="chartData" :options="chartOptions" />
+    </resizable-wrapper>
+  </div>
+  <div class="description">
+    <span class="toggle-label">데이터 자동 업데이트</span>
+    <ev-toggle v-model="isLive" />
+  </div>
+</template>
+
+<script>
+import { watch, ref, onBeforeUnmount, onMounted, reactive } from 'vue';
+import dayjs from 'dayjs';
+
+export default {
+  setup() {
+    const base = dayjs('2026-06-23 00:00:00');
+
+    const chartData = reactive({
+      series: {
+        cpu: { name: 'CPU', point: true },
+        mem: { name: 'MEM', point: true },
+      },
+      labels: [],
+      data: {
+        cpu: [],
+        mem: [],
+      },
+    });
+
+    const chartOptions = reactive({
+      type: 'line',
+      width: '100%',
+      height: '100%',
+      padding: { top: 40, right: 40, left: 10, bottom: 10 },
+      title: { text: 'Annotations & Badge', show: true },
+      legend: { show: true, position: 'right' },
+      axesX: [
+        {
+          type: 'time',
+          timeFormat: 'HH:mm',
+          interval: { time: 2, unit: 'hour' },
+          showAxisTick: true,
+        },
+      ],
+      axesY: [
+        {
+          type: 'linear',
+          showGrid: true,
+          startToZero: true,
+          formatter: value => `${value / 1000}k`,
+        },
+      ],
+      // ── 어노테이션 모듈 데모 ───────────────────────────────
+      annotations: [
+        // 1) callout: CPU 마지막 데이터 포인트 추적(라이브 시 자동 갱신) + 콜백 content
+        {
+          id: 'cpu-callout',
+          type: 'callout',
+          content: ctx => `${ctx.seriesName}: ${(ctx.yValue / 1000).toFixed(0)}k`,
+          position: {
+            type: 'series',
+            seriesId: 'cpu',
+            location: 'end',
+            offsetY: -24,
+          },
+          style: { backgroundColor: '#1F2937', color: '#FFFFFF', borderColor: '#1F2937' },
+        },
+        // 2) callout: MEM 마지막 데이터 포인트 추적
+        {
+          id: 'mem-callout',
+          type: 'callout',
+          content: ctx => `${ctx.seriesName}: ${(ctx.yValue / 1000).toFixed(0)}k`,
+          position: {
+            type: 'series',
+            seriesId: 'mem',
+            location: 'end',
+            offsetY: -24,
+          },
+          style: { backgroundColor: '#2563EB', color: '#FFFFFF', borderColor: '#2563EB' },
+        },
+        // 3) circle: 특정 데이터 포인트 강조(텍스트 없음)
+        {
+          id: 'peak-circle',
+          type: 'circle',
+          position: { type: 'series', seriesId: 'cpu', location: 8 },
+          style: { radius: 14, borderColor: '#EF4444', backgroundColor: 'rgba(239,68,68,0.12)', borderWidth: 2 },
+        },
+        // 4) badge: axis(time/linear) 기준 + connector(elbow) 로 임계선 표기
+        {
+          id: 'threshold-badge',
+          type: 'badge',
+          content: 'xValue position',
+          position: {
+            type: 'axis',
+            xValue: base.add(4, 'hour').valueOf(),
+            yValue: 30000,
+            offsetX: 70,
+            offsetY: -40,
+          },
+          connector: { enabled: true, type: 'elbow', style: { stroke: '#B24C4C', dashStyle: 'dash' } },
+        },
+        // 5) text: pixel(canvas 절대 좌표) 고정 라벨 + '\n' 멀티라인 데모
+        {
+          id: 'watermark',
+          type: 'text',
+          content: 'Pixel Position (150, 70)\n\\n 으로 멀티라인 지원\n세 번째 줄',
+          position: { type: 'pixel', x: 150, y: 70 },
+          style: { color: '#9CA3AF', fontSize: '12px' },
+        },
+      ],
+    });
+
+    const isLive = ref(false);
+    const liveInterval = ref();
+    let timeValue = base;
+
+    const addRandomChartData = () => {
+      if (isLive.value) {
+        chartData.labels.shift();
+        chartData.data.cpu.shift();
+        chartData.data.mem.shift();
+      }
+
+      timeValue = dayjs(timeValue).add(1, 'hour');
+      chartData.labels.push(timeValue);
+      chartData.data.cpu.push(Math.round(Math.random() * 40000 + 5000));
+      chartData.data.mem.push(Math.round(Math.random() * 40000 + 5000));
+    };
+
+    onMounted(() => {
+      for (let ix = 0; ix < 12; ix++) {
+        addRandomChartData();
+      }
+    });
+
+    watch(isLive, (newValue) => {
+      if (newValue) {
+        addRandomChartData();
+        liveInterval.value = setInterval(addRandomChartData, 1000);
+      } else {
+        clearInterval(liveInterval.value);
+      }
+    });
+
+    onBeforeUnmount(() => {
+      clearInterval(liveInterval.value);
+    });
+
+    return { chartData, chartOptions, isLive };
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.toggle-label {
+  vertical-align: top;
+  margin-right: 7px;
+}
+</style>

--- a/docs/views/lineChart/example/Segments.vue
+++ b/docs/views/lineChart/example/Segments.vue
@@ -9,24 +9,24 @@ import dayjs from 'dayjs';
 
 export default {
   setup() {
-    const time = dayjs().format('YYYY-MM-DD HH:mm:ss');
+    const baseTime = dayjs().format('YYYY-MM-DD 00:00:00');
     const chartData = {
       series: {
-        series1: { name: 'series#1', color: 'rgba(239, 58, 58, 0.5)', segments: [1, 2] },
-        series2: { name: 'series#2' },
+        thresholdSeries: { name: 'thresholdSeries', color: 'rgba(239, 58, 58, 0.5)', segments: [1, 2] },
+        dataSeries: { name: 'dataSeries' },
       },
       labels: [
-        dayjs(time),
-        dayjs(time).add(1, 'day'),
-        dayjs(time).add(2, 'day'),
-        dayjs(time).add(3, 'day'),
-        dayjs(time).add(4, 'day'),
-        dayjs(time).add(5, 'day'),
-        dayjs(time).add(6, 'day'),
+        dayjs(baseTime),
+        dayjs(baseTime).add(1, 'day'),
+        dayjs(baseTime).add(2, 'day'),
+        dayjs(baseTime).add(3, 'day'),
+        dayjs(baseTime).add(4, 'day'),
+        dayjs(baseTime).add(5, 'day'),
+        dayjs(baseTime).add(6, 'day'),
       ],
       data: {
-        series1: [25, 47, 47, 40, 50, 100, null],
-        series2: [100, 25, 47, 47, null, null, null],
+        thresholdSeries: [25, 47, 47, 40, 50, 100, null],
+        dataSeries: [100, 25, 47, 47, null, null, null],
       },
     };
 
@@ -71,6 +71,20 @@ export default {
           },
         },
       ],
+      annotations: [
+      {
+          id: 'threshold-badge',
+          type: 'badge',
+          content: 'Threshold',
+          position: {
+            type: 'series',
+            seriesId: 'thresholdSeries',
+            location: 'end',
+            offsetX: 10,
+            offsetY: -20,
+          },
+        },
+      ]
     };
 
     return {

--- a/docs/views/lineChart/props.js
+++ b/docs/views/lineChart/props.js
@@ -48,6 +48,8 @@ import UnSelectedOpacity from './example/UnSelectedOpacity';
 import UnSelectedOpacityRaw from './example/UnSelectedOpacity?raw';
 import PerfStressSingle from './example/PerfStressSingle';
 import PerfStressSingleRaw from './example/PerfStressSingle?raw';
+import Annotations from './example/Annotations';
+import AnnotationsRaw from './example/Annotations?raw';
 
 export default {
   mdText,
@@ -185,6 +187,13 @@ export default {
         '시리즈 수·포인트 수는 상수로 조절하며, append(슬라이딩 윈도우)/full-replace 갱신을 토글할 수 있습니다.',
       component: PerfStressSingle,
       parsedData: parse(PerfStressSingleRaw).descriptor,
+    },
+    Annotations: {
+      description:
+        'annotations 옵션으로 차트 위에 어노테이션/뱃지를 표시합니다. type(text/badge/callout/circle), '
+        + 'position(axis/pixel/series), content 토큰·콜백, connector(연결선)를 지원합니다.',
+      component: Annotations,
+      parsedData: parse(AnnotationsRaw).descriptor,
     },
   },
 };

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -293,7 +293,7 @@ const chartOptions = {
 | xValue | axis | Number \| String | null | X축 값(linear=숫자, time=숫자/날짜문자열, step=라벨/인덱스) |
 | yValue | axis | Number \| String | null | Y축 값 |
 | seriesId | series | String | null | 추적할 시리즈 id |
-| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스. 파이는 무시 |
+| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스('start'/'end'는 데이터 있는 non-null 첫/마지막). 파이는 무시 |
 
 - **이 차트의 `series` 기준점**: 조각 바깥 둘레의 각도 중간 지점(단일 조각이면 오른쪽 3시 방향)
 - **`axis` 위치**: 미지원 (파이는 x/y축이 없음)

--- a/docs/views/pieChart/api/pieChart.md
+++ b/docs/views/pieChart/api/pieChart.md
@@ -96,6 +96,7 @@ const chartData =
 | height           | String / Number | '100%'                                         | 차트의 높이                                                     | '100%', '150px', 150            |
 | title            | Object          | ([상세](#title))                               | 차트 상단에 위치할 차트 제목 표시 여부 및 속성                  |                                 |
 | legend           | Object          | ([상세](#legend))                              | 차트의 범례 표시 여부 및 속성                                   |                                 |
+| annotations | Array | ([상세](#annotation)) | 차트 위에 표시할 어노테이션/뱃지 목록 | |
 | doughnutHoleSize | number          | 0                                              | 내부 hole 사이즈                                                | 0 ~ 1                           |
 | pieStroke        | Object          | { show: true, color: '#FFFFFF', lineWidth: 2 } | 차트의 테두리선 표시 여부 및 색상, 두께를 설정하는 옵션         |                                 |
 | tooltip          | Object          | ([상세](#tooltip))                             | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성                |                                 |
@@ -256,3 +257,104 @@ const chartOptions = {
 | click-legend | e, data      | 범례를 클릭했을 때 발생하는 이벤트. 클릭 후 활성화된 시리즈 ID 목록과 모두 활성 여부를 반환한다. <br><br> ex) e : 이벤트 객체 <br> ex) data : { seriesIds: ['series1', 'series2', ...], isActiveAll: false } <br><br> seriesIds는 현재 활성화(show: true)된 시리즈의 ID 배열이다. 단, 시리즈가 모두 활성화된다면 빈배열([])로 반환한다. |
 
 - 단, `selectedItem` 옵션의 `use`값이 `true` 이어야 `selectedItem` 객체를 반환하며 false일 경우 빈 객체를 반환
+
+#### annotation
+
+차트 위에 어노테이션/뱃지를 표시합니다. `options.annotations`에 **배열**로 지정하며, 배열 순서가 그리는 순서(z-order, 뒤 항목이 위)입니다. 어노테이션은 전용 레이어에 그려져 hover 하이라이트 위에 표시됩니다.
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+|------|------|--------|------|-----------|
+| id | String | annotation-${index} | 식별/key 용도. 중복 시 콘솔 경고 | |
+| type | String | 'text' | 어노테이션 외형 종류 | 'text', 'badge', 'callout', 'circle' |
+| content | String \| Function | '' | 표시 텍스트(토큰/콜백 지원). circle은 무시 | [상세](#annotation-content) |
+| position | Object | ([상세](#annotation-position)) | 위치 지정 방식 | |
+| connector | Object | ([상세](#annotation-connector)) | 데이터 지점과 박스를 잇는 연결선(기본 비활성). callout은 무시 | |
+| style | Object | type별 기본값 | 외형/말풍선/도형 속성 | [상세](#annotation-style) |
+
+##### type 종류
+- `text` : 배경/테두리 없는 순수 텍스트(라벨)
+- `badge` : 배경 박스 + 라운딩을 가진 텍스트 뱃지
+- `callout` : 데이터 지점을 가리키는 꼬리가 달린 말풍선
+- `circle` : 텍스트 없는 강조용 원형 도형(`style.radius` 사용)
+
+##### annotation position
+
+위치 기준은 상호 배타적인 3가지 `type`으로 구분합니다.
+
+| 이름 | 적용 type | 타입 | 디폴트 | 설명 |
+|------|-----------|------|--------|------|
+| type | 공통 | String | 'pixel' | 'axis' \| 'pixel' \| 'series' |
+| offsetX | 공통 | Number | 0 | 기준점으로부터 X 오프셋(px) |
+| offsetY | 공통 | Number | 0 | 기준점으로부터 Y 오프셋(px) |
+| x | pixel | Number | 0 | canvas 좌상단(0,0) 기준 절대 X 좌표 |
+| y | pixel | Number | 0 | canvas 좌상단(0,0) 기준 절대 Y 좌표 |
+| xAxisIndex | axis | Number | 0 | 기준 X축 인덱스 |
+| yAxisIndex | axis | Number | 0 | 기준 Y축 인덱스 |
+| xValue | axis | Number \| String | null | X축 값(linear=숫자, time=숫자/날짜문자열, step=라벨/인덱스) |
+| yValue | axis | Number \| String | null | Y축 값 |
+| seriesId | series | String | null | 추적할 시리즈 id |
+| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스. 파이는 무시 |
+
+- **이 차트의 `series` 기준점**: 조각 바깥 둘레의 각도 중간 지점(단일 조각이면 오른쪽 3시 방향)
+- **`axis` 위치**: 미지원 (파이는 x/y축이 없음)
+- 기준점이 축 범위/줌 영역 밖이거나, 추적 `series`가 숨김 상태(`show: false`, 범례 토글 포함)이면 그리지 않습니다. `pixel`은 항상 표시됩니다.
+
+##### annotation content
+
+- 문자열: 그대로 표시
+- 토큰 치환: `{xValue}` `{yValue}` `{seriesId}` `{seriesName}` `{dataIndex}` `{percentage}` (알 수 없는 토큰은 원문 유지)
+- 콜백 `(ctx) => string` : `ctx = { xValue, yValue, seriesId, seriesName, dataIndex, percentage }` (`percentage`는 파이 전용, 그 외 null)
+- `\n` 으로 멀티라인 지원
+
+##### annotation connector
+
+데이터 지점과 어노테이션 박스의 가장 가까운 경계를 잇는 선입니다.
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류 |
+|------|------|--------|------|------|
+| enabled | Boolean | false | 연결선 사용 여부 | |
+| type | String | 'straight' | 선 모양 | 'straight', 'elbow' |
+| style.stroke | String | '#9E9E9E' | 선 색상 | |
+| style.strokeWidth | Number | 1 | 선 두께 | |
+| style.dashStyle | String | 'solid' | 점선 스타일 | 'solid', 'dash', 'dot' |
+
+> `callout`은 꼬리가 connector 역할을 하므로 connector를 켜도 자동으로 비활성화됩니다.
+
+##### annotation style
+
+text/badge/callout 공통 텍스트 속성과 type별 전용 속성을 `style` 하나로 통합합니다.
+
+| 이름 | 타입 | 설명 | 적용 type |
+|------|------|------|-----------|
+| color | String | 글자 색 | text, badge, callout |
+| backgroundColor | String | 배경 색('transparent' 가능) | 전체 |
+| borderColor | String | 테두리 색 | 전체 |
+| borderWidth | Number | 테두리 두께 | 전체 |
+| borderRadius | Number | 모서리 둥글기 | text, badge, callout |
+| padding | Number \| Array | 안쪽 여백. n / [상하,좌우] / [상,우,하,좌] | text, badge, callout |
+| fontSize | String | 글자 크기(예: '11px') | text, badge, callout |
+| fontWeight | String | 글자 굵기 | text, badge, callout |
+| fontFamily | String | 글꼴 | text, badge, callout |
+| textAlign | String | 정렬 | text, badge, callout |
+| anchor | String | 꼬리 방향('auto'는 offset 방향으로 결정) | callout |
+| arrowSize | Number | 꼬리 크기 | callout |
+| radius | Number | 원 반지름 | circle |
+
+**type별 style 기본값**
+
+| 속성 | text | badge | callout | circle |
+|------|------|-------|---------|--------|
+| color | #212121 | #8B2323 | #212121 | - |
+| backgroundColor | transparent | #FDF0F0 | #FFFFFF | rgba(178,76,76,0.15) |
+| borderColor | transparent | #B24C4C | #B0B0B0 | #B24C4C |
+| borderWidth | 0 | 1 | 1 | 1 |
+| borderRadius | 0 | 6 | 4 | - |
+| padding | [0,0] | [6,10] | [4,8] | - |
+| fontSize | 11px | 11px | 11px | - |
+| fontWeight | normal | normal | normal | - |
+| textAlign | center | center | center | - |
+| anchor | - | - | auto | - |
+| arrowSize | - | - | 4 | - |
+| radius | - | - | - | 10 |
+
+> 실제 사용 예시는 상단의 **Annotations** 예제를 참고하세요.

--- a/docs/views/pieChart/example/Annotations.vue
+++ b/docs/views/pieChart/example/Annotations.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="case">
+    <resizable-wrapper>
+      <ev-chart :data="chartData" :options="chartOptions" />
+    </resizable-wrapper>
+  </div>
+</template>
+
+<script>
+import { reactive } from 'vue';
+
+export default {
+  setup() {
+    const chartData = {
+      series: {
+        chrome: { name: 'Chrome' },
+        safari: { name: 'Safari' },
+        edge: { name: 'Edge' },
+        etc: { name: 'Etc' },
+      },
+      data: {
+        chrome: [62],
+        safari: [19],
+        edge: [11],
+        etc: [8],
+      },
+    };
+
+    const chartOptions = reactive({
+      type: 'pie',
+      width: '100%',
+      height: '100%',
+      title: { text: 'Pie Annotations', show: true },
+      legend: { show: true, position: 'right' },
+      // ── series 위치 어노테이션은 파이 조각의 'arc 중앙'(각도 중간 × 반지름 중점)에 정렬된다 ──
+      // (파이는 x/y축이 없어 axis 위치는 지원하지 않음)
+
+      annotations: [
+        // 1) callout: 가장 큰 조각(Chrome) arc 중앙 + 콜백(시리즈명/비율)
+        {
+          id: 'chrome-callout',
+          type: 'callout',
+          content: ctx => `${ctx.seriesName} ${ctx.percentage}%`,
+          position: { type: 'series', seriesId: 'chrome', offsetX: 50, offsetY: 0 },
+          style: { anchor: 'auto', backgroundColor: '#1F2937', color: '#FFFFFF', borderColor: '#1F2937' },
+        },
+        // 2) circle: 특정 조각(Safari) arc 중앙 강조
+        {
+          id: 'safari-circle',
+          type: 'circle',
+          position: { type: 'series', seriesId: 'safari' },
+          style: { radius: 30, borderColor: '#2563EB', backgroundColor: 'rgba(37,99,235,0.15)', borderWidth: 2 },
+        },
+        // 3) badge: 작은 조각(Edge)은 arc 중앙에서 connector로 바깥에 라벨 표시
+        {
+          id: 'edge-badge',
+          type: 'badge',
+          content: 'Edge',
+          position: { type: 'series', seriesId: 'edge', offsetX: -70, offsetY: 0 },
+          connector: { enabled: true, type: 'straight', style: { stroke: '#B24C4C', dashStyle: 'dash' } },
+        },
+        // 4) text: pixel(canvas 절대 좌표) 워터마크
+        {
+          id: 'watermark',
+          type: 'text',
+          content: 'pie demo',
+          position: { type: 'pixel', x: 450, y: 50 },
+          style: { color: '#9CA3AF', fontSize: '12px' },
+        },
+      ],
+    });
+
+    return { chartData, chartOptions };
+  },
+};
+</script>

--- a/docs/views/pieChart/props.js
+++ b/docs/views/pieChart/props.js
@@ -12,6 +12,8 @@ import ShowValue from './example/ShowValue';
 import ShowValueRaw from './example/ShowValue?raw';
 import Legend from './example/Legend';
 import LegendRaw from './example/Legend?raw';
+import Annotations from './example/Annotations';
+import AnnotationsRaw from './example/Annotations?raw';
 
 export default {
   mdText,
@@ -46,6 +48,13 @@ export default {
       description: 'Legend 영역에 Series Color, Name, Value 등을 표시할 수 있습니다.',
       component: Legend,
       parsedData: parse(LegendRaw).descriptor,
+    },
+    Annotations: {
+      description:
+        'annotations 옵션으로 파이 위에 어노테이션/뱃지를 표시합니다. series 위치 어노테이션은 조각(slice)의 '
+        + 'arc 중앙(각도 중간 지점)에 정렬됩니다. (파이는 x/y축이 없어 axis 위치는 미지원)',
+      component: Annotations,
+      parsedData: parse(AnnotationsRaw).descriptor,
     },
   },
 };

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -542,7 +542,7 @@ plotLines/plotBands(임계선·밴드)의 표시 순서(z-order) 전역 설정. 
 | location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스('start'/'end'는 데이터 있는 non-null 첫/마지막). 파이는 무시 |
 
 - **이 차트의 `series` 기준점**: 데이터 포인트 중심
-- **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정)
+- **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정). `xValue`와 `yValue`를 **모두** 지정해야 하며, 하나만 지정하면 표시되지 않습니다.
 - 기준점이 축 범위/줌 영역 밖이거나, 추적 `series`가 숨김 상태(`show: false`, 범례 토글 포함)이면 그리지 않습니다. `pixel`은 항상 표시됩니다.
 
 ##### annotation content

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -539,7 +539,7 @@ plotLines/plotBands(임계선·밴드)의 표시 순서(z-order) 전역 설정. 
 | xValue | axis | Number \| String | null | X축 값(linear=숫자, time=숫자/날짜문자열, step=라벨/인덱스) |
 | yValue | axis | Number \| String | null | Y축 값 |
 | seriesId | series | String | null | 추적할 시리즈 id |
-| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스. 파이는 무시 |
+| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스('start'/'end'는 데이터 있는 non-null 첫/마지막). 파이는 무시 |
 
 - **이 차트의 `series` 기준점**: 데이터 포인트 중심
 - **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정)

--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -92,6 +92,7 @@ const chartData =
   | axesY | Object | 없음 | Y축에 대한 속성 | [상세](#axesx-axesy) |
   | title | Object | ([상세](#title)) | 차트 상단에 위치할 차트 제목 표시 여부 및 속성 |  |
   | legend | Object | ([상세](#legend)) | 차트의 범례 표시 여부 및 속성 |  |
+  | annotations | Array | ([상세](#annotation)) | 차트 위에 표시할 어노테이션/뱃지 목록 | |
   | dragSelection | Object | ([상세](#dragselection)) | drag-select의 사용 여부 | |
   | padding | Object | { top: 20, right: 2, left: 2, bottom: 4 } | 차트 내부 padding 값 |
   | tooltip | Object | ([상세](#tooltip)) | 차트에 마우스를 올릴 경우 툴팁 표시 여부 및 속성 | |
@@ -502,3 +503,104 @@ plotLines/plotBands(임계선·밴드)의 표시 순서(z-order) 전역 설정. 
 
 - realTimeScatter 옵션을 사용할 때, 내부 데이터를 모두 초기화하고 싶을 때 사용.
 - realTimeScatterReset이 true가 되면 데이터를 모두 초기화하고 자동으로 false로 바뀜. 초기화하고 싶을 때마다 true로 바꿔주면 됩니다.
+
+#### annotation
+
+차트 위에 어노테이션/뱃지를 표시합니다. `options.annotations`에 **배열**로 지정하며, 배열 순서가 그리는 순서(z-order, 뒤 항목이 위)입니다. 어노테이션은 전용 레이어에 그려져 hover 하이라이트 위에 표시됩니다.
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류(예시) |
+|------|------|--------|------|-----------|
+| id | String | annotation-${index} | 식별/key 용도. 중복 시 콘솔 경고 | |
+| type | String | 'text' | 어노테이션 외형 종류 | 'text', 'badge', 'callout', 'circle' |
+| content | String \| Function | '' | 표시 텍스트(토큰/콜백 지원). circle은 무시 | [상세](#annotation-content) |
+| position | Object | ([상세](#annotation-position)) | 위치 지정 방식 | |
+| connector | Object | ([상세](#annotation-connector)) | 데이터 지점과 박스를 잇는 연결선(기본 비활성). callout은 무시 | |
+| style | Object | type별 기본값 | 외형/말풍선/도형 속성 | [상세](#annotation-style) |
+
+##### type 종류
+- `text` : 배경/테두리 없는 순수 텍스트(라벨)
+- `badge` : 배경 박스 + 라운딩을 가진 텍스트 뱃지
+- `callout` : 데이터 지점을 가리키는 꼬리가 달린 말풍선
+- `circle` : 텍스트 없는 강조용 원형 도형(`style.radius` 사용)
+
+##### annotation position
+
+위치 기준은 상호 배타적인 3가지 `type`으로 구분합니다.
+
+| 이름 | 적용 type | 타입 | 디폴트 | 설명 |
+|------|-----------|------|--------|------|
+| type | 공통 | String | 'pixel' | 'axis' \| 'pixel' \| 'series' |
+| offsetX | 공통 | Number | 0 | 기준점으로부터 X 오프셋(px) |
+| offsetY | 공통 | Number | 0 | 기준점으로부터 Y 오프셋(px) |
+| x | pixel | Number | 0 | canvas 좌상단(0,0) 기준 절대 X 좌표 |
+| y | pixel | Number | 0 | canvas 좌상단(0,0) 기준 절대 Y 좌표 |
+| xAxisIndex | axis | Number | 0 | 기준 X축 인덱스 |
+| yAxisIndex | axis | Number | 0 | 기준 Y축 인덱스 |
+| xValue | axis | Number \| String | null | X축 값(linear=숫자, time=숫자/날짜문자열, step=라벨/인덱스) |
+| yValue | axis | Number \| String | null | Y축 값 |
+| seriesId | series | String | null | 추적할 시리즈 id |
+| location | series | String \| Number | 'end' | 추적 위치. 'start' \| 'end' \| 데이터 인덱스. 파이는 무시 |
+
+- **이 차트의 `series` 기준점**: 데이터 포인트 중심
+- **`axis` 위치**: 지원 (linear/time/step 축 값으로 지정)
+- 기준점이 축 범위/줌 영역 밖이거나, 추적 `series`가 숨김 상태(`show: false`, 범례 토글 포함)이면 그리지 않습니다. `pixel`은 항상 표시됩니다.
+
+##### annotation content
+
+- 문자열: 그대로 표시
+- 토큰 치환: `{xValue}` `{yValue}` `{seriesId}` `{seriesName}` `{dataIndex}` `{percentage}` (알 수 없는 토큰은 원문 유지)
+- 콜백 `(ctx) => string` : `ctx = { xValue, yValue, seriesId, seriesName, dataIndex, percentage }` (`percentage`는 파이 전용, 그 외 null)
+- `\n` 으로 멀티라인 지원
+
+##### annotation connector
+
+데이터 지점과 어노테이션 박스의 가장 가까운 경계를 잇는 선입니다.
+
+| 이름 | 타입 | 디폴트 | 설명 | 종류 |
+|------|------|--------|------|------|
+| enabled | Boolean | false | 연결선 사용 여부 | |
+| type | String | 'straight' | 선 모양 | 'straight', 'elbow' |
+| style.stroke | String | '#9E9E9E' | 선 색상 | |
+| style.strokeWidth | Number | 1 | 선 두께 | |
+| style.dashStyle | String | 'solid' | 점선 스타일 | 'solid', 'dash', 'dot' |
+
+> `callout`은 꼬리가 connector 역할을 하므로 connector를 켜도 자동으로 비활성화됩니다.
+
+##### annotation style
+
+text/badge/callout 공통 텍스트 속성과 type별 전용 속성을 `style` 하나로 통합합니다.
+
+| 이름 | 타입 | 설명 | 적용 type |
+|------|------|------|-----------|
+| color | String | 글자 색 | text, badge, callout |
+| backgroundColor | String | 배경 색('transparent' 가능) | 전체 |
+| borderColor | String | 테두리 색 | 전체 |
+| borderWidth | Number | 테두리 두께 | 전체 |
+| borderRadius | Number | 모서리 둥글기 | text, badge, callout |
+| padding | Number \| Array | 안쪽 여백. n / [상하,좌우] / [상,우,하,좌] | text, badge, callout |
+| fontSize | String | 글자 크기(예: '11px') | text, badge, callout |
+| fontWeight | String | 글자 굵기 | text, badge, callout |
+| fontFamily | String | 글꼴 | text, badge, callout |
+| textAlign | String | 정렬 | text, badge, callout |
+| anchor | String | 꼬리 방향('auto'는 offset 방향으로 결정) | callout |
+| arrowSize | Number | 꼬리 크기 | callout |
+| radius | Number | 원 반지름 | circle |
+
+**type별 style 기본값**
+
+| 속성 | text | badge | callout | circle |
+|------|------|-------|---------|--------|
+| color | #212121 | #8B2323 | #212121 | - |
+| backgroundColor | transparent | #FDF0F0 | #FFFFFF | rgba(178,76,76,0.15) |
+| borderColor | transparent | #B24C4C | #B0B0B0 | #B24C4C |
+| borderWidth | 0 | 1 | 1 | 1 |
+| borderRadius | 0 | 6 | 4 | - |
+| padding | [0,0] | [6,10] | [4,8] | - |
+| fontSize | 11px | 11px | 11px | - |
+| fontWeight | normal | normal | normal | - |
+| textAlign | center | center | center | - |
+| anchor | - | - | auto | - |
+| arrowSize | - | - | 4 | - |
+| radius | - | - | - | 10 |
+
+> 실제 사용 예시는 상단의 **Annotations** 예제를 참고하세요.

--- a/docs/views/scatterChart/example/Annotations.vue
+++ b/docs/views/scatterChart/example/Annotations.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="case">
+    <resizable-wrapper>
+      <ev-chart :data="chartData" :options="chartOptions" />
+    </resizable-wrapper>
+  </div>
+</template>
+
+<script>
+import { reactive } from 'vue';
+
+export default {
+  setup() {
+    const chartData = reactive({
+      series: {
+        samples: { name: 'Samples', pointSize: 5 },
+      },
+      data: {
+        samples: [
+          { x: 10, y: 22 },
+          { x: 25, y: 38 },
+          { x: 40, y: 30 },
+          { x: 55, y: 64 },
+          { x: 70, y: 48 },
+          { x: 85, y: 80 },
+          { x: 95, y: 58 },
+          { x: 60, y: 18 },
+        ],
+      },
+    });
+
+    const peakIdx = 5; // { x: 85, y: 80 } 최댓값
+
+    const chartOptions = reactive({
+      type: 'scatter',
+      width: '100%',
+      height: '100%',
+      padding: { top: 40, right: 40, left: 10, bottom: 10 },
+      title: { text: 'Scatter Annotations', show: true },
+      legend: { show: false },
+      axesX: [{ type: 'linear', startToZero: true, showGrid: true }],
+      axesY: [{ type: 'linear', startToZero: true, showGrid: true }],
+      // ── series 위치 어노테이션이 포인트 '중심'에 정확히 붙는지 확인 ──
+      annotations: [
+        // 1) callout: 특정 포인트 추적(점 중심) + 콜백 content
+        {
+          id: 'peak-callout',
+          type: 'callout',
+          content: ctx => `Max (${ctx.xValue}, ${ctx.yValue})`,
+          position: { type: 'series', seriesId: 'samples', location: peakIdx, offsetY: -28 },
+          style: { backgroundColor: '#1F2937', color: '#FFFFFF', borderColor: '#1F2937' },
+        },
+        // 2) circle: 포인트 강조
+        {
+          id: 'mark-circle',
+          type: 'circle',
+          position: { type: 'series', seriesId: 'samples', location: 3 },
+          style: { radius: 12, borderColor: '#2563EB', backgroundColor: 'rgba(37,99,235,0.12)', borderWidth: 2 },
+        },
+        // 3) badge: axis(linear) 임계값 + connector(straight)
+        {
+          id: 'threshold-badge',
+          type: 'badge',
+          content: 'y = 60',
+          position: { type: 'axis', xValue: 30, yValue: 60, offsetY: -34 },
+          connector: { enabled: true, type: 'straight', style: { stroke: '#B24C4C', dashStyle: 'dash' } },
+        },
+        // 4) text: pixel(canvas 절대 좌표) 워터마크
+        {
+          id: 'watermark',
+          type: 'text',
+          content: 'scatter demo',
+          position: { type: 'pixel', x: 100, y: 60 },
+          style: { color: '#9CA3AF', fontSize: '12px' },
+        },
+      ],
+    });
+
+    return { chartData, chartOptions };
+  },
+};
+</script>

--- a/docs/views/scatterChart/props.js
+++ b/docs/views/scatterChart/props.js
@@ -16,6 +16,8 @@ import AxesScaleChange from './example/AxesScaleChange';
 import AxesScaleChangeRaw from './example/AxesScaleChange?raw';
 import TimeAxis from './example/TimeAxis';
 import TimeAxisRaw from './example/TimeAxis?raw';
+import Annotations from './example/Annotations';
+import AnnotationsRaw from './example/Annotations?raw';
 
 export default {
   mdText,
@@ -60,6 +62,13 @@ export default {
         '차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 확인할 수 있습니다.',
       component: AxesScaleChange,
       parsedData: parse(AxesScaleChangeRaw).descriptor,
+    },
+    Annotations: {
+      description:
+        'annotations 옵션으로 산점도 위에 어노테이션/뱃지를 표시합니다. series 위치 어노테이션은 포인트 '
+        + '중심에 정확히 정렬되며, axis(linear) 위치와 pixel 고정 라벨도 지원합니다.',
+      component: Annotations,
+      parsedData: parse(AnnotationsRaw).descriptor,
     },
   },
 };

--- a/src/components/chart/annotation/annotation.axis.js
+++ b/src/components/chart/annotation/annotation.axis.js
@@ -1,0 +1,113 @@
+import dayjs from 'dayjs';
+import Canvas from '../helpers/helpers.canvas';
+
+/**
+ * 축 디스크립터.
+ * @typedef {Object} AxisDescriptor
+ * @property {('linear'|'time'|'step'|'log')} [type] 축 타입(기본 linear)
+ * @property {number} graphMin 연속축의 표시 최소값(time: timestamp)
+ * @property {number} graphMax 연속축의 표시 최대값(time: timestamp)
+ * @property {number} [minIndex] step축의 가시 시작 인덱스
+ * @property {number} [maxIndex] step축의 가시 끝 인덱스
+ * @property {Array<string|number>} [labels] step축의 라벨 배열
+ */
+
+/**
+ * 어노테이션의 축 값(xValue/yValue)을 좌표 계산용 numeric 값으로 정규화한다.
+ *  - time : 문자열/Date 는 dayjs 로 timestamp(ms) 변환, number 는 그대로
+ *  - linear/log : Number() 강제, 비유한값은 null
+ *  - step : 여기서는 다루지 않음(slot-index 기반이라 stepValueToPixel 참조)
+ * @param {*} value
+ * @param {AxisDescriptor} axis
+ * @returns {number|null}
+ */
+export function normalizeAxisValue(value, axis) {
+  if (value == null) {
+    return null;
+  }
+  const type = axis?.type || 'linear';
+  if (type === 'time') {
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? value : null;
+    }
+    const t = dayjs(value).valueOf();
+    return Number.isFinite(t) ? t : null;
+  }
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * step(카테고리) 축에서 라벨/인덱스 값을 가시 인덱스로 환산한다.
+ *  - 라벨 문자열/숫자가 labels 에 있으면 그 인덱스
+ *  - labels 에 없고 정수면 raw 인덱스로 간주
+ * @param {*} value
+ * @param {Array<string|number>} labels
+ * @returns {number} 인덱스 (해석 불가 시 -1)
+ */
+export function resolveStepIndex(value, labels = []) {
+  const arr = Array.isArray(labels) ? labels : [];
+  const idx = arr.indexOf(value);
+  if (idx !== -1) {
+    return idx;
+  }
+  if (typeof value === 'number' && Number.isInteger(value)) {
+    return value;
+  }
+  return -1;
+}
+
+/**
+ * step 축 값 → 픽셀. 카테고리 슬롯의 "중심"에 배치한다(막대 차트 위 어노테이션 직관에 부합).
+ * 가시 윈도우([minIndex, maxIndex]) 밖이면 null(hide).
+ * @param {*} value
+ * @param {AxisDescriptor} axis
+ * @param {number} area 축 방향 길이(px)
+ * @param {number} startPoint 축 시작 픽셀(x: 좌측 경계, y: 하단 경계)
+ * @param {boolean} isX x축이면 true
+ * @returns {number|null}
+ */
+export function stepValueToPixel(value, axis, area, startPoint, isX) {
+  const labels = Array.isArray(axis.labels) ? axis.labels : [];
+  const minIndex = axis.minIndex ?? 0;
+  const maxIndex = axis.maxIndex ?? (labels.length - 1);
+  const steps = maxIndex - minIndex + 1;
+  if (steps <= 0) {
+    return null;
+  }
+  const idx = resolveStepIndex(value, labels);
+  if (idx < minIndex || idx > maxIndex) {
+    return null;
+  }
+  const slot = area / steps;
+  const along = slot * (idx - minIndex) + slot / 2;
+  // x 는 좌→우(+), y 는 하단 기준 상향(-)으로 진행한다.
+  return isX ? Math.round(startPoint + along) : Math.round(startPoint - along);
+}
+
+/**
+ * 축 타입을 인지하여 축 값을 픽셀 좌표로 변환한다. 범위 밖이면 null(hide 정책).
+ *  - step : 슬롯 중심 인덱스 매핑
+ *  - time/linear/log : 값 정규화 후 Canvas.calculateX/Y 재사용(시리즈 기하와 동일한 반올림/null 의미)
+ * @param {*} value
+ * @param {AxisDescriptor} axis
+ * @param {number} area
+ * @param {number} startPoint
+ * @param {boolean} isX
+ * @returns {number|null}
+ */
+export function axisValueToPixel(value, axis, area, startPoint, isX) {
+  if (!axis) {
+    return null;
+  }
+  if ((axis.type || 'linear') === 'step') {
+    return stepValueToPixel(value, axis, area, startPoint, isX);
+  }
+  const v = normalizeAxisValue(value, axis);
+  if (v === null) {
+    return null;
+  }
+  return isX
+    ? Canvas.calculateX(v, axis.graphMin, axis.graphMax, area, startPoint)
+    : Canvas.calculateY(v, axis.graphMin, axis.graphMax, area, startPoint);
+}

--- a/src/components/chart/annotation/annotation.axis.spec.js
+++ b/src/components/chart/annotation/annotation.axis.spec.js
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import dayjs from 'dayjs';
+import {
+  normalizeAxisValue,
+  resolveStepIndex,
+  stepValueToPixel,
+  axisValueToPixel,
+} from './annotation.axis';
+
+describe('annotation.axis', () => {
+  describe('normalizeAxisValue', () => {
+    it('linear coerces to number', () => {
+      expect(normalizeAxisValue('15000', { type: 'linear' })).toBe(15000);
+      expect(normalizeAxisValue(42, { type: 'linear' })).toBe(42);
+    });
+    it('linear rejects non-numeric', () => {
+      expect(normalizeAxisValue('abc', { type: 'linear' })).toBeNull();
+      expect(normalizeAxisValue(null, { type: 'linear' })).toBeNull();
+    });
+    it('time parses date string to timestamp', () => {
+      const expected = dayjs('2026-06-18').valueOf();
+      expect(normalizeAxisValue('2026-06-18', { type: 'time' })).toBe(expected);
+    });
+    it('time passes through numeric timestamp', () => {
+      expect(normalizeAxisValue(1718641200000, { type: 'time' })).toBe(1718641200000);
+    });
+    it('time rejects invalid date', () => {
+      expect(normalizeAxisValue('not-a-date', { type: 'time' })).toBeNull();
+    });
+  });
+
+  describe('resolveStepIndex', () => {
+    const labels = ['Q1', 'Q2', 'Q3', 'Q4'];
+    it('finds label index', () => {
+      expect(resolveStepIndex('Q2', labels)).toBe(1);
+    });
+    it('treats integer as raw index when not a label', () => {
+      expect(resolveStepIndex(2, labels)).toBe(2);
+    });
+    it('returns -1 for unknown', () => {
+      expect(resolveStepIndex('Q9', labels)).toBe(-1);
+    });
+    it('numeric labels matched by value', () => {
+      expect(resolveStepIndex(2020, [2018, 2019, 2020, 2021])).toBe(2);
+    });
+    it('tolerates non-array labels without throwing', () => {
+      expect(resolveStepIndex('Q2', undefined)).toBe(-1);
+      expect(resolveStepIndex('Q2', { x: [], y: [] })).toBe(-1);
+      expect(resolveStepIndex(1, { x: [] })).toBe(1); // 정수는 raw 인덱스로
+    });
+  });
+
+  describe('stepValueToPixel', () => {
+    // 4 categories over area 400 from startPoint 100 => slot 100, centers at 150,250,350,450
+    const axis = { type: 'step', labels: ['Q1', 'Q2', 'Q3', 'Q4'], minIndex: 0, maxIndex: 3 };
+    it('places category at slot center (x)', () => {
+      expect(stepValueToPixel('Q1', axis, 400, 100, true)).toBe(150);
+      expect(stepValueToPixel('Q2', axis, 400, 100, true)).toBe(250);
+      expect(stepValueToPixel('Q4', axis, 400, 100, true)).toBe(450);
+    });
+    it('y axis goes upward from bottom startPoint', () => {
+      // startPoint 500 (bottom), slot 100, Q1 center => 500 - 50 = 450
+      expect(stepValueToPixel('Q1', axis, 400, 500, false)).toBe(450);
+    });
+    it('hides when index outside visible window', () => {
+      const zoomed = { type: 'step', labels: ['Q1', 'Q2', 'Q3', 'Q4'], minIndex: 1, maxIndex: 2 };
+      expect(stepValueToPixel('Q1', zoomed, 400, 100, true)).toBeNull();
+      expect(stepValueToPixel('Q4', zoomed, 400, 100, true)).toBeNull();
+      expect(stepValueToPixel('Q2', zoomed, 400, 100, true)).not.toBeNull();
+    });
+    it('hides unknown label', () => {
+      expect(stepValueToPixel('Q9', axis, 400, 100, true)).toBeNull();
+    });
+  });
+
+  describe('axisValueToPixel', () => {
+    it('linear matches calculateX (value 50 over [0,100], area 300, start 100 => 250)', () => {
+      const axis = { type: 'linear', graphMin: 0, graphMax: 100 };
+      expect(axisValueToPixel(50, axis, 300, 100, true)).toBe(250);
+    });
+    it('linear out of range -> null', () => {
+      const axis = { type: 'linear', graphMin: 0, graphMax: 100 };
+      expect(axisValueToPixel(200, axis, 300, 100, true)).toBeNull();
+    });
+    it('time string maps within range', () => {
+      // 프로덕션과 동일하게 dayjs 로 경계 계산(시간대 일관성)
+      const min = dayjs('2026-06-01').valueOf();
+      const max = dayjs('2026-06-30').valueOf();
+      const axis = { type: 'time', graphMin: min, graphMax: max };
+      const px = axisValueToPixel('2026-06-01', axis, 290, 0, true);
+      expect(px).toBe(0); // at min
+      expect(axisValueToPixel('2026-07-15', axis, 290, 0, true)).toBeNull(); // beyond max
+    });
+    it('defaults to linear when type omitted (axesSteps fallback compat)', () => {
+      const axis = { graphMin: 0, graphMax: 100 };
+      expect(axisValueToPixel(50, axis, 300, 100, true)).toBe(250);
+    });
+    it('null axis -> null', () => {
+      expect(axisValueToPixel(1, null, 100, 0, true)).toBeNull();
+    });
+  });
+});

--- a/src/components/chart/annotation/annotation.constant.js
+++ b/src/components/chart/annotation/annotation.constant.js
@@ -1,0 +1,101 @@
+/**
+ * EvChart 어노테이션/뱃지 모듈 기본값(Default Config).
+ *
+ * 최상위 type(text/badge/callout/circle)별로 "그럴듯한" 외형을 미리 정의해 둔다.
+ * 개발자가 type/content/position 만 넘겨도 deepMerge 후 완성도 있는 결과가 나오도록 하는 것이 목표다.
+ *
+ * padding 은 정규화 단계에서 항상 [top, right, bottom, left] 4-튜플로 변환된다.
+ * 여기 정의된 [v, h] 2-튜플은 normalize 가 [v, h, v, h] 로 펼친다.
+ */
+
+export const ANNOTATION_TYPES = ['text', 'badge', 'callout', 'circle'];
+export const POSITION_TYPES = ['axis', 'pixel', 'series'];
+export const CONNECTOR_TYPES = ['straight', 'elbow'];
+export const CALLOUT_ANCHORS = ['top', 'bottom', 'left', 'right', 'auto'];
+
+/** position.type === 'series' 일 때 location 의 허용 키워드(number 는 별도 허용). */
+export const SERIES_LOCATIONS = ['start', 'end'];
+
+/** 모든 type 이 공유하는 position 기본값. */
+export const POSITION_DEFAULT = {
+  type: 'pixel',
+  // axis
+  xAxisIndex: 0,
+  yAxisIndex: 0,
+  xValue: null,
+  yValue: null,
+  // pixel (canvas 좌상단 0,0 기준 절대 좌표)
+  x: 0,
+  y: 0,
+  // series
+  seriesId: null,
+  location: 'end',
+  // 공통 오프셋
+  offsetX: 0,
+  offsetY: 0,
+};
+
+/** connector(연결선) 기본값. 기본 비활성. */
+export const CONNECTOR_DEFAULT = {
+  enabled: false,
+  type: 'straight',
+  style: {
+    stroke: '#9E9E9E',
+    strokeWidth: 1,
+    dashStyle: 'solid',
+  },
+};
+
+/** type 별 외형/스타일 기본값. style 하위로 모든 외형 속성을 대통합한다. */
+export const ANNOTATION_DEFAULT = {
+  text: {
+    style: {
+      color: '#212121',
+      backgroundColor: 'transparent',
+      borderColor: 'transparent',
+      borderWidth: 0,
+      borderRadius: 0,
+      padding: [0, 0],
+      fontSize: '11px',
+      fontWeight: 'normal',
+      textAlign: 'center',
+    },
+  },
+  badge: {
+    style: {
+      color: '#8B2323',
+      backgroundColor: '#FDF0F0',
+      borderColor: '#B24C4C',
+      borderWidth: 1,
+      borderRadius: 6,
+      padding: [6, 10],
+      fontSize: '11px',
+      fontWeight: 'normal',
+      textAlign: 'center',
+    },
+  },
+  callout: {
+    // maxTip 말풍선과 동일한 외형: 작은 라운딩(4) + 짧고 통통한 꼬리(4) + 컴팩트 패딩.
+    style: {
+      anchor: 'auto',
+      arrowSize: 4,
+      color: '#212121',
+      backgroundColor: '#FFFFFF',
+      borderColor: '#B0B0B0',
+      borderWidth: 1,
+      borderRadius: 4,
+      padding: [4, 8],
+      fontSize: '11px',
+      fontWeight: 'normal',
+      textAlign: 'center',
+    },
+  },
+  circle: {
+    style: {
+      radius: 10,
+      backgroundColor: 'rgba(178, 76, 76, 0.15)',
+      borderColor: '#B24C4C',
+      borderWidth: 1,
+    },
+  },
+};

--- a/src/components/chart/annotation/annotation.draw.js
+++ b/src/components/chart/annotation/annotation.draw.js
@@ -1,0 +1,39 @@
+/* eslint-disable import/prefer-default-export */
+import { Console } from '@/common/utils';
+import Util from '../helpers/helpers.util';
+import { resolveAnchor, buildContentContext, resolveContent } from './annotation.resolver';
+import { computeLayout } from './annotation.layout';
+import { renderAnnotation } from './annotation.renderer';
+
+/**
+ * 정규화된 어노테이션 배열을 캔버스에 그린다(resolve → layout → render 파이프라인).
+ * 매 프레임 호출되므로 normalize 는 호출하지 않는다(옵션 변경 시 1회 정규화한 결과를 받는다).
+ *
+ * @param {object} ctx canvas 2d context (보통 series overlay/ buffer ctx)
+ * @param {object[]} annotations normalizeAnnotations 로 정규화된 배열
+ * @param {object} viewportCtx resolveAnchor 의 ctx — { chartRect, labelOffset, axes|axesSteps, seriesList }
+ * @param {object} [plotBounds] { x1, y1, x2, y2 } 박스 overflow 판정용(선택)
+ * @param {Function} [measureFn] 텍스트 측정 함수(테스트 주입용, 기본 Util.calcTextSizeCanvas)
+ */
+export function drawAnnotations(ctx, annotations, viewportCtx, plotBounds, measureFn = Util.calcTextSizeCanvas) {
+  if (!ctx || !Array.isArray(annotations) || !annotations.length) {
+    return;
+  }
+
+  // 입력 순서 = z-order(나중 항목이 위). 충돌 회피는 v1 범위 밖.
+  annotations.forEach((ann) => {
+    // 항목별 격리: 어노테이션 하나가 throw 해도 나머지·차트 렌더는 정상 진행한다.
+    try {
+      const anchor = resolveAnchor(ann, viewportCtx);
+      if (!anchor.isVisible) {
+        return; // 기준점이 viewport 밖 → 숨김(hide 정책)
+      }
+      const evalCtx = buildContentContext(ann, viewportCtx);
+      const contentStr = ann.type === 'circle' ? '' : resolveContent(ann.content, evalCtx);
+      const layout = computeLayout(ann, anchor, contentStr, plotBounds, measureFn);
+      renderAnnotation(ctx, ann, layout, anchor);
+    } catch (e) {
+      Console.warn(`[EvChart] annotation render failed (id: ${ann && ann.id}):`, e);
+    }
+  });
+}

--- a/src/components/chart/annotation/annotation.draw.js
+++ b/src/components/chart/annotation/annotation.draw.js
@@ -12,10 +12,9 @@ import { renderAnnotation } from './annotation.renderer';
  * @param {object} ctx canvas 2d context (보통 series overlay/ buffer ctx)
  * @param {object[]} annotations normalizeAnnotations 로 정규화된 배열
  * @param {object} viewportCtx resolveAnchor 의 ctx — { chartRect, labelOffset, axes|axesSteps, seriesList }
- * @param {object} [plotBounds] { x1, y1, x2, y2 } 박스 overflow 판정용(선택)
  * @param {Function} [measureFn] 텍스트 측정 함수(테스트 주입용, 기본 Util.calcTextSizeCanvas)
  */
-export function drawAnnotations(ctx, annotations, viewportCtx, plotBounds, measureFn = Util.calcTextSizeCanvas) {
+export function drawAnnotations(ctx, annotations, viewportCtx, measureFn = Util.calcTextSizeCanvas) {
   if (!ctx || !Array.isArray(annotations) || !annotations.length) {
     return;
   }
@@ -30,7 +29,7 @@ export function drawAnnotations(ctx, annotations, viewportCtx, plotBounds, measu
       }
       const evalCtx = buildContentContext(ann, viewportCtx);
       const contentStr = ann.type === 'circle' ? '' : resolveContent(ann.content, evalCtx);
-      const layout = computeLayout(ann, anchor, contentStr, plotBounds, measureFn);
+      const layout = computeLayout(ann, anchor, contentStr, measureFn);
       renderAnnotation(ctx, ann, layout, anchor);
     } catch (e) {
       Console.warn(`[EvChart] annotation render failed (id: ${ann && ann.id}):`, e);

--- a/src/components/chart/annotation/annotation.layout.js
+++ b/src/components/chart/annotation/annotation.layout.js
@@ -1,0 +1,194 @@
+import Util from '../helpers/helpers.util';
+
+/**
+ * style 로부터 canvas/DOM 공용 CSS font shorthand 문자열을 만든다.
+ * 예: { fontWeight:'bold', fontSize:'11px', fontFamily:'Roboto' } -> "bold 11px Roboto"
+ * @param {object} style 정규화된 style
+ * @returns {string} CSS font shorthand
+ */
+export function buildFontStyle(style = {}) {
+  const weight = style.fontWeight || 'normal';
+  const size = typeof style.fontSize === 'number' ? `${style.fontSize}px` : style.fontSize || '11px';
+  const family = style.fontFamily || 'sans-serif';
+  return `${weight} ${size} ${family}`;
+}
+
+/**
+ * 멀티라인 텍스트를 측정한다. measureFn 을 주입받아 캔버스 없이 테스트 가능.
+ * @param {string} text       해석된 content 문자열 (\n 으로 줄 구분)
+ * @param {string} fontStyle  CSS font shorthand
+ * @param {(t:string, f:string)=>{width:number,height:number}} measureFn
+ * @returns {{ lines: {text:string,width:number}[], width:number, height:number, lineHeight:number }}
+ */
+export function measureContent(text, fontStyle, measureFn = Util.calcTextSizeCanvas) {
+  const raw = text == null ? '' : String(text);
+  const lineStrs = raw.split('\n');
+  let width = 0;
+  let lineHeight = 0;
+  const lines = lineStrs.map((t) => {
+    const m = measureFn(t, fontStyle);
+    width = Math.max(width, m.width);
+    lineHeight = Math.max(lineHeight, m.height);
+    return { text: t, width: m.width };
+  });
+  return { lines, width, height: lineHeight * lines.length, lineHeight };
+}
+
+/**
+ * type 별 박스 크기(content + padding)를 계산한다. circle 은 박스 대신 shape 로 처리.
+ * border 두께는 footprint 에 포함하지 않는다(draw 시 경계에 걸쳐 그림).
+ * @param {object} annotation 정규화된 어노테이션
+ * @param {string} contentStr 해석된 content
+ * @param {Function} measureFn 측정 함수
+ * @returns {{ w:number, h:number, content:object|null }}
+ */
+export function computeBoxSize(annotation, contentStr, measureFn = Util.calcTextSizeCanvas) {
+  const { type, style } = annotation;
+  if (type === 'circle') {
+    const r = style.radius || 0;
+    return { w: r * 2, h: r * 2, content: null };
+  }
+  const fontStyle = buildFontStyle(style);
+  // 측정 캐시: 텍스트 크기는 (content, fontStyle)에만 의존하므로 동일하면 재측정하지 않는다.
+  // 좌표(anchor/offset)는 매 프레임 다시 계산되므로 live/realtime 추적은 그대로 동작한다.
+  // 캐시는 정규화된 annotation 객체에 붙으며, 옵션 배열이 교체되면 새 객체와 함께 폐기된다.
+  const cacheKey = `${fontStyle}|${contentStr}`;
+  let content;
+  if (annotation._measure && annotation._measure.key === cacheKey) {
+    content = annotation._measure.value;
+  } else {
+    content = measureContent(contentStr, fontStyle, measureFn);
+    annotation._measure = { key: cacheKey, value: content };
+  }
+  const [pt, pr, pb, pl] = style.padding || [0, 0, 0, 0];
+  return {
+    w: content.width + pl + pr,
+    h: content.height + pt + pb,
+    content,
+  };
+}
+
+/**
+ * callout 꼬리의 방향(side)을 결정한다.
+ *  - anchor !== 'auto' : 그대로 사용
+ *  - anchor === 'auto' : 박스 중심에서 데이터 포인트(tip)로 향하는 방향(=offset 방향).
+ *    offset 은 줌과 무관한 고정값이므로 줌 시 꼬리가 깜빡이지 않는다(결정론적).
+ *    offset 이 0,0 이면 'bottom' 기본.
+ * @returns {('top'|'bottom'|'left'|'right')}
+ */
+export function resolveCalloutSide(requestedAnchor, boxCenter, tip) {
+  if (requestedAnchor && requestedAnchor !== 'auto') {
+    return requestedAnchor;
+  }
+  const dx = tip.x - boxCenter.x;
+  const dy = tip.y - boxCenter.y;
+  if (dx === 0 && dy === 0) {
+    return 'bottom';
+  }
+  if (Math.abs(dy) >= Math.abs(dx)) {
+    return dy >= 0 ? 'bottom' : 'top';
+  }
+  return dx >= 0 ? 'right' : 'left';
+}
+
+/**
+ * callout 꼬리 삼각형 기하를 계산한다.
+ * tip(꼭짓점)은 데이터 포인트, base 두 점은 박스의 side 변 위에 있다.
+ * @param {object} box  { x, y, w, h } 박스 top-left + 크기
+ * @param {object} tip  { x, y } 데이터 포인트(=anchorX/anchorY)
+ * @param {string} side 'top'|'bottom'|'left'|'right'
+ * @param {number} arrowSize 꼬리 반폭
+ * @returns {{ side, tipX, tipY, baseAX, baseAY, baseBX, baseBY }}
+ */
+export function computeTail(box, tip, side, arrowSize) {
+  const a = Math.max(arrowSize, 1);
+  let edgeFixed;
+  let baseCenter;
+  if (side === 'bottom' || side === 'top') {
+    edgeFixed = side === 'bottom' ? box.y + box.h : box.y;
+    // 꼬리 밑변이 박스 가로 변을 벗어나지 않도록 clamp
+    baseCenter = Math.min(Math.max(tip.x, box.x + a), box.x + box.w - a);
+    return {
+      side,
+      tipX: tip.x,
+      tipY: tip.y,
+      baseAX: baseCenter - a,
+      baseAY: edgeFixed,
+      baseBX: baseCenter + a,
+      baseBY: edgeFixed,
+    };
+  }
+  edgeFixed = side === 'right' ? box.x + box.w : box.x;
+  baseCenter = Math.min(Math.max(tip.y, box.y + a), box.y + box.h - a);
+  return {
+    side,
+    tipX: tip.x,
+    tipY: tip.y,
+    baseAX: edgeFixed,
+    baseAY: baseCenter - a,
+    baseBX: edgeFixed,
+    baseBY: baseCenter + a,
+  };
+}
+
+/**
+ * 박스가 plot 경계를 벗어나는지 방향별 플래그를 계산한다.
+ * @param {object} box { x, y, w, h }
+ * @param {object} [plotBounds] { x1, y1, x2, y2 }
+ * @returns {{ left:boolean, right:boolean, top:boolean, bottom:boolean, any:boolean }}
+ */
+export function computeOverflow(box, plotBounds) {
+  const none = { left: false, right: false, top: false, bottom: false, any: false };
+  if (!plotBounds) {
+    return none;
+  }
+  const left = box.x < plotBounds.x1;
+  const right = box.x + box.w > plotBounds.x2;
+  const top = box.y < plotBounds.y1;
+  const bottom = box.y + box.h > plotBounds.y2;
+  return { left, right, top, bottom, any: left || right || top || bottom };
+}
+
+/**
+ * 해석된 anchor + 박스 크기로 최종 렌더 레이아웃을 만든다. 순수 함수.
+ * 박스는 anchor(offset 적용 좌표)에 중심 정렬한다.
+ *  - text/badge : box 만
+ *  - callout    : box + tail(데이터 포인트 anchorX/anchorY 를 가리킴)
+ *  - circle     : shape(cx,cy,r)
+ * plotBounds 가 주어지면 박스가 plot 영역을 벗어나는지 overflow 플래그를 계산한다(자르기/넛지는 렌더 단계 책임).
+ *
+ * @param {object} annotation 정규화된 어노테이션
+ * @param {object} anchor resolveAnchor 결과 { x, y, anchorX, anchorY, isVisible }
+ * @param {string} contentStr 해석된 content
+ * @param {object} [plotBounds] { x1, y1, x2, y2 }
+ * @param {Function} [measureFn]
+ * @returns {object} 레이아웃 { type, box, content, shape, tail, overflow }
+ */
+export function computeLayout(annotation, anchor, contentStr, plotBounds, measureFn = Util.calcTextSizeCanvas) {
+  const { type, style } = annotation;
+  const size = computeBoxSize(annotation, contentStr, measureFn);
+
+  if (type === 'circle') {
+    const r = style.radius || 0;
+    const shape = { cx: anchor.x, cy: anchor.y, r };
+    const box = { x: anchor.x - r, y: anchor.y - r, w: r * 2, h: r * 2 };
+    return { type, box, shape, content: null, tail: null, overflow: computeOverflow(box, plotBounds) };
+  }
+
+  const box = {
+    x: Math.round(anchor.x - size.w / 2),
+    y: Math.round(anchor.y - size.h / 2),
+    w: size.w,
+    h: size.h,
+  };
+
+  let tail = null;
+  if (type === 'callout') {
+    const boxCenter = { x: box.x + box.w / 2, y: box.y + box.h / 2 };
+    const tip = { x: anchor.anchorX, y: anchor.anchorY };
+    const side = resolveCalloutSide(style.anchor, boxCenter, tip);
+    tail = computeTail(box, tip, side, style.arrowSize || 8);
+  }
+
+  return { type, box, content: size.content, shape: null, tail, overflow: computeOverflow(box, plotBounds) };
+}

--- a/src/components/chart/annotation/annotation.layout.js
+++ b/src/components/chart/annotation/annotation.layout.js
@@ -132,39 +132,19 @@ export function computeTail(box, tip, side, arrowSize) {
 }
 
 /**
- * 박스가 plot 경계를 벗어나는지 방향별 플래그를 계산한다.
- * @param {object} box { x, y, w, h }
- * @param {object} [plotBounds] { x1, y1, x2, y2 }
- * @returns {{ left:boolean, right:boolean, top:boolean, bottom:boolean, any:boolean }}
- */
-export function computeOverflow(box, plotBounds) {
-  const none = { left: false, right: false, top: false, bottom: false, any: false };
-  if (!plotBounds) {
-    return none;
-  }
-  const left = box.x < plotBounds.x1;
-  const right = box.x + box.w > plotBounds.x2;
-  const top = box.y < plotBounds.y1;
-  const bottom = box.y + box.h > plotBounds.y2;
-  return { left, right, top, bottom, any: left || right || top || bottom };
-}
-
-/**
  * 해석된 anchor + 박스 크기로 최종 렌더 레이아웃을 만든다. 순수 함수.
  * 박스는 anchor(offset 적용 좌표)에 중심 정렬한다.
  *  - text/badge : box 만
  *  - callout    : box + tail(데이터 포인트 anchorX/anchorY 를 가리킴)
  *  - circle     : shape(cx,cy,r)
- * plotBounds 가 주어지면 박스가 plot 영역을 벗어나는지 overflow 플래그를 계산한다(자르기/넛지는 렌더 단계 책임).
  *
  * @param {object} annotation 정규화된 어노테이션
  * @param {object} anchor resolveAnchor 결과 { x, y, anchorX, anchorY, isVisible }
  * @param {string} contentStr 해석된 content
- * @param {object} [plotBounds] { x1, y1, x2, y2 }
  * @param {Function} [measureFn]
- * @returns {object} 레이아웃 { type, box, content, shape, tail, overflow }
+ * @returns {object} 레이아웃 { type, box, content, shape, tail }
  */
-export function computeLayout(annotation, anchor, contentStr, plotBounds, measureFn = Util.calcTextSizeCanvas) {
+export function computeLayout(annotation, anchor, contentStr, measureFn = Util.calcTextSizeCanvas) {
   const { type, style } = annotation;
   const size = computeBoxSize(annotation, contentStr, measureFn);
 
@@ -172,7 +152,7 @@ export function computeLayout(annotation, anchor, contentStr, plotBounds, measur
     const r = style.radius || 0;
     const shape = { cx: anchor.x, cy: anchor.y, r };
     const box = { x: anchor.x - r, y: anchor.y - r, w: r * 2, h: r * 2 };
-    return { type, box, shape, content: null, tail: null, overflow: computeOverflow(box, plotBounds) };
+    return { type, box, shape, content: null, tail: null };
   }
 
   const box = {
@@ -190,5 +170,5 @@ export function computeLayout(annotation, anchor, contentStr, plotBounds, measur
     tail = computeTail(box, tip, side, style.arrowSize || 8);
   }
 
-  return { type, box, content: size.content, shape: null, tail, overflow: computeOverflow(box, plotBounds) };
+  return { type, box, content: size.content, shape: null, tail };
 }

--- a/src/components/chart/annotation/annotation.layout.spec.js
+++ b/src/components/chart/annotation/annotation.layout.spec.js
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildFontStyle,
+  measureContent,
+  computeBoxSize,
+  resolveCalloutSide,
+  computeTail,
+  computeLayout,
+  computeOverflow,
+} from './annotation.layout';
+
+// 결정론적 측정기: 글자당 폭 10, 줄 높이 12
+const fakeMeasure = t => ({ width: (t ? t.length : 0) * 10, height: 12 });
+
+describe('annotation.layout', () => {
+  describe('buildFontStyle', () => {
+    it('builds CSS font shorthand', () => {
+      expect(buildFontStyle({ fontWeight: 'bold', fontSize: '11px', fontFamily: 'Roboto' }))
+        .toBe('bold 11px Roboto');
+    });
+    it('numeric fontSize -> px, defaults', () => {
+      expect(buildFontStyle({ fontSize: 12 })).toBe('normal 12px sans-serif');
+      expect(buildFontStyle()).toBe('normal 11px sans-serif');
+    });
+  });
+
+  describe('measureContent', () => {
+    it('single line', () => {
+      const r = measureContent('abc', 'x', fakeMeasure);
+      expect(r).toMatchObject({ width: 30, height: 12, lineHeight: 12 });
+      expect(r.lines).toHaveLength(1);
+    });
+    it('multiline takes max width, sums height', () => {
+      const r = measureContent('a\nabcd', 'x', fakeMeasure);
+      expect(r.width).toBe(40); // max(10, 40)
+      expect(r.height).toBe(24); // 2 lines * 12
+      expect(r.lines).toHaveLength(2);
+    });
+  });
+
+  describe('computeBoxSize', () => {
+    it('badge adds padding', () => {
+      const ann = { type: 'badge', style: { padding: [6, 10, 6, 10] } };
+      const s = computeBoxSize(ann, 'ab', fakeMeasure);
+      expect(s.w).toBe(20 + 20); // content 20 + pl/pr 10+10
+      expect(s.h).toBe(12 + 12); // content 12 + pt/pb 6+6
+    });
+    it('text has no padding by default', () => {
+      const ann = { type: 'text', style: { padding: [0, 0, 0, 0] } };
+      const s = computeBoxSize(ann, 'abc', fakeMeasure);
+      expect(s).toMatchObject({ w: 30, h: 12 });
+    });
+    it('circle uses radius', () => {
+      const ann = { type: 'circle', style: { radius: 8 } };
+      expect(computeBoxSize(ann, '', fakeMeasure)).toMatchObject({ w: 16, h: 16, content: null });
+    });
+    it('caches measurement by (content, fontStyle); re-measures when content changes', () => {
+      let calls = 0;
+      const counting = (t) => { calls += 1; return { width: (t ? t.length : 0) * 10, height: 12 }; };
+      const ann = { type: 'badge', style: { padding: [0, 0, 0, 0], fontSize: '11px' } };
+      computeBoxSize(ann, 'ab', counting); // 측정 1회
+      computeBoxSize(ann, 'ab', counting); // 동일 → 캐시 사용(추가 측정 없음)
+      expect(calls).toBe(1);
+      computeBoxSize(ann, 'abc', counting); // 내용 변경 → 재측정
+      expect(calls).toBe(2);
+    });
+  });
+
+  describe('resolveCalloutSide', () => {
+    const center = { x: 100, y: 100 };
+    it('explicit anchor wins', () => {
+      expect(resolveCalloutSide('left', center, { x: 200, y: 100 })).toBe('left');
+    });
+    it('auto: tip below -> bottom', () => {
+      expect(resolveCalloutSide('auto', center, { x: 100, y: 200 })).toBe('bottom');
+    });
+    it('auto: tip above -> top', () => {
+      expect(resolveCalloutSide('auto', center, { x: 100, y: 10 })).toBe('top');
+    });
+    it('auto: tip right -> right', () => {
+      expect(resolveCalloutSide('auto', center, { x: 300, y: 110 })).toBe('right');
+    });
+    it('auto: coincident -> bottom', () => {
+      expect(resolveCalloutSide('auto', center, { x: 100, y: 100 })).toBe('bottom');
+    });
+  });
+
+  describe('computeTail', () => {
+    const box = { x: 100, y: 100, w: 80, h: 40 };
+    it('bottom side base sits on bottom edge, tip at data point', () => {
+      const t = computeTail(box, { x: 140, y: 200 }, 'bottom', 8);
+      expect(t).toMatchObject({ side: 'bottom', tipX: 140, tipY: 200, baseAY: 140, baseBY: 140 });
+      expect(t.baseAX).toBe(132); // 140 - 8
+      expect(t.baseBX).toBe(148);
+    });
+    it('clamps base center within edge', () => {
+      const t = computeTail(box, { x: 1000, y: 200 }, 'bottom', 8);
+      // baseCenter clamped to box.x + w - a = 172
+      expect(t.baseBX).toBe(180);
+      expect(t.baseAX).toBe(164);
+    });
+    it('right side base on right edge', () => {
+      const t = computeTail(box, { x: 300, y: 120 }, 'right', 8);
+      expect(t).toMatchObject({ side: 'right', baseAX: 180, baseBX: 180 });
+    });
+  });
+
+  describe('computeLayout', () => {
+    it('badge centers box on anchor', () => {
+      const ann = { type: 'badge', style: { padding: [0, 0, 0, 0] } };
+      const anchor = { x: 100, y: 100, anchorX: 100, anchorY: 100 };
+      const l = computeLayout(ann, anchor, 'ab', null, fakeMeasure);
+      // size 20x12, centered
+      expect(l.box).toMatchObject({ x: 90, y: 94, w: 20, h: 12 });
+      expect(l.tail).toBeNull();
+    });
+
+    it('callout tail points to pre-offset data point', () => {
+      const ann = { type: 'callout', style: { padding: [0, 0, 0, 0], anchor: 'auto', arrowSize: 8 } };
+      // box centered at offset target (100,70); data point at (100,100) below -> side bottom
+      const anchor = { x: 100, y: 70, anchorX: 100, anchorY: 100 };
+      const l = computeLayout(ann, anchor, 'ab', null, fakeMeasure);
+      expect(l.tail.side).toBe('bottom');
+      expect(l.tail).toMatchObject({ tipX: 100, tipY: 100 });
+    });
+
+    it('circle returns shape', () => {
+      const ann = { type: 'circle', style: { radius: 10 } };
+      const anchor = { x: 50, y: 50, anchorX: 50, anchorY: 50 };
+      const l = computeLayout(ann, anchor, '', null, fakeMeasure);
+      expect(l.shape).toMatchObject({ cx: 50, cy: 50, r: 10 });
+      expect(l.box).toMatchObject({ x: 40, y: 40, w: 20, h: 20 });
+    });
+  });
+
+  describe('computeOverflow', () => {
+    const bounds = { x1: 0, y1: 0, x2: 200, y2: 200 };
+    it('no bounds -> none', () => {
+      expect(computeOverflow({ x: -10, y: 0, w: 10, h: 10 }, null).any).toBe(false);
+    });
+    it('detects left/top overflow', () => {
+      const o = computeOverflow({ x: -5, y: -5, w: 10, h: 10 }, bounds);
+      expect(o).toMatchObject({ left: true, top: true, any: true });
+    });
+    it('detects right/bottom overflow', () => {
+      const o = computeOverflow({ x: 195, y: 195, w: 20, h: 20 }, bounds);
+      expect(o).toMatchObject({ right: true, bottom: true, any: true });
+    });
+    it('inside -> none', () => {
+      expect(computeOverflow({ x: 50, y: 50, w: 10, h: 10 }, bounds).any).toBe(false);
+    });
+  });
+});

--- a/src/components/chart/annotation/annotation.layout.spec.js
+++ b/src/components/chart/annotation/annotation.layout.spec.js
@@ -6,7 +6,6 @@ import {
   resolveCalloutSide,
   computeTail,
   computeLayout,
-  computeOverflow,
 } from './annotation.layout';
 
 // 결정론적 측정기: 글자당 폭 10, 줄 높이 12
@@ -109,7 +108,7 @@ describe('annotation.layout', () => {
     it('badge centers box on anchor', () => {
       const ann = { type: 'badge', style: { padding: [0, 0, 0, 0] } };
       const anchor = { x: 100, y: 100, anchorX: 100, anchorY: 100 };
-      const l = computeLayout(ann, anchor, 'ab', null, fakeMeasure);
+      const l = computeLayout(ann, anchor, 'ab', fakeMeasure);
       // size 20x12, centered
       expect(l.box).toMatchObject({ x: 90, y: 94, w: 20, h: 12 });
       expect(l.tail).toBeNull();
@@ -119,7 +118,7 @@ describe('annotation.layout', () => {
       const ann = { type: 'callout', style: { padding: [0, 0, 0, 0], anchor: 'auto', arrowSize: 8 } };
       // box centered at offset target (100,70); data point at (100,100) below -> side bottom
       const anchor = { x: 100, y: 70, anchorX: 100, anchorY: 100 };
-      const l = computeLayout(ann, anchor, 'ab', null, fakeMeasure);
+      const l = computeLayout(ann, anchor, 'ab', fakeMeasure);
       expect(l.tail.side).toBe('bottom');
       expect(l.tail).toMatchObject({ tipX: 100, tipY: 100 });
     });
@@ -127,27 +126,9 @@ describe('annotation.layout', () => {
     it('circle returns shape', () => {
       const ann = { type: 'circle', style: { radius: 10 } };
       const anchor = { x: 50, y: 50, anchorX: 50, anchorY: 50 };
-      const l = computeLayout(ann, anchor, '', null, fakeMeasure);
+      const l = computeLayout(ann, anchor, '', fakeMeasure);
       expect(l.shape).toMatchObject({ cx: 50, cy: 50, r: 10 });
       expect(l.box).toMatchObject({ x: 40, y: 40, w: 20, h: 20 });
-    });
-  });
-
-  describe('computeOverflow', () => {
-    const bounds = { x1: 0, y1: 0, x2: 200, y2: 200 };
-    it('no bounds -> none', () => {
-      expect(computeOverflow({ x: -10, y: 0, w: 10, h: 10 }, null).any).toBe(false);
-    });
-    it('detects left/top overflow', () => {
-      const o = computeOverflow({ x: -5, y: -5, w: 10, h: 10 }, bounds);
-      expect(o).toMatchObject({ left: true, top: true, any: true });
-    });
-    it('detects right/bottom overflow', () => {
-      const o = computeOverflow({ x: 195, y: 195, w: 20, h: 20 }, bounds);
-      expect(o).toMatchObject({ right: true, bottom: true, any: true });
-    });
-    it('inside -> none', () => {
-      expect(computeOverflow({ x: 50, y: 50, w: 10, h: 10 }, bounds).any).toBe(false);
     });
   });
 });

--- a/src/components/chart/annotation/annotation.normalize.js
+++ b/src/components/chart/annotation/annotation.normalize.js
@@ -1,0 +1,149 @@
+import { cloneDeep, defaultsDeep, isFunction } from 'lodash-es';
+import {
+  ANNOTATION_TYPES,
+  POSITION_TYPES,
+  CONNECTOR_TYPES,
+  CALLOUT_ANCHORS,
+  SERIES_LOCATIONS,
+  ANNOTATION_DEFAULT,
+  POSITION_DEFAULT,
+  CONNECTOR_DEFAULT,
+} from './annotation.constant';
+
+/**
+ * padding 입력을 내부 표준인 [top, right, bottom, left] 4-튜플로 정규화한다.
+ *  - number n        -> [n, n, n, n]
+ *  - [v, h]          -> [v, h, v, h]
+ *  - [t, r, b, l]    -> 그대로
+ *  - 그 외/누락       -> [0, 0, 0, 0]
+ * @param {number|number[]} padding
+ * @returns {number[]} [top, right, bottom, left]
+ */
+export function normalizePadding(padding) {
+  if (typeof padding === 'number' && Number.isFinite(padding)) {
+    return [padding, padding, padding, padding];
+  }
+  if (Array.isArray(padding)) {
+    const nums = padding.map(p => (Number.isFinite(p) ? p : 0));
+    if (nums.length === 2) {
+      return [nums[0], nums[1], nums[0], nums[1]];
+    }
+    if (nums.length >= 4) {
+      return [nums[0], nums[1], nums[2], nums[3]];
+    }
+    if (nums.length === 1) {
+      return [nums[0], nums[0], nums[0], nums[0]];
+    }
+  }
+  return [0, 0, 0, 0];
+}
+
+/**
+ * position.type 별 필수 필드 검증. 누락 시 경고 메시지를 push 한다(throw 하지 않음).
+ * @param {object} position 정규화된 position
+ * @param {string} id       어노테이션 id (경고 메시지용)
+ * @param {string[]} warnings 경고 누적 배열
+ */
+function validatePosition(position, id, warnings) {
+  if (!POSITION_TYPES.includes(position.type)) {
+    warnings.push(`[annotation:${id}] unknown position.type "${position.type}" — fallback to "pixel".`);
+    position.type = 'pixel';
+  }
+
+  if (position.type === 'axis') {
+    if (position.xValue == null && position.yValue == null) {
+      warnings.push(`[annotation:${id}] position.type "axis" requires xValue and/or yValue.`);
+    }
+  } else if (position.type === 'series') {
+    if (position.seriesId == null) {
+      warnings.push(`[annotation:${id}] position.type "series" requires seriesId.`);
+    }
+    const loc = position.location;
+    const validLoc = SERIES_LOCATIONS.includes(loc) || (typeof loc === 'number' && Number.isInteger(loc));
+    if (!validLoc) {
+      warnings.push(`[annotation:${id}] invalid location "${loc}" — fallback to "end".`);
+      position.location = 'end';
+    }
+  }
+}
+
+/**
+ * 단일 어노테이션을 정규화한다.
+ * @param {object} raw   사용자가 넘긴 raw 어노테이션
+ * @param {number} index 배열 내 인덱스 (id 자동 생성용)
+ * @param {string[]} warnings 경고 누적 배열
+ * @returns {object} 내부 표준 어노테이션 모델
+ */
+function normalizeOne(raw, index, warnings) {
+  const id = raw.id != null ? String(raw.id) : `annotation-${index}`;
+
+  let type = raw.type;
+  if (!ANNOTATION_TYPES.includes(type)) {
+    warnings.push(`[annotation:${id}] unknown type "${type}" — fallback to "text".`);
+    type = 'text';
+  }
+
+  // 1) style: type 별 Default Config 와 deepMerge
+  const style = defaultsDeep({}, cloneDeep(raw.style) || {}, ANNOTATION_DEFAULT[type].style);
+  if ('padding' in style) {
+    style.padding = normalizePadding(style.padding);
+  }
+  if (type === 'callout' && !CALLOUT_ANCHORS.includes(style.anchor)) {
+    warnings.push(`[annotation:${id}] invalid style.anchor "${style.anchor}" — fallback to "auto".`);
+    style.anchor = 'auto';
+  }
+
+  // 2) position: 기본값 병합 + 검증
+  const position = defaultsDeep({}, cloneDeep(raw.position) || {}, POSITION_DEFAULT);
+  validatePosition(position, id, warnings);
+
+  // 3) connector: 기본값 병합
+  const connector = defaultsDeep({}, cloneDeep(raw.connector) || {}, CONNECTOR_DEFAULT);
+  if (!CONNECTOR_TYPES.includes(connector.type)) {
+    warnings.push(`[annotation:${id}] invalid connector.type "${connector.type}" — fallback to "straight".`);
+    connector.type = 'straight';
+  }
+  // 규칙: callout 의 꼬리가 곧 connector 역할이므로, callout 이면 connector 를 강제 비활성화한다.
+  if (type === 'callout' && connector.enabled) {
+    warnings.push(`[annotation:${id}] connector is ignored for type "callout" (the arrow acts as the connector).`);
+    connector.enabled = false;
+  }
+
+  // 4) content: circle 은 무시. string/function 만 허용(그 외는 빈 문자열로).
+  let content = raw.content;
+  if (type === 'circle') {
+    content = '';
+  } else if (!isFunction(content) && typeof content !== 'string') {
+    content = content == null ? '' : String(content);
+  }
+
+  return { id, type, content, position, connector, style };
+}
+
+/**
+ * 어노테이션 배열을 내부 표준 모델 배열로 정규화한다(선언형 v1: 통째 갱신 → 전체 정규화).
+ * 순수 함수 — 캔버스/차트 인스턴스 의존 없음.
+ * @param {object[]} rawList options.annotations 원본 배열
+ * @returns {{ annotations: object[], warnings: string[] }}
+ */
+export function normalizeAnnotations(rawList) {
+  const warnings = [];
+  if (!Array.isArray(rawList)) {
+    return { annotations: [], warnings };
+  }
+
+  const seenIds = new Set();
+  const annotations = rawList
+    .filter(raw => raw && typeof raw === 'object')
+    .map((raw, index) => normalizeOne(raw, index, warnings));
+
+  // id 중복 경고(선언형 key 용도이므로 유니크해야 한다)
+  annotations.forEach((ann) => {
+    if (seenIds.has(ann.id)) {
+      warnings.push(`[annotation:${ann.id}] duplicate id — annotations should have unique ids.`);
+    }
+    seenIds.add(ann.id);
+  });
+
+  return { annotations, warnings };
+}

--- a/src/components/chart/annotation/annotation.normalize.js
+++ b/src/components/chart/annotation/annotation.normalize.js
@@ -11,28 +11,36 @@ import {
 } from './annotation.constant';
 
 /**
- * padding 입력을 내부 표준인 [top, right, bottom, left] 4-튜플로 정규화한다.
+ * padding 입력을 내부 표준인 [top, right, bottom, left] 4-튜플로 정규화한다(CSS shorthand 규칙).
  *  - number n        -> [n, n, n, n]
+ *  - [a]             -> [a, a, a, a]
  *  - [v, h]          -> [v, h, v, h]
+ *  - [t, h, b]       -> [t, h, b, h]
  *  - [t, r, b, l]    -> 그대로
  *  - 그 외/누락       -> [0, 0, 0, 0]
+ * 음수는 0 으로 클램프한다(박스 크기가 content 보다 작아지는 것을 방지).
  * @param {number|number[]} padding
  * @returns {number[]} [top, right, bottom, left]
  */
 export function normalizePadding(padding) {
-  if (typeof padding === 'number' && Number.isFinite(padding)) {
-    return [padding, padding, padding, padding];
+  const clamp = p => (Number.isFinite(p) && p > 0 ? p : 0);
+  if (typeof padding === 'number') {
+    const n = clamp(padding);
+    return [n, n, n, n];
   }
   if (Array.isArray(padding)) {
-    const nums = padding.map(p => (Number.isFinite(p) ? p : 0));
+    const nums = padding.map(clamp);
+    if (nums.length === 1) {
+      return [nums[0], nums[0], nums[0], nums[0]];
+    }
     if (nums.length === 2) {
       return [nums[0], nums[1], nums[0], nums[1]];
     }
+    if (nums.length === 3) {
+      return [nums[0], nums[1], nums[2], nums[1]];
+    }
     if (nums.length >= 4) {
       return [nums[0], nums[1], nums[2], nums[3]];
-    }
-    if (nums.length === 1) {
-      return [nums[0], nums[0], nums[0], nums[0]];
     }
   }
   return [0, 0, 0, 0];
@@ -51,8 +59,10 @@ function validatePosition(position, id, warnings) {
   }
 
   if (position.type === 'axis') {
-    if (position.xValue == null && position.yValue == null) {
-      warnings.push(`[annotation:${id}] position.type "axis" requires xValue and/or yValue.`);
+    // 점 어노테이션(text/badge/callout/circle)은 선 타입이 없어 xValue·yValue 둘 다 있어야 좌표가 정해진다.
+    // 하나만 주면 resolveAnchor 가 조용히 숨기므로(silent failure), 여기서 경고한다.
+    if (position.xValue == null || position.yValue == null) {
+      warnings.push(`[annotation:${id}] position.type "axis" requires both xValue and yValue.`);
     }
   } else if (position.type === 'series') {
     if (position.seriesId == null) {
@@ -84,9 +94,18 @@ function normalizeOne(raw, index, warnings) {
   }
 
   // 1) style: type 별 Default Config 와 deepMerge
-  const style = defaultsDeep({}, cloneDeep(raw.style) || {}, ANNOTATION_DEFAULT[type].style);
+  const rawStyle = cloneDeep(raw.style) || {};
+  const style = defaultsDeep({}, rawStyle, ANNOTATION_DEFAULT[type].style);
+  // padding 은 배열이라 defaultsDeep 의 인덱스 단위 병합이 짧은 사용자 배열을 기본값으로 오염시킨다
+  // (예: 사용자 [5] + 기본 [6,10] → [5,10]). 병합 결과 대신 "사용자 원본 우선"으로 다시 정규화한다.
   if ('padding' in style) {
-    style.padding = normalizePadding(style.padding);
+    const rawPadding = 'padding' in rawStyle ? rawStyle.padding : ANNOTATION_DEFAULT[type].style.padding;
+    style.padding = normalizePadding(rawPadding);
+  }
+  // circle radius 음수 방어: ctx.arc 는 음수 반지름에 IndexSizeError 를 던지므로 0 으로 클램프한다.
+  if (type === 'circle' && typeof style.radius === 'number' && style.radius < 0) {
+    warnings.push(`[annotation:${id}] style.radius must be >= 0 — clamped to 0.`);
+    style.radius = 0;
   }
   if (type === 'callout' && !CALLOUT_ANCHORS.includes(style.anchor)) {
     warnings.push(`[annotation:${id}] invalid style.anchor "${style.anchor}" — fallback to "auto".`);

--- a/src/components/chart/annotation/annotation.normalize.spec.js
+++ b/src/components/chart/annotation/annotation.normalize.spec.js
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAnnotations, normalizePadding } from './annotation.normalize';
+
+describe('annotation.normalize', () => {
+  describe('normalizePadding', () => {
+    it('number -> 4-tuple', () => {
+      expect(normalizePadding(5)).toEqual([5, 5, 5, 5]);
+    });
+    it('[v, h] -> [v, h, v, h]', () => {
+      expect(normalizePadding([6, 10])).toEqual([6, 10, 6, 10]);
+    });
+    it('[t, r, b, l] -> as-is', () => {
+      expect(normalizePadding([1, 2, 3, 4])).toEqual([1, 2, 3, 4]);
+    });
+    it('invalid -> zeros', () => {
+      expect(normalizePadding(undefined)).toEqual([0, 0, 0, 0]);
+      expect(normalizePadding('x')).toEqual([0, 0, 0, 0]);
+    });
+  });
+
+  describe('normalizeAnnotations', () => {
+    it('non-array input returns empty', () => {
+      expect(normalizeAnnotations(null).annotations).toEqual([]);
+      expect(normalizeAnnotations(undefined).annotations).toEqual([]);
+    });
+
+    it('applies type-based default config via deepMerge', () => {
+      const { annotations } = normalizeAnnotations([{ type: 'badge', content: 'Hi' }]);
+      const a = annotations[0];
+      expect(a.style.backgroundColor).toBe('#FDF0F0');
+      expect(a.style.borderRadius).toBe(6);
+      expect(a.style.padding).toEqual([6, 10, 6, 10]);
+    });
+
+    it('user style overrides default but keeps untouched defaults', () => {
+      const { annotations } = normalizeAnnotations([
+        { type: 'badge', content: 'Hi', style: { backgroundColor: '#000' } },
+      ]);
+      expect(annotations[0].style.backgroundColor).toBe('#000');
+      expect(annotations[0].style.borderColor).toBe('#B24C4C'); // default kept
+    });
+
+    it('generates id when missing, preserves provided id', () => {
+      const { annotations } = normalizeAnnotations([{ type: 'text' }, { id: 'x', type: 'text' }]);
+      expect(annotations[0].id).toBe('annotation-0');
+      expect(annotations[1].id).toBe('x');
+    });
+
+    it('unknown type falls back to text with warning', () => {
+      const { annotations, warnings } = normalizeAnnotations([{ type: 'bogus' }]);
+      expect(annotations[0].type).toBe('text');
+      expect(warnings.some(w => w.includes('unknown type'))).toBe(true);
+    });
+
+    it('callout forces connector off with warning', () => {
+      const { annotations, warnings } = normalizeAnnotations([
+        { type: 'callout', content: 'C', connector: { enabled: true } },
+      ]);
+      expect(annotations[0].connector.enabled).toBe(false);
+      expect(warnings.some(w => w.includes('connector is ignored'))).toBe(true);
+    });
+
+    it('non-callout keeps connector enabled', () => {
+      const { annotations } = normalizeAnnotations([
+        { type: 'badge', content: 'B', connector: { enabled: true } },
+      ]);
+      expect(annotations[0].connector.enabled).toBe(true);
+    });
+
+    it('circle ignores content', () => {
+      const { annotations } = normalizeAnnotations([{ type: 'circle', content: 'ignored' }]);
+      expect(annotations[0].content).toBe('');
+    });
+
+    it('keeps function content as-is', () => {
+      const fn = () => 'dynamic';
+      const { annotations } = normalizeAnnotations([{ type: 'text', content: fn }]);
+      expect(annotations[0].content).toBe(fn);
+    });
+
+    it('warns on axis position without xValue/yValue', () => {
+      const { warnings } = normalizeAnnotations([{ type: 'text', position: { type: 'axis' } }]);
+      expect(warnings.some(w => w.includes('requires xValue'))).toBe(true);
+    });
+
+    it('warns on series position without seriesId and invalid location', () => {
+      const { annotations, warnings } = normalizeAnnotations([
+        { type: 'text', position: { type: 'series', location: 'middle' } },
+      ]);
+      expect(warnings.some(w => w.includes('requires seriesId'))).toBe(true);
+      expect(annotations[0].position.location).toBe('end'); // fallback
+    });
+
+    it('warns on duplicate ids', () => {
+      const { warnings } = normalizeAnnotations([
+        { id: 'dup', type: 'text' },
+        { id: 'dup', type: 'text' },
+      ]);
+      expect(warnings.some(w => w.includes('duplicate id'))).toBe(true);
+    });
+
+    it('defaults position type to pixel with offsets', () => {
+      const { annotations } = normalizeAnnotations([{ type: 'text' }]);
+      expect(annotations[0].position.type).toBe('pixel');
+      expect(annotations[0].position.offsetX).toBe(0);
+      expect(annotations[0].position.offsetY).toBe(0);
+    });
+  });
+});

--- a/src/components/chart/annotation/annotation.normalize.spec.js
+++ b/src/components/chart/annotation/annotation.normalize.spec.js
@@ -6,11 +6,21 @@ describe('annotation.normalize', () => {
     it('number -> 4-tuple', () => {
       expect(normalizePadding(5)).toEqual([5, 5, 5, 5]);
     });
+    it('[a] -> [a, a, a, a]', () => {
+      expect(normalizePadding([5])).toEqual([5, 5, 5, 5]);
+    });
     it('[v, h] -> [v, h, v, h]', () => {
       expect(normalizePadding([6, 10])).toEqual([6, 10, 6, 10]);
     });
+    it('[t, h, b] -> [t, h, b, h]', () => {
+      expect(normalizePadding([12, 8, 20])).toEqual([12, 8, 20, 8]);
+    });
     it('[t, r, b, l] -> as-is', () => {
       expect(normalizePadding([1, 2, 3, 4])).toEqual([1, 2, 3, 4]);
+    });
+    it('clamps negative values to 0', () => {
+      expect(normalizePadding(-5)).toEqual([0, 0, 0, 0]);
+      expect(normalizePadding([-1, 4])).toEqual([0, 4, 0, 4]);
     });
     it('invalid -> zeros', () => {
       expect(normalizePadding(undefined)).toEqual([0, 0, 0, 0]);
@@ -38,6 +48,27 @@ describe('annotation.normalize', () => {
       ]);
       expect(annotations[0].style.backgroundColor).toBe('#000');
       expect(annotations[0].style.borderColor).toBe('#B24C4C'); // default kept
+    });
+
+    it('user padding is not contaminated by default via array index merge', () => {
+      // 사용자 [5](균일 의도) + badge 기본 [6,10] → 예전엔 [5,10,5,10] 로 오염됐다. 이제 [5,5,5,5].
+      const { annotations } = normalizeAnnotations([
+        { type: 'badge', content: 'Hi', style: { padding: [5] } },
+      ]);
+      expect(annotations[0].style.padding).toEqual([5, 5, 5, 5]);
+    });
+
+    it('user 3-value padding is preserved (not dropped to zeros)', () => {
+      const { annotations } = normalizeAnnotations([
+        { type: 'badge', content: 'Hi', style: { padding: [12, 8, 20] } },
+      ]);
+      expect(annotations[0].style.padding).toEqual([12, 8, 20, 8]);
+    });
+
+    it('clamps negative circle radius to 0 with warning', () => {
+      const { annotations, warnings } = normalizeAnnotations([{ type: 'circle', style: { radius: -5 } }]);
+      expect(annotations[0].style.radius).toBe(0);
+      expect(warnings.some(w => w.includes('radius must be'))).toBe(true);
     });
 
     it('generates id when missing, preserves provided id', () => {
@@ -80,7 +111,21 @@ describe('annotation.normalize', () => {
 
     it('warns on axis position without xValue/yValue', () => {
       const { warnings } = normalizeAnnotations([{ type: 'text', position: { type: 'axis' } }]);
-      expect(warnings.some(w => w.includes('requires xValue'))).toBe(true);
+      expect(warnings.some(w => w.includes('requires both xValue and yValue'))).toBe(true);
+    });
+
+    it('warns on axis position with only one of xValue/yValue (single-axis unsupported)', () => {
+      const onlyX = normalizeAnnotations([{ type: 'text', position: { type: 'axis', xValue: 50 } }]);
+      expect(onlyX.warnings.some(w => w.includes('requires both xValue and yValue'))).toBe(true);
+      const onlyY = normalizeAnnotations([{ type: 'text', position: { type: 'axis', yValue: 50 } }]);
+      expect(onlyY.warnings.some(w => w.includes('requires both xValue and yValue'))).toBe(true);
+    });
+
+    it('no axis warning when both xValue and yValue are given', () => {
+      const { warnings } = normalizeAnnotations([
+        { type: 'text', position: { type: 'axis', xValue: 10, yValue: 20 } },
+      ]);
+      expect(warnings.some(w => w.includes('requires both xValue and yValue'))).toBe(false);
     });
 
     it('warns on series position without seriesId and invalid location', () => {

--- a/src/components/chart/annotation/annotation.renderer.js
+++ b/src/components/chart/annotation/annotation.renderer.js
@@ -34,20 +34,25 @@ export function drawConnector(ctx, from, box, connector) {
   const end = nearestBoxPoint(box, from);
   const style = connector.style || {};
   ctx.save();
-  ctx.beginPath();
-  ctx.strokeStyle = style.stroke || '#9E9E9E';
-  ctx.lineWidth = style.strokeWidth || 1;
-  ctx.setLineDash(DASH_MAP[style.dashStyle] || DASH_MAP.solid);
-  ctx.moveTo(from.x, from.y);
-  if (connector.type === 'elbow') {
-    // 수평 먼저 → 수직(L자). 결정론적.
-    ctx.lineTo(end.x, from.y);
-    ctx.lineTo(end.x, end.y);
-  } else {
-    ctx.lineTo(end.x, end.y);
+  // save() 와 restore() 를 try/finally 로 짝지어, 본문에서 throw 가 나도 캔버스 save 스택이
+  // 불균형해지지 않게 한다(drawAnnotations 의 항목별 격리 catch 는 상태를 복원하지 않으므로).
+  try {
+    ctx.beginPath();
+    ctx.strokeStyle = style.stroke || '#9E9E9E';
+    ctx.lineWidth = style.strokeWidth || 1;
+    ctx.setLineDash(DASH_MAP[style.dashStyle] || DASH_MAP.solid);
+    ctx.moveTo(from.x, from.y);
+    if (connector.type === 'elbow') {
+      // 수평 먼저 → 수직(L자). 결정론적.
+      ctx.lineTo(end.x, from.y);
+      ctx.lineTo(end.x, end.y);
+    } else {
+      ctx.lineTo(end.x, end.y);
+    }
+    ctx.stroke();
+  } finally {
+    ctx.restore();
   }
-  ctx.stroke();
-  ctx.restore();
 }
 
 /**
@@ -63,18 +68,21 @@ export function drawBox(ctx, box, style) {
     return;
   }
   ctx.save();
-  ctx.beginPath();
-  Canvas.roundedRect(ctx, box.x, box.y, box.w, box.h, style.borderRadius || 0);
-  if (hasFill) {
-    ctx.fillStyle = style.backgroundColor;
-    ctx.fill();
+  try {
+    ctx.beginPath();
+    Canvas.roundedRect(ctx, box.x, box.y, box.w, box.h, style.borderRadius || 0);
+    if (hasFill) {
+      ctx.fillStyle = style.backgroundColor;
+      ctx.fill();
+    }
+    if (hasBorder) {
+      ctx.lineWidth = style.borderWidth;
+      ctx.strokeStyle = style.borderColor;
+      ctx.stroke();
+    }
+  } finally {
+    ctx.restore();
   }
-  if (hasBorder) {
-    ctx.lineWidth = style.borderWidth;
-    ctx.strokeStyle = style.borderColor;
-    ctx.stroke();
-  }
-  ctx.restore();
 }
 
 /**
@@ -96,56 +104,59 @@ export function drawCallout(ctx, box, tail, style) {
   const side = tail?.side;
 
   ctx.save();
-  ctx.beginPath();
-  ctx.moveTo(left + r, top);
+  try {
+    ctx.beginPath();
+    ctx.moveTo(left + r, top);
 
-  // TOP edge (L→R)
-  if (side === 'top') {
-    ctx.lineTo(Math.min(tail.baseAX, tail.baseBX), top);
-    ctx.lineTo(tail.tipX, tail.tipY);
-    ctx.lineTo(Math.max(tail.baseAX, tail.baseBX), top);
-  }
-  ctx.lineTo(right - r, top);
-  ctx.quadraticCurveTo(right, top, right, top + r);
+    // TOP edge (L→R)
+    if (side === 'top') {
+      ctx.lineTo(Math.min(tail.baseAX, tail.baseBX), top);
+      ctx.lineTo(tail.tipX, tail.tipY);
+      ctx.lineTo(Math.max(tail.baseAX, tail.baseBX), top);
+    }
+    ctx.lineTo(right - r, top);
+    ctx.quadraticCurveTo(right, top, right, top + r);
 
-  // RIGHT edge (T→B)
-  if (side === 'right') {
-    ctx.lineTo(right, Math.min(tail.baseAY, tail.baseBY));
-    ctx.lineTo(tail.tipX, tail.tipY);
-    ctx.lineTo(right, Math.max(tail.baseAY, tail.baseBY));
-  }
-  ctx.lineTo(right, bottom - r);
-  ctx.quadraticCurveTo(right, bottom, right - r, bottom);
+    // RIGHT edge (T→B)
+    if (side === 'right') {
+      ctx.lineTo(right, Math.min(tail.baseAY, tail.baseBY));
+      ctx.lineTo(tail.tipX, tail.tipY);
+      ctx.lineTo(right, Math.max(tail.baseAY, tail.baseBY));
+    }
+    ctx.lineTo(right, bottom - r);
+    ctx.quadraticCurveTo(right, bottom, right - r, bottom);
 
-  // BOTTOM edge (R→L)
-  if (side === 'bottom') {
-    ctx.lineTo(Math.max(tail.baseAX, tail.baseBX), bottom);
-    ctx.lineTo(tail.tipX, tail.tipY);
-    ctx.lineTo(Math.min(tail.baseAX, tail.baseBX), bottom);
-  }
-  ctx.lineTo(left + r, bottom);
-  ctx.quadraticCurveTo(left, bottom, left, bottom - r);
+    // BOTTOM edge (R→L)
+    if (side === 'bottom') {
+      ctx.lineTo(Math.max(tail.baseAX, tail.baseBX), bottom);
+      ctx.lineTo(tail.tipX, tail.tipY);
+      ctx.lineTo(Math.min(tail.baseAX, tail.baseBX), bottom);
+    }
+    ctx.lineTo(left + r, bottom);
+    ctx.quadraticCurveTo(left, bottom, left, bottom - r);
 
-  // LEFT edge (B→T)
-  if (side === 'left') {
-    ctx.lineTo(left, Math.max(tail.baseAY, tail.baseBY));
-    ctx.lineTo(tail.tipX, tail.tipY);
-    ctx.lineTo(left, Math.min(tail.baseAY, tail.baseBY));
-  }
-  ctx.lineTo(left, top + r);
-  ctx.quadraticCurveTo(left, top, left + r, top);
-  ctx.closePath();
+    // LEFT edge (B→T)
+    if (side === 'left') {
+      ctx.lineTo(left, Math.max(tail.baseAY, tail.baseBY));
+      ctx.lineTo(tail.tipX, tail.tipY);
+      ctx.lineTo(left, Math.min(tail.baseAY, tail.baseBY));
+    }
+    ctx.lineTo(left, top + r);
+    ctx.quadraticCurveTo(left, top, left + r, top);
+    ctx.closePath();
 
-  if (style.backgroundColor && style.backgroundColor !== 'transparent') {
-    ctx.fillStyle = style.backgroundColor;
-    ctx.fill();
+    if (style.backgroundColor && style.backgroundColor !== 'transparent') {
+      ctx.fillStyle = style.backgroundColor;
+      ctx.fill();
+    }
+    if (style.borderWidth > 0 && style.borderColor && style.borderColor !== 'transparent') {
+      ctx.lineWidth = style.borderWidth;
+      ctx.strokeStyle = style.borderColor;
+      ctx.stroke();
+    }
+  } finally {
+    ctx.restore();
   }
-  if (style.borderWidth > 0 && style.borderColor && style.borderColor !== 'transparent') {
-    ctx.lineWidth = style.borderWidth;
-    ctx.strokeStyle = style.borderColor;
-    ctx.stroke();
-  }
-  ctx.restore();
 }
 
 /**
@@ -156,22 +167,25 @@ export function drawCallout(ctx, box, tail, style) {
  */
 export function drawCircle(ctx, shape, style) {
   ctx.save();
-  ctx.beginPath();
-  ctx.arc(shape.cx, shape.cy, shape.r, 0, Math.PI * 2);
-  if (style.backgroundColor && style.backgroundColor !== 'transparent') {
-    ctx.fillStyle = style.backgroundColor;
-    ctx.fill();
+  try {
+    ctx.beginPath();
+    ctx.arc(shape.cx, shape.cy, shape.r, 0, Math.PI * 2);
+    if (style.backgroundColor && style.backgroundColor !== 'transparent') {
+      ctx.fillStyle = style.backgroundColor;
+      ctx.fill();
+    }
+    if (style.borderWidth > 0 && style.borderColor && style.borderColor !== 'transparent') {
+      ctx.lineWidth = style.borderWidth;
+      ctx.strokeStyle = style.borderColor;
+      ctx.stroke();
+    }
+  } finally {
+    ctx.restore();
   }
-  if (style.borderWidth > 0 && style.borderColor && style.borderColor !== 'transparent') {
-    ctx.lineWidth = style.borderWidth;
-    ctx.strokeStyle = style.borderColor;
-    ctx.stroke();
-  }
-  ctx.restore();
 }
 
 /**
- * 박스 안에 멀티라인 텍스트를 그린다(가로 중앙, 세로 중앙 정렬).
+ * 박스 안에 멀티라인 텍스트를 그린다(style.textAlign 존중: left/right/center, 기본 center. 세로는 항상 중앙).
  * @param {object} ctx
  * @param {object} box  { x, y, w, h }
  * @param {object} content measureContent 결과 { lines, lineHeight }
@@ -182,18 +196,32 @@ export function drawText(ctx, box, content, style) {
     return;
   }
   ctx.save();
-  ctx.fillStyle = style.color || '#212121';
-  ctx.font = buildFontStyle(style);
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'middle';
-  const cx = box.x + box.w / 2;
-  const { lineHeight } = content;
-  const totalH = lineHeight * content.lines.length;
-  const startY = box.y + box.h / 2 - totalH / 2 + lineHeight / 2;
-  content.lines.forEach((line, i) => {
-    ctx.fillText(line.text, cx, startY + i * lineHeight);
-  });
-  ctx.restore();
+  try {
+    ctx.fillStyle = style.color || '#212121';
+    ctx.font = buildFontStyle(style);
+    // style.textAlign 존중(left/right/center). 유효하지 않은 값은 center 로 폴백.
+    const align = ['left', 'right'].includes(style.textAlign) ? style.textAlign : 'center';
+    ctx.textAlign = align;
+    ctx.textBaseline = 'middle';
+    // 정렬에 맞춰 x 앵커를 박스의 해당 변(padding 안쪽)으로 옮긴다. padding = [top, right, bottom, left].
+    const [, pr, , pl] = style.padding || [0, 0, 0, 0];
+    let cx;
+    if (align === 'left') {
+      cx = box.x + pl;
+    } else if (align === 'right') {
+      cx = box.x + box.w - pr;
+    } else {
+      cx = box.x + box.w / 2;
+    }
+    const { lineHeight } = content;
+    const totalH = lineHeight * content.lines.length;
+    const startY = box.y + box.h / 2 - totalH / 2 + lineHeight / 2;
+    content.lines.forEach((line, i) => {
+      ctx.fillText(line.text, cx, startY + i * lineHeight);
+    });
+  } finally {
+    ctx.restore();
+  }
 }
 
 /**

--- a/src/components/chart/annotation/annotation.renderer.js
+++ b/src/components/chart/annotation/annotation.renderer.js
@@ -1,0 +1,227 @@
+import Canvas from '../helpers/helpers.canvas';
+import { buildFontStyle } from './annotation.layout';
+
+const DASH_MAP = {
+  solid: [],
+  dash: [4, 4],
+  dot: [1, 3],
+};
+
+/**
+ * 박스의 둘레에서 주어진 점(데이터 포인트)에 가장 가까운 점을 구한다(connector 종착점).
+ * @param {object} box { x, y, w, h }
+ * @param {object} pt { x, y }
+ * @returns {{x:number, y:number}}
+ */
+export function nearestBoxPoint(box, pt) {
+  return {
+    x: Math.min(Math.max(pt.x, box.x), box.x + box.w),
+    y: Math.min(Math.max(pt.y, box.y), box.y + box.h),
+  };
+}
+
+/**
+ * connector(연결선)를 그린다. callout 은 정규화 단계에서 connector 가 꺼지므로 여기 오지 않는다.
+ * @param {object} ctx canvas 2d context
+ * @param {object} from 데이터 포인트 { x, y } (anchorX/anchorY)
+ * @param {object} box  { x, y, w, h }
+ * @param {object} connector 정규화된 connector
+ */
+export function drawConnector(ctx, from, box, connector) {
+  if (!connector?.enabled) {
+    return;
+  }
+  const end = nearestBoxPoint(box, from);
+  const style = connector.style || {};
+  ctx.save();
+  ctx.beginPath();
+  ctx.strokeStyle = style.stroke || '#9E9E9E';
+  ctx.lineWidth = style.strokeWidth || 1;
+  ctx.setLineDash(DASH_MAP[style.dashStyle] || DASH_MAP.solid);
+  ctx.moveTo(from.x, from.y);
+  if (connector.type === 'elbow') {
+    // 수평 먼저 → 수직(L자). 결정론적.
+    ctx.lineTo(end.x, from.y);
+    ctx.lineTo(end.x, end.y);
+  } else {
+    ctx.lineTo(end.x, end.y);
+  }
+  ctx.stroke();
+  ctx.restore();
+}
+
+/**
+ * 둥근 사각형 박스(badge/text 배경)를 채우고 테두리를 그린다.
+ * @param {object} ctx
+ * @param {object} box { x, y, w, h }
+ * @param {object} style 정규화된 style
+ */
+export function drawBox(ctx, box, style) {
+  const hasFill = style.backgroundColor && style.backgroundColor !== 'transparent';
+  const hasBorder = style.borderWidth > 0 && style.borderColor && style.borderColor !== 'transparent';
+  if (!hasFill && !hasBorder) {
+    return;
+  }
+  ctx.save();
+  ctx.beginPath();
+  Canvas.roundedRect(ctx, box.x, box.y, box.w, box.h, style.borderRadius || 0);
+  if (hasFill) {
+    ctx.fillStyle = style.backgroundColor;
+    ctx.fill();
+  }
+  if (hasBorder) {
+    ctx.lineWidth = style.borderWidth;
+    ctx.strokeStyle = style.borderColor;
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+/**
+ * callout 박스 + 꼬리를 하나의 둥근-모서리 path 로 그린다(maxTip 말풍선과 동일한 외형).
+ * 시계방향으로 각 변을 진행하며 모서리는 quadraticCurveTo 로 둥글리고, tail.side 변에서
+ * base→tip→base 로 꺾어 꼬리를 삽입한다. 단일 path 라 테두리가 꼬리까지 매끄럽게 이어진다.
+ * @param {object} ctx
+ * @param {object} box  { x, y, w, h }
+ * @param {object} tail computeTail 결과
+ * @param {object} style 정규화된 style
+ */
+export function drawCallout(ctx, box, tail, style) {
+  const { x, y, w, h } = box;
+  const left = x;
+  const right = x + w;
+  const top = y;
+  const bottom = y + h;
+  const r = Math.min(style.borderRadius || 0, w / 2, h / 2);
+  const side = tail?.side;
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.moveTo(left + r, top);
+
+  // TOP edge (L→R)
+  if (side === 'top') {
+    ctx.lineTo(Math.min(tail.baseAX, tail.baseBX), top);
+    ctx.lineTo(tail.tipX, tail.tipY);
+    ctx.lineTo(Math.max(tail.baseAX, tail.baseBX), top);
+  }
+  ctx.lineTo(right - r, top);
+  ctx.quadraticCurveTo(right, top, right, top + r);
+
+  // RIGHT edge (T→B)
+  if (side === 'right') {
+    ctx.lineTo(right, Math.min(tail.baseAY, tail.baseBY));
+    ctx.lineTo(tail.tipX, tail.tipY);
+    ctx.lineTo(right, Math.max(tail.baseAY, tail.baseBY));
+  }
+  ctx.lineTo(right, bottom - r);
+  ctx.quadraticCurveTo(right, bottom, right - r, bottom);
+
+  // BOTTOM edge (R→L)
+  if (side === 'bottom') {
+    ctx.lineTo(Math.max(tail.baseAX, tail.baseBX), bottom);
+    ctx.lineTo(tail.tipX, tail.tipY);
+    ctx.lineTo(Math.min(tail.baseAX, tail.baseBX), bottom);
+  }
+  ctx.lineTo(left + r, bottom);
+  ctx.quadraticCurveTo(left, bottom, left, bottom - r);
+
+  // LEFT edge (B→T)
+  if (side === 'left') {
+    ctx.lineTo(left, Math.max(tail.baseAY, tail.baseBY));
+    ctx.lineTo(tail.tipX, tail.tipY);
+    ctx.lineTo(left, Math.min(tail.baseAY, tail.baseBY));
+  }
+  ctx.lineTo(left, top + r);
+  ctx.quadraticCurveTo(left, top, left + r, top);
+  ctx.closePath();
+
+  if (style.backgroundColor && style.backgroundColor !== 'transparent') {
+    ctx.fillStyle = style.backgroundColor;
+    ctx.fill();
+  }
+  if (style.borderWidth > 0 && style.borderColor && style.borderColor !== 'transparent') {
+    ctx.lineWidth = style.borderWidth;
+    ctx.strokeStyle = style.borderColor;
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+/**
+ * 강조용 순수 원형 도형을 그린다(circle 타입).
+ * @param {object} ctx
+ * @param {object} shape { cx, cy, r }
+ * @param {object} style
+ */
+export function drawCircle(ctx, shape, style) {
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(shape.cx, shape.cy, shape.r, 0, Math.PI * 2);
+  if (style.backgroundColor && style.backgroundColor !== 'transparent') {
+    ctx.fillStyle = style.backgroundColor;
+    ctx.fill();
+  }
+  if (style.borderWidth > 0 && style.borderColor && style.borderColor !== 'transparent') {
+    ctx.lineWidth = style.borderWidth;
+    ctx.strokeStyle = style.borderColor;
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+/**
+ * 박스 안에 멀티라인 텍스트를 그린다(가로 중앙, 세로 중앙 정렬).
+ * @param {object} ctx
+ * @param {object} box  { x, y, w, h }
+ * @param {object} content measureContent 결과 { lines, lineHeight }
+ * @param {object} style
+ */
+export function drawText(ctx, box, content, style) {
+  if (!content || !content.lines?.length) {
+    return;
+  }
+  ctx.save();
+  ctx.fillStyle = style.color || '#212121';
+  ctx.font = buildFontStyle(style);
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  const cx = box.x + box.w / 2;
+  const { lineHeight } = content;
+  const totalH = lineHeight * content.lines.length;
+  const startY = box.y + box.h / 2 - totalH / 2 + lineHeight / 2;
+  content.lines.forEach((line, i) => {
+    ctx.fillText(line.text, cx, startY + i * lineHeight);
+  });
+  ctx.restore();
+}
+
+/**
+ * 단일 어노테이션을 layout 기준으로 그린다. 그리기 순서: connector → 도형/박스 → 텍스트.
+ * @param {object} ctx canvas 2d context
+ * @param {object} annotation 정규화된 어노테이션
+ * @param {object} layout computeLayout 결과
+ * @param {object} anchor resolveAnchor 결과(데이터 포인트 anchorX/anchorY 보유)
+ */
+export function renderAnnotation(ctx, annotation, layout, anchor) {
+  const { type, style } = annotation;
+
+  if (type === 'circle') {
+    drawCircle(ctx, layout.shape, style);
+    return;
+  }
+
+  // connector 먼저(박스 아래). callout 은 normalize 에서 connector 가 꺼져 있다.
+  if (annotation.connector?.enabled && type !== 'callout') {
+    drawConnector(ctx, { x: anchor.anchorX, y: anchor.anchorY }, layout.box, annotation.connector);
+  }
+
+  if (type === 'callout') {
+    drawCallout(ctx, layout.box, layout.tail, style);
+  } else {
+    // text/badge: text 는 보통 배경 없음(normalize 기본값), badge 는 배경/테두리 있음.
+    drawBox(ctx, layout.box, style);
+  }
+
+  drawText(ctx, layout.box, layout.content, style);
+}

--- a/src/components/chart/annotation/annotation.renderer.spec.js
+++ b/src/components/chart/annotation/annotation.renderer.spec.js
@@ -91,6 +91,15 @@ describe('annotation.renderer', () => {
       expect(arc.args.slice(0, 3)).toEqual([5, 5, 10]);
       expect(names(ctx)).toContain('fill');
     });
+    it('restores canvas state even when a draw call throws (balanced save/restore)', () => {
+      const ctx = createMockCtx();
+      // 실제 캔버스는 음수 반지름 arc 에 IndexSizeError 를 던진다. throw 를 흉내낸다.
+      ctx.arc = () => { throw new Error('IndexSizeError'); };
+      expect(() => drawCircle(ctx, { cx: 0, cy: 0, r: -5 }, { backgroundColor: '#f00' })).toThrow();
+      const saves = ctx.calls.filter(c => c.name === 'save').length;
+      const restores = ctx.calls.filter(c => c.name === 'restore').length;
+      expect(saves).toBe(restores); // finally 로 restore 가 보장되어 save 스택이 불균형해지지 않는다
+    });
   });
 
   describe('drawText', () => {
@@ -100,6 +109,34 @@ describe('annotation.renderer', () => {
       drawText(ctx, { x: 0, y: 0, w: 40, h: 24 }, content, { color: '#000', fontSize: '11px' });
       expect(ctx.calls.filter(c => c.name === 'fillText')).toHaveLength(2);
       expect(ctx.textAlign).toBe('center');
+    });
+    it('defaults to center anchor (box center) when textAlign is absent', () => {
+      const ctx = createMockCtx();
+      const content = { lines: [{ text: 'a' }], lineHeight: 12 };
+      drawText(ctx, { x: 0, y: 0, w: 40, h: 24 }, content, {});
+      expect(ctx.textAlign).toBe('center');
+      expect(ctx.calls.find(c => c.name === 'fillText').args[1]).toBe(20); // box.x + w/2
+    });
+    it('respects textAlign:left (anchors to left padding edge)', () => {
+      const ctx = createMockCtx();
+      const content = { lines: [{ text: 'a' }], lineHeight: 12 };
+      drawText(ctx, { x: 0, y: 0, w: 40, h: 24 }, content, { textAlign: 'left', padding: [4, 8, 4, 6] });
+      expect(ctx.textAlign).toBe('left');
+      expect(ctx.calls.find(c => c.name === 'fillText').args[1]).toBe(6); // box.x + paddingLeft
+    });
+    it('respects textAlign:right (anchors to right padding edge)', () => {
+      const ctx = createMockCtx();
+      const content = { lines: [{ text: 'a' }], lineHeight: 12 };
+      drawText(ctx, { x: 0, y: 0, w: 40, h: 24 }, content, { textAlign: 'right', padding: [4, 8, 4, 6] });
+      expect(ctx.textAlign).toBe('right');
+      expect(ctx.calls.find(c => c.name === 'fillText').args[1]).toBe(32); // box.x + w - paddingRight
+    });
+    it('falls back to center for an invalid textAlign value', () => {
+      const ctx = createMockCtx();
+      const content = { lines: [{ text: 'a' }], lineHeight: 12 };
+      drawText(ctx, { x: 0, y: 0, w: 40, h: 24 }, content, { textAlign: 'justify' });
+      expect(ctx.textAlign).toBe('center');
+      expect(ctx.calls.find(c => c.name === 'fillText').args[1]).toBe(20);
     });
     it('skips empty content', () => {
       const ctx = createMockCtx();

--- a/src/components/chart/annotation/annotation.renderer.spec.js
+++ b/src/components/chart/annotation/annotation.renderer.spec.js
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import {
+  nearestBoxPoint,
+  drawConnector,
+  drawBox,
+  drawCircle,
+  drawText,
+  renderAnnotation,
+} from './annotation.renderer';
+import { drawAnnotations } from './annotation.draw';
+
+/** 호출을 기록하는 mock 2d context. */
+function createMockCtx() {
+  const calls = [];
+  const rec = name => (...args) => calls.push({ name, args });
+  return {
+    calls,
+    save: rec('save'),
+    restore: rec('restore'),
+    beginPath: rec('beginPath'),
+    closePath: rec('closePath'),
+    moveTo: rec('moveTo'),
+    lineTo: rec('lineTo'),
+    quadraticCurveTo: rec('quadraticCurveTo'),
+    arc: rec('arc'),
+    fill: rec('fill'),
+    stroke: rec('stroke'),
+    fillText: rec('fillText'),
+    setLineDash: rec('setLineDash'),
+    fillStyle: null,
+    strokeStyle: null,
+    lineWidth: null,
+    font: null,
+    textAlign: null,
+    textBaseline: null,
+  };
+}
+const names = ctx => ctx.calls.map(c => c.name);
+
+describe('annotation.renderer', () => {
+  describe('nearestBoxPoint', () => {
+    const box = { x: 100, y: 100, w: 100, h: 50 };
+    it('clamps point to box perimeter/interior', () => {
+      expect(nearestBoxPoint(box, { x: 0, y: 0 })).toEqual({ x: 100, y: 100 });
+      expect(nearestBoxPoint(box, { x: 150, y: 300 })).toEqual({ x: 150, y: 150 });
+      expect(nearestBoxPoint(box, { x: 999, y: 120 })).toEqual({ x: 200, y: 120 });
+    });
+  });
+
+  describe('drawConnector', () => {
+    const box = { x: 100, y: 100, w: 80, h: 40 };
+    it('skips when disabled', () => {
+      const ctx = createMockCtx();
+      drawConnector(ctx, { x: 0, y: 0 }, box, { enabled: false });
+      expect(ctx.calls).toHaveLength(0);
+    });
+    it('straight line with dash applies setLineDash', () => {
+      const ctx = createMockCtx();
+      drawConnector(ctx, { x: 0, y: 0 }, box, { enabled: true, type: 'straight', style: { dashStyle: 'dash' } });
+      expect(ctx.calls.find(c => c.name === 'setLineDash').args[0]).toEqual([4, 4]);
+      expect(names(ctx)).toContain('stroke');
+      // straight: one lineTo
+      expect(ctx.calls.filter(c => c.name === 'lineTo')).toHaveLength(1);
+    });
+    it('elbow draws two segments', () => {
+      const ctx = createMockCtx();
+      drawConnector(ctx, { x: 0, y: 0 }, box, { enabled: true, type: 'elbow', style: {} });
+      expect(ctx.calls.filter(c => c.name === 'lineTo')).toHaveLength(2);
+    });
+  });
+
+  describe('drawBox', () => {
+    it('fills and strokes when style present', () => {
+      const ctx = createMockCtx();
+      drawBox(ctx, { x: 0, y: 0, w: 10, h: 10 }, { backgroundColor: '#fff', borderColor: '#000', borderWidth: 1, borderRadius: 4 });
+      expect(names(ctx)).toContain('fill');
+      expect(names(ctx)).toContain('stroke');
+    });
+    it('does nothing for transparent/no-border', () => {
+      const ctx = createMockCtx();
+      drawBox(ctx, { x: 0, y: 0, w: 10, h: 10 }, { backgroundColor: 'transparent', borderWidth: 0 });
+      expect(ctx.calls).toHaveLength(0);
+    });
+  });
+
+  describe('drawCircle', () => {
+    it('arcs and fills', () => {
+      const ctx = createMockCtx();
+      drawCircle(ctx, { cx: 5, cy: 5, r: 10 }, { backgroundColor: '#f00', borderColor: '#000', borderWidth: 1 });
+      const arc = ctx.calls.find(c => c.name === 'arc');
+      expect(arc.args.slice(0, 3)).toEqual([5, 5, 10]);
+      expect(names(ctx)).toContain('fill');
+    });
+  });
+
+  describe('drawText', () => {
+    it('draws one fillText per line', () => {
+      const ctx = createMockCtx();
+      const content = { lines: [{ text: 'a' }, { text: 'b' }], lineHeight: 12 };
+      drawText(ctx, { x: 0, y: 0, w: 40, h: 24 }, content, { color: '#000', fontSize: '11px' });
+      expect(ctx.calls.filter(c => c.name === 'fillText')).toHaveLength(2);
+      expect(ctx.textAlign).toBe('center');
+    });
+    it('skips empty content', () => {
+      const ctx = createMockCtx();
+      drawText(ctx, { x: 0, y: 0, w: 10, h: 10 }, { lines: [] }, {});
+      expect(ctx.calls).toHaveLength(0);
+    });
+  });
+
+  describe('renderAnnotation dispatch', () => {
+    it('circle path only draws shape', () => {
+      const ctx = createMockCtx();
+      const ann = { type: 'circle', style: { backgroundColor: '#f00', borderWidth: 0 } };
+      renderAnnotation(ctx, ann, { shape: { cx: 1, cy: 1, r: 5 } }, { anchorX: 1, anchorY: 1 });
+      expect(names(ctx)).toContain('arc');
+      expect(names(ctx)).not.toContain('fillText');
+    });
+    it('callout ignores connector even if enabled', () => {
+      const ctx = createMockCtx();
+      const ann = {
+        type: 'callout',
+        connector: { enabled: true, style: {} },
+        style: { backgroundColor: '#fff', borderColor: '#000', borderWidth: 1 },
+      };
+      const layout = {
+        box: { x: 10, y: 10, w: 40, h: 20 },
+        tail: { side: 'bottom', tipX: 30, tipY: 60, baseAX: 22, baseAY: 30, baseBX: 38, baseBY: 30 },
+        content: { lines: [{ text: 'C' }], lineHeight: 12 },
+      };
+      renderAnnotation(ctx, ann, layout, { anchorX: 30, anchorY: 60 });
+      // no setLineDash because connector not drawn for callout
+      expect(names(ctx)).not.toContain('setLineDash');
+      expect(names(ctx)).toContain('fillText');
+    });
+  });
+});
+
+describe('annotation.draw orchestrator', () => {
+  const viewportCtx = {
+    chartRect: { x1: 50, x2: 450, y1: 20, y2: 320, chartWidth: 400, chartHeight: 300 },
+    labelOffset: { left: 50, right: 50, top: 50, bottom: 50 },
+    axesSteps: { x: [{ graphMin: 0, graphMax: 100 }], y: [{ graphMin: 0, graphMax: 100 }] },
+    seriesList: {},
+  };
+
+  // jsdom 에는 canvas 2d 가 없어 실제 측정 대신 결정론적 측정기를 주입한다.
+  const fakeMeasure = t => ({ width: (t ? t.length : 0) * 10, height: 12 });
+
+  it('skips hidden (out-of-range axis) annotations', () => {
+    const ctx = createMockCtx();
+    const annotations = [
+      { id: 'a', type: 'badge', content: 'hidden', position: { type: 'axis', xValue: 999, yValue: 50 }, style: { backgroundColor: '#fff', borderWidth: 0 } },
+    ];
+    drawAnnotations(ctx, annotations, viewportCtx, null, fakeMeasure);
+    expect(ctx.calls).toHaveLength(0);
+  });
+
+  it('draws a visible pixel badge with resolved token content', () => {
+    const ctx = createMockCtx();
+    const annotations = [{
+      id: 'b',
+      type: 'badge',
+      content: 'x={xValue}',
+      position: { type: 'pixel', x: 100, y: 100 },
+      style: { backgroundColor: '#fff', borderColor: '#000', borderWidth: 1, borderRadius: 4, padding: [4, 4, 4, 4], fontSize: '11px' },
+    }];
+    drawAnnotations(ctx, annotations, viewportCtx, null, fakeMeasure);
+    const text = ctx.calls.find(c => c.name === 'fillText');
+    // pixel position has no xValue token source -> token kept verbatim
+    expect(text.args[0]).toBe('x={xValue}');
+  });
+
+  it('no-ops on empty/invalid input', () => {
+    const ctx = createMockCtx();
+    drawAnnotations(ctx, [], viewportCtx, null, fakeMeasure);
+    drawAnnotations(ctx, null, viewportCtx, null, fakeMeasure);
+    drawAnnotations(null, [{}], viewportCtx, null, fakeMeasure);
+    expect(ctx.calls).toHaveLength(0);
+  });
+
+  it('isolates a failing annotation; subsequent ones still render', () => {
+    const ctx = createMockCtx();
+    const annotations = [
+      // style 누락 → computeLayout(circle)에서 throw, try/catch 로 격리되어야 함
+      { id: 'bad', type: 'circle', position: { type: 'pixel', x: 10, y: 10 } },
+      {
+        id: 'ok',
+        type: 'badge',
+        content: 'OK',
+        position: { type: 'pixel', x: 50, y: 50 },
+        style: { backgroundColor: '#fff', borderColor: '#000', borderWidth: 1, borderRadius: 4, padding: [4, 4, 4, 4], fontSize: '11px' },
+      },
+    ];
+    drawAnnotations(ctx, annotations, viewportCtx, null, fakeMeasure);
+    // 두 번째(정상) 어노테이션은 그려진다
+    const text = ctx.calls.find(c => c.name === 'fillText');
+    expect(text && text.args[0]).toBe('OK');
+  });
+});

--- a/src/components/chart/annotation/annotation.renderer.spec.js
+++ b/src/components/chart/annotation/annotation.renderer.spec.js
@@ -152,7 +152,7 @@ describe('annotation.draw orchestrator', () => {
     const annotations = [
       { id: 'a', type: 'badge', content: 'hidden', position: { type: 'axis', xValue: 999, yValue: 50 }, style: { backgroundColor: '#fff', borderWidth: 0 } },
     ];
-    drawAnnotations(ctx, annotations, viewportCtx, null, fakeMeasure);
+    drawAnnotations(ctx, annotations, viewportCtx, fakeMeasure);
     expect(ctx.calls).toHaveLength(0);
   });
 
@@ -165,7 +165,7 @@ describe('annotation.draw orchestrator', () => {
       position: { type: 'pixel', x: 100, y: 100 },
       style: { backgroundColor: '#fff', borderColor: '#000', borderWidth: 1, borderRadius: 4, padding: [4, 4, 4, 4], fontSize: '11px' },
     }];
-    drawAnnotations(ctx, annotations, viewportCtx, null, fakeMeasure);
+    drawAnnotations(ctx, annotations, viewportCtx, fakeMeasure);
     const text = ctx.calls.find(c => c.name === 'fillText');
     // pixel position has no xValue token source -> token kept verbatim
     expect(text.args[0]).toBe('x={xValue}');
@@ -173,9 +173,9 @@ describe('annotation.draw orchestrator', () => {
 
   it('no-ops on empty/invalid input', () => {
     const ctx = createMockCtx();
-    drawAnnotations(ctx, [], viewportCtx, null, fakeMeasure);
-    drawAnnotations(ctx, null, viewportCtx, null, fakeMeasure);
-    drawAnnotations(null, [{}], viewportCtx, null, fakeMeasure);
+    drawAnnotations(ctx, [], viewportCtx, fakeMeasure);
+    drawAnnotations(ctx, null, viewportCtx, fakeMeasure);
+    drawAnnotations(null, [{}], viewportCtx, fakeMeasure);
     expect(ctx.calls).toHaveLength(0);
   });
 
@@ -192,7 +192,7 @@ describe('annotation.draw orchestrator', () => {
         style: { backgroundColor: '#fff', borderColor: '#000', borderWidth: 1, borderRadius: 4, padding: [4, 4, 4, 4], fontSize: '11px' },
       },
     ];
-    drawAnnotations(ctx, annotations, viewportCtx, null, fakeMeasure);
+    drawAnnotations(ctx, annotations, viewportCtx, fakeMeasure);
     // 두 번째(정상) 어노테이션은 그려진다
     const text = ctx.calls.find(c => c.name === 'fillText');
     expect(text && text.args[0]).toBe('OK');

--- a/src/components/chart/annotation/annotation.resolver.js
+++ b/src/components/chart/annotation/annotation.resolver.js
@@ -3,27 +3,52 @@ import { axisValueToPixel } from './annotation.axis';
 
 /**
  * position.type === 'series' 일 때 location 을 데이터 인덱스로 환산한다.
- *  - 'start' -> 0
- *  - 'end'   -> data.length - 1
- *  - number  -> [0, length-1] 로 clamp
+ *  - 'start' -> 데이터가 있는(non-null) 첫 번째 인덱스
+ *  - 'end'   -> 데이터가 있는(non-null) 마지막 인덱스
+ *  - number  -> [0, length-1] 로 clamp (명시 인덱스는 null 여부와 무관하게 그대로)
+ * data 에 배열을 넘기면 null 값을 건너뛴다. number(길이)를 넘기면(하위호환) start/end 는 0/length-1.
  * @param {('start'|'end'|number)} location
- * @param {number} length 데이터 길이
- * @returns {number} 인덱스 (length 0 이면 -1)
+ * @param {object[]|number} data 데이터 배열(권장) 또는 길이
+ * @param {boolean} [horizontal=false] 값축이 X축이면 true(가로 막대). 값 유무 판정 필드 선택용
+ * @returns {number} 인덱스 (없으면 -1)
  */
-export function resolveLocationIndex(location, length) {
+export function resolveLocationIndex(location, data, horizontal = false) {
+  const isArr = Array.isArray(data);
+  let length = 0;
+  if (isArr) {
+    length = data.length;
+  } else if (typeof data === 'number') {
+    length = data;
+  }
   if (length <= 0) {
     return -1;
-  }
-  if (location === 'start') {
-    return 0;
-  }
-  if (location === 'end') {
-    return length - 1;
   }
   if (typeof location === 'number' && Number.isInteger(location)) {
     return Math.min(Math.max(location, 0), length - 1);
   }
-  return length - 1;
+  // 값 유무: 값축(가로=x, 세로=y) 필드가 non-null 인지로 판정
+  const hasValue = pt => pt && (horizontal ? pt.x != null : pt.y != null);
+  if (location === 'start') {
+    if (!isArr) {
+      return 0;
+    }
+    for (let i = 0; i < length; i++) {
+      if (hasValue(data[i])) {
+        return i;
+      }
+    }
+    return -1;
+  }
+  // 'end' 및 그 외(기본 end)
+  if (!isArr) {
+    return length - 1;
+  }
+  for (let i = length - 1; i >= 0; i--) {
+    if (hasValue(data[i])) {
+      return i;
+    }
+  }
+  return -1;
 }
 
 /**
@@ -120,15 +145,15 @@ export function resolveAnchor(annotation, ctx) {
     if (!Array.isArray(data)) {
       return hidden;
     }
-    const idx = resolveLocationIndex(position.location, data.length);
+    // 'start'/'end' 는 데이터가 있는(non-null) 첫/마지막 포인트를 가리킨다(앞뒤 null 구간 건너뜀).
+    const idx = resolveLocationIndex(position.location, data, !!series.isHorizontal);
     const pt = idx >= 0 ? data[idx] : null;
-    // xp/yp 는 시리즈 기하 계산(computeGeometry) 결과. 줌으로 화면 밖이면 null → hide.
+    // 선택된 포인트가 줌으로 화면 밖이면(xp/yp null) 숨긴다. (전부 null 이면 idx=-1 → pt 없음)
     if (!pt || pt.xp == null || pt.yp == null) {
       return hidden;
     }
     // 기준점은 시리즈 타입에 따라 다르게 잡는다(xp/yp 는 박스형의 좌상단 코너, w/h 는 부호 포함 크기).
-    //  - bar : 막대의 '값 끝 가장자리 중심' — 카테고리축은 중앙, 값축은 막대 끝(tip). 막대 위 라벨/콜아웃의
-    //          자연스러운 위치다. isHorizontal 로 값축을 판별하며, 양수/음수·스택 막대 모두 부호로 처리된다.
+    //  - bar : 막대의 '값 끝 가장자리 중심'(카테고리축 중앙 + 값축 막대 끝). isHorizontal 로 값축 판별.
     //  - 그 외 박스형(heatMap 등) : 셀 중심(xp+w/2, yp+h/2)
     //  - line/scatter : w/h 가 null 이므로 점 좌표(xp/yp) 그대로
     let baseX = pt.xp;
@@ -185,7 +210,8 @@ export function buildContentContext(annotation, ctx) {
       base.percentage = series.data?.percentage ?? null;
       base.dataIndex = 0;
     } else if (Array.isArray(data)) {
-      const idx = resolveLocationIndex(position.location, data.length);
+      // anchor 와 동일한 인덱스(데이터 있는 첫/마지막)를 써서 토큰 값이 표시 위치와 일치하게 한다.
+      const idx = resolveLocationIndex(position.location, data, !!series.isHorizontal);
       base.dataIndex = idx;
       if (idx >= 0 && data[idx]) {
         base.xValue = data[idx].x;

--- a/src/components/chart/annotation/annotation.resolver.js
+++ b/src/components/chart/annotation/annotation.resolver.js
@@ -1,0 +1,226 @@
+import { isFunction } from 'lodash-es';
+import { axisValueToPixel } from './annotation.axis';
+
+/**
+ * position.type === 'series' 일 때 location 을 데이터 인덱스로 환산한다.
+ *  - 'start' -> 0
+ *  - 'end'   -> data.length - 1
+ *  - number  -> [0, length-1] 로 clamp
+ * @param {('start'|'end'|number)} location
+ * @param {number} length 데이터 길이
+ * @returns {number} 인덱스 (length 0 이면 -1)
+ */
+export function resolveLocationIndex(location, length) {
+  if (length <= 0) {
+    return -1;
+  }
+  if (location === 'start') {
+    return 0;
+  }
+  if (location === 'end') {
+    return length - 1;
+  }
+  if (typeof location === 'number' && Number.isInteger(location)) {
+    return Math.min(Math.max(location, 0), length - 1);
+  }
+  return length - 1;
+}
+
+/**
+ * 어노테이션의 기준점(anchor) 픽셀 좌표를 해석한다. 순수 함수.
+ *
+ * 반환 좌표는 offsetX/offsetY 가 더해진 최종 위치다. 기준점이 현재 viewport(축 범위) 밖이면
+ * isVisible:false 를 반환한다(정책: hide). pixel 은 canvas 좌상단(0,0) 절대 좌표이므로 항상 보인다.
+ *
+ * @param {object} annotation 정규화된 어노테이션
+ * @param {object} ctx 뷰포트 컨텍스트
+ * @param {object} ctx.chartRect  { x1, x2, y1, y2, chartWidth, chartHeight }
+ * @param {object} ctx.labelOffset { left, right, top, bottom }
+ * @param {object} ctx.axesSteps  { x: [{graphMin, graphMax}...], y: [...] }
+ * @param {object} ctx.seriesList { [seriesId]: { data: [{xp, yp, x, y}...] } }
+ * @returns {{ x: number, y: number, isVisible: boolean, anchorX: number, anchorY: number }}
+ *          anchorX/anchorY 는 offset 적용 전의 "원래 기준점"(connector 시작점 계산용).
+ */
+export function resolveAnchor(annotation, ctx) {
+  const hidden = { x: 0, y: 0, anchorX: 0, anchorY: 0, isVisible: false };
+  const { position } = annotation;
+  if (!position) {
+    return hidden;
+  }
+  const offsetX = position.offsetX || 0;
+  const offsetY = position.offsetY || 0;
+
+  if (position.type === 'pixel') {
+    const ax = position.x || 0;
+    const ay = position.y || 0;
+    return { x: ax + offsetX, y: ay + offsetY, anchorX: ax, anchorY: ay, isVisible: true };
+  }
+
+  if (position.type === 'axis') {
+    const { chartRect, labelOffset } = ctx || {};
+    // ctx.axes(타입 포함 디스크립터) 우선, 없으면 axesSteps(linear/time numeric)로 폴백.
+    const axisX = ctx?.axes?.x?.[position.xAxisIndex] ?? ctx?.axesSteps?.x?.[position.xAxisIndex];
+    const axisY = ctx?.axes?.y?.[position.yAxisIndex] ?? ctx?.axesSteps?.y?.[position.yAxisIndex];
+    if (!axisX || !axisY || !chartRect || !labelOffset) {
+      return hidden;
+    }
+
+    const xArea = chartRect.chartWidth - (labelOffset.left + labelOffset.right);
+    const yArea = chartRect.chartHeight - (labelOffset.top + labelOffset.bottom);
+    const xAxisPosition = chartRect.x1 + labelOffset.left;
+    const yAxisPosition = chartRect.y2 - labelOffset.bottom;
+
+    // 축 타입 인지 변환. 범위 밖이면 null → hide.
+    const px = axisValueToPixel(position.xValue, axisX, xArea, xAxisPosition, true);
+    const py = axisValueToPixel(position.yValue, axisY, yArea, yAxisPosition, false);
+    if (px === null || py === null) {
+      return hidden;
+    }
+    return { x: px + offsetX, y: py + offsetY, anchorX: px, anchorY: py, isVisible: true };
+  }
+
+  if (position.type === 'series') {
+    const series = ctx?.seriesList?.[position.seriesId];
+    if (!series) {
+      return hidden;
+    }
+
+    // 시리즈가 숨김 상태(범례 토글 또는 옵션 show:false)면 그 시리즈를 추적하는 어노테이션도 그리지 않는다.
+    // EVUI 의 가시성 플래그는 series.show 다(범례 클릭이 이 값을 토글). show 가 명시적으로 false 일 때만 숨긴다.
+    if (series.show === false) {
+      return hidden;
+    }
+
+    // 파이/도넛: 조각마다 seriesId 가 다르고 기하는 series 인스턴스에 각도로 저장된다(data 는 배열이 아님).
+    // 조각의 바깥 원둘레(outer arc) 위 각도 중간 지점을 기준점으로 한다 — 라벨/콜아웃을 바깥으로 빼기 좋다.
+    // (offset 으로 더 바깥으로 밀 수 있다.) hole 과 무관하게 바깥 반지름 기준. location 무시.
+    if (series.type === 'pie') {
+      const {
+        centerX, centerY, radius, startAngle, endAngle,
+      } = series;
+      if (centerX == null || centerY == null || radius == null
+        || startAngle == null || endAngle == null) {
+        return hidden;
+      }
+      let midAngle = (startAngle + endAngle) / 2;
+      // 단일 조각(전체 원, sweep≈2π)일 때 mid-angle 이 위/아래(세로)로 떨어져 라벨 공간이 부족하다.
+      // 가로 여유가 더 크므로 오른쪽(3시, 0 rad)에 배치한다(offset 으로 좌측 등으로 옮길 수 있음).
+      const sweep = Math.abs(endAngle - startAngle);
+      if (sweep >= Math.PI * 2 - 1e-6) {
+        midAngle = 0;
+      }
+      const baseX = centerX + Math.cos(midAngle) * radius;
+      const baseY = centerY + Math.sin(midAngle) * radius;
+      return {
+        x: baseX + offsetX, y: baseY + offsetY, anchorX: baseX, anchorY: baseY, isVisible: true,
+      };
+    }
+
+    const data = series.data;
+    if (!Array.isArray(data)) {
+      return hidden;
+    }
+    const idx = resolveLocationIndex(position.location, data.length);
+    const pt = idx >= 0 ? data[idx] : null;
+    // xp/yp 는 시리즈 기하 계산(computeGeometry) 결과. 줌으로 화면 밖이면 null → hide.
+    if (!pt || pt.xp == null || pt.yp == null) {
+      return hidden;
+    }
+    // 기준점은 시리즈 타입에 따라 다르게 잡는다(xp/yp 는 박스형의 좌상단 코너, w/h 는 부호 포함 크기).
+    //  - bar : 막대의 '값 끝 가장자리 중심' — 카테고리축은 중앙, 값축은 막대 끝(tip). 막대 위 라벨/콜아웃의
+    //          자연스러운 위치다. isHorizontal 로 값축을 판별하며, 양수/음수·스택 막대 모두 부호로 처리된다.
+    //  - 그 외 박스형(heatMap 등) : 셀 중심(xp+w/2, yp+h/2)
+    //  - line/scatter : w/h 가 null 이므로 점 좌표(xp/yp) 그대로
+    let baseX = pt.xp;
+    let baseY = pt.yp;
+    const hasBox = typeof pt.w === 'number' && typeof pt.h === 'number';
+    if (series.type === 'bar' && hasBox) {
+      if (series.isHorizontal) {
+        baseX = pt.xp + pt.w; // 값축(X): 막대 끝
+        baseY = pt.yp + pt.h / 2; // 카테고리축(Y): 중앙
+      } else {
+        baseX = pt.xp + pt.w / 2; // 카테고리축(X): 중앙
+        baseY = pt.yp + pt.h; // 값축(Y): 막대 끝
+      }
+    } else if (hasBox) {
+      baseX = pt.xp + pt.w / 2;
+      baseY = pt.yp + pt.h / 2;
+    }
+    return { x: baseX + offsetX, y: baseY + offsetY, anchorX: baseX, anchorY: baseY, isVisible: true };
+  }
+
+  return hidden;
+}
+
+/**
+ * series 추적 포인트(있으면)에서 토큰 치환/콜백 평가에 쓸 컨텍스트를 만든다.
+ * @param {object} annotation 정규화된 어노테이션
+ * @param {object} ctx 뷰포트 컨텍스트(resolveAnchor 와 동일)
+ * @returns {object} { xValue, yValue, seriesId, seriesName, dataIndex, percentage }
+ */
+export function buildContentContext(annotation, ctx) {
+  const { position } = annotation;
+  const base = {
+    xValue: null,
+    yValue: null,
+    seriesId: null,
+    seriesName: null,
+    dataIndex: -1,
+    percentage: null,
+  };
+  if (!position) {
+    return base;
+  }
+  if (position.type === 'axis') {
+    base.xValue = position.xValue;
+    base.yValue = position.yValue;
+  } else if (position.type === 'series') {
+    const series = ctx?.seriesList?.[position.seriesId];
+    const data = series?.data;
+    base.seriesId = position.seriesId;
+    base.seriesName = series?.name ?? null;
+    if (series?.type === 'pie') {
+      // 파이 조각: 값/비율은 series.data({ o, percentage })에 있다.
+      base.yValue = series.data?.o ?? null;
+      base.percentage = series.data?.percentage ?? null;
+      base.dataIndex = 0;
+    } else if (Array.isArray(data)) {
+      const idx = resolveLocationIndex(position.location, data.length);
+      base.dataIndex = idx;
+      if (idx >= 0 && data[idx]) {
+        base.xValue = data[idx].x;
+        base.yValue = data[idx].y;
+      }
+    }
+  }
+  return base;
+}
+
+/**
+ * content 를 최종 문자열로 해석한다.
+ *  - function (ctx) => string : evalCtx 를 인자로 호출
+ *  - string : {token} 치환 ({xValue}, {yValue}, {seriesId}, {seriesName}, {dataIndex})
+ * 순수 함수.
+ * @param {string|Function} content 정규화된 content
+ * @param {object} evalCtx buildContentContext 결과
+ * @returns {string}
+ */
+export function resolveContent(content, evalCtx = {}) {
+  if (isFunction(content)) {
+    try {
+      const out = content(evalCtx);
+      return out == null ? '' : String(out);
+    } catch (e) {
+      return '';
+    }
+  }
+  if (typeof content !== 'string') {
+    return content == null ? '' : String(content);
+  }
+  return content.replace(/\{(\w+)\}/g, (match, token) => {
+    if (token in evalCtx && evalCtx[token] != null) {
+      return String(evalCtx[token]);
+    }
+    return match; // 알 수 없는 토큰은 원문 유지
+  });
+}

--- a/src/components/chart/annotation/annotation.resolver.spec.js
+++ b/src/components/chart/annotation/annotation.resolver.spec.js
@@ -28,13 +28,31 @@ const ctx = {
 
 describe('annotation.resolver', () => {
   describe('resolveLocationIndex', () => {
-    it('start/end/number/clamp/empty', () => {
+    it('start/end/number/clamp/empty (length 하위호환)', () => {
       expect(resolveLocationIndex('start', 5)).toBe(0);
       expect(resolveLocationIndex('end', 5)).toBe(4);
       expect(resolveLocationIndex(2, 5)).toBe(2);
       expect(resolveLocationIndex(99, 5)).toBe(4); // clamp
       expect(resolveLocationIndex(-3, 5)).toBe(0); // clamp
       expect(resolveLocationIndex('end', 0)).toBe(-1);
+    });
+    it('array: start/end 는 데이터 있는(non-null) 첫/마지막', () => {
+      const data = [{ y: null }, { y: 5 }, { y: 6 }, { y: null }];
+      expect(resolveLocationIndex('start', data)).toBe(1);
+      expect(resolveLocationIndex('end', data)).toBe(2);
+    });
+    it('array: 명시 인덱스는 null 여부 무관하게 그대로(clamp)', () => {
+      const data = [{ y: null }, { y: 5 }];
+      expect(resolveLocationIndex(0, data)).toBe(0);
+      expect(resolveLocationIndex(9, data)).toBe(1);
+    });
+    it('array: 전부 null 이면 -1', () => {
+      expect(resolveLocationIndex('start', [{ y: null }, { y: null }])).toBe(-1);
+      expect(resolveLocationIndex('end', [{ y: null }, { y: null }])).toBe(-1);
+    });
+    it('horizontal 은 x 필드로 값 유무 판정', () => {
+      const data = [{ x: null }, { x: 5 }];
+      expect(resolveLocationIndex('start', data, true)).toBe(1);
     });
   });
 
@@ -81,6 +99,51 @@ describe('annotation.resolver', () => {
       const ann = { position: { type: 'series', seriesId: 's1', location: 'end' } };
       // last index has yp null => hidden
       expect(resolveAnchor(ann, ctx).isVisible).toBe(false);
+    });
+
+    it('start skips leading null values to first data point', () => {
+      const skipCtx = {
+        seriesList: {
+          s: {
+            data: [
+              { x: 0, y: null, xp: 50, yp: null },
+              { x: 1, y: 20, xp: 100, yp: 240 },
+              { x: 2, y: 30, xp: 150, yp: 220 },
+            ],
+          },
+        },
+      };
+      const ann = { position: { type: 'series', seriesId: 's', location: 'start' } };
+      expect(resolveAnchor(ann, skipCtx)).toMatchObject({ x: 100, y: 240, isVisible: true });
+    });
+
+    it('end skips trailing null values to last data point', () => {
+      const skipCtx = {
+        seriesList: {
+          s: {
+            data: [
+              { x: 0, y: 10, xp: 50, yp: 260 },
+              { x: 1, y: 20, xp: 100, yp: 240 },
+              { x: 2, y: null, xp: 150, yp: null },
+            ],
+          },
+        },
+      };
+      const ann = { position: { type: 'series', seriesId: 's', location: 'end' } };
+      expect(resolveAnchor(ann, skipCtx)).toMatchObject({ x: 100, y: 240, isVisible: true });
+    });
+
+    it('hides when all data points are null', () => {
+      const allNull = { seriesList: { s: { data: [{ y: null, xp: null, yp: null }, { y: null, xp: null, yp: null }] } } };
+      const ann = { position: { type: 'series', seriesId: 's', location: 'start' } };
+      expect(resolveAnchor(ann, allNull).isVisible).toBe(false);
+    });
+
+    it('numeric index is literal (does not skip null)', () => {
+      const nullAt0 = { seriesList: { s: { data: [{ x: 0, y: null, xp: 50, yp: null }, { x: 1, y: 20, xp: 100, yp: 240 }] } } };
+      const ann = { position: { type: 'series', seriesId: 's', location: 0 } };
+      // 명시 인덱스 0 은 null 이어도 그대로 → yp null → 숨김
+      expect(resolveAnchor(ann, nullAt0).isVisible).toBe(false);
     });
     it('numeric index', () => {
       const ann = { position: { type: 'series', seriesId: 's1', location: 1 } };

--- a/src/components/chart/annotation/annotation.resolver.spec.js
+++ b/src/components/chart/annotation/annotation.resolver.spec.js
@@ -1,0 +1,258 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveAnchor,
+  resolveLocationIndex,
+  resolveContent,
+  buildContentContext,
+} from './annotation.resolver';
+
+// graphMin=0, graphMax=100, area=200 => 1 unit = 2px
+const ctx = {
+  chartRect: { x1: 50, x2: 450, y1: 20, y2: 320, chartWidth: 400, chartHeight: 300 },
+  labelOffset: { left: 50, right: 50, top: 50, bottom: 50 },
+  axesSteps: {
+    x: [{ graphMin: 0, graphMax: 100 }],
+    y: [{ graphMin: 0, graphMax: 100 }],
+  },
+  seriesList: {
+    s1: {
+      name: 'Series One',
+      data: [
+        { x: 0, y: 10, xp: 100, yp: 260 },
+        { x: 1, y: 20, xp: 150, yp: 240 },
+        { x: 2, y: 30, xp: 200, yp: null }, // zoomed-out point
+      ],
+    },
+  },
+};
+
+describe('annotation.resolver', () => {
+  describe('resolveLocationIndex', () => {
+    it('start/end/number/clamp/empty', () => {
+      expect(resolveLocationIndex('start', 5)).toBe(0);
+      expect(resolveLocationIndex('end', 5)).toBe(4);
+      expect(resolveLocationIndex(2, 5)).toBe(2);
+      expect(resolveLocationIndex(99, 5)).toBe(4); // clamp
+      expect(resolveLocationIndex(-3, 5)).toBe(0); // clamp
+      expect(resolveLocationIndex('end', 0)).toBe(-1);
+    });
+  });
+
+  describe('resolveAnchor - pixel', () => {
+    it('absolute canvas coord + offset, always visible', () => {
+      const ann = { position: { type: 'pixel', x: 30, y: 40, offsetX: 5, offsetY: -10 } };
+      expect(resolveAnchor(ann, ctx)).toMatchObject({ x: 35, y: 30, isVisible: true });
+    });
+  });
+
+  describe('resolveAnchor - axis', () => {
+    // xAxisPosition = x1 + left = 100; xArea = chartWidth - (left+right) = 300
+    // value 50 => 100 + (300/100)*50 = 250
+    it('maps axis value to pixel + offset', () => {
+      const ann = {
+        position: {
+          type: 'axis', xAxisIndex: 0, yAxisIndex: 0, xValue: 50, yValue: 50, offsetX: 0, offsetY: 0,
+        },
+      };
+      const r = resolveAnchor(ann, ctx);
+      expect(r.isVisible).toBe(true);
+      expect(r.x).toBe(250);
+      // yAxisPosition = y2 - bottom = 270; yArea = 300 - 100 = 200; 270 - (200/100)*50 = 170
+      expect(r.y).toBe(170);
+    });
+
+    it('hides when value is out of axis range', () => {
+      const ann = { position: { type: 'axis', xValue: 999, yValue: 50 } };
+      expect(resolveAnchor(ann, ctx).isVisible).toBe(false);
+    });
+
+    it('hides when axis step missing', () => {
+      const ann = { position: { type: 'axis', xAxisIndex: 3, xValue: 1, yValue: 1 } };
+      expect(resolveAnchor(ann, ctx).isVisible).toBe(false);
+    });
+  });
+
+  describe('resolveAnchor - series', () => {
+    it('start tracks first point', () => {
+      const ann = { position: { type: 'series', seriesId: 's1', location: 'start', offsetX: 0, offsetY: -30 } };
+      expect(resolveAnchor(ann, ctx)).toMatchObject({ x: 100, y: 230, anchorX: 100, anchorY: 260, isVisible: true });
+    });
+    it('end tracks last point with non-null xp/yp gating', () => {
+      const ann = { position: { type: 'series', seriesId: 's1', location: 'end' } };
+      // last index has yp null => hidden
+      expect(resolveAnchor(ann, ctx).isVisible).toBe(false);
+    });
+    it('numeric index', () => {
+      const ann = { position: { type: 'series', seriesId: 's1', location: 1 } };
+      expect(resolveAnchor(ann, ctx)).toMatchObject({ x: 150, y: 240, isVisible: true });
+    });
+    it('hides for unknown series', () => {
+      const ann = { position: { type: 'series', seriesId: 'nope', location: 'end' } };
+      expect(resolveAnchor(ann, ctx).isVisible).toBe(false);
+    });
+
+    it('hides when the tracked series is not visible (show:false)', () => {
+      const hiddenCtx = {
+        seriesList: { s1: { show: false, data: [{ xp: 100, yp: 200 }] } },
+      };
+      const ann = { position: { type: 'series', seriesId: 's1', location: 0 } };
+      expect(resolveAnchor(ann, hiddenCtx).isVisible).toBe(false);
+    });
+
+    it('hides pie slice when its series is not visible (legend toggle)', () => {
+      const hiddenPie = {
+        seriesList: {
+          's-0': {
+            type: 'pie', show: false, centerX: 100, centerY: 100, radius: 80,
+            startAngle: 0, endAngle: Math.PI, data: { o: 1, percentage: 50 },
+          },
+        },
+      };
+      const ann = { position: { type: 'series', seriesId: 's-0' } };
+      expect(resolveAnchor(ann, hiddenPie).isVisible).toBe(false);
+    });
+
+    it('vertical bar anchors to value-end edge center (top-center)', () => {
+      const barCtx = {
+        seriesList: {
+          // 수직 bar: xp/yp = 좌상단 코너, h 음수(위로 확장)
+          bars: { type: 'bar', isHorizontal: false, name: 'Bars', data: [{ x: 0, y: 60, xp: 100, yp: 200, w: 40, h: -60 }] },
+        },
+      };
+      const ann = { position: { type: 'series', seriesId: 'bars', location: 0 } };
+      // 카테고리축(X) 중앙 = 100+40/2 = 120, 값축(Y) 막대 끝 = 200+(-60) = 140
+      expect(resolveAnchor(ann, barCtx)).toMatchObject({
+        x: 120, y: 140, anchorX: 120, anchorY: 140, isVisible: true,
+      });
+    });
+
+    it('horizontal bar anchors to value-end edge center (end-center)', () => {
+      const barCtx = {
+        seriesList: {
+          bars: { type: 'bar', isHorizontal: true, data: [{ xp: 50, yp: 100, w: 80, h: -20 }] },
+        },
+      };
+      const ann = { position: { type: 'series', seriesId: 'bars', location: 0 } };
+      // 값축(X) 막대 끝 = 50+80 = 130, 카테고리축(Y) 중앙 = 100+(-20)/2 = 90
+      expect(resolveAnchor(ann, barCtx)).toMatchObject({
+        x: 130, y: 90, anchorX: 130, anchorY: 90, isVisible: true,
+      });
+    });
+
+    it('bar respects offset on top of edge center', () => {
+      const barCtx = {
+        seriesList: { bars: { type: 'bar', isHorizontal: false, data: [{ xp: 50, yp: 100, w: 80, h: -20 }] } },
+      };
+      const ann = { position: { type: 'series', seriesId: 'bars', location: 0, offsetX: 5, offsetY: -10 } };
+      // edge center = (50+40, 100-20) = (90, 80); +offset => (95, 70); anchor stays at edge center
+      expect(resolveAnchor(ann, barCtx)).toMatchObject({
+        x: 95, y: 70, anchorX: 90, anchorY: 80, isVisible: true,
+      });
+    });
+
+    it('non-bar box (heatMap) still anchors to cell center', () => {
+      const hmCtx = {
+        seriesList: { cells: { type: 'heatMap', data: [{ xp: 10, yp: 10, w: 20, h: 20 }] } },
+      };
+      const ann = { position: { type: 'series', seriesId: 'cells', location: 0 } };
+      // center = (20, 20)
+      expect(resolveAnchor(ann, hmCtx)).toMatchObject({ x: 20, y: 20, isVisible: true });
+    });
+
+    it('pie slice anchors to outer circumference at mid-angle', () => {
+      const pieCtx = {
+        seriesList: {
+          's-0': {
+            type: 'pie', name: 'A', centerX: 100, centerY: 100, radius: 80,
+            startAngle: 0, endAngle: Math.PI, doughnutHoleSize: 0,
+            data: { o: 250, percentage: 25 },
+          },
+        },
+      };
+      const ann = { position: { type: 'series', seriesId: 's-0' } };
+      // midAngle = π/2 → cos=0, sin=1; outer radius 80 → (100, 180)
+      const r = resolveAnchor(ann, pieCtx);
+      expect(r.isVisible).toBe(true);
+      expect(Math.round(r.x)).toBe(100);
+      expect(Math.round(r.y)).toBe(180);
+    });
+
+    it('single full-circle slice anchors to the right (3 o\'clock), not bottom', () => {
+      const pieCtx = {
+        seriesList: {
+          's-0': {
+            type: 'pie', centerX: 100, centerY: 100, radius: 80,
+            // 전체 원: 12시(1.5π) 시작 + 2π sweep
+            startAngle: 1.5 * Math.PI, endAngle: 3.5 * Math.PI, doughnutHoleSize: 0,
+            data: { o: 1, percentage: 100 },
+          },
+        },
+      };
+      const ann = { position: { type: 'series', seriesId: 's-0' } };
+      // sweep≈2π → midAngle 0(오른쪽) → (180, 100)
+      const r = resolveAnchor(ann, pieCtx);
+      expect(Math.round(r.x)).toBe(180);
+      expect(Math.round(r.y)).toBe(100);
+    });
+
+    it('doughnut anchors at outer circumference (hole-independent)', () => {
+      const pieCtx = {
+        seriesList: {
+          's-0': {
+            type: 'pie', centerX: 100, centerY: 100, radius: 80,
+            startAngle: 0, endAngle: Math.PI, doughnutHoleSize: 40,
+            data: { o: 1, percentage: 50 },
+          },
+        },
+      };
+      const ann = { position: { type: 'series', seriesId: 's-0' } };
+      // 바깥 반지름 80 기준(hole 무관) → (100, 180)
+      const r = resolveAnchor(ann, pieCtx);
+      expect(Math.round(r.x)).toBe(100);
+      expect(Math.round(r.y)).toBe(180);
+    });
+
+    it('pie hidden when geometry not yet populated', () => {
+      const pieCtx = { seriesList: { 's-0': { type: 'pie', name: 'A' } } };
+      const ann = { position: { type: 'series', seriesId: 's-0' } };
+      expect(resolveAnchor(ann, pieCtx).isVisible).toBe(false);
+    });
+
+    it('pie content context exposes value and percentage', () => {
+      const pieCtx = {
+        seriesList: {
+          's-0': { type: 'pie', name: 'Sales', data: { o: 250, percentage: 25 } },
+        },
+      };
+      const ann = { position: { type: 'series', seriesId: 's-0' } };
+      const ec = buildContentContext(ann, pieCtx);
+      expect(ec).toMatchObject({ seriesName: 'Sales', yValue: 250, percentage: 25 });
+      expect(resolveContent('{seriesName} {percentage}%', ec)).toBe('Sales 25%');
+    });
+  });
+
+  describe('buildContentContext + resolveContent', () => {
+    it('series tokens', () => {
+      const ann = { position: { type: 'series', seriesId: 's1', location: 1 } };
+      const ec = buildContentContext(ann, ctx);
+      expect(ec).toMatchObject({ seriesName: 'Series One', xValue: 1, yValue: 20, dataIndex: 1 });
+      expect(resolveContent('{seriesName}: {yValue}', ec)).toBe('Series One: 20');
+    });
+    it('axis tokens', () => {
+      const ann = { position: { type: 'axis', xValue: 5, yValue: 15000 } };
+      const ec = buildContentContext(ann, ctx);
+      expect(resolveContent('y={yValue}', ec)).toBe('y=15000');
+    });
+    it('unknown token kept verbatim', () => {
+      expect(resolveContent('{nope}', {})).toBe('{nope}');
+    });
+    it('callback content receives ctx', () => {
+      const fn = c => `val ${c.yValue}`;
+      expect(resolveContent(fn, { yValue: 42 })).toBe('val 42');
+    });
+    it('callback throwing yields empty string', () => {
+      const fn = () => { throw new Error('boom'); };
+      expect(resolveContent(fn, {})).toBe('');
+    });
+  });
+});

--- a/src/components/chart/annotation/index.js
+++ b/src/components/chart/annotation/index.js
@@ -3,7 +3,7 @@
  *
  * 사용 흐름:
  *   1) 옵션 변경 시 1회: const { annotations, warnings } = normalizeAnnotations(options.annotations)
- *   2) 매 렌더 프레임: drawAnnotations(ctx, annotations, viewportCtx, plotBounds)
+ *   2) 매 렌더 프레임: drawAnnotations(ctx, annotations, viewportCtx)
  *
  * viewportCtx 계약:
  *   { chartRect: {x1,x2,y1,y2,chartWidth,chartHeight},

--- a/src/components/chart/annotation/index.js
+++ b/src/components/chart/annotation/index.js
@@ -1,0 +1,28 @@
+/**
+ * EvChart 어노테이션/뱃지 모듈 공개 API.
+ *
+ * 사용 흐름:
+ *   1) 옵션 변경 시 1회: const { annotations, warnings } = normalizeAnnotations(options.annotations)
+ *   2) 매 렌더 프레임: drawAnnotations(ctx, annotations, viewportCtx, plotBounds)
+ *
+ * viewportCtx 계약:
+ *   { chartRect: {x1,x2,y1,y2,chartWidth,chartHeight},
+ *     labelOffset: {left,right,top,bottom},
+ *     axes|axesSteps: { x:[AxisDescriptor], y:[AxisDescriptor] },
+ *     seriesList: { [seriesId]: { name, data:[{x,y,xp,yp}] } } }
+ */
+export { normalizeAnnotations, normalizePadding } from './annotation.normalize';
+export { drawAnnotations } from './annotation.draw';
+export {
+  resolveAnchor,
+  resolveContent,
+  buildContentContext,
+  resolveLocationIndex,
+} from './annotation.resolver';
+export { computeLayout, computeBoxSize, measureContent } from './annotation.layout';
+export { axisValueToPixel, normalizeAxisValue } from './annotation.axis';
+export {
+  ANNOTATION_TYPES,
+  POSITION_TYPES,
+  ANNOTATION_DEFAULT,
+} from './annotation.constant';

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -19,6 +19,8 @@ import Blit from './chart.blit';
 import Selection from './chart.selection';
 import { WorkerRenderGate } from './render/render.worker.gate';
 import { toRenderSnapshot, packSeries } from './render/render.snapshot';
+import { normalizeAnnotations } from './annotation/annotation.normalize';
+import { drawAnnotations } from './annotation/annotation.draw';
 
 // realtime scatter blit: 시프트 누적으로 생기는 sub-pixel 오차를 주기적으로 리셋하기 위해,
 // 이 프레임 수마다 게이트 통과 여부와 무관하게 full redraw 로 돌아가 픽셀을 절대 좌표와 일치시킨다.
@@ -491,6 +493,8 @@ class EvChart {
     this.drawForeground(this.bufferCtx);
 
     this.commitToDisplay(this.displayCtx, this.bufferCanvas);
+
+    this.drawAnnotationLayer();
   }
 
   /**
@@ -539,6 +543,9 @@ class EvChart {
       // commitWorkerFrame 이 series bitmap 위에 그린다(z-order). 여기서 tip 을 buffer 에 그리면 가려진다.
       this.drawSeriesOverlay();
     }
+
+    this.drawAnnotationLayer();
+    
     return true;
   }
 
@@ -1131,6 +1138,112 @@ class EvChart {
   }
 
   /**
+   * 어노테이션 전용 캔버스(z-index:3, pointer-events:none)를 지연 생성한다.
+   * options.annotations 를 실제로 쓸 때만 호출되어, 미사용 차트의 캔버스 메모리/합성 레이어 비용을 없앤다.
+   * @returns {boolean} 사용 가능 여부(brush 차트 등은 false)
+   */
+  ensureAnnotationCanvas() {
+    if (this.annotationCtx) {
+      return true;
+    }
+    
+    // brush(미니맵) 차트는 overlay 도 없고 어노테이션을 쓰지 않는다.
+    if (this.options.brush || !this.chartDOM || !this.displayCanvas) {
+      return false;
+    }
+
+    const isPie = this.options.type === 'pie';
+    this.annotationCanvas = document.createElement('canvas');
+    this.annotationCanvas.setAttribute('style', 'display: block; z-index: 3;');
+    this.annotationCanvas.setAttribute('class', 'annotation-canvas');
+    this.annotationCtx = this.annotationCanvas.getContext('2d', { willReadFrequently: isPie });
+    this.chartDOM.appendChild(this.annotationCanvas);
+    this.annotationCanvas.style.position = 'absolute';
+    this.annotationCanvas.style.top = '0px';
+    this.annotationCanvas.style.left = '0px';
+    this.annotationCanvas.style.pointerEvents = 'none';
+
+    // 현재 display 캔버스 치수/배율로 즉시 정렬(이후 리사이즈는 setWidth/setHeight 가 동기화).
+    this.annotationCanvas.width = this.displayCanvas.width;
+    this.annotationCanvas.style.width = this.displayCanvas.style.width;
+    this.annotationCanvas.height = this.displayCanvas.height;
+    this.annotationCanvas.style.height = this.displayCanvas.style.height;
+    this.annotationCtx.setTransform(this.pixelRatio, 0, 0, this.pixelRatio, 0, 0);
+
+    return true;
+  }
+
+  /**
+   * 어노테이션 레이어를 전용 캔버스(시리즈/overlay 위, tooltip 아래)에 그린다. main/realtime 경로 공통.
+   * options.annotations 가 바뀔 때만 normalize 하고(참조 동일성 캐시), 매 프레임 좌표만 재해석한다.
+   * 좌표는 시리즈 기하(xp/yp)와 동일한 chartRect/labelOffset/axesSteps 계약을 쓰므로 줌/리사이즈에 일관.
+   * @returns {undefined}
+   */
+  drawAnnotationLayer() {
+    const raw = this.options?.annotations;
+    const hasAnnotations = Array.isArray(raw) && raw.length > 0;
+
+    if (!hasAnnotations) {
+      // 어노테이션 미사용: 캔버스를 만들지도, clear 하지도 않는다(미사용 차트 비용 0).
+      // 단, 직전 프레임에 그려둔 게 있으면(어노테이션이 제거된 경우) 한 번 지워 잔상을 없앤다.
+      if (this._hadAnnotations && this.annotationCtx) {
+        const r = this.pixelRatio < 1 ? this.pixelRatio : 1;
+        this.annotationCtx.clearRect(0, 0, this.annotationCanvas.width / r, this.annotationCanvas.height / r);
+        this._hadAnnotations = false;
+      }
+      return;
+    }
+
+    if (!this.ensureAnnotationCanvas()) {
+      return;
+    }
+
+    const ctx = this.annotationCtx;
+    // 전용 레이어(overlay 위)라 hover 하이라이트가 어노테이션을 가리지 않는다. hover repaint 는
+    // overlay 만 건드리므로 이 레이어는 geometry 가 바뀌는 drawChart 에서만 비우고 다시 그린다.
+    const ratio = this.pixelRatio < 1 ? this.pixelRatio : 1;
+    ctx.clearRect(0, 0, this.annotationCanvas.width / ratio, this.annotationCanvas.height / ratio);
+    this._hadAnnotations = true;
+
+    if (this._annotationSource !== raw) {
+      const { annotations, warnings } = normalizeAnnotations(raw);
+      this._normalizedAnnotations = annotations;
+      this._annotationSource = raw;
+      warnings.forEach((w) => Console.warn(w));
+    }
+
+    drawAnnotations(ctx, this._normalizedAnnotations, this.buildAnnotationViewport());
+  }
+
+  /**
+   * 어노테이션 좌표 해석용 viewport 컨텍스트를 만든다.
+   * axesSteps(graphMin/graphMax/minIndex/maxIndex)에 축 타입과 카테고리 라벨을 합쳐 디스크립터로 구성한다.
+   * @returns {object} { chartRect, labelOffset, axes, seriesList }
+   */
+  buildAnnotationViewport() {
+    // line/bar 는 labels 가 평면 배열(주로 카테고리 x축), heatMap 은 { x:[], y:[] } 객체다.
+    // step 축의 라벨→인덱스 변환에 쓰이므로 축 방향별로 알맞은 배열을 골라 넘긴다.
+    const rawLabels = this.data?.labels;
+    const isAxisLabelObject = rawLabels && !Array.isArray(rawLabels) && typeof rawLabels === 'object';
+    const xLabels = isAxisLabelObject ? rawLabels.x : rawLabels;
+    const yLabels = isAxisLabelObject ? rawLabels.y : rawLabels;
+    const buildAxes = (steps, axisOpts, labels) => (steps ?? []).map((step, i) => ({
+      ...step,
+      type: axisOpts?.[i]?.type || 'linear',
+      labels,
+    }));
+    return {
+      chartRect: this.chartRect,
+      labelOffset: this.labelOffset,
+      axes: {
+        x: buildAxes(this.axesSteps?.x, this.options?.axesX, xLabels),
+        y: buildAxes(this.axesSteps?.y, this.options?.axesY, yLabels),
+      },
+      seriesList: this.seriesList,
+    };
+  }
+
+  /**
    * Draw Tip with hitInfo and defaultSelectItemInfo
    * @param {CanvasRenderingContext2D} [ctx]  그릴 ctx. worker 경로(commitWorkerFrame)는 series bitmap
    *   위에 합성하려고 displayCtx 를 넘긴다(미전달 시 drawTips 가 main buffer 사용).
@@ -1389,6 +1502,10 @@ class EvChart {
     if (this.overlayCtx) {
       this.overlayCtx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
     }
+    
+    if (this.annotationCtx) {
+      this.annotationCtx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+    }
   }
 
   /**
@@ -1536,6 +1653,11 @@ class EvChart {
       this.overlayCanvas.style.width = `${width}px`;
     }
 
+    if (this.annotationCanvas) {
+      this.annotationCanvas.width = deviceWidth;
+      this.annotationCanvas.style.width = `${width}px`;
+    }
+
     // pointsLayer 는 치수가 실제로 바뀔 때만 재할당한다. canvas.width 대입은 값이 같아도 비트맵을
     // 전부 지우므로, render() 마다 호출되는 이 경로에서 무조건 대입하면 blit 누적 픽셀이 매 틱 사라진다.
     // 비교값은 canvas.width 대입 시의 정수 절삭 규칙과 동일하게 floor 한다 — DOM 폭이 소수(예: 590.5)면
@@ -1575,6 +1697,11 @@ class EvChart {
     if (this.overlayCanvas) {
       this.overlayCanvas.height = deviceHeight;
       this.overlayCanvas.style.height = `${height}px`;
+    }
+
+    if (this.annotationCanvas) {
+      this.annotationCanvas.height = deviceHeight;
+      this.annotationCanvas.style.height = `${height}px`;
     }
 
     // setWidth 와 동일 이유: 치수 변경 시에만 재할당(매 틱 clear 방지).

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -2365,6 +2365,13 @@ class EvChart {
     this.displayCanvas = null;
     this.bufferCanvas = null;
     this.overlayCanvas = null;
+    // 어노테이션 전용 캔버스/캐시도 형제 캔버스와 대칭으로 정리한다. 그래야 향후 destroy()→init()
+    // 재사용 시 ensureAnnotationCanvas 의 stale-ctx 단락(보이지 않는 캔버스에 그리기)이 발생하지 않는다.
+    this.annotationCanvas = null;
+    this.annotationCtx = null;
+    this._normalizedAnnotations = null;
+    this._annotationSource = null;
+    this._hadAnnotations = false;
 
     while (target.hasChildNodes()) {
       target.removeChild(target.firstChild);


### PR DESCRIPTION
## 개요
EvChart에 차트 위 텍스트/뱃지/말풍선/원형 강조를 표시하는 **어노테이션 모듈**을 추가합니다.
`options.annotations` 배열로 선언하며, line/bar/scatter/heatMap/pie 전 차트 타입을 지원합니다.

## 주요 기능
- **type 4종**: `text`(라벨) / `badge`(배경 박스) / `callout`(꼬리 말풍선) / `circle`(강조 원)
- **position 3종**
  - `pixel`: canvas 절대 좌표
  - `axis`: 축 값 기준 (linear/time/step, pie 제외)
  - `series`: 시리즈/데이터 추적
- **content**: 문자열 + 토큰 치환(`{yValue}`, `{seriesName}`, `{percentage}` 등) + 콜백 `(ctx)=>string` + 멀티라인(`\n`)
- **connector**: 데이터 지점↔박스 연결선 (`straight`/`elbow`, `dashStyle`)
- **type별 기본값** 내장 — `type`/`content`/`position`만 줘도 완성된 외형으로 렌더

## 차트 타입별 series 기준점
| 타입 | 기준점 | axis 지원 |
|---|---|---|
| line / scatter | 데이터 포인트 중심 | ✅ |
| bar | 막대 값 끝 변 중앙(가로/세로 자동) | ✅ |
| heatMap | 셀 중심 | ✅(step x/y 라벨) |
| pie | 조각 바깥 둘레(단일 조각이면 오른쪽) | ❌(축 없음) |

## 구현
- 신규 모듈 `src/components/chart/annotation/` — 계산(순수 함수)과 캔버스 렌더 분리
  - `constant` / `normalize` / `axis` / `resolver` / `layout` / `renderer` / `draw` / `index`
- `chart.core.js` 통합
  - **전용 캔버스 레이어**(`z-index:3`, `pointer-events:none`)에 렌더 → hover 하이라이트(overlay)에 가려지지 않음
  - main / worker / realtime 3개 렌더 경로 공통 적용
- **동작 규칙**
  - 기준점이 축 범위/줌 밖이면 미표시
  - 시리즈 숨김(`show:false` 또는 범례 토글) 시 추적 어노테이션 미표시
  - 배열 순서 = z-order(뒤가 위), `callout`이면 connector 자동 비활성

## 성능
- **지연 생성**: 어노테이션 미사용 차트는 전용 캔버스를 만들지 않음(메모리/매 프레임 clear 비용 0)
- **측정 캐시**: 텍스트 크기를 `(content, fontStyle)` 키로 캐싱 → live/realtime에서 재측정 방지
- **항목 격리**: 어노테이션 1개가 throw해도 나머지·차트 렌더는 정상

## 테스트
- 단위 테스트 99개 추가 (정규화/축변환/좌표해석/레이아웃/렌더/캐시/격리)
- 전체 1308개 통과, lint clean

## 문서 / 예제
- 5개 차트 `api/*.md`에 `annotations` 옵션 + 상세 섹션(position/content/connector/style + type별 기본값) 추가
- 5개 차트에 `Annotations` 예제 추가 (line: 라이브 토글, bar: Horizontal 토글 등)

## 테스트 가이드 
- http://localhost:9999/EVUI/heatMap#annotations
- http://localhost:9999/EVUI/pieChart#annotations
- http://localhost:9999/EVUI/scatterChart#annotations
- http://localhost:9999/EVUI/lineChart#annotations
- http://localhost:9999/EVUI/barChart#annotations

## 타입별 예시 이미지 
1. Text
   - <img width="512" height="262" alt="image" src="https://github.com/user-attachments/assets/25968ef1-a9cf-4f3a-9deb-0dbd84ac149d" />

2. Badge
   - <img width="514" height="241" alt="image" src="https://github.com/user-attachments/assets/3cf7b6a9-0692-4fcc-868d-8394e5c6b3ec" />

3. Callout
   - <img width="528" height="246" alt="image" src="https://github.com/user-attachments/assets/b9908b3f-8ad3-4c2c-8738-166c79157fba" />

5. Circle
   - <img width="519" height="238" alt="image" src="https://github.com/user-attachments/assets/2d20692a-89e9-4f96-9a24-7ed1ccce5f8b" />

### 기타 
<img width="708" height="303" alt="image" src="https://github.com/user-attachments/assets/66a367ed-078d-4cda-990c-bace11dc3496" />
