### PR TITLE
fix: realtime scatter blit vs full redraw 차이 발생 현상

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [3.0, 3.4]
+
+jobs:
+  unit:
+    name: Unit (node)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test:run
+
+  visual:
+    name: Visual (browser, blit 계약)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
+
+      # blit≡full 픽셀 동등 가드(chart.blit.*·chart.realtime.*)만 돈다. 이들은 같은 실행 안에서
+      # blit 라스터 vs full redraw 를 getImageData 로 자기비교하므로 OS 독립적이다.
+      # Chart.visual.spec.js 는 커밋된 스크린샷 베이스라인이 macOS(chromium-darwin) 전용이라
+      # ubuntu 러너에서는 재현이 불가해 제외한다(별도 macOS job 이 필요하면 후속 과제).
+      - name: Run blit equivalence visual tests
+        run: npx vitest run --config vitest.config.browser.js chart.blit chart.realtime

--- a/src/components/chart/chart.blit.color.visual.spec.js
+++ b/src/components/chart/chart.blit.color.visual.spec.js
@@ -258,9 +258,11 @@ describe('EvChart realtime scatter blit 2-series color/hit-test', () => {
     window.__EVUI_BLIT_REFRESH_INTERVAL__ = undefined;
   });
 
-  it('소수 폭 + gap 지터 + 실스케일(60k/6k) 장기(24틱)에서 blit 색 구성이 full(golden) 과 동급이다', async () => {
+  it('소수 폭 + gap 지터 + 실스케일(30k/3k) 장기(24틱)에서 blit 색 구성이 full(golden) 과 동급이다', async () => {
     // 실데모 조건 재현: resizable-wrapper 의 소수 CSS 폭, setTimeout 드리프트로 gapCount 3/4 교차,
-    // 100k/8k 급 밀도, 장기 누적. width '100%' 호스트로 소수 폭(590.5px)을 강제한다.
+    // 고밀도 장기 누적. width '100%' 호스트로 소수 폭(590.5px)을 강제한다. seed/tick 규모(30k/3k)는
+    // 컬럼당 수백 점이 쌓이는 밀도(med≫8, comb 가드 유효)를 유지하면서 CI(ubuntu) 런타임 여유를 확보한
+    // 값이다 — golden ring 은 tick 누적이 지배하므로 seed 뿐 아니라 per-tick 점 수도 함께 줄여야 한다.
     const Host = {
       components: { EvChart },
       props: ['data', 'options'],
@@ -279,14 +281,14 @@ describe('EvChart realtime scatter blit 2-series color/hit-test', () => {
     window.__EVUI_BLIT_DEBUG__ = true;
     window.__EVUI_BLIT_DIAG__ = undefined;
     const { container, rerender } = render(Host, {
-      props: { data: genData(BASE, 60000, FULL_SPAN, 57000), options: fluidOptions },
+      props: { data: genData(BASE, 30000, FULL_SPAN, 57000), options: fluidOptions },
     });
     await settle();
     let now = BASE;
     for (let t = 1; t <= 24; t++) {
       now += t % 2 ? 3000 : 4000; // gapCount 3/4 교차(실제 setTimeout 드리프트 모사)
       // eslint-disable-next-line no-await-in-loop
-      await rerender({ data: genData(now, 6000, TICK_SPAN, 95000), options: fluidOptions });
+      await rerender({ data: genData(now, 3000, TICK_SPAN, 95000), options: fluidOptions });
       // eslint-disable-next-line no-await-in-loop
       await settle();
     }
@@ -297,15 +299,17 @@ describe('EvChart realtime scatter blit 2-series color/hit-test', () => {
 
     // golden: 동일 누적 상태(carry 보존)를 full redraw. 데이터 idempotent(toTime 불변, dataKeys dedupe).
     window.__EVUI_BLIT_FORCE_OFF__ = true;
-    await rerender({ data: genData(now, 6000, TICK_SPAN, 95000), options: fluidOptions });
+    await rerender({ data: genData(now, 3000, TICK_SPAN, 95000), options: fluidOptions });
     await settle();
     const golden = getDisplayImageData(container);
 
     window.__EVUI_BLIT_DEBUG__ = false;
     assertNoColorBleed(compare(golden, blit));
     assertNoWhiteLine(golden, blit);
-    // cross-series dedupe(owner-map) 복원으로 60k seed 워크로드가 무거워져 240s 로 상향(#2308 리뷰 후속).
-  }, 240000);
+    // 워크로드 30k/3k(로컬 ~44s, med~143). 이전 60k/6k 는 dedupe 복원(owner-map)으로 full redraw 가
+    // 초선형이 돼 241s(240s 초과)로 flaky — golden·fallback full redraw 가 dominant 라 seed 뿐 아니라
+    // per-tick 점 수도 함께 줄였다. 상한 180s 는 CI(ubuntu) 여유를 두면서 워크로드 회귀 트립와이어로 둔다.
+  }, 180000);
 
   it('hollow 마커(cross/star) + cross-series 동일좌표: blit strip dedupe 가 owner 만 그려 full 과 일치', async () => {
     // strip cross-series dedupe(collectStripDuplicatePoints)가 실효를 갖는 유일 케이스 가드.

--- a/src/components/chart/chart.blit.color.visual.spec.js
+++ b/src/components/chart/chart.blit.color.visual.spec.js
@@ -182,7 +182,7 @@ describe('EvChart realtime scatter blit 2-series color/hit-test', () => {
       `blit red=${bRed} blue=${bBlue} (blue율 ${bRatio.toFixed(4)}, colMax ${bColMax}) / ` +
       `red→blue ${redToBlue}px (${(redToBlue / Math.max(1, gRed)).toFixed(4)}) / ` +
       `blue→red ${blueToRed}px`;
-    return { gRatio, bRatio, redToBlue, blueToRed, gRed, gColMax, bColMax, summary };
+    return { gRatio, bRatio, redToBlue, blueToRed, gRed, gBlue, gColMax, bColMax, summary };
   };
 
   const assertNoColorBleed = (m) => {
@@ -193,15 +193,64 @@ describe('EvChart realtime scatter blit 2-series color/hit-test', () => {
     ).toBeLessThan(Math.max(m.gRatio * 1.3, 0.002));
     // ② 세로줄: blit 의 컬럼별 blue 최댓값이 golden 의 2배 + 5px 를 넘으면 strip 경계 줄무늬.
     expect(m.bColMax, `세로 blue 줄무늬 — ${m.summary}`).toBeLessThanOrEqual(m.gColMax * 2 + 5);
-    // ③ 픽셀 뒤집힘 비대칭: ±1px 재양자화 지터는 양방향 대칭으로 발생하며 비가시적(blit 설계
-    //    허용 오차). 절대량은 데이터 밀도에 비례하므로 임계로 쓰지 않고, 한쪽으로 쏠리면(비대칭)
-    //    실제 색 오염이므로 양방향 균형만 단언한다.
-    expect(m.redToBlue, `red→blue 가 blue→red 대비 과도(비대칭 오염) — ${m.summary}`).toBeLessThan(
-      Math.max(200, m.blueToRed * 1.6),
-    );
-    expect(m.blueToRed, `blue→red 가 red→blue 대비 과도(비대칭 오염) — ${m.summary}`).toBeLessThan(
-      Math.max(200, m.redToBlue * 1.6),
-    );
+    // ③ 픽셀 뒤집힘 총량 바운드. golden 을 blit 과 *동일 carry* 로 캡처하므로(아래 본문) 점 위치는
+    //    동일하고, 남는 flip 은 순수 겹침 z-order 차이다 — blit 은 누적(나중 틱이 위), full 은 단일
+    //    패스 seriesReverse(series1 이 위). 이 차이는 *단방향*(full 의 위 series 가 고정이라 한쪽으로만
+    //    뒤집힘, blue→red≈0)이라 예전의 양방향 대칭 가정은 더 이상 성립하지 않는다(append-only 의
+    //    구조적 특성 — legend hover 는 series 를 격리해 그려 겹침이 없으므로 사용자 시나리오엔 비가시).
+    //    gross 색 오염은 ①(blue율)·②(colMax)가 잡고, 여기선 전체 flip 이 데이터의 작은 비율인지만 본다.
+    const flips = m.redToBlue + m.blueToRed;
+    const flipBudget = Math.round((m.gRed + m.gBlue) * 0.015);
+    expect(
+      flips,
+      `색 flip 총량 과다(${flips}px / 데이터 ${m.gRed + m.gBlue}px) — ${m.summary}`,
+    ).toBeLessThanOrEqual(flipBudget);
+  };
+
+  // 세로 흰줄(comb) 직접 가드. 기존 가드(color bleed=과밀, occupancy cell=3)는 1px 흰줄을 못 잡는다
+  // — 원래 comb 가 그 스펙들을 통과하며 ship 된 이유다. 이 가드가 comb 회귀의 직접 방어선이다.
+  //
+  // 흰줄 = "고립된 빈 컬럼"(양옆은 밀집인데 자기만 결손). golden(full redraw)도 데이터/축 매핑 고유
+  // gap 이 약간 있으므로(절대 0 이 아님), blit 의 고립 gap 수가 golden 대비 늘지 않았는지로 본다.
+  // 이 검출은 blit 의 ±1px 전역 시프트 드리프트(설계 허용 오차 — 데이터는 다 있고 위치만 <1px 이동)에
+  // 불변이다: 밀도 프로파일이 통째로 1px 평행이동해도 고립 gap 형상은 보존된다. golden 과 컬럼을 1:1
+  // 비교하면 그 1px 드리프트가 거짓 결손으로 잡히므로, 반드시 각자 내부의 고립 gap 수로 비교한다.
+  const isolatedGapCount = (cls, w) => {
+    const x0 = Math.floor(PLOT_REGION.x0 * w);
+    const x1 = Math.ceil(PLOT_REGION.x1 * w);
+    const col = new Uint32Array(w);
+    for (let i = 0; i < cls.length; i++) {
+      if (cls[i]) col[i % w]++;
+    }
+    const vals = [];
+    for (let x = x0; x < x1; x++) {
+      if (col[x] > 0) vals.push(col[x]);
+    }
+    vals.sort((a, c) => a - c);
+    const med = vals.length ? vals[Math.floor(vals.length / 2)] : 0;
+    if (med <= 8) {
+      return { count: 0, med, cols: [] };
+    }
+    const gaps = [];
+    for (let x = x0 + 2; x < x1 - 2; x++) {
+      const left = Math.max(col[x - 1], col[x - 2]);
+      const right = Math.max(col[x + 1], col[x + 2]);
+      if (col[x] < med * 0.12 && left > med * 0.5 && right > med * 0.5) {
+        gaps.push(x);
+      }
+    }
+    return { count: gaps.length, med, cols: gaps };
+  };
+  const assertNoWhiteLine = (golden, blit) => {
+    const w = golden.w;
+    const g = isolatedGapCount(classify(golden, PLOT_REGION), w);
+    const b = isolatedGapCount(classify(blit, PLOT_REGION), w);
+    // blit 의 고립 gap 이 golden 대비 +2 이상 늘면 blit 특이 흰줄(comb) 회귀.
+    expect(
+      b.count,
+      `blit 세로 흰줄(comb) — golden gap=${g.count}(med ${g.med}) vs blit gap=${b.count}(med ${b.med}) ` +
+        `cols=${JSON.stringify(b.cols.slice(0, 12))}`,
+    ).toBeLessThanOrEqual(g.count + 2);
   };
 
   afterEach(() => {
@@ -220,33 +269,41 @@ describe('EvChart realtime scatter blit 2-series color/hit-test', () => {
         '<ev-chart :data="data" :options="options" /></div>',
     };
     const fluidOptions = { ...options, width: '100%', height: '100%' };
-    const runStress = async (forceOff) => {
-      window.__EVUI_BLIT_FORCE_OFF__ = forceOff;
-      const { container, rerender } = render(Host, {
-        props: { data: genData(BASE, 60000, FULL_SPAN, 57000), options: fluidOptions },
-      });
-      await settle();
-      let now = BASE;
-      for (let t = 1; t <= 24; t++) {
-        now += t % 2 ? 3000 : 4000; // gapCount 3/4 교차(실제 setTimeout 드리프트 모사)
-        // eslint-disable-next-line no-await-in-loop
-        await rerender({ data: genData(now, 6000, TICK_SPAN, 95000), options: fluidOptions });
-        // eslint-disable-next-line no-await-in-loop
-        await settle();
-      }
-      return getDisplayImageData(container);
-    };
-
+    // blit 으로 24틱 누적 → blit 라스터 캡처 → 같은 인스턴스를 force-off + 동일 데이터 재렌더해
+    // golden(full redraw) 캡처. golden 은 blit 과 *동일 carry 위상*에서 그려지므로 점 위치는 일치하고
+    // owner/z-order 색 합성만 차이날 수 있다 — 이 스펙의 본래 목적(색 오염). 독립 force-off 스트림
+    // (carry=0)과 비교하면 정수-CSS 시프트의 sub-pixel carry 만큼 경계 컬럼 위상이 달라 거짓 stripe 가
+    // 잡힌다(blit↔full 위치 동등은 chart.blit.equiv.visual.spec.js 가 exactDiff 로 직접 단언).
     window.__EVUI_BLIT_REFRESH_INTERVAL__ = 100000;
-    const golden = await runStress(true);
+    window.__EVUI_BLIT_FORCE_OFF__ = false;
     window.__EVUI_BLIT_DEBUG__ = true;
     window.__EVUI_BLIT_DIAG__ = undefined;
-    const blit = await runStress(false);
+    const { container, rerender } = render(Host, {
+      props: { data: genData(BASE, 60000, FULL_SPAN, 57000), options: fluidOptions },
+    });
+    await settle();
+    let now = BASE;
+    for (let t = 1; t <= 24; t++) {
+      now += t % 2 ? 3000 : 4000; // gapCount 3/4 교차(실제 setTimeout 드리프트 모사)
+      // eslint-disable-next-line no-await-in-loop
+      await rerender({ data: genData(now, 6000, TICK_SPAN, 95000), options: fluidOptions });
+      // eslint-disable-next-line no-await-in-loop
+      await settle();
+    }
+    const blit = getDisplayImageData(container);
     // blit 이 실제로 실행됐는지 확인 — 폴백만 하면 비교가 무의미하다.
     const diag = window.__EVUI_BLIT_DIAG__;
     expect(diag?.blitted ?? 0, `blit 미실행: diag=${JSON.stringify(diag)}`).toBeGreaterThan(15);
+
+    // golden: 동일 누적 상태(carry 보존)를 full redraw. 데이터 idempotent(toTime 불변, dataKeys dedupe).
+    window.__EVUI_BLIT_FORCE_OFF__ = true;
+    await rerender({ data: genData(now, 6000, TICK_SPAN, 95000), options: fluidOptions });
+    await settle();
+    const golden = getDisplayImageData(container);
+
     window.__EVUI_BLIT_DEBUG__ = false;
     assertNoColorBleed(compare(golden, blit));
+    assertNoWhiteLine(golden, blit);
   }, 120000);
 
   it('blit 누적으로 어긋난 hit-test 좌표(xp)가 지연 재계산으로 복구된다', async () => {

--- a/src/components/chart/chart.blit.color.visual.spec.js
+++ b/src/components/chart/chart.blit.color.visual.spec.js
@@ -304,6 +304,84 @@ describe('EvChart realtime scatter blit 2-series color/hit-test', () => {
     window.__EVUI_BLIT_DEBUG__ = false;
     assertNoColorBleed(compare(golden, blit));
     assertNoWhiteLine(golden, blit);
+    // cross-series dedupe(owner-map) 복원으로 60k seed 워크로드가 무거워져 240s 로 상향(#2308 리뷰 후속).
+  }, 240000);
+
+  it('hollow 마커(cross/star) + cross-series 동일좌표: blit strip dedupe 가 owner 만 그려 full 과 일치', async () => {
+    // strip cross-series dedupe(collectStripDuplicatePoints)가 실효를 갖는 유일 케이스 가드.
+    // opaque solid 마커는 합성 z-order 가 owner-dedupe 와 같지만, hollow(stroke-only: cross/star)는
+    // 위 series 마커의 빈 곳으로 아래 series 가 비친다 → owner 외 series 를 안 그려야 full(dedupe)과 일치.
+    // 두 series 에 *동일 좌표* 점을 넣는다(coordinateDedupe on, seriesReverse → series1=red 가 owner).
+    // owner=red cross(작은 마커), 비-owner=blue star(큰 마커: cross + 대각선) — owner 가 비-owner 를
+    // 덮지 못하므로, dedupe 가 없으면 blue star 의 대각선이 새어 나온다. blit 라스터에 그 blue 누출이
+    // 없는지 검증한다(strip dedupe 를 빼면 실패 — 이 케이스가 strip dedupe 의 유일한 실효 지점).
+    const RANGE2 = 60;
+    const hollowOptions = { ...options, realTimeScatter: { use: true, range: RANGE2 } };
+    const genHollow = (toMs) => {
+      // 신규 점은 최신 ~1버킷에 집중(maxDirtyAge 작게 → late-arrival 가드 통과). 매 틱 시프트로 누적.
+      const pts = [{ x: toMs - 1, y: 50 }];
+      for (let i = 0; i < 24; i++) {
+        const h = (i * 2654435761) >>> 0;
+        const x = toMs - 2 - (h % 900);
+        const y = (6000 + ((i * 7919) % 88000)) / 1000;
+        pts.push({ x, y });
+      }
+      return {
+        series: {
+          series1: {
+            name: 'series1',
+            pointSize: 6,
+            pointStyle: 'cross',
+            color: '#DF6264',
+            pointFill: '#DF6264',
+            overflowColor: '#FF00FF',
+          },
+          series2: {
+            name: 'series2',
+            pointSize: 6,
+            pointStyle: 'star',
+            color: '#3CA0FF',
+            pointFill: '#3CA0FF',
+            overflowColor: '#A3D3FF',
+          },
+        },
+        data: { series1: [...pts], series2: [...pts] }, // 동일 좌표(coincident)
+      };
+    };
+
+    window.__EVUI_BLIT_REFRESH_INTERVAL__ = 100000;
+    window.__EVUI_BLIT_FORCE_OFF__ = false;
+    window.__EVUI_BLIT_DEBUG__ = true;
+    window.__EVUI_BLIT_DIAG__ = undefined;
+
+    const { container, rerender } = render(EvChart, {
+      props: { data: genHollow(BASE), options: hollowOptions },
+    });
+    await settle();
+    let now = BASE;
+    for (let t = 1; t <= 12; t++) {
+      now += 1000;
+      // eslint-disable-next-line no-await-in-loop
+      await rerender({ data: genHollow(now), options: hollowOptions });
+      // eslint-disable-next-line no-await-in-loop
+      await settle();
+    }
+    const blit = getDisplayImageData(container);
+    const diag = window.__EVUI_BLIT_DIAG__;
+    expect(diag?.blitted ?? 0, `blit 미실행: diag=${JSON.stringify(diag)}`).toBeGreaterThan(6);
+
+    window.__EVUI_BLIT_FORCE_OFF__ = true;
+    await rerender({ data: genHollow(now), options: hollowOptions });
+    await settle();
+    const golden = getDisplayImageData(container);
+    window.__EVUI_BLIT_DEBUG__ = false;
+
+    const m = compare(golden, blit);
+    // owner=series1(red cross, seriesReverse → 마지막 set). golden 은 owner-only 라 blue(series2 star)
+    // 거의 0. strip dedupe 가 빠지면 blit 에 blue star 대각선이 새어 blit blue율이 급증한다 →
+    // assertNoColorBleed(blit blue율 < golden×1.3, flip 총량 바운드)가 실패한다. owner red 렌더도 확인.
+    expect(m.gRed, `owner(red star) 미렌더(빈 비교 방지) — ${m.summary}`).toBeGreaterThan(50);
+    assertNoColorBleed(m);
   }, 120000);
 
   it('blit 누적으로 어긋난 hit-test 좌표(xp)가 지연 재계산으로 복구된다', async () => {

--- a/src/components/chart/chart.blit.equiv.visual.spec.js
+++ b/src/components/chart/chart.blit.equiv.visual.spec.js
@@ -487,4 +487,84 @@ describe('EvChart realtime scatter blit ↔ full redraw 픽셀 동등', () => {
       `멀티 반투명 blit 알파 누적 ${alphaOver}px / 겹침 ${both}px — per-series strip double-draw 회귀`,
     ).toBeLessThanOrEqual(Math.max(4, Math.round(both * 0.01)));
   }, 180000);
+
+  // 분수 DPR(Windows 디스플레이 배율 125%/150% = 5/4·3/2) 등가 가드.
+  // 과거엔 deviceIntegerRatio 게이트가 분수 pr 에서 blit 을 완전히 끄고 매 틱 full 로 폴백했다. 지금은
+  // 시프트를 q(=pr 기약분모)의 배수로 양자화해 device 시프트(gCss·pr)를 정수로 만들어 drawImage 를
+  // 무손실로 유지하면서 blit 을 켠다. 이 테스트는 실제 device 해상도가 1.25×/1.5× 인 canvas 에서
+  // ⑴ blit 이 실제로 실행되고(가속 유지) ⑵ 누적 라스터가 동일 데이터 full redraw 와 픽셀 위치가
+  // 정확히 일치하는지(=시프트 리샘플 블러 없음) 검증한다. 유닛(blitShiftDenominator)의 정수성만으로는
+  // 파이프라인 전체(drawImage 무손실·composite clip·carry)의 등가를 보장하지 못하므로 이 브라우저
+  // 케이스가 최종 판별자다.
+  [1.25, 1.5].forEach((dpr) => {
+    it(`분수 DPR(${dpr}배) 에서도 blit 이 실행되고 full redraw 와 픽셀 위치가 동일하다`, async () => {
+      const TICK = 3000;
+      const options = mkOptions(300);
+      const genData = (toMs) => {
+        const s1 = [{ x: toMs - 1, y: 50 }]; // toTime 앵커
+        for (let i = 0; i < 1500; i++) {
+          const hsh = (i * 2654435761) >>> 0;
+          const x = toMs - 2 - (hsh % (TICK - 2));
+          const y = (3000 + ((i * 7919) % (95000 - 3000 + 1))) / 1000;
+          s1.push({ x, y });
+        }
+        return {
+          series: {
+            series1: { name: 'series1', pointSize: 2, color: '#DF6264', pointFill: '#DF6264' },
+          },
+          data: { series1: s1 },
+        };
+      };
+
+      window.__EVUI_BLIT_REFRESH_INTERVAL__ = 100000;
+      window.__EVUI_BLIT_DEBUG__ = true;
+      window.__EVUI_BLIT_DIAG__ = undefined;
+      window.__EVUI_BLIT_FORCE_OFF__ = false;
+
+      const originalDpr = Object.getOwnPropertyDescriptor(window, 'devicePixelRatio');
+      Object.defineProperty(window, 'devicePixelRatio', { value: dpr, configurable: true });
+      try {
+        const { container, rerender } = render(EvChart, { props: { data: genData(BASE), options } });
+        await settle();
+
+        // canvas backing store 가 실제로 dpr 배로 커졌는지 확인(오버라이드가 먹혔다는 전제).
+        const canvas = container.querySelector('canvas:not(.overlay-canvas)');
+        expect(canvas.width, `DPR 오버라이드 미적용: width=${canvas.width}`).toBeGreaterThan(600);
+
+        let now = BASE;
+        for (let t = 1; t <= 12; t++) {
+          now += TICK;
+          // eslint-disable-next-line no-await-in-loop
+          await rerender({ data: genData(now), options });
+          // eslint-disable-next-line no-await-in-loop
+          await settle();
+        }
+        // 분수 DPR 에서도 blit 이 실제로 돌아야 한다(가속 유지 — 과거엔 여기서 blitted=0 이었다).
+        expect(
+          window.__EVUI_BLIT_DIAG__?.blitted ?? 0,
+          `분수 DPR(${dpr}) blit 미실행: ${JSON.stringify(window.__EVUI_BLIT_DIAG__)}`,
+        ).toBeGreaterThan(6);
+
+        const blitRaster = getImageData(container);
+
+        // force-off 로 동일 시각 데이터를 재렌더 → 현재 carry 그대로 full redraw(외형 불변).
+        window.__EVUI_BLIT_FORCE_OFF__ = true;
+        await rerender({ data: genData(now), options });
+        await settle();
+        const fullRaster = getImageData(container);
+
+        // 위치(onOff)가 정확히 0 이어야 한다 — 소수 dxInt 리샘플 블러가 있으면 시프트된 라스터가
+        // full 대비 어긋나 onOff>0 이 된다.
+        const { onOff, dataPx, reg, samples } = exactDiff(blitRaster, fullRaster);
+        expect(
+          onOff,
+          `분수 DPR(${dpr}) blit↔full 위치 불일치 ${onOff}px / 데이터 ${dataPx}px 좌=${reg[0]} 중=${reg[1]} 우=${reg[2]} samples=${samples.join(' ')}`,
+        ).toBe(0);
+      } finally {
+        if (originalDpr) {
+          Object.defineProperty(window, 'devicePixelRatio', originalDpr);
+        }
+      }
+    }, 120000);
+  });
 });

--- a/src/components/chart/chart.blit.equiv.visual.spec.js
+++ b/src/components/chart/chart.blit.equiv.visual.spec.js
@@ -203,6 +203,88 @@ describe('EvChart realtime scatter blit ↔ full redraw 픽셀 동등', () => {
     expect(color, `단일 series 는 색 불일치도 0 이어야 함(${color}px)`).toBe(0);
   }, 120000);
 
+  it('반투명(rgba alpha<1) 단일 series: opaqueFill 게이트로 blit off → full redraw 로 알파 정확(누적 없음)', async () => {
+    // #2 회귀 가드. strip 은 dirtyBuckets 의 점을 매 틱 전부 재그려, 시프트로 이미 옮겨진 옛 점 위에
+    // 덧칠한다 — opaque 면 멱등이지만 반투명이면 source-over 로 알파가 누적된다(α→2α-α²). 따라서
+    // 반투명 series 는 opaqueFill 게이트가 blit 을 막고 full redraw(rebuild+composite, 점당 1회)로 보낸다.
+    // 이 테스트는 ⑴ 반투명에서 blit 이 실제로 off(blitted===0) 되는지 ⑵ 그 결과 알파가 full 과 일치하는지 단언한다.
+    const TICK = 1000;
+    const options = mkOptions(60);
+    const FILL = 'rgba(223,98,100,0.4)';
+    // 희소 데이터: 버킷당 1점, y 를 넓게 분산 → 점이 공간적으로 안 겹쳐 알파가 포화되지 않는다.
+    // (밀집 데이터는 blit·full 둘 다 알파가 255로 포화돼 double-draw 누적이 가려진다.)
+    const genData = (toMs) => {
+      const s1 = [];
+      for (let i = 0; i < 55; i++) {
+        const x = toMs - 1 - i * 1000; // 버킷마다 1점(1초 간격)
+        const y = 5 + ((i * 37) % 90); // 5..95 분산
+        s1.push({ x, y });
+      }
+      return {
+        series: { series1: { name: 'series1', pointSize: 2, color: FILL, pointFill: FILL } },
+        data: { series1: s1 },
+      };
+    };
+
+    window.__EVUI_BLIT_REFRESH_INTERVAL__ = 100000;
+    window.__EVUI_BLIT_DEBUG__ = true;
+    window.__EVUI_BLIT_DIAG__ = undefined;
+
+    const { container, rerender } = render(EvChart, { props: { data: genData(BASE), options } });
+    await settle();
+
+    let now = BASE;
+    for (let t = 1; t <= 12; t++) {
+      now += TICK;
+      // eslint-disable-next-line no-await-in-loop
+      await rerender({ data: genData(now), options });
+      // eslint-disable-next-line no-await-in-loop
+      await settle();
+    }
+    // opaqueFill 게이트가 반투명 series 의 blit 을 전면 차단해야 한다(누적 라스터가 곧 full redraw).
+    expect(
+      window.__EVUI_BLIT_DIAG__?.blitted ?? 0,
+      `반투명인데 blit 이 실행됨(opaqueFill 게이트 미작동): ${JSON.stringify(window.__EVUI_BLIT_DIAG__)}`,
+    ).toBe(0);
+
+    const blit = getImageData(container);
+
+    // 단일 series highlight → legendHover full redraw(downplay 없음 → alpha 0.4 유지). 게이트로 이미
+    // 매 틱 full 이라 두 라스터가 같아야 한다(알파 누적 0).
+    const ec = window.__EVUI_BLIT_CHART__;
+    expect(ec, 'debug 차트 핸들 없음').toBeTruthy();
+    ec.highlightSeries('series1');
+    await settle();
+    const full = getImageData(container);
+
+    // "둘 다 on" 픽셀의 알파 채널 비교. double-draw 면 blit 알파(2α-α²≈163)가 full(α≈102)보다 ~60 높다.
+    // AA 가장자리 차이(<24)는 무시하고 알파 초과 > 40 인 픽셀만 센다. 정상(점당 1회)이면 ≈0.
+    const { w, h } = blit;
+    const x0 = Math.floor(0.08 * w);
+    const x1 = Math.ceil(0.99 * w);
+    const y0 = Math.floor(0.07 * h);
+    const y1 = Math.ceil(0.82 * h);
+    let alphaOver = 0;
+    let both = 0;
+    for (let y = y0; y < y1; y++) {
+      for (let x = x0; x < x1; x++) {
+        const i = (y * w + x) * 4;
+        const ba = blit.data[i + 3];
+        const fa = full.data[i + 3];
+        if (ba >= 32 && fa >= 32) {
+          both++;
+          if (ba - fa > 40) {
+            alphaOver++;
+          }
+        }
+      }
+    }
+    expect(
+      alphaOver,
+      `반투명 blit 알파 누적 ${alphaOver}px / 겹침 ${both}px — strip double-draw 회귀`,
+    ).toBeLessThanOrEqual(Math.max(4, Math.round(both * 0.01)));
+  }, 120000);
+
   it('2-series(seriesReverse) range 50 밀집: blit 누적과 동일 데이터 full redraw 의 점 위치가 픽셀 동일하다', async () => {
     // 데모와 동형(2 series, seriesReverse). legend hover 는 호버 series 만 그려 위치 비교가 불가하므로
     // force-off + 동일 데이터 재렌더(현재 carry 유지, 데이터 idempotent)로 full redraw 를 만든다.

--- a/src/components/chart/chart.blit.equiv.visual.spec.js
+++ b/src/components/chart/chart.blit.equiv.visual.spec.js
@@ -1,0 +1,288 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render } from 'vitest-browser-vue';
+import EvChart from './Chart.vue';
+
+/**
+ * realtime scatter blit ↔ full redraw 픽셀 동등성(pixel-exact equivalence) 가드.
+ *
+ * 사용자 보고: blit 으로 그리다 legend 영역에 hover 하면 full redraw 로 전환되며 점 구름이 미세하게
+ * "스냅"한다(blit_fulldraw.mov). 원인은 blit(정수 device px 시프트)과 full(ceil CSS px 재양자화)이
+ * 점마다 ≤1px 어긋나는 것. 수정: blit 을 정수 CSS px 시프트(Bresenham carry)로 바꾸고, full/strip 이
+ * 동일 carry 를 startPoint 오프셋으로 반영 + realtime aliasPixel 제거 → 점별 ceil 양자화가 시프트와
+ * 교환돼 blit raster ≡ full raster 가 된다.
+ *
+ * 이 스펙은 같은 인스턴스에서 blit 으로 누적한 라스터와, 그 직후 동일 데이터를 full redraw 한 라스터가
+ * plot 영역에서 픽셀 단위로 일치하는지 단언한다. on/off 차이(=점 위치 어긋남, 반드시 0)와 color
+ * 차이(=같은 좌표의 owner series 가 다름, ±1px 재양자화로 드물게 발생하는 설계 허용 오차)를 분리한다.
+ */
+describe('EvChart realtime scatter blit ↔ full redraw 픽셀 동등', () => {
+  const settle = async () => {
+    await new Promise((r) => setTimeout(r, 60));
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    await new Promise((r) => setTimeout(r, 40));
+  };
+
+  const getImageData = (container) => {
+    const canvas = container.querySelector('canvas:not(.overlay-canvas)');
+    const ctx = canvas.getContext('2d');
+    return {
+      data: ctx.getImageData(0, 0, canvas.width, canvas.height).data,
+      w: canvas.width,
+      h: canvas.height,
+    };
+  };
+
+  // plot 내부(좌측 라벨/상단 padding/하단 축·legend 제외)
+  const PLOT = { x0: 0.08, x1: 0.99, y0: 0.07, y1: 0.82 };
+
+  // blit/full 라스터의 plot 영역 비교. onOff = 한쪽만 데이터(=점 위치 어긋남), color = 둘 다 데이터인데
+  // 색이 다름(=coincident 좌표 owner 불일치). 위치 어긋남(onOff)이 사용자가 본 스냅이며 0 이어야 한다.
+  const exactDiff = (a, b) => {
+    const { w, h } = a;
+    const x0 = Math.floor(PLOT.x0 * w);
+    const x1 = Math.ceil(PLOT.x1 * w);
+    const y0 = Math.floor(PLOT.y0 * h);
+    const y1 = Math.ceil(PLOT.y1 * h);
+    const da = a.data;
+    const db = b.data;
+    let onOff = 0;
+    let color = 0;
+    let dataPx = 0;
+    const reg = [0, 0, 0]; // 좌/중/우 onOff
+    const samples = [];
+    const t3 = x0 + (x1 - x0) / 3;
+    const t6 = x0 + (2 * (x1 - x0)) / 3;
+    // 컬럼별 blue(2번 series 색) 픽셀 수 — 세로 줄무늬(특정 컬럼 집중) 검출용
+    const aBlueCol = new Uint32Array(w);
+    const bBlueCol = new Uint32Array(w);
+    const isBlue = (d, i) => d[i + 3] >= 32 && d[i + 2] > d[i] + 40;
+    for (let y = y0; y < y1; y++) {
+      for (let x = x0; x < x1; x++) {
+        const i = (y * w + x) * 4;
+        if (isBlue(da, i)) aBlueCol[x]++;
+        if (isBlue(db, i)) bBlueCol[x]++;
+        const aOn = da[i + 3] >= 32;
+        const bOn = db[i + 3] >= 32;
+        if (aOn || bOn) dataPx++;
+        if (aOn !== bOn) {
+          onOff++;
+          let r = 2;
+          if (x < t3) {
+            r = 0;
+          } else if (x < t6) {
+            r = 1;
+          }
+          reg[r]++;
+          if (samples.length < 16) {
+            samples.push(`(${x},${y})b=${aOn ? 1 : 0}f=${bOn ? 1 : 0}`);
+          }
+        } else if (
+          aOn &&
+          bOn &&
+          (Math.abs(da[i] - db[i]) > 24 ||
+            Math.abs(da[i + 1] - db[i + 1]) > 24 ||
+            Math.abs(da[i + 2] - db[i + 2]) > 24)
+        ) {
+          color++;
+        }
+      }
+    }
+    let aBlueColMax = 0;
+    let bBlueColMax = 0;
+    for (let x = x0; x < x1; x++) {
+      if (aBlueCol[x] > aBlueColMax) aBlueColMax = aBlueCol[x];
+      if (bBlueCol[x] > bBlueColMax) bBlueColMax = bBlueCol[x];
+    }
+    return {
+      onOff,
+      color,
+      dataPx,
+      reg,
+      samples,
+      aBlueColMax,
+      bBlueColMax,
+      bounds: { x0, x1, y0, y1, w, h },
+    };
+  };
+
+  const mkOptions = (range) => ({
+    type: 'scatter',
+    width: '600px',
+    height: '400px',
+    padding: { top: 20, right: 2, bottom: 4, left: 2 },
+    axesX: [
+      {
+        type: 'time',
+        timeFormat: 'HH:mm:ss',
+        interval: { time: 10, unit: 'second' },
+        showAxis: true,
+        showGrid: false,
+        labelStyle: { show: true, fontSize: 12, color: '#25262E' },
+      },
+    ],
+    axesY: [
+      {
+        type: 'linear',
+        showAxis: true,
+        startToZero: false,
+        showGrid: true,
+        gridLineColor: '#C9CFDC',
+        labelStyle: { show: true, fontSize: 12, color: '#25262E' },
+        range: [0, 100],
+      },
+    ],
+    tooltip: { use: true },
+    legend: { show: true, position: 'bottom', height: 32 },
+    displayOverflow: true,
+    realTimeScatter: { use: true, range },
+    seriesReverse: true,
+  });
+
+  afterEach(() => {
+    window.__EVUI_BLIT_FORCE_OFF__ = false;
+    window.__EVUI_BLIT_REFRESH_INTERVAL__ = undefined;
+    window.__EVUI_BLIT_DEBUG__ = false;
+  });
+
+  const BASE = 1_700_000_000_000;
+
+  it('단일 series: blit 누적 라스터와 legend hover full redraw 가 픽셀 동일하다(range 300)', async () => {
+    const TICK = 3000;
+    const options = mkOptions(300);
+    const genData = (toMs) => {
+      const s1 = [{ x: toMs - 1, y: 50 }]; // toTime 앵커
+      for (let i = 0; i < 1500; i++) {
+        const hsh = (i * 2654435761) >>> 0;
+        const x = toMs - 2 - (hsh % (TICK - 2));
+        const y = (3000 + ((i * 7919) % (95000 - 3000 + 1))) / 1000;
+        s1.push({ x, y });
+      }
+      return {
+        series: {
+          series1: { name: 'series1', pointSize: 1, color: '#DF6264', pointFill: '#DF6264' },
+        },
+        data: { series1: s1 },
+      };
+    };
+
+    window.__EVUI_BLIT_REFRESH_INTERVAL__ = 100000; // 검증 구간 내 강제 full 금지
+    window.__EVUI_BLIT_DEBUG__ = true;
+    window.__EVUI_BLIT_DIAG__ = undefined;
+
+    const { container, rerender } = render(EvChart, { props: { data: genData(BASE), options } });
+    await settle();
+
+    let now = BASE;
+    for (let t = 1; t <= 12; t++) {
+      now += TICK;
+      // eslint-disable-next-line no-await-in-loop
+      await rerender({ data: genData(now), options });
+      // eslint-disable-next-line no-await-in-loop
+      await settle();
+    }
+    expect(
+      window.__EVUI_BLIT_DIAG__?.blitted ?? 0,
+      `blit 미실행: ${JSON.stringify(window.__EVUI_BLIT_DIAG__)}`,
+    ).toBeGreaterThan(6);
+
+    const blitRaster = getImageData(container);
+
+    // 사용자 시나리오 그대로: legend hover → full redraw(legendHover 로 blit gate 차단).
+    // 단일 series 는 자기 자신이 downplay 되지 않아(getOpacity) 색 불변 → 위치만 비교.
+    const ec = window.__EVUI_BLIT_CHART__;
+    expect(ec, 'debug 차트 핸들 없음').toBeTruthy();
+    ec.highlightSeries('series1');
+    await settle();
+    const fullRaster = getImageData(container);
+
+    const { onOff, color, dataPx, reg, samples } = exactDiff(blitRaster, fullRaster);
+    expect(
+      onOff,
+      `blit↔full 위치 불일치 ${onOff}px / 데이터 ${dataPx}px 좌=${reg[0]} 중=${reg[1]} 우=${reg[2]} samples=${samples.join(' ')}`,
+    ).toBe(0);
+    expect(color, `단일 series 는 색 불일치도 0 이어야 함(${color}px)`).toBe(0);
+  }, 120000);
+
+  it('2-series(seriesReverse) range 50 밀집: blit 누적과 동일 데이터 full redraw 의 점 위치가 픽셀 동일하다', async () => {
+    // 데모와 동형(2 series, seriesReverse). legend hover 는 호버 series 만 그려 위치 비교가 불가하므로
+    // force-off + 동일 데이터 재렌더(현재 carry 유지, 데이터 idempotent)로 full redraw 를 만든다.
+    const TICK = 1000;
+    const options = mkOptions(50);
+    // 두 series 의 toTime 기준(max x)이 같은 초에 들도록 앵커를 둔다 — 어긋나면 areBlitSeriesAligned
+    // 가 매 틱 full 폴백시켜 blit 이 검증되지 않는다.
+    const genData = (toMs) => {
+      const s1 = [{ x: toMs - 1, y: 50 }];
+      const s2 = [{ x: toMs - 2, y: 50 }];
+      for (let i = 0; i < 800; i++) {
+        const hsh = (i * 2654435761) >>> 0;
+        const x = toMs - 3 - (hsh % (TICK - 2));
+        const y = (3000 + ((i * 7919) % (95000 - 3000 + 1))) / 1000;
+        if ((hsh >>> 13) & 1) {
+          s1.push({ x, y });
+        } else {
+          s2.push({ x, y });
+        }
+      }
+      return {
+        series: {
+          series1: { name: 'series1', pointSize: 1, color: '#DF6264', pointFill: '#DF6264' },
+          series2: { name: 'series2', pointSize: 1, color: '#3CA0FF', pointFill: '#3CA0FF' },
+        },
+        data: { series1: s1, series2: s2 },
+      };
+    };
+
+    window.__EVUI_BLIT_REFRESH_INTERVAL__ = 100000;
+    window.__EVUI_BLIT_DEBUG__ = true;
+    window.__EVUI_BLIT_DIAG__ = undefined;
+    window.__EVUI_BLIT_FORCE_OFF__ = false;
+
+    const { container, rerender } = render(EvChart, { props: { data: genData(BASE), options } });
+    await settle();
+
+    let now = BASE;
+    for (let t = 1; t <= 12; t++) {
+      now += TICK;
+      // eslint-disable-next-line no-await-in-loop
+      await rerender({ data: genData(now), options });
+      // eslint-disable-next-line no-await-in-loop
+      await settle();
+    }
+    expect(
+      window.__EVUI_BLIT_DIAG__?.blitted ?? 0,
+      `blit 미실행: ${JSON.stringify(window.__EVUI_BLIT_DIAG__)}`,
+    ).toBeGreaterThan(6);
+
+    const blitRaster = getImageData(container);
+
+    // force-off 로 동일 시각 데이터를 재렌더 → 현재 carry 그대로 full redraw(외형 불변).
+    window.__EVUI_BLIT_FORCE_OFF__ = true;
+    await rerender({ data: genData(now), options });
+    await settle();
+    const fullRaster = getImageData(container);
+
+    const { onOff, color, dataPx, reg, samples, aBlueColMax, bBlueColMax } = exactDiff(
+      blitRaster,
+      fullRaster,
+    );
+    // 위치(onOff)는 정확히 일치해야 한다 — 사용자가 본 스냅.
+    expect(
+      onOff,
+      `2-series 위치 불일치 ${onOff}px / 데이터 ${dataPx}px 좌=${reg[0]} 중=${reg[1]} 우=${reg[2]} samples=${samples.join(' ')}`,
+    ).toBe(0);
+    // 세로 줄무늬: blit 의 컬럼별 blue 최댓값이 full(동일 carry) 대비 크게 늘면 blit 특이 집중(줄무늬).
+    // full 도 carry 를 쓰므로 경계 집중은 양쪽 동일 → blit≈full 이어야 한다(color 스펙의 golden 은
+    // force-off carry=0 라 경계 위상이 달라 stripe 로 보이지만, 그건 실사용 아닌 비교 baseline 차이).
+    expect(
+      bBlueColMax,
+      `blit blue 세로 집중 ${bBlueColMax} vs full ${aBlueColMax} — 동일 carry full 대비 줄무늬(seam)면 회귀`,
+    ).toBeLessThanOrEqual(aBlueColMax + 2);
+    // 색(겹침 z-order) 동등: series 별 레이어를 full 과 동일 순서로 합성하므로 겹친 픽셀의 top 색이
+    // full 과 일치 → 색 flip 이 0 에 수렴(틱 경계 seam 색줄 제거). 과거 단일 라스터의 틱별 z-order
+    // 누적(seam)은 제거됐다. AA 가장자리 미세 차이만 허용(데이터의 0.1%).
+    expect(
+      color,
+      `색 z-order 불일치(${color}px / 데이터 ${dataPx}px) — seam 회귀`,
+    ).toBeLessThanOrEqual(Math.max(20, Math.round(dataPx * 0.001)));
+  }, 120000);
+});

--- a/src/components/chart/chart.blit.equiv.visual.spec.js
+++ b/src/components/chart/chart.blit.equiv.visual.spec.js
@@ -203,22 +203,36 @@ describe('EvChart realtime scatter blit ↔ full redraw 픽셀 동등', () => {
     expect(color, `단일 series 는 색 불일치도 0 이어야 함(${color}px)`).toBe(0);
   }, 120000);
 
-  it('반투명(rgba alpha<1) 단일 series: opaqueFill 게이트로 blit off → full redraw 로 알파 정확(누적 없음)', async () => {
-    // #2 회귀 가드. strip 은 dirtyBuckets 의 점을 매 틱 전부 재그려, 시프트로 이미 옮겨진 옛 점 위에
-    // 덧칠한다 — opaque 면 멱등이지만 반투명이면 source-over 로 알파가 누적된다(α→2α-α²). 따라서
-    // 반투명 series 는 opaqueFill 게이트가 blit 을 막고 full redraw(rebuild+composite, 점당 1회)로 보낸다.
-    // 이 테스트는 ⑴ 반투명에서 blit 이 실제로 off(blitted===0) 되는지 ⑵ 그 결과 알파가 full 과 일치하는지 단언한다.
+  it('반투명(rgba alpha<1) 단일 series: blit 이 실행돼도 drawn-플래그로 점당 1회 raster → 알파 누적 0', async () => {
+    // #2 회귀 가드(opacity 를 blit 으로 처리). strip 은 "아직 raster 된 적 없는 점"(item.drawn=false)만
+    // 그리고, 시프트로 이미 레이어에 살아 있는 옛 점은 다시 그리지 않는다 → 경계 버킷의 옛 점이 2회
+    // 합성되던 over-darken(α→2α-α²)이 소멸한다. 따라서 반투명이어도 blit raster ≡ full redraw(점당 1회).
+    // 이 테스트는 ⑴ 반투명에서 blit 이 실제로 실행(blitted>0)되고 ⑵ 알파가 full 과 일치(누적 0)하며
+    // ⑶ 위치가 어긋나지 않는지(deferred 점 누락 0) 단언한다. dense 가 아닌 *희소+지터* 데이터라야
+    // ⑵(알파 포화로 가려지지 않음)·⑶(지터 없으면 deferred 점이 없어 누락이 안 드러남)을 동시에 잡는다.
     const TICK = 1000;
-    const options = mkOptions(60);
+    const RANGE = 60;
+    const options = mkOptions(RANGE);
     const FILL = 'rgba(223,98,100,0.4)';
-    // 희소 데이터: 버킷당 1점, y 를 넓게 분산 → 점이 공간적으로 안 겹쳐 알파가 포화되지 않는다.
-    // (밀집 데이터는 blit·full 둘 다 알파가 255로 포화돼 double-draw 누적이 가려진다.)
+    // over-darken 은 "age 0 에 그려진 점이 다음 틱 경계 버킷(age 1)에서 재그려질 때"만 난다(점당 2회
+    // 합성). 따라서 데이터에 두 종류를 섞는다:
+    //  · 정시(x=toMs=floored toTime=graphMax): 도착 틱에 age 0 으로 *그려지고*, 다음 틱 age 1(경계)에서
+    //    재그려진다 → 반투명이면 α→2α-α² 누적(redraw-all 회귀의 핵심).
+    //  · graphMax 초과(x>toMs): 도착 틱엔 xp=null 로 미뤄졌다가(deferred) 다음 틱 경계에서 *처음* raster.
+    //    drawn-플래그가 "push 시점"이 아니라 "raster 시점"을 봐야 이들을 안 빠뜨린다(누락 시 onOff>0).
+    // 희소(틱당 정시 5 + deferred 3)+y 분산 → 알파가 포화되지 않아 누적이 보인다. 매 틱 새 슬라이스에만
+    // 생성(옛 점은 ring 보존) → maxDirtyAge=0 으로 strip 가드 통과.
     const genData = (toMs) => {
-      const s1 = [];
-      for (let i = 0; i < 55; i++) {
-        const x = toMs - 1 - i * 1000; // 버킷마다 1점(1초 간격)
-        const y = 5 + ((i * 37) % 90); // 5..95 분산
-        s1.push({ x, y });
+      const tk = Math.round((toMs - BASE) / TICK);
+      const s1 = [{ x: toMs + 500, y: 50 }]; // 앵커: floored toTime=toMs, 이번 틱 deferred
+      for (let i = 0; i < 8; i++) {
+        const hsh = ((tk * 131 + i) * 2654435761) >>> 0;
+        const y = 5 + (hsh % 90); // 5..94 분산(세로 격리)
+        if (i < 5) {
+          s1.push({ x: toMs, y }); // 정시 → age 0 그림 → 다음 틱 경계 재그림 → double-draw 대상
+        } else {
+          s1.push({ x: toMs + 1 + (hsh % 800), y }); // graphMax 초과 → deferred(다음 틱 첫 raster)
+        }
       }
       return {
         series: { series1: { name: 'series1', pointSize: 2, color: FILL, pointFill: FILL } },
@@ -226,39 +240,48 @@ describe('EvChart realtime scatter blit ↔ full redraw 픽셀 동등', () => {
       };
     };
 
-    window.__EVUI_BLIT_REFRESH_INTERVAL__ = 100000;
+    // REFRESH 강제 full(rebuild)을 검증 구간 안에서 여러 번 겪게 한다 — rebuild 가 drawn-플래그
+    // 기준선을 다시 세우지 못하면 직후 strip 이 전부 재그려 알파 스파이크가 누적된다(>300 프레임을
+    // override 로 압축: interval 30 × 80틱 ≈ 2회 rebuild + 다수의 rebuild-후 strip).
+    window.__EVUI_BLIT_REFRESH_INTERVAL__ = 30;
     window.__EVUI_BLIT_DEBUG__ = true;
     window.__EVUI_BLIT_DIAG__ = undefined;
+    window.__EVUI_BLIT_FORCE_OFF__ = false;
 
     const { container, rerender } = render(EvChart, { props: { data: genData(BASE), options } });
     await settle();
 
     let now = BASE;
-    for (let t = 1; t <= 12; t++) {
+    for (let t = 1; t <= 80; t++) {
       now += TICK;
       // eslint-disable-next-line no-await-in-loop
       await rerender({ data: genData(now), options });
       // eslint-disable-next-line no-await-in-loop
       await settle();
     }
-    // opaqueFill 게이트가 반투명 series 의 blit 을 전면 차단해야 한다(누적 라스터가 곧 full redraw).
+    // 반투명이어도 blit 이 실제로 돌아야 한다(가속 유지).
     expect(
       window.__EVUI_BLIT_DIAG__?.blitted ?? 0,
-      `반투명인데 blit 이 실행됨(opaqueFill 게이트 미작동): ${JSON.stringify(window.__EVUI_BLIT_DIAG__)}`,
-    ).toBe(0);
+      `반투명 blit 미실행(가속 상실): ${JSON.stringify(window.__EVUI_BLIT_DIAG__)}`,
+    ).toBeGreaterThan(6);
 
     const blit = getImageData(container);
 
-    // 단일 series highlight → legendHover full redraw(downplay 없음 → alpha 0.4 유지). 게이트로 이미
-    // 매 틱 full 이라 두 라스터가 같아야 한다(알파 누적 0).
-    const ec = window.__EVUI_BLIT_CHART__;
-    expect(ec, 'debug 차트 핸들 없음').toBeTruthy();
-    ec.highlightSeries('series1');
+    // force-off 로 동일 시각 데이터를 재렌더 → 현재 carry 그대로 full redraw(점당 1회, 외형 불변).
+    window.__EVUI_BLIT_FORCE_OFF__ = true;
+    await rerender({ data: genData(now), options });
     await settle();
     const full = getImageData(container);
 
-    // "둘 다 on" 픽셀의 알파 채널 비교. double-draw 면 blit 알파(2α-α²≈163)가 full(α≈102)보다 ~60 높다.
-    // AA 가장자리 차이(<24)는 무시하고 알파 초과 > 40 인 픽셀만 센다. 정상(점당 1회)이면 ≈0.
+    // ⑶ 위치: deferred 점 누락이 있으면 한쪽만 on → onOff>0.
+    const { onOff, dataPx, reg, samples } = exactDiff(blit, full);
+    expect(
+      onOff,
+      `반투명 blit↔full 위치 불일치 ${onOff}px / 데이터 ${dataPx}px 좌=${reg[0]} 중=${reg[1]} 우=${reg[2]} samples=${samples.join(' ')} — deferred 점 누락 의심`,
+    ).toBe(0);
+
+    // ⑵ 알파: "둘 다 on" 픽셀의 알파 채널 비교. double-draw 면 blit 알파(2α-α²≈163)가 full(α≈102)보다
+    // ~60 높다. AA 가장자리 차이(<40)는 무시. 정상(점당 1회)이면 ≈0.
     const { w, h } = blit;
     const x0 = Math.floor(0.08 * w);
     const x1 = Math.ceil(0.99 * w);
@@ -283,7 +306,7 @@ describe('EvChart realtime scatter blit ↔ full redraw 픽셀 동등', () => {
       alphaOver,
       `반투명 blit 알파 누적 ${alphaOver}px / 겹침 ${both}px — strip double-draw 회귀`,
     ).toBeLessThanOrEqual(Math.max(4, Math.round(both * 0.01)));
-  }, 120000);
+  }, 180000);
 
   it('2-series(seriesReverse) range 50 밀집: blit 누적과 동일 데이터 full redraw 의 점 위치가 픽셀 동일하다', async () => {
     // 데모와 동형(2 series, seriesReverse). legend hover 는 호버 series 만 그려 위치 비교가 불가하므로
@@ -367,4 +390,101 @@ describe('EvChart realtime scatter blit ↔ full redraw 픽셀 동등', () => {
       `색 z-order 불일치(${color}px / 데이터 ${dataPx}px) — seam 회귀`,
     ).toBeLessThanOrEqual(Math.max(20, Math.round(dataPx * 0.001)));
   }, 120000);
+
+  it('반투명(rgba alpha<1) 2-series(seriesReverse) 희소: blit 점당 1회 raster → 알파 누적 0 (데모 동형)', async () => {
+    // 멀티-series + 반투명은 실제 데모가 켜는 조합. per-series 레이어가 각자 1회 누적·합성하므로
+    // 메커니즘상 정확해야 하나 알파 차원이 미검증이었다(기존 멀티 테스트는 전부 opaque hex). 좌표는
+    // series 간 disjoint(같은 x라도 y 짝/홀로 분리)로 둔다 — coincident-coord owner-flip(REFRESH 로
+    // bounded 되는 *pre-existing* z-order 코너, drawn 플래그가 오히려 개선)이 알파 단언에 끼지 않게.
+    const TICK = 1000;
+    const RANGE = 60;
+    const options = mkOptions(RANGE);
+    const F1 = 'rgba(223,98,100,0.4)';
+    const F2 = 'rgba(60,160,255,0.4)';
+    // 두 series 가 같은 초로 floor 되도록 동일 앵커(toTime 정렬 → areBlitSeriesAligned). 정시(age0
+    // 그림→다음 틱 경계 재그림 대상)+deferred 혼합으로 over-darken 을 유발한다.
+    const genData = (toMs) => {
+      const tk = Math.round((toMs - BASE) / TICK);
+      const s1 = [{ x: toMs + 500, y: 50 }];
+      const s2 = [{ x: toMs + 500, y: 51 }];
+      for (let i = 0; i < 4; i++) {
+        const h1 = ((tk * 131 + i) * 2654435761) >>> 0;
+        const h2 = ((tk * 977 + i) * 2246822519) >>> 0;
+        const y1 = 6 + (h1 % 44) * 2; // 짝수 계열
+        const y2 = 7 + (h2 % 44) * 2; // 홀수 계열 → series 간 좌표 disjoint
+        if (i < 3) {
+          s1.push({ x: toMs, y: y1 }); // 정시 → 다음 틱 경계 재그림 대상
+          s2.push({ x: toMs, y: y2 });
+        } else {
+          s1.push({ x: toMs + 1 + (h1 % 800), y: y1 }); // deferred
+          s2.push({ x: toMs + 1 + (h2 % 800), y: y2 });
+        }
+      }
+      return {
+        series: {
+          series1: { name: 'series1', pointSize: 2, color: F1, pointFill: F1 },
+          series2: { name: 'series2', pointSize: 2, color: F2, pointFill: F2 },
+        },
+        data: { series1: s1, series2: s2 },
+      };
+    };
+
+    window.__EVUI_BLIT_REFRESH_INTERVAL__ = 30;
+    window.__EVUI_BLIT_DEBUG__ = true;
+    window.__EVUI_BLIT_DIAG__ = undefined;
+    window.__EVUI_BLIT_FORCE_OFF__ = false;
+
+    const { container, rerender } = render(EvChart, { props: { data: genData(BASE), options } });
+    await settle();
+
+    let now = BASE;
+    for (let t = 1; t <= 80; t++) {
+      now += TICK;
+      // eslint-disable-next-line no-await-in-loop
+      await rerender({ data: genData(now), options });
+      // eslint-disable-next-line no-await-in-loop
+      await settle();
+    }
+    expect(
+      window.__EVUI_BLIT_DIAG__?.blitted ?? 0,
+      `멀티 반투명 blit 미실행: ${JSON.stringify(window.__EVUI_BLIT_DIAG__)}`,
+    ).toBeGreaterThan(6);
+
+    const blit = getImageData(container);
+    window.__EVUI_BLIT_FORCE_OFF__ = true;
+    await rerender({ data: genData(now), options });
+    await settle();
+    const full = getImageData(container);
+
+    const { onOff, dataPx, reg, samples } = exactDiff(blit, full);
+    expect(
+      onOff,
+      `멀티 반투명 위치 불일치 ${onOff}px / 데이터 ${dataPx}px 좌=${reg[0]} 중=${reg[1]} 우=${reg[2]} samples=${samples.join(' ')}`,
+    ).toBe(0);
+
+    const { w, h } = blit;
+    const x0 = Math.floor(0.08 * w);
+    const x1 = Math.ceil(0.99 * w);
+    const y0 = Math.floor(0.07 * h);
+    const y1 = Math.ceil(0.82 * h);
+    let alphaOver = 0;
+    let both = 0;
+    for (let y = y0; y < y1; y++) {
+      for (let x = x0; x < x1; x++) {
+        const i = (y * w + x) * 4;
+        const ba = blit.data[i + 3];
+        const fa = full.data[i + 3];
+        if (ba >= 32 && fa >= 32) {
+          both++;
+          if (ba - fa > 40) {
+            alphaOver++;
+          }
+        }
+      }
+    }
+    expect(
+      alphaOver,
+      `멀티 반투명 blit 알파 누적 ${alphaOver}px / 겹침 ${both}px — per-series strip double-draw 회귀`,
+    ).toBeLessThanOrEqual(Math.max(4, Math.round(both * 0.01)));
+  }, 180000);
 });

--- a/src/components/chart/chart.blit.js
+++ b/src/components/chart/chart.blit.js
@@ -1,3 +1,5 @@
+import Util from './helpers/helpers.util';
+
 /**
  * EvChart realtime scatter blit fast-path 모듈.
  * chart.core.js 의 EvChart.prototype 에 Object.assign 으로 합쳐진다(메서드는 this 로 인스턴스에 접근).
@@ -244,6 +246,16 @@ const blit = {
       selectionOk,
       // blit 은 realtime scatter 전용이다.
       scatterOnly: this.hasOnlyVisibleScatter(),
+      // 반투명(rgba alpha<1) fill 이 있으면 full redraw 로 폴백한다. strip 은 시프트된 옛 라스터 위에
+      // 경계 버킷 점을 다시 그리므로(픽셀 제거 없는 덧그림), 반투명 점은 source-over 로 알파가 누적돼
+      // (α→2α-α²) full(점당 1회)보다 진해진다 → blit≠full. opaque 면 source-over 가 멱등이라 무해.
+      // 폴백 경로(rebuild+composite)는 점당 1회 그리므로 반투명도 정확하다(가속만 양보).
+      opaqueFill: this.hasOnlyOpaqueScatterFill(),
+      // 분수 pixelRatio(예: Windows 125%/150% = 1.25/1.5)에서는 정수 CSS px 시프트의 device 폭
+      // (gCss·pr)이 비정수가 돼 drawImage 시프트가 bilinear 리샘플(블러)을 일으키고, strip 밖 라스터에
+      // 매 틱 누적된다(blit≠full). 정수 pr 에서만 시프트가 bit-exact 하므로 분수면 full 폴백한다
+      // (rebuild+composite 는 시프트가 없어 분수 pr 에서도 정확).
+      deviceIntegerRatio: Number.isInteger(this.pixelRatio),
       hasPrev: !!prev,
       // 옵션 변화(색·스타일 등)는 레이어 픽셀을 바꿀 수 있다. Chart.vue options watcher 가
       // 변화 시 options 참조를 통째 교체하므로 참조 비교 1회로 보수적으로 차단한다.
@@ -307,6 +319,8 @@ const blit = {
       parts.seriesAligned &&
       parts.selectionOk &&
       parts.scatterOnly &&
+      parts.opaqueFill &&
+      parts.deviceIntegerRatio &&
       parts.hasPrev &&
       parts.optionsStable &&
       parts.yFixed &&
@@ -339,6 +353,28 @@ const blit = {
         if (this.seriesList[ids[j]]?.show) {
           return false;
         }
+      }
+    }
+    return true;
+  },
+
+  /**
+   * 보이는 scatter series 의 fill·stroke 가 전부 불투명(alpha=1)인가.
+   * 반투명(rgba alpha<1)이면 strip 의 경계 버킷 덧그림이 source-over 로 알파를 누적시켜 blit≠full 이
+   * 되므로 fast-path 를 막고 full redraw(점당 1회)로 폴백한다. Util.getOpacity 는 rgba 면 alpha 문자열,
+   * 그 외엔 '1' 을 돌려준다. 참고: series 단위 색만 검사한다 — point 별 rgba(item.color)까지는 보지
+   * 않는다(매 게이트 전수 스캔 비용 회피). 그런 경우엔 REFRESH_INTERVAL 강제 full 이 주기적으로 정정한다.
+   * @returns {boolean}
+   */
+  hasOnlyOpaqueScatterFill() {
+    const list = this.getBlitScatterSeriesList();
+    for (let i = 0; i < list.length; i++) {
+      const s = list[i].series;
+      if (
+        Number(Util.getOpacity(s.pointFill ?? s.color)) < 1 ||
+        Number(Util.getOpacity(s.color)) < 1
+      ) {
+        return false;
       }
     }
     return true;
@@ -440,6 +476,49 @@ const blit = {
   },
 
   /**
+   * blit strip 전용 cross-series owner 맵. dirtyBuckets 의 모든 점을 순회해 좌표→owner(sId) 를 채운다.
+   * 같은 좌표(=같은 ms=같은 버킷)는 strip 안에서 owner 가 닫히므로 전체 dedupe 없이 strip 만으로 정확하다
+   * (#2011 coordinateDedupe 존중 — owner 외 series 는 그 좌표를 그리지 않아 반투명 겹침/hollow 비침이
+   * full redraw 와 일치). 순서/owner 규칙은 collectDuplicatePoints 와 동일(seriesReverse 면 역순 순회 →
+   * 마지막 set 이 owner). blit 은 opaqueFill 게이트로 반투명 series 를 받지 않으므로 strip 의 cross-series
+   * 알파 누적 우려는 게이트가 차단한다(여기 dedupe 는 hollow 마커·z-order 정합을 보장).
+   * @param {Map<string,string>} duple       owner 맵(coordKey → sId)
+   * @param {number[]} dirtyBuckets           strip 으로 다시 그릴 ring 버킷 인덱스 목록
+   * @returns {undefined}
+   */
+  collectStripDuplicatePoints(duple, dirtyBuckets) {
+    const scatterIds = this.seriesInfo?.charts?.scatter ?? [];
+    const isReverseOrder = !!this.options.seriesReverse;
+    for (
+      let jx = isReverseOrder ? scatterIds.length - 1 : 0;
+      isReverseOrder ? jx >= 0 : jx < scatterIds.length;
+      isReverseOrder ? jx-- : jx++
+    ) {
+      const series = this.seriesList[scatterIds[jx]];
+      if (!series?.show) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      const dataGroup = series.data[series.sId]?.dataGroup;
+      if (!dataGroup) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      for (let b = 0; b < dirtyBuckets.length; b++) {
+        const group = dataGroup[dirtyBuckets[b]];
+        if (!group?.data) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+        for (let j = 0; j < group.data.length; j++) {
+          const item = group.data[j];
+          duple.set(item.k ?? Util.coordinateKey(item.x, item.y), series.sId);
+        }
+      }
+    }
+  },
+
+  /**
    * blit fast-path 본체. 게이트 통과 시 호출된다.
    * 이전 점 라스터를 왼쪽으로 dx 만큼 밀고(drawImage), 신규 시간대(strip)만 다시 그려 buffer 에
    * 합성한다. draw 라스터 비용을 "전체 점"에서 "신규 strip"으로 줄인다. 픽셀 복사라 좌표는 불변.
@@ -519,7 +598,9 @@ const blit = {
     //
     // 흰줄(comb) 불가 보장: 흰줄은 "픽셀을 지웠는데 다시 안 그리는" 경우(clear + clip 의 결손 컬럼)에만
     // 생긴다. 아래 시프트는 OLD 픽셀을 비트단위 무손실로 옮긴 뒤(정수좌표·동일크기 drawImage → 재양자화
-    // 없음) 그 위에 strip 버킷을 덧그리기만 한다 — 픽셀 제거 연산이 없으므로 세로 흰줄이 원천 불가.
+    // 없음) 그 위에 strip 버킷의 점을 다시 그리기만 한다 — 픽셀 제거 연산이 없으므로 세로 흰줄이 원천 불가.
+    // (경계 버킷은 시프트된 옛 점 위에 다시 그려져 opaque 면 멱등이지만 반투명이면 알파가 누적되므로,
+    //  반투명 series 는 evaluateBlitGate 의 opaqueFill 게이트가 막아 full redraw 로 보낸다.)
     const { gapCount, endIndex, length } = lastTick;
     // 최소 gapCount+1: 시프트로 비워진 strip(gapCount 버킷) + 경계 버킷(age gapCount) 1개.
     // 경계 버킷은 직전 틱 graphMax(=floor(maxX)) 초과로 그려지지 못한 점(x 가 초 경계 직전)이 이번 틱
@@ -534,9 +615,17 @@ const blit = {
       dirtyBuckets[k] = idx;
     }
 
-    // series 별 레이어이므로 cross-series dedupe 가 필요 없다 — 겹침에서 "어느 series 가 위"인지는
-    // 합성 순서(compositePointsLayer)가 full redraw 와 동일하게 결정한다. 각 series 는 자기 점만 자기
-    // 레이어에 그린다(intra-series 좌표 유일성은 push 단계 dedupe 가 보장).
+    // cross-series dedupe(#2011 coordinateDedupe 존중): 보이는 scatter 가 2개 이상이고 옵션이 켜져 있으면
+    // 같은 좌표는 owner series 만 그린다(full redraw 와 동일). series 별 레이어라 합성 z-order 가 "어느
+    // series 가 위"인지는 결정하지만, 반투명(alpha<1) fill·hollow 마커는 비-owner 점도 레이어에 남으면
+    // 합성 시 알파가 누적/비침 → owner 외 좌표는 레이어에 아예 그리지 않아야 full 과 일치한다.
+    // 단일 series 면 push 단계가 좌표 유일성을 보장하므로 duple 이 불필요(null → 전부 그림).
+    const dedupeOn = this.options.coordinateDedupe !== false && scatterList.length > 1;
+    const duple = dedupeOn ? new Map() : null;
+    if (dedupeOn) {
+      this.collectStripDuplicatePoints(duple, dirtyBuckets);
+    }
+
     const param = {
       chartRect: cr,
       labelOffset: lo,
@@ -545,8 +634,8 @@ const blit = {
       selectInfo: null,
       legendHitInfo: null,
       unSelectedOpacity: this.options.unSelectedOpacity,
-      duple: null,
-      coordinateDedupe: false,
+      duple,
+      coordinateDedupe: dedupeOn,
       // 시프트 후 잔차 carry. strip 신규 점도 시프트된 옛 점과 동일 위상으로 찍어 라스터 정합 유지.
       rtXOffsetCss: this._blitCarry,
     };
@@ -806,7 +895,16 @@ const blit = {
     }
 
     const pr = this.pixelRatio;
-    // series 별 레이어에 자기 점만 그린다 — cross-series dedupe 불필요(z-order 는 합성 순서가 담당).
+    // cross-series dedupe(#2011 coordinateDedupe 존중): baseline(full) 도 같은 좌표는 owner series 만
+    // 그린다 — strip 과 동일 규칙이라 fast-path 전환 시 정합. 반투명·hollow 마커에서 비-owner 점이
+    // 레이어에 남으면 합성 시 알파 누적/비침으로 full(직접 drawSeries)과 어긋난다. 전체 점 기준 owner.
+    const scatterIds = this.seriesInfo?.charts?.scatter ?? [];
+    const dedupeOn =
+      this.options.coordinateDedupe !== false && !this.canSkipRealtimeScatterDedupe(scatterIds);
+    const duple = dedupeOn ? new Map() : null;
+    if (dedupeOn) {
+      this.collectDuplicatePoints(duple, scatterIds);
+    }
     // 각 series 의 현재 유효 라스터(cur)에 직접 다시 그려 다음 fast-path 의 baseline 을 세운다.
     for (let i = 0; i < scatterList.length; i++) {
       const entry = scatterList[i];
@@ -827,8 +925,8 @@ const blit = {
         labelOffset: this.labelOffset,
         axesSteps: this.axesSteps,
         displayOverflow: this.options.displayOverflow,
-        duple: null,
-        coordinateDedupe: false,
+        duple,
+        coordinateDedupe: dedupeOn,
         selectInfo: null,
         legendHitInfo: null,
         unSelectedOpacity: this.options.unSelectedOpacity,

--- a/src/components/chart/chart.blit.js
+++ b/src/components/chart/chart.blit.js
@@ -1,5 +1,3 @@
-import Util from './helpers/helpers.util';
-
 /**
  * EvChart realtime scatter blit fast-path 모듈.
  * chart.core.js 의 EvChart.prototype 에 Object.assign 으로 합쳐진다(메서드는 this 로 인스턴스에 접근).
@@ -17,15 +15,14 @@ const blit = {
     // _blitPrev: 직전 렌더의 축/기하 스냅샷(진입 게이트 비교용). _blitDiag: 진입률 진단(개발용).
     this._blitPrev = null;
     this._blitDiag = null;
-    // 점 라스터 전용 오프스크린 레이어(ping-pong 2장). 공유 setWidth/setHeight 가 매 렌더 clear 하는
+    // 점 라스터 전용 오프스크린 레이어 — series 별 ping-pong 2장(Map: sId → {a,b,actx,bctx,cur}).
+    // series 마다 분리해야 full redraw 와 동일한 z-order(seriesReverse 면 series1 이 전역 위)를 합성
+    // 단계에서 재현할 수 있다. 단일 라스터면 매 틱 strip 을 위에 덧그려 틱 경계마다 newer series 가
+    // older series 를 덮는 seam(세로 색줄)이 생긴다. 공유 setWidth/setHeight 가 매 렌더 clear 하는
     // bufferCanvas 와 달리, 치수가 실제로 바뀔 때만 재할당해 프레임 간 픽셀을 보존한다.
-    this.pointsLayerA = null;
-    this.pointsLayerB = null;
-    this.pointsLayerACtx = null;
-    this.pointsLayerBCtx = null;
-    this.curPointsLayer = 'A'; // 현재 유효 점 라스터를 담은 레이어
+    this.pointsLayers = new Map();
     this.pointsLayerValid = false; // full redraw 로 baseline 이 세워졌는가
-    this._blitCarry = 0; // 정수 px 시프트 후 남는 소수부 누산(장기 drift 방지)
+    this._blitCarry = 0; // 정수 CSS px 시프트의 잔차 carry([-0.5,0.5]). full/strip 의 startPoint 위상으로 반영
     this._framesSinceFullRedraw = 0; // 주기적 강제 full redraw(BLIT_REFRESH_INTERVAL) 카운터
     // points layer 가 어떤 (데이터·축 매핑·기하·옵션) 상태를 그린 것인지의 스탬프.
     // full 폴백 렌더라도 스탬프가 현재 상태와 일치하면(예: legend hover 처럼 데이터가 그대로인
@@ -42,93 +39,106 @@ const blit = {
   },
 
   /**
-   * 점 라스터 전용 ping-pong 레이어 2장을 생성한다(미부착 오프스크린 canvas). 치수는 setWidth/
-   * setHeight 가 device px 로 맞춘다. realTimeScatter.use 일 때만 의미가 있다.
+   * scatter series 별 ping-pong 레이어(미부착 오프스크린 canvas 2장)를 생성/조정한다. 현재 scatter
+   * series 집합과 레이어 sId 집합이 같으면 재사용하고, 다르면 전부 재생성한다(런타임 series add/remove).
+   * 신규 canvas 는 bufferCanvas 치수로 즉시 맞춘다(레이어가 layout 이후 생성돼도 사이즈가 0 으로 남지
+   * 않도록). 치수 유지는 setWidth/setHeight 가 담당. realTimeScatter.use 일 때만 의미가 있다.
    * @returns {undefined}
    */
   createPointsLayers() {
-    if (this.pointsLayerA) {
+    const scatterIds = this.seriesInfo?.charts?.scatter ?? [];
+    const same =
+      this.pointsLayers.size === scatterIds.length &&
+      scatterIds.every((sId) => this.pointsLayers.has(sId));
+    if (same && this.pointsLayers.size) {
       return;
     }
-    this.pointsLayerA = document.createElement('canvas');
-    this.pointsLayerB = document.createElement('canvas');
-    this.pointsLayerACtx = this.pointsLayerA.getContext('2d');
-    this.pointsLayerBCtx = this.pointsLayerB.getContext('2d');
-    this.curPointsLayer = 'A';
+    const w = this.bufferCanvas?.width ?? 0;
+    const h = this.bufferCanvas?.height ?? 0;
+    const next = new Map();
+    for (let i = 0; i < scatterIds.length; i++) {
+      const a = document.createElement('canvas');
+      const b = document.createElement('canvas');
+      if (w > 1 && h > 1) {
+        a.width = w;
+        a.height = h;
+        b.width = w;
+        b.height = h;
+      }
+      next.set(scatterIds[i], {
+        a,
+        b,
+        actx: a.getContext('2d'),
+        bctx: b.getContext('2d'),
+        cur: 'A',
+      });
+    }
+    this.pointsLayers = next;
     this.pointsLayerValid = false;
   },
 
   /**
-   * 현재 유효 점 라스터를 담은 레이어(canvas+ctx) 와 반대편(쓰기 대상) 레이어를 반환한다.
-   * @returns {{ src: HTMLCanvasElement, srcCtx: CanvasRenderingContext2D,
-   *            dst: HTMLCanvasElement, dstCtx: CanvasRenderingContext2D, dstName: string }}
+   * 한 series 의 현재 유효 라스터(src) 와 반대편 쓰기 대상(dst) 레이어를 반환한다.
+   * @param {string} sId  series id
+   * @returns {{ src, srcCtx, dst, dstCtx, dstName, layer } | null}
    */
-  getPointsLayers() {
-    const isA = this.curPointsLayer === 'A';
+  getSeriesLayer(sId) {
+    const layer = this.pointsLayers.get(sId);
+    if (!layer) {
+      return null;
+    }
+    const isA = layer.cur === 'A';
     return {
-      src: isA ? this.pointsLayerA : this.pointsLayerB,
-      srcCtx: isA ? this.pointsLayerACtx : this.pointsLayerBCtx,
-      dst: isA ? this.pointsLayerB : this.pointsLayerA,
-      dstCtx: isA ? this.pointsLayerBCtx : this.pointsLayerACtx,
+      src: isA ? layer.a : layer.b,
+      srcCtx: isA ? layer.actx : layer.bctx,
+      dst: isA ? layer.b : layer.a,
+      dstCtx: isA ? layer.bctx : layer.actx,
       dstName: isA ? 'B' : 'A',
+      layer,
     };
   },
 
   /**
-   * 점 레이어가 현재 device 치수로 할당되어 있는지 확인한다.
-   * @returns {boolean}
+   * 모든 series 레이어 canvas 를 device 치수(dw,dh)로 맞춘다(setWidth/setHeight 에서 호출).
+   * canvas.width/height 대입은 비트맵을 지우므로 치수가 실제로 바뀔 때만 호출해야 한다.
+   * @param {number} dw   device width
+   * @param {number} dh   device height
+   * @returns {boolean}   하나라도 재할당(=픽셀 소거)됐으면 true → baseline 무효화 필요
    */
-  pointsLayersSized() {
-    if (!this.pointsLayerA || !this.bufferCanvas) {
-      return false;
-    }
-    return (
-      this.pointsLayerA.width === this.bufferCanvas.width &&
-      this.pointsLayerA.height === this.bufferCanvas.height &&
-      this.pointsLayerA.width > 1 &&
-      this.pointsLayerA.height > 1
-    );
+  resizePointsLayers(dw, dh) {
+    let changed = false;
+    this.pointsLayers.forEach((layer) => {
+      if (layer.a.width !== dw || layer.a.height !== dh) {
+        layer.a.width = dw;
+        layer.a.height = dh;
+        layer.b.width = dw;
+        layer.b.height = dh;
+        changed = true;
+      }
+    });
+    return changed;
   },
 
   /**
-   * blit fast-path 전용 strip-local owner 맵. dirtyBuckets(신규 strip) 버킷의 점만 순회해 duple 을 채운다.
-   * 같은 좌표(=같은 ms=같은 버킷)는 strip 안에서 owner 가 닫히므로 전체 dedupe 없이 strip 만으로 정확하다.
-   * 순서/owner 규칙은 collectDuplicatePoints(realtime 경로)와 동일하게 맞춰 full redraw 와 픽셀이 일치한다
-   * (seriesReverse 면 역순 순회 → 마지막 set 이 owner).
-   * @param {Map<string,string>} duple              owner 맵(coordKey → sId)
-   * @param {number[]} dirtyBuckets                  strip 으로 다시 그릴 ring 버킷 인덱스 목록
-   * @returns {undefined}
+   * 모든 점 레이어가 현재 bufferCanvas device 치수로 할당되어 있는지 확인한다.
+   * @returns {boolean}
    */
-  collectStripDuplicatePoints(duple, dirtyBuckets) {
-    const scatterIds = this.seriesInfo?.charts?.scatter ?? [];
-    const isReverseOrder = !!this.options.seriesReverse;
-    for (
-      let jx = isReverseOrder ? scatterIds.length - 1 : 0;
-      isReverseOrder ? jx >= 0 : jx < scatterIds.length;
-      isReverseOrder ? jx-- : jx++
-    ) {
-      const series = this.seriesList[scatterIds[jx]];
-      if (!series?.show) {
-        // eslint-disable-next-line no-continue
-        continue;
-      }
-      const dataGroup = series.data[series.sId]?.dataGroup;
-      if (!dataGroup) {
-        // eslint-disable-next-line no-continue
-        continue;
-      }
-      for (let b = 0; b < dirtyBuckets.length; b++) {
-        const group = dataGroup[dirtyBuckets[b]];
-        if (!group?.data) {
-          // eslint-disable-next-line no-continue
-          continue;
-        }
-        for (let j = 0; j < group.data.length; j++) {
-          const item = group.data[j];
-          duple.set(item.k ?? Util.coordinateKey(item.x, item.y), series.sId);
-        }
-      }
+  pointsLayersSized() {
+    if (!this.pointsLayers.size || !this.bufferCanvas) {
+      return false;
     }
+    const bw = this.bufferCanvas.width;
+    const bh = this.bufferCanvas.height;
+    if (!(bw > 1) || !(bh > 1)) {
+      return false;
+    }
+    let ok = true;
+    this.pointsLayers.forEach((layer) => {
+      if (layer.a.width !== bw || layer.a.height !== bh) {
+        ok = false;
+      }
+    });
+    return ok;
   },
 
   /**
@@ -457,19 +467,25 @@ const blit = {
     }
 
     // calcItem 과 동일한 시간→px 매핑: 시간이 shiftMs 전진하면 점이 dxCss 만큼 왼쪽으로 이동한다.
-    // 시프트는 정수 px 로만 하고 소수부는 carry 에 누산해 장기 drift 를 막는다.
+    // 시프트는 *정수 CSS px* 로만 한다(소수부는 _blitCarry 에 누산). calcItem 은 CSS px 에서 ceil 로
+    // 양자화하므로, 정수 CSS px 시프트만이 ceil 과 교환돼 full redraw 와 픽셀이 일치한다(정수 device
+    // px 시프트는 pr 그리드와 어긋나 점마다 ≤1px 스냅 발생 → legend hover 시 구름이 튐).
+    // device 시프트 = gCss·pr (항상 pr 배수). 잔차 carry(_blitCarry, [-0.5,0.5] CSS px)는 full
+    // redraw·strip 의 calcItem 이 startPoint 오프셋으로 그대로 반영한다(rtXOffsetCss).
     const dxCss = (xArea / wMs) * gate.shiftMs;
-    const dxDev = dxCss * pr;
-    const dxTotal = dxDev + this._blitCarry;
-    const dxInt = Math.floor(dxTotal);
-    if (dxInt < 1) {
+    const accCss = this._blitCarry + dxCss;
+    const gCss = Math.round(accCss);
+    if (gCss < 1) {
       return false; // sub-pixel 이동 → full redraw 가 안전(아주 넓은 윈도우 등 드문 경우)
     }
+    const dxInt = gCss * pr;
 
-    // 신규 점이 우측 strip 보다 오래된 버킷에 떨어졌으면(지연/역순 데이터) strip-only 로는 누락 →
-    // full redraw 로 폴백한다. strip 은 endIndex 부터 gapCount+1 버킷(age 0..gapCount+1)을 덮는다.
-    // multi-series: visible series 중 maxDirtyAge 최댓값으로 판정(하나라도 strip 밖이면 full).
-    // 동시에 seam pad·합성 clip 에 쓸 pointSize 최댓값을 구한다.
+    // 신규 점이 우측단에서 떨어진 최대 버킷 거리(maxDirtyAge)까지 strip 으로 다시 그린다. 신규 점은
+    // 보통 brand-new 슬롯(age 0..gapCount-1)에 떨어지지만, x 가 초 경계 직전(graphMax floor 초과)이라
+    // 도착 틱엔 범위 밖(xp=null)이고 다음 틱에야 age=gapCount 경계 버킷에서 그려지는 점이 흔하다
+    // (데모: x=now ± 3초). 이를 strip 에 포함하지 않으면 영영 누락된다. strip 범위(gapCount+1)를
+    // 넘는 지연/역순 데이터만 full redraw 로 폴백한다. multi-series: visible series 중 maxDirtyAge 최댓값.
+    // 동시에 합성 clip 에 쓸 pointSize 최댓값을 구한다.
     let maxDirtyAge = lastTick.maxDirtyAge;
     let maxPointSize =
       typeof target.series.pointSize === 'number'
@@ -496,44 +512,19 @@ const blit = {
       return false;
     }
 
-    // 모든 가드 통과 → 이번 시프트를 확정하고 잔차를 적립([0,1)).
-    this._blitCarry = dxTotal - dxInt;
+    // 모든 가드 통과 → 이번 시프트를 확정하고 잔차를 적립([-0.5,0.5] CSS px).
+    this._blitCarry = accCss - gCss;
 
-    const { src, dst, dstCtx, dstName } = this.getPointsLayers();
-
-    // 1) shift: src[dxInt..W] → dst[0..W-dxInt] (device px, identity transform)
-    dstCtx.setTransform(1, 0, 0, 1, 0, 0);
-    dstCtx.clearRect(0, 0, wDev, hDev);
-    dstCtx.drawImage(src, dxInt, 0, wDev - dxInt, hDev, 0, 0, wDev - dxInt, hDev);
-
-    // 2) 신규 strip clear + redraw
+    // dirty 버킷(신규 strip) 인덱스 — 모든 series 공통(정렬 전제).
     //
-    // 경계 불변식: "지운 픽셀 영역에 그릴 수 있는 모든 점은 반드시 redraw 대상(dirty 버킷)이어야 한다."
-    // 점 좌표는 매 프레임 ceil 로 재양자화되어 ±1px 움직일 수 있으므로, 경계가 버킷 내용을 관통하면
-    // 경계 왼쪽으로 이동한 점이 clip 에 걸려 "지웠는데 다시 안 그려지는" 결손 컬럼이 매 틱 쌓인다
-    // (누적 라스터에 세로 줄무늬로 노출). 이를 막기 위해 경계를 가장 오래된 dirty 버킷의 좌단에서
-    // 안쪽(inset)으로 둔다 — 경계 오른쪽에 마커가 닿을 수 있는 점은 전부 dirty 버킷 소속이 되어
-    // 완전 redraw 가 보장된다.
-    const padDev = Math.ceil(maxPointSize * pr) + 1; // seam 마진(마커 반경 + AA, MAX pointSize)
-    const plotRightDev = (cr.x1 + lo.left + xArea) * pr;
-    const pxPerSecDev = (xArea / wMs) * 1000 * pr; // 1초 버킷의 device px 폭
-
+    // 흰줄(comb) 불가 보장: 흰줄은 "픽셀을 지웠는데 다시 안 그리는" 경우(clear + clip 의 결손 컬럼)에만
+    // 생긴다. 아래 시프트는 OLD 픽셀을 비트단위 무손실로 옮긴 뒤(정수좌표·동일크기 drawImage → 재양자화
+    // 없음) 그 위에 strip 버킷을 덧그리기만 한다 — 픽셀 제거 연산이 없으므로 세로 흰줄이 원천 불가.
     const { gapCount, endIndex, length } = lastTick;
-    // 경계 안쪽 마진: 버킷 좌단 시각의 점이 경계 너머로 칠할 수 있는 최대 도달 거리.
-    // ceil 라운딩(+1) + aliasPixel(+1) + 마커 반경(pointSize) + stroke/AA(+2) — 보수적으로 잡는다.
-    const insetDev = padDev + Math.ceil(4 * pr);
-    // 버킷 px 폭이 좁으면 dirty 버킷을 자동 확장해 경계 조건을 만족시킨다:
-    // extra·pxPerSec ≥ inset + pad + 2 (좌측 완전성 마진 + 우측 신규 strip 커버 마진).
-    const extraBuckets = Math.max(
-      2,
-      Math.ceil((insetDev + padDev + 2) / Math.max(1e-6, pxPerSecDev)),
-    );
-    const dirtyCount = Math.min(length, gapCount + extraBuckets);
-    // clear/clip 경계는 정수 device px — 소수 경계 반복 clear 는 경계 픽셀 알파를 매 틱 감쇠시킨다.
-    const oldestLeftDev = plotRightDev - dirtyCount * pxPerSecDev;
-    const clearLeftDev = Math.max(0, Math.floor(oldestLeftDev + insetDev));
-    dstCtx.clearRect(clearLeftDev, 0, wDev - clearLeftDev, hDev);
-
+    // 최소 gapCount+1: 시프트로 비워진 strip(gapCount 버킷) + 경계 버킷(age gapCount) 1개.
+    // 경계 버킷은 직전 틱 graphMax(=floor(maxX)) 초과로 그려지지 못한 점(x 가 초 경계 직전)이 이번 틱
+    // 범위 안으로 들어와 그려지는 자리라 반드시 포함해야 한다. maxDirtyAge 가 더 멀면(지연 데이터) 거기까지.
+    const dirtyCount = Math.min(length, Math.max(gapCount + 1, maxDirtyAge + 1));
     const dirtyBuckets = new Array(dirtyCount);
     for (let k = 0; k < dirtyCount; k++) {
       let idx = (endIndex - k) % length;
@@ -543,16 +534,9 @@ const blit = {
       dirtyBuckets[k] = idx;
     }
 
-    // multi-series: strip-local owner 맵으로 cross-series dedupe(full redraw 와 픽셀 일치).
-    // 단일 series 면 duple=null → realTimeScatterDrawStrip 이 전부 그린다.
-    // 판정 술어는 full 경로(drawSeries·rebuildPointsLayer)와 동일해야 한다: coordinateDedupe
-    // opt-out(#2011) 존중 + 2개 이상일 때만. series 개수만으로 판정하면 opt-out 시 픽셀이 어긋난다.
-    const dedupeOn = this.options.coordinateDedupe !== false && scatterList.length > 1;
-    const duple = dedupeOn ? new Map() : null;
-    if (dedupeOn) {
-      this.collectStripDuplicatePoints(duple, dirtyBuckets);
-    }
-
+    // series 별 레이어이므로 cross-series dedupe 가 필요 없다 — 겹침에서 "어느 series 가 위"인지는
+    // 합성 순서(compositePointsLayer)가 full redraw 와 동일하게 결정한다. 각 series 는 자기 점만 자기
+    // 레이어에 그린다(intra-series 좌표 유일성은 push 단계 dedupe 가 보장).
     const param = {
       chartRect: cr,
       labelOffset: lo,
@@ -561,39 +545,33 @@ const blit = {
       selectInfo: null,
       legendHitInfo: null,
       unSelectedOpacity: this.options.unSelectedOpacity,
-      duple,
-      coordinateDedupe: dedupeOn,
+      duple: null,
+      coordinateDedupe: false,
+      // 시프트 후 잔차 carry. strip 신규 점도 시프트된 옛 점과 동일 위상으로 찍어 라스터 정합 유지.
+      rtXOffsetCss: this._blitCarry,
     };
 
-    // 3) 신규 strip redraw: 모든 visible series 를 drawSeries 와 동일 순서(seriesReverse 면 역순)로 그린다.
-    // dirty 버킷(gapCount+2개)의 px 범위는 clear 폭(dxInt+pad)보다 넓다 — seam 버킷이 clear 경계
-    // 왼쪽까지 걸친다. clip 없이 그리면 "안 지운 픽셀 위에 ±1px 재양자화된 점을 덧칠"하게 되어
-    // 이미 쌓인 라스터 위로 다른 series 색이 새어 나오고(z-order 누적 오염), 윈도우가 흐르며 전 화면에
-    // 퍼진다. clear 한 영역만 다시 그리도록 clip 으로 불변식을 강제한다(지운 곳 = 그리는 곳).
-    dstCtx.save();
-    dstCtx.beginPath();
-    dstCtx.rect(clearLeftDev, 0, wDev - clearLeftDev, hDev);
-    dstCtx.clip();
-    dstCtx.setTransform(pr, 0, 0, pr, 0, 0);
-    const reverse = !!this.options.seriesReverse;
+    // visible series 마다 독립적으로: 1) dxInt 무손실 시프트, 2) 자기 신규 strip 덧그림, 3) ping-pong swap.
     for (let i = 0; i < scatterList.length; i++) {
-      const entry = reverse ? scatterList[scatterList.length - 1 - i] : scatterList[i];
-      entry.series.realTimeScatterDrawStrip(dstCtx, dirtyBuckets, param);
-    }
-    dstCtx.restore();
-    dstCtx.setTransform(1, 0, 0, 1, 0, 0);
-
-    // 4) ping-pong swap → dst 가 현재 유효 레이어
-    this.curPointsLayer = dstName;
-
-    // 5) mousemove(findGraphData)용 전체 카운트 갱신(모든 series, 점 수 무관 O(버킷))
-    for (let i = 0; i < scatterList.length; i++) {
-      scatterList[i].series.refreshRtTotalCount();
+      const entry = scatterList[i];
+      const ly = this.getSeriesLayer(entry.sId);
+      if (!ly) {
+        return false; // 레이어 누락(series 셋 desync) → full 폴백
+      }
+      ly.dstCtx.setTransform(1, 0, 0, 1, 0, 0);
+      ly.dstCtx.clearRect(0, 0, wDev, hDev);
+      ly.dstCtx.drawImage(ly.src, dxInt, 0, wDev - dxInt, hDev, 0, 0, wDev - dxInt, hDev);
+      ly.dstCtx.setTransform(pr, 0, 0, pr, 0, 0);
+      entry.series.realTimeScatterDrawStrip(ly.dstCtx, dirtyBuckets, param);
+      ly.dstCtx.setTransform(1, 0, 0, 1, 0, 0);
+      ly.layer.cur = ly.dstName;
+      // mousemove(findGraphData)용 전체 카운트 갱신(점 수 무관 O(버킷)).
+      entry.series.refreshRtTotalCount();
     }
 
-    // 6) buffer 재구성: 축 새로 그리고 점 레이어를 plot 영역에 합성(clip 확장 = MAX pointSize)
+    // buffer 재구성: 축 새로 그리고 series 레이어들을 z-order 순서로 plot 영역에 합성.
     this.drawStaticLayer(this.bufferCtx, hitInfo);
-    this.compositePointsLayer(dst, maxPointSize);
+    this.compositePointsLayer(maxPointSize);
 
     return true;
   },
@@ -607,11 +585,13 @@ const blit = {
    * pointSize 의 수 배라 한 틱에 이 좁은 마진 밖으로 빠져나가고, 장기 잔재는 REFRESH_INTERVAL 강제
    * full 이 정리한다.
    * bufferCtx 는 합성 후 drawTip 을 위해 scale(pr)·unclip 상태로 복구되어야 하므로 save/restore 로 감싼다.
-   * @param {HTMLCanvasElement} layerCanvas   합성할 점 레이어 canvas
+   *
+   * series 별 레이어를 full redraw 와 *동일한 그리기 순서*(seriesReverse 면 [..., series1] 로 마지막이
+   * 위)로 겹쳐 합성한다 → 겹친 픽셀에서 위에 오는 series 가 full 과 일치(z-order 동등, seam 색줄 제거).
    * @param {number} pointSize                clip 확장에 쓸 pointSize(multi-series 면 visible MAX)
    * @returns {undefined}
    */
-  compositePointsLayer(layerCanvas, pointSize) {
+  compositePointsLayer(pointSize) {
     const pr = this.pixelRatio;
     const cr = this.chartRect;
     const lo = this.labelOffset;
@@ -625,15 +605,32 @@ const blit = {
 
     const clipLeft = (xsp - pointSize) * pr;
     const clipTop = (plotTop - pointSize) * pr;
-    const clipRight = (plotRight + pointSize) * pr;
+    // 우측 경계는 정수 device px 로 올림 정렬하고 carry bump 만큼 넉넉히 넓힌다. realtime 점은
+    // startPoint 에 carry(rtXOffsetCss, |·|<1)가 더해져 graphMax 경계 마커 중심이 ceil(plotRight+carry)
+    // = 최대 ceil(plotRight)+1 까지, 반경 pointSize 만큼 더 우측을 칠한다. full redraw 는 clip 이 없어
+    // 그 픽셀을 온전히 그리므로, clip 이 소수 경계에서 그 컬럼을 반쪽(AA 반감)으로 자르면 blit≠full
+    // 이 된다. ceil + (pointSize+2) 로 정수 정렬·충분 마진을 줘 경계 마커를 온전히 합성한다(우측엔
+    // 신규 점만 있어 over-clip 마진이 노출하는 stale 픽셀이 없다).
+    const clipRight = (Math.ceil(plotRight) + pointSize + 2) * pr;
     const clipBottom = (plotBottom + pointSize) * pr;
+
+    // full(drawSeriesLayer)의 scatter 그리기 순서와 동일하게: seriesReverse 면 show 목록을 뒤집어
+    // 마지막에 그린 series 가 위에 오게 한다. 합성도 같은 순서로 겹쳐 z-order 를 일치시킨다.
+    const scatterList = this.getBlitScatterSeriesList();
+    const reverse = !!this.options.seriesReverse;
 
     this.bufferCtx.save();
     this.bufferCtx.setTransform(1, 0, 0, 1, 0, 0);
     this.bufferCtx.beginPath();
     this.bufferCtx.rect(clipLeft, clipTop, clipRight - clipLeft, clipBottom - clipTop);
     this.bufferCtx.clip();
-    this.bufferCtx.drawImage(layerCanvas, 0, 0);
+    for (let i = 0; i < scatterList.length; i++) {
+      const entry = reverse ? scatterList[scatterList.length - 1 - i] : scatterList[i];
+      const layer = this.pointsLayers.get(entry.sId);
+      if (layer) {
+        this.bufferCtx.drawImage(layer.cur === 'A' ? layer.a : layer.b, 0, 0);
+      }
+    }
     this.bufferCtx.restore();
   },
 
@@ -766,6 +763,8 @@ const blit = {
       labelOffset: this.labelOffset,
       axesSteps: this.axesSteps,
       displayOverflow: this.options.displayOverflow,
+      // hit-test 좌표도 그려진 위치와 동일 위상으로 — tooltip/select 가 화면 점과 일치하게.
+      rtXOffsetCss: this._blitCarry,
     };
     for (let i = 0; i < scatterList.length; i++) {
       scatterList[i].series.refreshRtHitCoords?.(param);
@@ -807,47 +806,43 @@ const blit = {
     }
 
     const pr = this.pixelRatio;
-    const isA = this.curPointsLayer === 'A';
-    const layer = isA ? this.pointsLayerA : this.pointsLayerB;
-    const layerCtx = isA ? this.pointsLayerACtx : this.pointsLayerBCtx;
-
-    layerCtx.setTransform(1, 0, 0, 1, 0, 0);
-    layerCtx.clearRect(0, 0, layer.width, layer.height);
-    layerCtx.setTransform(pr, 0, 0, pr, 0, 0);
-
-    // drawSeries 의 scatter 경로와 동일 출력: multi-series 면 owner-dedupe(전체 duple), 단일이면 전부 그림.
-    const scatterIds = this.seriesInfo?.charts?.scatter ?? [];
-    const dedupeOn =
-      this.options.coordinateDedupe !== false && !this.canSkipRealtimeScatterDedupe(scatterIds);
-    const duple = new Map();
-    if (dedupeOn) {
-      this.collectDuplicatePoints(duple, scatterIds);
-    }
-
-    const baseParam = {
-      ctx: layerCtx,
-      chartRect: this.chartRect,
-      labelOffset: this.labelOffset,
-      axesSteps: this.axesSteps,
-      displayOverflow: this.options.displayOverflow,
-      duple,
-      coordinateDedupe: dedupeOn,
-      selectInfo: null,
-      legendHitInfo: null,
-      unSelectedOpacity: this.options.unSelectedOpacity,
-    };
-
-    // seriesReverse 면 역순으로 그려 owner(마지막 set)가 위에 오도록 drawSeries 와 z-order 일치.
-    const reverse = !!this.options.seriesReverse;
+    // series 별 레이어에 자기 점만 그린다 — cross-series dedupe 불필요(z-order 는 합성 순서가 담당).
+    // 각 series 의 현재 유효 라스터(cur)에 직접 다시 그려 다음 fast-path 의 baseline 을 세운다.
     for (let i = 0; i < scatterList.length; i++) {
-      const entry = reverse ? scatterList[scatterList.length - 1 - i] : scatterList[i];
+      const entry = scatterList[i];
+      const layer = this.pointsLayers.get(entry.sId);
+      if (!layer) {
+        this.pointsLayerValid = false;
+        return;
+      }
+      const canvas = layer.cur === 'A' ? layer.a : layer.b;
+      const layerCtx = layer.cur === 'A' ? layer.actx : layer.bctx;
+      layerCtx.setTransform(1, 0, 0, 1, 0, 0);
+      layerCtx.clearRect(0, 0, canvas.width, canvas.height);
+      layerCtx.setTransform(pr, 0, 0, pr, 0, 0);
+
+      const baseParam = {
+        ctx: layerCtx,
+        chartRect: this.chartRect,
+        labelOffset: this.labelOffset,
+        axesSteps: this.axesSteps,
+        displayOverflow: this.options.displayOverflow,
+        duple: null,
+        coordinateDedupe: false,
+        selectInfo: null,
+        legendHitInfo: null,
+        unSelectedOpacity: this.options.unSelectedOpacity,
+        // baseline 도 현재 carry 위상으로 그린다 — 직전 blit 프레임과 위치 연속(REFRESH rebuild 무-스냅).
+        rtXOffsetCss: this._blitCarry,
+      };
+
       // 기하 패스를 먼저 돌려 item.xp/yp 를 채운다 — realTimeScatterDraw 는 좌표를 읽기만 하므로
       // element.draw() 를 거치지 않는 이 직접 호출 경로에선 computeGeometry 를 명시 호출해야 한다.
       entry.series.computeGeometry(baseParam);
       entry.series.realTimeScatterDraw(baseParam);
+      layerCtx.setTransform(1, 0, 0, 1, 0, 0);
     }
 
-    layerCtx.setTransform(1, 0, 0, 1, 0, 0);
     this.pointsLayerValid = true;
   },
 };

--- a/src/components/chart/chart.blit.js
+++ b/src/components/chart/chart.blit.js
@@ -206,6 +206,32 @@ const blit = {
   },
 
   /**
+   * pixelRatio 의 기약분수 분모 q(= q·pr 이 정수가 되는 최소 양의 정수)를 반환한다.
+   * 시프트를 정수 CSS px(gCss)로 하되 q 의 배수로 양자화하면 device 시프트(gCss·pr)가 정수가 돼
+   * drawImage 가 bilinear 리샘플(블러) 없이 비트 단위로 복사되고, 라스터가 pr 그리드에 정렬된 채로
+   * 남아 full redraw 와 픽셀이 일치한다(blit≡full). 정수 pr 은 q=1(기존 동작 그대로).
+   * 표준 디스플레이 배율은 분모가 작다: 125%/150%/175%/225%/250% = 5/4·3/2·7/4·9/4·5/2 → q≤4.
+   * q 를 못 찾는 pr(브라우저 임의 줌 등 분모가 큰 값)은 null → full 폴백(정확하지만 가속 없음).
+   * @returns {number|null}
+   */
+  blitShiftDenominator() {
+    const pr = this.pixelRatio;
+    if (!(pr > 0)) {
+      return null;
+    }
+    if (Number.isInteger(pr)) {
+      return 1;
+    }
+    const MAX_Q = 4;
+    for (let q = 2; q <= MAX_Q; q++) {
+      if (Math.abs(pr * q - Math.round(pr * q)) < 1e-6) {
+        return q;
+      }
+    }
+    return null;
+  },
+
+  /**
    * blit fast-path 진입 게이트. 하나라도 위반하면 ok=false → full redraw 폴백.
    * 진단(instrumentation) 목적으로 각 게이트 항목을 개별 boolean(parts)으로 분해해 반환한다.
    * 게이트는 drawChart 가 adjustXAndYAxisWidth 로 axesSteps/labelOffset/chartRect 를 확정한 뒤 평가한다.
@@ -246,11 +272,11 @@ const blit = {
       selectionOk,
       // blit 은 realtime scatter 전용이다.
       scatterOnly: this.hasOnlyVisibleScatter(),
-      // 분수 pixelRatio(예: Windows 125%/150% = 1.25/1.5)에서는 정수 CSS px 시프트의 device 폭
-      // (gCss·pr)이 비정수가 돼 drawImage 시프트가 bilinear 리샘플(블러)을 일으키고, strip 밖 라스터에
-      // 매 틱 누적된다(blit≠full). 정수 pr 에서만 시프트가 bit-exact 하므로 분수면 full 폴백한다
-      // (rebuild+composite 는 시프트가 없어 분수 pr 에서도 정확).
-      deviceIntegerRatio: Number.isInteger(this.pixelRatio),
+      // 분수 pixelRatio(예: Windows 125%/150% = 1.25/1.5)여도 정수 CSS px 시프트를 q(=pr 기약분모)의
+      // 배수로 양자화하면 device 시프트(gCss·pr)가 정수가 돼 drawImage 가 무손실(bilinear 블러 없음)이고
+      // 라스터가 pr 그리드에 정렬된 채로 남아 full 과 픽셀이 일치한다(blit≡full). q 를 못 찾는 pr
+      // (브라우저 임의 줌 등 분모가 큰 값)만 full 폴백한다. blitShiftDenominator 참조.
+      deviceRatioBlittable: this.blitShiftDenominator() !== null,
       hasPrev: !!prev,
       // 옵션 변화(색·스타일 등)는 레이어 픽셀을 바꿀 수 있다. Chart.vue options watcher 가
       // 변화 시 options 참조를 통째 교체하므로 참조 비교 1회로 보수적으로 차단한다.
@@ -314,7 +340,7 @@ const blit = {
       parts.seriesAligned &&
       parts.selectionOk &&
       parts.scatterOnly &&
-      parts.deviceIntegerRatio &&
+      parts.deviceRatioBlittable &&
       parts.hasPrev &&
       parts.optionsStable &&
       parts.yFixed &&
@@ -521,15 +547,19 @@ const blit = {
     // 시프트는 *정수 CSS px* 로만 한다(소수부는 _blitCarry 에 누산). calcItem 은 CSS px 에서 ceil 로
     // 양자화하므로, 정수 CSS px 시프트만이 ceil 과 교환돼 full redraw 와 픽셀이 일치한다(정수 device
     // px 시프트는 pr 그리드와 어긋나 점마다 ≤1px 스냅 발생 → legend hover 시 구름이 튐).
-    // device 시프트 = gCss·pr (항상 pr 배수). 잔차 carry(_blitCarry, [-0.5,0.5] CSS px)는 full
-    // redraw·strip 의 calcItem 이 startPoint 오프셋으로 그대로 반영한다(rtXOffsetCss).
+    // 나아가 gCss 를 q(=pr 기약분모)의 배수로 양자화하면 device 시프트(gCss·pr)까지 정수가 돼
+    // drawImage 가 무손실(bilinear 블러 없음)이면서도 pr 그리드 정렬이 유지된다(분수 pr 에서도 blit≡full).
+    // 정수 pr 은 q=1 이라 매 정수 px 시프트(기존 동작). 잔차 carry(_blitCarry, [-q/2,q/2] CSS px)는
+    // full redraw·strip 의 calcItem 이 startPoint 오프셋으로 그대로 반영한다(rtXOffsetCss).
+    const q = this.blitShiftDenominator() ?? 1;
     const dxCss = (xArea / wMs) * gate.shiftMs;
     const accCss = this._blitCarry + dxCss;
-    const gCss = Math.round(accCss);
+    const gCss = Math.round(accCss / q) * q;
     if (gCss < 1) {
-      return false; // sub-pixel 이동 → full redraw 가 안전(아주 넓은 윈도우 등 드문 경우)
+      return false; // sub-q 이동 → full redraw 가 안전(아주 넓은 윈도우/분수 pr 의 느린 시프트)
     }
-    const dxInt = gCss * pr;
+    // gCss 가 q 배수라 gCss·pr 은 정수(pr 은 유한 이진수) — Math.round 는 fp 오차만 제거한다.
+    const dxInt = Math.round(gCss * pr);
 
     // 신규 점이 우측단에서 떨어진 최대 버킷 거리(maxDirtyAge)까지 strip 으로 다시 그린다. 신규 점은
     // 보통 brand-new 슬롯(age 0..gapCount-1)에 떨어지지만, x 가 초 경계 직전(graphMax floor 초과)이라
@@ -667,12 +697,14 @@ const blit = {
     const clipLeft = (xsp - pointSize) * pr;
     const clipTop = (plotTop - pointSize) * pr;
     // 우측 경계는 정수 device px 로 올림 정렬하고 carry bump 만큼 넉넉히 넓힌다. realtime 점은
-    // startPoint 에 carry(rtXOffsetCss, |·|<1)가 더해져 graphMax 경계 마커 중심이 ceil(plotRight+carry)
-    // = 최대 ceil(plotRight)+1 까지, 반경 pointSize 만큼 더 우측을 칠한다. full redraw 는 clip 이 없어
-    // 그 픽셀을 온전히 그리므로, clip 이 소수 경계에서 그 컬럼을 반쪽(AA 반감)으로 자르면 blit≠full
-    // 이 된다. ceil + (pointSize+2) 로 정수 정렬·충분 마진을 줘 경계 마커를 온전히 합성한다(우측엔
-    // 신규 점만 있어 over-clip 마진이 노출하는 stale 픽셀이 없다).
-    const clipRight = (Math.ceil(plotRight) + pointSize + 2) * pr;
+    // startPoint 에 carry(rtXOffsetCss, |·|≤q/2)가 더해져 graphMax 경계 마커 중심이 ceil(plotRight+carry)
+    // = 최대 ceil(plotRight)+ceil(q/2) 까지, 반경 pointSize 만큼 더 우측을 칠한다. full redraw 는 clip 이
+    // 없어 그 픽셀을 온전히 그리므로, clip 이 소수 경계에서 그 컬럼을 반쪽(AA 반감)으로 자르면 blit≠full
+    // 이 된다. ceil + (pointSize + ceil(q/2) + 1) 로 정수 정렬·충분 마진을 줘 경계 마커를 온전히 합성한다
+    // (q=1·2 는 기존과 동일한 +2, 분수 pr 로 carry 가 커지는 q=4 는 +3; 우측엔 신규 점만 있어 over-clip
+    // 마진이 노출하는 stale 픽셀이 없다).
+    const q = this.blitShiftDenominator() ?? 1;
+    const clipRight = (Math.ceil(plotRight) + pointSize + Math.ceil(q / 2) + 1) * pr;
     const clipBottom = (plotBottom + pointSize) * pr;
 
     // full(drawSeriesLayer)의 scatter 그리기 순서와 동일하게: seriesReverse 면 show 목록을 뒤집어

--- a/src/components/chart/chart.blit.js
+++ b/src/components/chart/chart.blit.js
@@ -246,11 +246,6 @@ const blit = {
       selectionOk,
       // blit 은 realtime scatter 전용이다.
       scatterOnly: this.hasOnlyVisibleScatter(),
-      // 반투명(rgba alpha<1) fill 이 있으면 full redraw 로 폴백한다. strip 은 시프트된 옛 라스터 위에
-      // 경계 버킷 점을 다시 그리므로(픽셀 제거 없는 덧그림), 반투명 점은 source-over 로 알파가 누적돼
-      // (α→2α-α²) full(점당 1회)보다 진해진다 → blit≠full. opaque 면 source-over 가 멱등이라 무해.
-      // 폴백 경로(rebuild+composite)는 점당 1회 그리므로 반투명도 정확하다(가속만 양보).
-      opaqueFill: this.hasOnlyOpaqueScatterFill(),
       // 분수 pixelRatio(예: Windows 125%/150% = 1.25/1.5)에서는 정수 CSS px 시프트의 device 폭
       // (gCss·pr)이 비정수가 돼 drawImage 시프트가 bilinear 리샘플(블러)을 일으키고, strip 밖 라스터에
       // 매 틱 누적된다(blit≠full). 정수 pr 에서만 시프트가 bit-exact 하므로 분수면 full 폴백한다
@@ -319,7 +314,6 @@ const blit = {
       parts.seriesAligned &&
       parts.selectionOk &&
       parts.scatterOnly &&
-      parts.opaqueFill &&
       parts.deviceIntegerRatio &&
       parts.hasPrev &&
       parts.optionsStable &&
@@ -353,28 +347,6 @@ const blit = {
         if (this.seriesList[ids[j]]?.show) {
           return false;
         }
-      }
-    }
-    return true;
-  },
-
-  /**
-   * 보이는 scatter series 의 fill·stroke 가 전부 불투명(alpha=1)인가.
-   * 반투명(rgba alpha<1)이면 strip 의 경계 버킷 덧그림이 source-over 로 알파를 누적시켜 blit≠full 이
-   * 되므로 fast-path 를 막고 full redraw(점당 1회)로 폴백한다. Util.getOpacity 는 rgba 면 alpha 문자열,
-   * 그 외엔 '1' 을 돌려준다. 참고: series 단위 색만 검사한다 — point 별 rgba(item.color)까지는 보지
-   * 않는다(매 게이트 전수 스캔 비용 회피). 그런 경우엔 REFRESH_INTERVAL 강제 full 이 주기적으로 정정한다.
-   * @returns {boolean}
-   */
-  hasOnlyOpaqueScatterFill() {
-    const list = this.getBlitScatterSeriesList();
-    for (let i = 0; i < list.length; i++) {
-      const s = list[i].series;
-      if (
-        Number(Util.getOpacity(s.pointFill ?? s.color)) < 1 ||
-        Number(Util.getOpacity(s.color)) < 1
-      ) {
-        return false;
       }
     }
     return true;
@@ -480,8 +452,8 @@ const blit = {
    * 같은 좌표(=같은 ms=같은 버킷)는 strip 안에서 owner 가 닫히므로 전체 dedupe 없이 strip 만으로 정확하다
    * (#2011 coordinateDedupe 존중 — owner 외 series 는 그 좌표를 그리지 않아 반투명 겹침/hollow 비침이
    * full redraw 와 일치). 순서/owner 규칙은 collectDuplicatePoints 와 동일(seriesReverse 면 역순 순회 →
-   * 마지막 set 이 owner). blit 은 opaqueFill 게이트로 반투명 series 를 받지 않으므로 strip 의 cross-series
-   * 알파 누적 우려는 게이트가 차단한다(여기 dedupe 는 hollow 마커·z-order 정합을 보장).
+   * 마지막 set 이 owner). 반투명 cross-series 알파 누적은 drawn 플래그가 점당 1회 raster 를 보장해 막고
+   * (시프트된 옛 점은 재그리지 않음), 여기 dedupe 는 hollow 마커·z-order 정합을 보장한다.
    * @param {Map<string,string>} duple       owner 맵(coordKey → sId)
    * @param {number[]} dirtyBuckets           strip 으로 다시 그릴 ring 버킷 인덱스 목록
    * @returns {undefined}
@@ -598,9 +570,9 @@ const blit = {
     //
     // 흰줄(comb) 불가 보장: 흰줄은 "픽셀을 지웠는데 다시 안 그리는" 경우(clear + clip 의 결손 컬럼)에만
     // 생긴다. 아래 시프트는 OLD 픽셀을 비트단위 무손실로 옮긴 뒤(정수좌표·동일크기 drawImage → 재양자화
-    // 없음) 그 위에 strip 버킷의 점을 다시 그리기만 한다 — 픽셀 제거 연산이 없으므로 세로 흰줄이 원천 불가.
-    // (경계 버킷은 시프트된 옛 점 위에 다시 그려져 opaque 면 멱등이지만 반투명이면 알파가 누적되므로,
-    //  반투명 series 는 evaluateBlitGate 의 opaqueFill 게이트가 막아 full redraw 로 보낸다.)
+    // 없음) 그 위에 strip 버킷의 *아직 안 그려진* 점만 다시 그린다 — 픽셀 제거 연산이 없으므로 세로 흰줄이
+    // 원천 불가. 경계 버킷의 옛 점(이미 raster=drawn)은 시프트로 정위치에 살아 있어 strip 이 건너뛰므로
+    // (realTimeScatterDrawStrip 의 item.drawn 가드) 반투명에서도 점당 정확히 1회만 합성된다(알파 누적 0).
     const { gapCount, endIndex, length } = lastTick;
     // 최소 gapCount+1: 시프트로 비워진 strip(gapCount 버킷) + 경계 버킷(age gapCount) 1개.
     // 경계 버킷은 직전 틱 graphMax(=floor(maxX)) 초과로 그려지지 못한 점(x 가 초 경계 직전)이 이번 틱
@@ -932,6 +904,10 @@ const blit = {
         unSelectedOpacity: this.options.unSelectedOpacity,
         // baseline 도 현재 carry 위상으로 그린다 — 직전 blit 프레임과 위치 연속(REFRESH rebuild 무-스냅).
         rtXOffsetCss: this._blitCarry,
+        // 이 패스는 점 레이어 baseline 을 raster 한다 → 그린 점에 drawn 표식을 남겨 직후 strip 이
+        // 재그리지 않게 한다(REFRESH/legend 후 첫 strip 의 반투명 알파 스파이크 차단). 미raster 점
+        // (deferred xp=null·비-owner)은 표식이 없어 윈도우 진입 시 strip 이 처음 그린다.
+        markDrawn: true,
       };
 
       // 기하 패스를 먼저 돌려 item.xp/yp 를 채운다 — realTimeScatterDraw 는 좌표를 읽기만 하므로

--- a/src/components/chart/chart.core.blitGate.spec.js
+++ b/src/components/chart/chart.core.blitGate.spec.js
@@ -217,7 +217,10 @@ describe('EvChart.canRouteFallbackViaLayer — 폴백 렌더의 layer 합성 라
   const makeRouteCore = () => {
     const core = makeCore();
     core.bufferCanvas = { width: 580, height: 380 };
-    core.pointsLayerA = { width: 580, height: 380 };
+    // series 별 레이어(pointsLayersSized 가 bufferCanvas 치수와 일치하는지 검사) 모킹.
+    core.pointsLayers = new Map([
+      ['s0', { a: { width: 580, height: 380 }, b: { width: 580, height: 380 }, cur: 'A' }],
+    ]);
     return core;
   };
 

--- a/src/components/chart/chart.core.blitGate.spec.js
+++ b/src/components/chart/chart.core.blitGate.spec.js
@@ -120,23 +120,42 @@ describe('EvChart.evaluateBlitGate — 진입 게이트', () => {
     expect(core.evaluateBlitGate(undefined).parts.deviceStable).toBe(false);
   });
 
-  it('★ 분수 pixelRatio(Windows 125%/150% = 1.25/1.5) → deviceIntegerRatio=false → full', () => {
+  it('★ 표준 분수 pixelRatio(Windows 150% = 3/2) → deviceRatioBlittable=true (blit 유지)', () => {
     const core = makeCore();
-    // prev 도 1.5 로 맞춰 deviceStable 은 통과시키고 deviceIntegerRatio 만 뒤집는다.
+    // prev 도 1.5 로 맞춰 deviceStable 은 통과. q=2 배수 시프트로 device 시프트가 정수가 돼 blit≡full.
     core.pixelRatio = 1.5;
     core._blitPrev.pixelRatio = 1.5;
     const gate = core.evaluateBlitGate(undefined);
     expect(gate.parts.deviceStable).toBe(true);
-    expect(gate.parts.deviceIntegerRatio).toBe(false);
+    expect(gate.parts.deviceRatioBlittable).toBe(true);
+    expect(gate.ok).toBe(true);
+  });
+
+  it('★ 표준 분수 pixelRatio(Windows 125% = 5/4) → deviceRatioBlittable=true (blit 유지)', () => {
+    const core = makeCore();
+    core.pixelRatio = 1.25;
+    core._blitPrev.pixelRatio = 1.25;
+    const gate = core.evaluateBlitGate(undefined);
+    expect(gate.parts.deviceRatioBlittable).toBe(true);
+    expect(gate.ok).toBe(true);
+  });
+
+  it('분모가 큰 pixelRatio(브라우저 임의 줌 1.1 = 11/10, q>4) → deviceRatioBlittable=false → full', () => {
+    const core = makeCore();
+    core.pixelRatio = 1.1;
+    core._blitPrev.pixelRatio = 1.1;
+    const gate = core.evaluateBlitGate(undefined);
+    expect(gate.parts.deviceStable).toBe(true);
+    expect(gate.parts.deviceRatioBlittable).toBe(false);
     expect(gate.ok).toBe(false);
   });
 
-  it('정수 pixelRatio(2, 레티나) → deviceIntegerRatio=true (분수 게이트 통과)', () => {
+  it('정수 pixelRatio(2, 레티나) → deviceRatioBlittable=true', () => {
     const core = makeCore();
     core.pixelRatio = 2;
     core._blitPrev.pixelRatio = 2;
     const gate = core.evaluateBlitGate(undefined);
-    expect(gate.parts.deviceIntegerRatio).toBe(true);
+    expect(gate.parts.deviceRatioBlittable).toBe(true);
     expect(gate.ok).toBe(true);
   });
 
@@ -191,6 +210,42 @@ describe('EvChart.evaluateBlitGate — 진입 게이트', () => {
     core.seriesInfo.charts.line = ['l0'];
     core.seriesList.l0 = { show: false };
     expect(core.evaluateBlitGate(undefined).parts.scatterOnly).toBe(true);
+  });
+});
+
+describe('EvChart.blitShiftDenominator — 분수 DPR 시프트 분모', () => {
+  const q = (pr) => Object.assign(Object.create(EvChart.prototype), { pixelRatio: pr }).blitShiftDenominator();
+
+  it('정수 pr 은 q=1 (매 정수 CSS px 시프트, 기존 동작)', () => {
+    expect(q(1)).toBe(1);
+    expect(q(2)).toBe(1);
+    expect(q(3)).toBe(1);
+  });
+
+  it('표준 디스플레이 배율은 q≤4 (125%/150%/175%/225%/250%)', () => {
+    expect(q(1.5)).toBe(2); // 3/2
+    expect(q(1.25)).toBe(4); // 5/4
+    expect(q(1.75)).toBe(4); // 7/4
+    expect(q(2.25)).toBe(4); // 9/4
+    expect(q(2.5)).toBe(2); // 5/2
+  });
+
+  it('분모가 큰 pr(브라우저 임의 줌)은 null → full 폴백', () => {
+    expect(q(1.1)).toBeNull(); // 11/10
+    expect(q(1.2)).toBeNull(); // 6/5 (q=5 > MAX_Q)
+    expect(q(0)).toBeNull();
+  });
+
+  it('q 배수 시프트는 device 시프트(gCss·pr)를 정수로 만든다 (drawImage 무손실 불변식)', () => {
+    // 이 정수성이 곧 "블러 없음"이다: drawImage 오프셋이 정수여야 bilinear 리샘플이 없다.
+    [1.25, 1.5, 1.75, 2.25, 2.5].forEach((pr) => {
+      const denom = q(pr);
+      for (let k = 1; k <= 5; k++) {
+        const gCss = k * denom; // q 배수 시프트
+        const dxDev = gCss * pr;
+        expect(Number.isInteger(Math.round(dxDev)) && Math.abs(dxDev - Math.round(dxDev)) < 1e-9).toBe(true);
+      }
+    });
   });
 });
 

--- a/src/components/chart/chart.core.blitGate.spec.js
+++ b/src/components/chart/chart.core.blitGate.spec.js
@@ -140,21 +140,16 @@ describe('EvChart.evaluateBlitGate — 진입 게이트', () => {
     expect(gate.ok).toBe(true);
   });
 
-  it('★ 반투명 fill(rgba alpha<1) → opaqueFill=false → full (strip 알파 누적 회피)', () => {
+  it('★ 반투명 fill(rgba alpha<1) → blit 차단 안 함(over-darken 은 점당 1회 raster=drawn 플래그로 처리)', () => {
+    // 과거엔 opaqueFill 게이트가 반투명 series 의 blit 을 막았다(strip 의 경계 버킷 재그림이 알파를
+    // 누적). 지금은 strip 이 "아직 raster 안 된 점"만 그려(item.drawn 가드) 점당 1회 합성을 보장하므로
+    // 반투명도 blit 으로 정확히 그린다 — 게이트는 더는 색/투명도로 차단하지 않는다. 알파 누적 0 의
+    // 픽셀 검증은 chart.blit.equiv.visual.spec.js 가 담당한다.
     const core = makeCore();
     core.seriesList.s0.pointFill = 'rgba(223, 98, 100, 0.4)';
     core.seriesList.s0.color = 'rgba(223, 98, 100, 0.4)';
     const gate = core.evaluateBlitGate(undefined);
-    expect(gate.parts.opaqueFill).toBe(false);
-    expect(gate.ok).toBe(false);
-  });
-
-  it('불투명 fill(hex) → opaqueFill=true (반투명 게이트 통과)', () => {
-    const core = makeCore();
-    core.seriesList.s0.pointFill = '#DF6264';
-    core.seriesList.s0.color = '#DF6264';
-    const gate = core.evaluateBlitGate(undefined);
-    expect(gate.parts.opaqueFill).toBe(true);
+    expect(gate.parts.opaqueFill).toBeUndefined(); // opaqueFill 게이트 제거됨
     expect(gate.ok).toBe(true);
   });
 

--- a/src/components/chart/chart.core.blitGate.spec.js
+++ b/src/components/chart/chart.core.blitGate.spec.js
@@ -120,6 +120,44 @@ describe('EvChart.evaluateBlitGate — 진입 게이트', () => {
     expect(core.evaluateBlitGate(undefined).parts.deviceStable).toBe(false);
   });
 
+  it('★ 분수 pixelRatio(Windows 125%/150% = 1.25/1.5) → deviceIntegerRatio=false → full', () => {
+    const core = makeCore();
+    // prev 도 1.5 로 맞춰 deviceStable 은 통과시키고 deviceIntegerRatio 만 뒤집는다.
+    core.pixelRatio = 1.5;
+    core._blitPrev.pixelRatio = 1.5;
+    const gate = core.evaluateBlitGate(undefined);
+    expect(gate.parts.deviceStable).toBe(true);
+    expect(gate.parts.deviceIntegerRatio).toBe(false);
+    expect(gate.ok).toBe(false);
+  });
+
+  it('정수 pixelRatio(2, 레티나) → deviceIntegerRatio=true (분수 게이트 통과)', () => {
+    const core = makeCore();
+    core.pixelRatio = 2;
+    core._blitPrev.pixelRatio = 2;
+    const gate = core.evaluateBlitGate(undefined);
+    expect(gate.parts.deviceIntegerRatio).toBe(true);
+    expect(gate.ok).toBe(true);
+  });
+
+  it('★ 반투명 fill(rgba alpha<1) → opaqueFill=false → full (strip 알파 누적 회피)', () => {
+    const core = makeCore();
+    core.seriesList.s0.pointFill = 'rgba(223, 98, 100, 0.4)';
+    core.seriesList.s0.color = 'rgba(223, 98, 100, 0.4)';
+    const gate = core.evaluateBlitGate(undefined);
+    expect(gate.parts.opaqueFill).toBe(false);
+    expect(gate.ok).toBe(false);
+  });
+
+  it('불투명 fill(hex) → opaqueFill=true (반투명 게이트 통과)', () => {
+    const core = makeCore();
+    core.seriesList.s0.pointFill = '#DF6264';
+    core.seriesList.s0.color = '#DF6264';
+    const gate = core.evaluateBlitGate(undefined);
+    expect(gate.parts.opaqueFill).toBe(true);
+    expect(gate.ok).toBe(true);
+  });
+
   it('옵션 참조 교체(Chart.vue options watcher) → optionsStable=false → full', () => {
     const core = makeCore();
     core.options = { ...core.options };

--- a/src/components/chart/chart.core.js
+++ b/src/components/chart/chart.core.js
@@ -564,7 +564,8 @@ class EvChart {
 
     // 미지원 타입(scatter/pie 등)에 visible 시리즈가 있으면 worker 가 그 시리즈를 무음 누락한다.
     const unsupported = Object.keys(charts).find(
-      (type) => !supported[type] && (charts[type] ?? []).some((id) => this.seriesList[id]?.show !== false),
+      (type) =>
+        !supported[type] && (charts[type] ?? []).some((id) => this.seriesList[id]?.show !== false),
     );
     if (unsupported) {
       return { ok: false, reason: `unsupported-type:${unsupported}` };
@@ -676,6 +677,11 @@ class EvChart {
    * @returns {undefined}
    */
   drawAxisAndSeries(hitInfo) {
+    // series 별 점 레이어를 현재 scatter series 집합과 동기화한다(idempotent: 집합이 같으면 no-op).
+    // seriesInfo·bufferCanvas 가 확정된 draw 시점이라, 신규 레이어가 올바른 치수로 생성된다.
+    if (this.options.realTimeScatter?.use) {
+      this.createPointsLayers();
+    }
     // realtime scatter blit fast-path 진입 가능 여부 평가.
     const blitGate = this.evaluateBlitGate(hitInfo);
 
@@ -729,10 +735,7 @@ class EvChart {
         // 주기 강제 full(refreshDue)은 drift 리셋이 목적이므로 스탬프가 같아도 재raster 강제.
         rebuilt = this.maybeRebuildPointsLayer(blitBlockers.blockedByRefreshDue);
         if (this.pointsLayerValid) {
-          this.compositePointsLayer(
-            this.getPointsLayers().src,
-            this.getMaxVisibleScatterPointSize(),
-          );
+          this.compositePointsLayer(this.getMaxVisibleScatterPointSize());
         } else {
           this.drawSeriesLayer(this.bufferCtx, hitInfo); // 레이어 사용 불가(치수 미확보 등) → 기존 직접 경로
           coordsRefreshed = true;
@@ -753,7 +756,9 @@ class EvChart {
         // 렌더(rebuild 생략)는 레이어의 누적 상태도 그대로이므로 카운터를 유지해야
         // 주기적 강제 full(REFRESH_INTERVAL)의 drift 상한이 깨지지 않는다.
         this._framesSinceFullRedraw = 0;
-        this._blitCarry = 0;
+        // _blitCarry 는 리셋하지 않는다 — rebuild baseline 을 현재 위상(rtXOffsetCss)으로 그리므로
+        // 직전 blit 프레임과 위치가 연속(REFRESH rebuild 시에도 무-스냅). carry 는 Bresenham 으로
+        // 매 blit [-0.5,0.5] 에 머물러 누적 drift 가 없다.
       }
     }
   }
@@ -850,10 +855,10 @@ class EvChart {
     const ys = this.axesSteps?.y ?? [];
 
     let key =
-      `${cr.x1},${cr.x2},${cr.y1},${cr.y2},${cr.chartWidth},${cr.chartHeight}|`
-      + `${lo.left},${lo.right},${lo.top},${lo.bottom}|`
-      + `${this.pixelRatio}|${opt.horizontal ? 1 : 0}|`
-      + `${opt.thickness},${opt.cPadRatio},${opt.borderRadius}|`;
+      `${cr.x1},${cr.x2},${cr.y1},${cr.y2},${cr.chartWidth},${cr.chartHeight}|` +
+      `${lo.left},${lo.right},${lo.top},${lo.bottom}|` +
+      `${this.pixelRatio}|${opt.horizontal ? 1 : 0}|` +
+      `${opt.thickness},${opt.cPadRatio},${opt.borderRadius}|`;
     for (let i = 0; i < xs.length; i++) {
       const a = xs[i];
       key += `${a?.graphMin}:${a?.graphMax}:${a?.minIndex}:${a?.maxIndex}:${a?.oriSteps};`;
@@ -945,6 +950,9 @@ class EvChart {
       isHorizontal: this.options.horizontal,
       dataEpoch: this._dataEpoch,
       scaleVersion: this._scaleVersion,
+      // realtime scatter blit↔full 동등: full redraw(legend hover 등)도 blit 라스터에 베이크된
+      // sub-pixel 위상(_blitCarry)으로 점을 찍어야 위치가 일치한다(element.scatter calcItem 이 읽음).
+      rtXOffsetCss: this._blitCarry,
     };
 
     let showIndex = 0;
@@ -1487,11 +1495,10 @@ class EvChart {
     // 전부 지우므로, render() 마다 호출되는 이 경로에서 무조건 대입하면 blit 누적 픽셀이 매 틱 사라진다.
     // 비교값은 canvas.width 대입 시의 정수 절삭 규칙과 동일하게 floor 한다 — DOM 폭이 소수(예: 590.5)면
     // float 비교는 영원히 불일치해 매 렌더 소거+무효화가 반복된다.
-    if (this.pointsLayerA) {
-      const dw = Math.floor(width * this.pixelRatio);
-      if (this.pointsLayerA.width !== dw) {
-        this.pointsLayerA.width = dw;
-        this.pointsLayerB.width = dw;
+    // 모든 series 레이어를 현재 bufferCanvas device 치수에 맞춘다(canvas.width 대입은 정수 절삭 →
+    // bufferCanvas.width 와 동일 정수). 치수가 실제로 바뀐 레이어가 있으면 baseline 무효화.
+    if (this.pointsLayers?.size) {
+      if (this.resizePointsLayers(this.bufferCanvas.width, this.bufferCanvas.height)) {
         this.pointsLayerValid = false; // 치수 변경 → baseline 무효화(다음 full redraw 에서 재구성)
       }
     }
@@ -1525,12 +1532,9 @@ class EvChart {
       this.overlayCanvas.style.height = `${height}px`;
     }
 
-    // setWidth 와 동일 이유: 치수 변경 시에만 재할당(매 틱 clear 방지). floor 도 setWidth 와 동일.
-    if (this.pointsLayerA) {
-      const dh = Math.floor(height * this.pixelRatio);
-      if (this.pointsLayerA.height !== dh) {
-        this.pointsLayerA.height = dh;
-        this.pointsLayerB.height = dh;
+    // setWidth 와 동일 이유: 치수 변경 시에만 재할당(매 틱 clear 방지).
+    if (this.pointsLayers?.size) {
+      if (this.resizePointsLayers(this.bufferCanvas.width, this.bufferCanvas.height)) {
         this.pointsLayerValid = false;
       }
     }
@@ -1670,8 +1674,9 @@ class EvChart {
     if (updateSeries) {
       this.pointsLayerValid = false;
     }
-    // realTimeScatter 가 런타임에 켜졌는데 레이어가 없으면 생성한다.
-    if (this.options.realTimeScatter?.use && !this.pointsLayerA) {
+    // realTimeScatter 면 series 별 레이어를 생성/조정한다(런타임 on 또는 scatter series add/remove).
+    // createPointsLayers 는 현재 scatter series 집합과 다를 때만 재생성한다(idempotent).
+    if (this.options.realTimeScatter?.use) {
       this.createPointsLayers();
     }
     if (updateSeries) {

--- a/src/components/chart/chart.realtime.leftedge.visual.spec.js
+++ b/src/components/chart/chart.realtime.leftedge.visual.spec.js
@@ -1,0 +1,143 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render } from 'vitest-browser-vue';
+import EvChart from './Chart.vue';
+
+/**
+ * realtime scatter 좌단(맨 왼쪽) 결손 회귀 — 실제 canvas(browser).
+ *
+ * 배경(버그): X축 좌단 graphMin = fromTime = toTime - range*1000 인데, 링 버퍼가 실제 보유한
+ * 가장 오래된 버킷은 toTime - (range-1)*1000 (= fromTime + 1000) 이다. 즉 축 좌단이 보유 데이터보다
+ * 1버킷(1초) 더 왼쪽이라 맨 왼쪽 ~1초(약 1버킷 폭)가 항상 빈다. full redraw 는 이 빈 구간을 그대로
+ * 비우고(좌단 결손), blit 은 윈도우 밖으로 밀려난 점의 고스트로 가려 틱마다 좌단이 깜빡인다.
+ *
+ * 이 테스트는 blit 고스트에 가려지지 않도록 full redraw(__EVUI_BLIT_FORCE_OFF__) 로, 가장 오래된
+ * 버킷까지 데이터가 채워진 상태에서 plot 좌단(xsp) 컬럼에 데이터가 그려지는지 검증한다.
+ */
+describe('EvChart realtime scatter 좌단 결손 회귀', () => {
+  const RANGE = 50;
+  const BASE = 1_700_000_000_000;
+  const POINT = 1;
+
+  // 두 series 가 동일 x-grid 를 공유(정렬). 초기 적재는 윈도우의 가장 오래된 버킷까지 촘촘히 채운다.
+  const genData = (baseMs, n, spanMs) => {
+    const series1 = [];
+    const series2 = [];
+    for (let i = 0; i < n; i++) {
+      const x = baseMs - Math.floor((i / Math.max(1, n)) * spanMs);
+      series1.push({ x, y: 5 + ((i * 37) % 90) });
+      series2.push({ x, y: 5 + ((i * 53) % 90) });
+    }
+    return {
+      series: {
+        series1: { name: 's1', pointSize: POINT, color: '#DF6264', pointFill: '#DF6264' },
+        series2: { name: 's2', pointSize: POINT, color: '#3CA0FF', pointFill: '#3CA0FF' },
+      },
+      data: { series1, series2 },
+    };
+  };
+
+  // 가장 오래된 보유 버킷(toTime-(RANGE-1)*1000)까지 덮도록 초기 적재 폭을 (RANGE-1)초로 둔다.
+  const FULL_SPAN = (RANGE - 1) * 1000;
+  const TICK_SPAN = 3000;
+
+  const options = {
+    type: 'scatter',
+    width: '600px',
+    height: '400px',
+    padding: { top: 20, right: 2, bottom: 4, left: 2 },
+    axesX: [
+      {
+        type: 'time',
+        timeFormat: 'HH:mm:ss',
+        interval: { time: 10, unit: 'second' },
+        showAxis: true,
+        showGrid: false,
+        labelStyle: { show: true, fontSize: 12 },
+      },
+    ],
+    axesY: [
+      {
+        type: 'linear',
+        range: [0, 100],
+        showAxis: true,
+        showGrid: false,
+        labelStyle: { show: true, fontSize: 12 },
+      },
+    ],
+    realTimeScatter: { use: true, range: RANGE },
+    legend: { show: false },
+    tooltip: { use: false },
+    seriesReverse: true,
+  };
+
+  const settle = async () => {
+    await new Promise((r) => setTimeout(r, 60));
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    await new Promise((r) => setTimeout(r, 40));
+  };
+
+  afterEach(() => {
+    window.__EVUI_BLIT_FORCE_OFF__ = false;
+    window.__EVUI_BLIT_DEBUG__ = false;
+  });
+
+  it('full redraw 에서 plot 좌단(xsp) 에 데이터가 그려진다(좌단 1버킷 결손 없음)', async () => {
+    window.__EVUI_BLIT_FORCE_OFF__ = true; // 고스트 배제 — 좌단 결손을 그대로 검증
+    window.__EVUI_BLIT_DEBUG__ = true;
+    const { container, rerender } = render(EvChart, {
+      props: { data: genData(BASE, 1500, FULL_SPAN), options },
+    });
+    await settle();
+    for (let t = 1; t <= 4; t++) {
+      // eslint-disable-next-line no-await-in-loop
+      await rerender({ data: genData(BASE + t * 3000, 300, TICK_SPAN), options });
+      // eslint-disable-next-line no-await-in-loop
+      await settle();
+    }
+
+    const ec = window.__EVUI_BLIT_CHART__;
+    const pr = ec.pixelRatio;
+    const cr = ec.chartRect;
+    const lo = ec.labelOffset;
+    const xsp = (cr.x1 + lo.left) * pr;
+    const xArea = (cr.chartWidth - lo.left - lo.right) * pr;
+    const plotTop = (cr.y2 - lo.bottom - (cr.chartHeight - lo.top - lo.bottom)) * pr;
+    const plotBot = (cr.y2 - lo.bottom) * pr;
+    const pxPerBucket = xArea / RANGE;
+
+    const canvas = container.querySelector('canvas:not(.overlay-canvas)');
+    const img = canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height).data;
+    const w = canvas.width;
+    const y0 = Math.round(plotTop + 1);
+    const y1 = Math.round(plotBot - 1);
+    // red/blue 데이터 픽셀만(축/그리드 제외)
+    const dataCount = (x) => {
+      let c = 0;
+      for (let y = y0; y < y1; y++) {
+        const i = (y * w + x) * 4;
+        if (img[i + 3] < 32) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+        const r = img[i];
+        const b = img[i + 2];
+        if (r > b + 40 || b > r + 40) c++;
+      }
+      return c;
+    };
+    // 좌단에서 첫 데이터 컬럼까지의 오프셋(px)
+    let firstDataOffset = -1;
+    const xStart = Math.round(xsp);
+    for (let x = xStart; x < xStart + Math.ceil(pxPerBucket) + 6; x++) {
+      if (dataCount(x) >= 20 && firstDataOffset < 0) {
+        firstDataOffset = x - xStart;
+        break;
+      }
+    }
+
+    const ctx = `firstDataOffset=${firstDataOffset}px, pxPerBucket=${pxPerBucket.toFixed(1)}`;
+    // 좌단 데이터가 xsp 근처(< 절반 버킷)에서 시작해야 한다. 1버킷 결손이면 ~pxPerBucket 만큼 비어 RED.
+    expect(firstDataOffset, `좌단 결손 — ${ctx}`).toBeGreaterThanOrEqual(0);
+    expect(firstDataOffset, `좌단 1버킷 결손 — ${ctx}`).toBeLessThan(pxPerBucket * 0.5);
+  });
+});

--- a/src/components/chart/element/element.scatter.js
+++ b/src/components/chart/element/element.scatter.js
@@ -344,6 +344,13 @@ class Scatter {
               ctx.fillStyle = fillStyle;
               Canvas.drawPoint(ctx, pointStyle, pointSize, item.xp, item.yp);
             }
+            // blit 점 레이어 baseline 을 그리는 경우(rebuildPointsLayer)에만 raster 표식을 남긴다.
+            // 이후 strip 은 drawn=true 인 점을 건너뛰어 점당 1회 합성을 유지한다(반투명 알파 누적 차단).
+            // buffer 직접 그리기(drawSeriesLayer/legend hover)는 markDrawn 없이 호출돼 레이어 상태를
+            // 오염시키지 않는다 — 그 경로는 점 레이어가 아니라 buffer 에 그리기 때문이다.
+            if (param.markDrawn) {
+              item.drawn = true;
+            }
           }
         }
       }
@@ -400,6 +407,17 @@ class Scatter {
       for (let j = 0; j < group.data.length; j++) {
         const item = group.data[j];
 
+        // 이미 레이어에 raster 된 점은 무손실 시프트로 정위치에 살아 있다 — 다시 그리면 source-over 가
+        // 반투명에서 멱등이 아니라 알파를 누적(α→2α-α²)시켜 full(점당 1회)보다 진해진다. "점당 정확히
+        // 1회 raster" 불변식을 지키려 한 번이라도 그려진 점은 건너뛴다(calcItem 도 생략 — 좌표는
+        // hit-test 진입 시 ensureHitCoordsFresh 가 일괄 갱신). 아직 안 그려진 점(신규/지연)만 strip 이
+        // 그린다. drawn 은 실제 raster 시점에만 set 되므로, x>graphMax 로 미뤄졌던 deferred 점도
+        // 윈도우에 들어와 처음 그려지는 틱에 정확히 한 번 raster 된다(누락 없음).
+        if (item.drawn) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+
         if (isDedupeOn && duple.get(item.k ?? Util.coordinateKey(item.x, item.y)) !== this.sId) {
           // 이 좌표의 owner 가 아니면 그리지 않는다(cross-series overdraw 방지).
           // eslint-disable-next-line no-continue
@@ -420,6 +438,7 @@ class Scatter {
           ctx.fillStyle = this.getCachedColor(baseFillColor, fillOpacity);
 
           Canvas.drawPoint(ctx, pointStyle, pointSize, item.xp, item.yp);
+          item.drawn = true; // 이제 이 점은 레이어에 있다 — 이후 틱은 시프트로만 이동(재그림 금지)
         }
       }
     }

--- a/src/components/chart/element/element.scatter.js
+++ b/src/components/chart/element/element.scatter.js
@@ -180,13 +180,16 @@ class Scatter {
   calcItem(item, param) {
     const { chartRect, labelOffset, axesSteps, displayOverflow } = param;
 
-    let aliasPixel;
     const minmaxX = axesSteps.x[this.xAxisIndex];
     const minmaxY = axesSteps.y[this.yAxisIndex];
 
     const xArea = chartRect.chartWidth - (labelOffset.left + labelOffset.right);
     const yArea = chartRect.chartHeight - (labelOffset.top + labelOffset.bottom);
-    const xsp = chartRect.x1 + labelOffset.left;
+    // realtime scatter blit: full redraw 가 blit 시프트(정수 CSS px)와 ceil 양자화를 일치시키도록
+    // startPoint 에 sub-pixel carry(rtXOffsetCss, [-0.5,0.5])를 더한다. blit 라스터에 베이크된 위상과
+    // 동일 위상으로 점을 찍어, full 전환(legend hover 등) 시 점이 한 점도 안 움직인다(chart.blit.js).
+    const rtXOffset = this.realTimeScatter ? (param.rtXOffsetCss ?? 0) : 0;
+    const xsp = chartRect.x1 + labelOffset.left + rtXOffset;
     const ysp = chartRect.y2 - labelOffset.bottom;
 
     let x = Canvas.calculateX(item.x, minmaxX.graphMin, minmaxX.graphMax, xArea, xsp);
@@ -198,9 +201,11 @@ class Scatter {
       ysp,
     );
 
-    if (x !== null) {
-      aliasPixel = Util.aliasPixel(x);
-      x += aliasPixel;
+    // realtime scatter 는 aliasPixel(정수 x 의 홀/짝에 따라 +0.5)을 적용하지 않는다 — 패리티가
+    // 시프트(Σg 누적)로 바뀌어 시프트된 옛 점(생성시 패리티)과 fresh full-draw(현재 패리티)가
+    // 1px 어긋난다. aliasPixel 을 빼면 device x = pr·ceil(...) 로 시프트 불변이 되어 blit≡full.
+    if (x !== null && !this.realTimeScatter) {
+      x += Util.aliasPixel(x);
     }
 
     item.xp = x;

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -69,8 +69,8 @@ const modules = {
             if (series && series.show !== false) {
               const rawData = data?.[seriesID];
               const { passingValue, interpolation } = series;
-              const needsTransform = interpolation === 'zero'
-                || (passingValue != null && passingValue !== undefined);
+              const needsTransform =
+                interpolation === 'zero' || (passingValue != null && passingValue !== undefined);
 
               let hasPassingValueInData = false;
               let sData;
@@ -398,7 +398,10 @@ const modules = {
       const series = this.seriesList[seriesID];
       series.data = this.dataSet;
       series.minMax = {
-        minX: dayjs(minMaxValues.fromTime),
+        // X축 좌단은 "실제 보유한 가장 오래된 버킷"에 맞춘다. fromTime(= toTime - range*1000)은 링이
+        // 보유하는 가장 오래된 버킷(toTime - (range-1)*1000)보다 1버킷(=1초) 더 왼쪽이라, 그대로 쓰면
+        // 맨 왼쪽 1버킷이 항상 비어 좌단 결손(full redraw)·좌단 깜빡임(blit 고스트)이 생긴다.
+        minX: dayjs(minMaxValues.fromTime + 1000),
         minY: minMaxValues.minY,
         maxX: dayjs(minMaxValues.toTime),
         maxY: minMaxValues.maxY,
@@ -681,11 +684,32 @@ const modules = {
             reused.dataTextColor = null;
             sdata.push(reused);
           } else {
-            sdata.push(isHorizontal
-              ? { x: v, y: ldata, o, b: null, xp: null, yp: null,
-                  w: null, h: null, dataColor: null, dataTextColor: null }
-              : { x: ldata, y: v, o, b: null, xp: null, yp: null,
-                  w: null, h: null, dataColor: null, dataTextColor: null },
+            sdata.push(
+              isHorizontal
+                ? {
+                    x: v,
+                    y: ldata,
+                    o,
+                    b: null,
+                    xp: null,
+                    yp: null,
+                    w: null,
+                    h: null,
+                    dataColor: null,
+                    dataTextColor: null,
+                  }
+                : {
+                    x: ldata,
+                    y: v,
+                    o,
+                    b: null,
+                    xp: null,
+                    yp: null,
+                    w: null,
+                    h: null,
+                    dataColor: null,
+                    dataTextColor: null,
+                  },
             );
           }
         }
@@ -868,11 +892,7 @@ const modules = {
    *   (2) 윈도우 안에 유효한(finite) 값이 하나도 없음.
    */
   getVisibleWindowMaxSeries(minIndex, maxIndex) {
-    if (
-      !Number.isFinite(minIndex)
-      || !Number.isFinite(maxIndex)
-      || maxIndex < minIndex
-    ) {
+    if (!Number.isFinite(minIndex) || !Number.isFinite(maxIndex) || maxIndex < minIndex) {
       return null;
     }
 


### PR DESCRIPTION
# 작업 배경

realtime scatter(`realTimeScatter.use`)는 매 틱 수만 개의 점을 전부 다시 그리지 않으려고, 이전 점 라스터를 왼쪽으로 밀고 새로 들어온 시간대(strip)만 다시 그리는 **blit fast-path**를 쓴다. 조건이 깨지면 **full redraw**(전체 재그리기)로 폴백한다.

전제는 "blit 결과 == full redraw 결과(픽셀 동일)"인데, 이 전제가 깨져 평소(blit)와 full redraw가 일어나는 순간(legend 영역 hover·주기 refresh·resize)에 화면이 미세하게 달라지는 결함이 있었다.

# 변경 사항 요약(Key changes)

- blit시에 차트 표현이 누락 되는 문제 수정

# 기존 동작
https://github.com/user-attachments/assets/3042187c-107c-4060-a6f4-86f666b1b4d4
- blit과 full draw간의 차이가 큼.
- blit시에 모든 점이 그려지지 않아 툴팁과 괴리감이 생김.

# 기대 동작
https://github.com/user-attachments/assets/060a95ab-fd23-4531-95da-e95a965bdf62

# 테스트 가이드
-`change range (s)`를 50으로 줄여서 테스트 해보실 수 있습니다.