### PR TITLE
fix: realTimeScatter 만료된 개별 series 자동 제거

### DIFF
--- a/docs/views/scatterChart/api/scatterChart.md
+++ b/docs/views/scatterChart/api/scatterChart.md
@@ -441,6 +441,17 @@ plotLines/plotBands(임계선·밴드)의 표시 순서(z-order) 전역 설정. 
 
 - 페이지단에서 chartData를 shallowRef / shallowReactive로 선언해야 합니다.
 
+##### 개별 series 자동 만료 (기본 동작)
+
+가시 범위 밖으로 완전히 밀려나고 신규 점도 끊긴 **개별 series** 는 누적 저장소·범례에서 **자동 제거**됩니다. 별도 옵션 없이 realTimeScatter 의 기본 동작이며, 누적 데이터가 무한정 쌓이는 것을 막습니다.
+
+- 제거 조건(AND, 만족하는 즉시 제거):
+  - **(a)** 해당 series 가 현재 가시 X축 범위 `[xMax - range, xMax]` 안에 점이 하나도 없음.
+  - **(b)** 이번 수신 `:data` 틱에 그 series 의 신규 점이 없음(이번 틱에 점을 보낸 series 는 보존).
+- "series 키 부재"로 판정하지 않습니다 — 죽은 series 키가 `data.series` 에 계속 남아 있어도, 위 (a)+(b)로만 판정합니다.
+- 제거된 series 는 신규 점이 다시 들어오면 자동으로 부활(재생성)합니다.
+- `v-model:realTimeScatterReset`(전체 초기화)과 독립적으로 동작합니다.
+
 ##### etc
 
 | 이름    | 타입   | 디폴트 | 설명 | 종류(예시) |

--- a/docs/views/scatterChart/example/RealTimeScatter.vue
+++ b/docs/views/scatterChart/example/RealTimeScatter.vue
@@ -21,9 +21,24 @@
       </div>
       <div class="row-item">
         <span class="item-title"> change range (s) </span>
-        <ev-input-number v-model="realTimeScatterRange" class="component" :min="50" :step="50" />
+        <ev-input-number v-model="realTimeScatterRange" class="component" :min="10" :step="10" />
       </div>
     </div>
+    <div class="row">
+      <div class="row-item">
+        <label>series1 공급</label>
+        <ev-toggle v-model="feeding.series1" />
+      </div>
+      <div class="row-item">
+        <label>series2 공급</label>
+        <ev-toggle v-model="feeding.series2" />
+      </div>
+    </div>
+    <p class="guide">
+      특정 series 의 공급을 끄면, 그 series 의 누적 점이 가시 범위(range) 밖으로 모두 밀려난 뒤
+      신규 점이 없을 때 누적 저장소·범례에서 <b>자동 제거</b>됩니다(realTimeScatter 기본 동작).
+      다시 켜면 부활합니다. (빠르게 확인하려면 range 를 10s 수준으로 낮추세요.)
+    </p>
   </div>
 </template>
 
@@ -115,12 +130,16 @@ export default {
         virtualScroll: true,
       },
       displayOverflow: true,
+      selectItem: { use: true },
       realTimeScatter: {
         use: true,
         range: realTimeScatterRange.value, // 총 5분, 초 단위
       },
       seriesReverse: true,
     });
+
+    // series 별 데이터 공급 on/off. 끄면 그 series 는 빈 배열로 보내져(키는 유지) 만료 대상이 된다.
+    const feeding = reactive({ series1: true, series2: true });
 
     let timeoutId;
 
@@ -136,11 +155,11 @@ export default {
         let randomX = 0;
         let randomY = 0;
         if (!isInit) {
-          randomX = floor(Date.now() + getRandomInt(-3000, 0)); // -3초 ~ 현재
-          randomY = floor(getRandomInt(3000, 95000));
+          randomX = Math.round((Date.now() + getRandomInt(-3000, 0)) / 1000) * 1000; // 1초 격자
+          randomY = getRandomInt(3, 15) * 1000;
         } else {
-          randomX = floor(Date.now() + getRandomInt(-300000, 0)); // -5분 ~ 현재
-          randomY = floor(getRandomInt(3000, 57000));
+          randomX = Math.round((Date.now() + getRandomInt(-300000, 0)) / 1000) * 1000; // 1초 격자
+          randomY = getRandomInt(3, 15) * 1000;
         }
         const randomType = getRandomInt(0, 1);
 
@@ -159,10 +178,10 @@ export default {
       series2 = [];
 
       if (isInit) {
-        data = generateData(100000);
+        data = generateData(600);
         isInit = false;
       } else {
-        data = generateData(8000);
+        data = generateData(60);
       }
 
       for (let i = 0; i < data.length; i++) {
@@ -171,11 +190,13 @@ export default {
         const type = data[i].type;
 
         if (type === 1) {
-          series1.push({
-            x: dataX,
-            y: dataY / 1000,
-          });
-        } else {
+          if (feeding.series1) {
+            series1.push({
+              x: dataX,
+              y: dataY / 1000,
+            });
+          }
+        } else if (feeding.series2) {
           series2.push({
             x: dataX,
             y: dataY / 1000,
@@ -221,6 +242,8 @@ export default {
     const resetFlag = ref(false);
     const dataReset = () => {
       resetFlag.value = true;
+      feeding.series1 = true;
+      feeding.series2 = true;
       chartData.value = {
         series,
         data: {
@@ -239,6 +262,7 @@ export default {
       chartData,
       chartOptions,
       realTimeScatterRange,
+      feeding,
       resetFlag,
       dataReset,
     };
@@ -269,5 +293,12 @@ export default {
       min-width: 80px;
     }
   }
+}
+
+.guide {
+  margin-top: 12px;
+  line-height: 1.5;
+  font-size: 13px;
+  color: #555;
 }
 </style>

--- a/src/components/chart/Chart.vue
+++ b/src/components/chart/Chart.vue
@@ -259,8 +259,19 @@ export default {
         const isUpdateSeriesData = !isEqual(newData.series, evChart.data.series);
         const isUpdateGroups = !isEqual(newData.groups, evChart.data.groups);
 
+        // 만료 제거된 realTimeScatter series 가 신규 점과 함께 돌아오면(부활) updateSeries 를 강제한다.
+        // 그래야 reconcileSeriesSet 이 돌아 seriesList/seriesInfo.charts.scatter 에 인스턴스를 복구하고
+        // (이 경로에서 prunedRealTimeScatterSeries 에서도 제거), pointsLayer baseline 도 무효화돼
+        // 부활 series 가 다시 그려지고 범례에도 표시된다.
+        const prunedSet = evChart.prunedRealTimeScatterSeries;
+        const isRevived =
+          !!prunedSet?.size &&
+          Object.keys(newData.data ?? {}).some(
+            (key) => prunedSet.has(key) && newData.data[key]?.length,
+          );
+
         const isUpdateSeries =
-          isUpdateSeriesData || isUpdateGroups || props.options.type === 'heatMap';
+          isUpdateSeriesData || isUpdateGroups || isRevived || props.options.type === 'heatMap';
 
         const isUpdateData =
           isUpdateSeriesData ||
@@ -358,6 +369,9 @@ export default {
               evChart.dataSet[series].dataGroup = [];
             }
           });
+
+          // 전체 리셋 후에는 만료 제거 가드도 비워, 데이터가 다시 오면 series 가 재생성되게 한다.
+          evChart.prunedRealTimeScatterSeries?.clear();
 
           emit('update:realTimeScatterReset', false);
         }

--- a/src/components/chart/model/model.series.js
+++ b/src/components/chart/model/model.series.js
@@ -71,6 +71,21 @@ const modules = {
     const prev = prevSeriesList || {};
     const newSeriesList = {};
 
+    // 만료 제거(expire)된 realTimeScatter series 부활 일원화(재추가 방지 가드의 단일 해제 지점):
+    //  - 신규 점이 들어온 pruned 키는 가드에서 빼고 일반 경로로 재생성한다(부활).
+    //  - 신규 점이 없는 pruned 키는 data.series 에 키가 남아 있어도 재생성 대상에서 제외한다.
+    // (createRealTimeScatterDataSet 의 키 필터는 skip 만 하고 Set 에서 빼지 않으므로 해제는 여기서만.)
+    const prunedSet = this.prunedRealTimeScatterSeries;
+    if (prunedSet?.size) {
+      for (let i = 0; i < seriesKeys.length; i++) {
+        const key = seriesKeys[i];
+        if (prunedSet.has(key) && this.data?.data?.[key]?.length) {
+          prunedSet.delete(key);
+        }
+      }
+      seriesKeys = seriesKeys.filter((key) => !prunedSet.has(key));
+    }
+
     for (let i = 0; i < seriesKeys.length; i++) {
       const key = seriesKeys[i];
       const opt = series[key];

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -151,7 +151,14 @@ const modules = {
    * @returns {undefined}
    */
   createRealTimeScatterDataSet(datas) {
-    const keys = Object.keys(datas);
+    // 만료 제거(expire)된 series 는 신규 점이 도착하기 전까지 누적 저장소를 재생성하지 않는다.
+    // 소비자가 증분 틱에서 죽은 series 키(data.data 의 빈 배열)를 계속 보내도 orphan dataSet 으로
+    // 되살아나지 않게, 처리 대상 키에서 제외한다. 신규 점이 다시 오면 부활은 reconcileSeriesSet
+    // (updateSeries 강제)에서 일원화 처리하며, 그 시점엔 이미 prunedRealTimeScatterSeries 에서 빠진다.
+    const prunedSet = this.prunedRealTimeScatterSeries;
+    const keys = prunedSet?.size
+      ? Object.keys(datas).filter((key) => !prunedSet.has(key))
+      : Object.keys(datas);
 
     const minMaxValues = {
       // 음수 전용 데이터에서 maxY 가 0 으로 clamp 되지 않도록 -Infinity 에서 시작한다.
@@ -394,6 +401,10 @@ const modules = {
       minMaxValues.maxY = 0;
     }
 
+    // 개별 series 만료 제거(realTimeScatter 기본 동작). append 직후 스캔하므로 toTime 이 최신 상태다.
+    // seriesInfo.charts.scatter 를 splice 한 뒤 아래 forEach 가 잔여 series 만 순회하도록 여기서 호출.
+    this.pruneExpiredRealTimeScatterSeries(datas);
+
     this.seriesInfo.charts.scatter.forEach((seriesID) => {
       const series = this.seriesList[seriesID];
       series.data = this.dataSet;
@@ -407,6 +418,115 @@ const modules = {
         maxY: minMaxValues.maxY,
       };
     });
+  },
+
+  /**
+   * realTimeScatter 누적 저장소에서 개별 series 를 만료 제거한다.
+   *
+   * realTimeScatter 의 기본 동작이다(별도 옵션 없이 항상 동작). 가시 범위 밖으로 완전히 밀려나고
+   * 신규 점도 끊긴 series 가 누적 저장소·범례에 무한정 남지 않도록 자동 정리한다.
+   * 제거 조건(AND)을 만족하면 즉시 제거한다(grace 없음):
+   *  - (a) 가시 윈도우 `[globalToTime - range, globalToTime]` 안에 점이 하나도 없음.
+   *        ring 버퍼는 윈도우 밖 점을 비우고 점은 항상 `<= toTime` 에 존재하므로,
+   *        `ds.toTime < windowStart` 가 (a)와 정확히 등가다(series 별 최신 누적 x 로 O(1) short-circuit).
+   *  - (b) 이번 수신 틱에 그 series 의 신규 점이 없음(`!datas[sId]?.length`).
+   *        이번 틱에 점을 보낸 series 는 (오래된 점이라도) 활성으로 보고 보존한다.
+   * "series 키 부재"로는 판정하지 않는다 — 죽은 키가 data.series/data.data 에 남아 있을 수 있어서다.
+   *
+   * @param {object} datas  이번 틱 수신 데이터(createRealTimeScatterDataSet 인자)
+   * @returns {undefined}
+   */
+  pruneExpiredRealTimeScatterSeries(datas) {
+    const dataSet = this.dataSet;
+    const keys = Object.keys(dataSet);
+    if (!keys.length) {
+      return;
+    }
+
+    // 전역 윈도우 우측단 = 모든 series 의 toTime 중 최댓값(= 살아있는 series 의 최신 시각).
+    let globalToTime = 0;
+    for (let i = 0; i < keys.length; i++) {
+      const t = dataSet[keys[i]].toTime || 0;
+      if (t > globalToTime) {
+        globalToTime = t;
+      }
+    }
+
+    const range = this.options.realTimeScatter?.range || 300;
+    const windowStart = globalToTime - range * 1000;
+
+    const pruned = [];
+    for (let i = 0; i < keys.length; i++) {
+      const sId = keys[i];
+      const ds = dataSet[sId];
+      const hasNoVisiblePoint = ds.toTime < windowStart; // (a)
+      const hasNoNewData = !datas[sId]?.length; // (b)
+
+      // (a)+(b)면 가시 범위 밖으로 완전히 밀려났고 신규 점도 없으므로 즉시 제거한다(grace 없음).
+      if (hasNoVisiblePoint && hasNoNewData) {
+        pruned.push(sId);
+      }
+    }
+
+    if (!pruned.length) {
+      return;
+    }
+
+    for (let i = 0; i < pruned.length; i++) {
+      this.removeRealTimeScatterSeries(pruned[i]);
+    }
+
+    // 외부 범례는 update() 의 emitLegendData(매 데이터 틱) 로도 갱신되지만, 내부 범례는
+    // updateSeries=false 인 정상 틱에서 행이 재생성되지 않으므로 여기서 직접 rebuild 한다.
+    // (단위 테스트 store 에는 두 메서드가 없어 optional 호출.)
+    const legend = this.options.legend;
+    if (legend?.show && legend?.external) {
+      this.emitLegendData?.();
+    } else if (legend?.show) {
+      this.updateLegend?.();
+    }
+  },
+
+  /**
+   * 만료된 realTimeScatter series 하나를 누적 저장소·레지스트리·선택 상태에서 제거한다.
+   * 재추가 방지 가드(prunedRealTimeScatterSeries)에 등록해, data.series 에 키가 남아 있어도
+   * 신규 점이 오기 전까지는 createRealTimeScatterDataSet/reconcileSeriesSet 가 재생성하지 않는다.
+   *
+   * @param {string} sId  제거할 series ID
+   * @returns {undefined}
+   */
+  removeRealTimeScatterSeries(sId) {
+    delete this.dataSet[sId];
+
+    if (this.seriesList?.[sId]) {
+      delete this.seriesList[sId];
+    }
+
+    const scatter = this.seriesInfo?.charts?.scatter;
+    if (Array.isArray(scatter)) {
+      const idx = scatter.indexOf(sId);
+      if (idx !== -1) {
+        scatter.splice(idx, 1);
+      }
+    }
+
+    // show series 수 재계산(외부 범례 toggle 로직과 드리프트 방지). 단위 테스트엔 없어 optional.
+    this._updateSeriesCount?.();
+
+    // 재추가 방지 가드.
+    (this.prunedRealTimeScatterSeries ??= new Set()).add(sId);
+
+    // 선택 상태가 제거된 series 를 가리키면 해제.
+    const selSeriesId = this.defaultSelectInfo?.seriesId;
+    if (Array.isArray(selSeriesId)) {
+      const idx = selSeriesId.indexOf(sId);
+      if (idx !== -1) {
+        selSeriesId.splice(idx, 1);
+      }
+    }
+    if (this.defaultSelectItemInfo?.seriesID === sId) {
+      this.defaultSelectItemInfo = null;
+    }
   },
 
   /**

--- a/src/components/chart/model/model.store.js
+++ b/src/components/chart/model/model.store.js
@@ -392,8 +392,14 @@ const modules = {
         minMaxValues.maxY = Math.max(minMaxValues.maxY, tempMinMax.maxY);
         minMaxValues.minY = Math.min(minMaxValues.minY, tempMinMax.minY);
       }
-      minMaxValues.fromTime = dataset.fromTime;
-      minMaxValues.toTime = dataset.toTime;
+      // 렌더 X축 윈도우는 전역 우측단(= 모든 series 의 toTime 최댓값)을 따라야 prune 윈도우(globalToTime)와
+      // 일치한다. last-write-wins 로 마지막 처리 키의 toTime 을 쓰면, 신규 점이 끊긴 stale series 가 마지막
+      // 키일 때 살아있는 series 의 maxX 까지 그 옛 시각에 묶여 축이 prune 전까지 freeze 된다. fromTime 은
+      // 항상 toTime - length*1000 이므로 max 인 series 의 fromTime 을 함께 취한다.
+      if (dataset.toTime > minMaxValues.toTime) {
+        minMaxValues.toTime = dataset.toTime;
+        minMaxValues.fromTime = dataset.fromTime;
+      }
     }
 
     if (!Number.isFinite(minMaxValues.minY)) {

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -924,6 +924,33 @@ describe('model.store createRealTimeScatterDataSet 개별 series 만료 제거',
     });
     expect(store.dataSet.c).toBeDefined();
   });
+
+  // 렌더 윈도우(series.minMax.maxX)는 prune 윈도우(globalToTime = max toTime)와 같은 기준이어야 한다.
+  // 회귀: minMaxValues.toTime 이 마지막 처리 키의 toTime 으로 덮어써지면(last-write-wins), 죽은(stale)
+  // series 가 마지막 키이고 아직 prune 전이면, 살아있는 series 의 maxX 가 그 stale 시각에 묶여 축이 freeze 된다.
+  it('생존 series 의 maxX 는 stale 마지막 키가 아니라 전역 max toTime 을 따른다', () => {
+    const store = buildStore({ range: 10 });
+    const t0 = Math.floor(Date.now() / SECOND) * SECOND;
+
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0, y: 1 }],
+      b: [{ x: t0, y: 2 }],
+      c: [{ x: t0, y: 3 }],
+    });
+
+    // a,b 만 +3s 전진(range 10 안이라 c 는 아직 prune 안 됨), c 는 빈 배열이면서 마지막 키.
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0 + 3 * SECOND, y: 1 }],
+      b: [{ x: t0 + 3 * SECOND, y: 2 }],
+      c: [],
+    });
+
+    // c 는 아직 누적 저장소에 남아 있다(prune 전).
+    expect(store.dataSet.c).toBeDefined();
+    // 축 우측단은 전역 max(t0+3s)여야 한다 — c 의 stale toTime(t0)이 아니라.
+    expect(store.seriesList.a.minMax.maxX.valueOf()).toBe(t0 + 3 * SECOND);
+    expect(store.seriesList.b.minMax.maxX.valueOf()).toBe(t0 + 3 * SECOND);
+  });
 });
 
 describe('model.store createDataSet stack (누적 top 기반)', () => {

--- a/src/components/chart/model/model.store.spec.js
+++ b/src/components/chart/model/model.store.spec.js
@@ -753,6 +753,179 @@ describe('model.store createRealTimeScatterDataSet (x,y) dedupe', () => {
   });
 });
 
+/**
+ * createRealTimeScatterDataSet 의 개별 series 만료 제거 회귀 테스트.
+ * realTimeScatter 의 기본 동작으로(별도 옵션 없이) 가시 윈도우 밖으로 완전히 밀려나고 신규 점도 없는
+ * series 를 즉시(grace 없음) 누적 저장소에서 제거하고, 나머지는 보존한다.
+ * 데이터 레이어만 검증한다(seriesList 인스턴스 부활은 통합/문서 레벨).
+ */
+describe('model.store createRealTimeScatterDataSet 개별 series 만료 제거', () => {
+  const SECOND = 1000;
+
+  const buildStore = ({ range = 5, scatterIds = ['a', 'b', 'c'] }) => {
+    const store = Object.create(modules);
+    Object.assign(store, {
+      isInit: false,
+      updateSeries: false,
+      dataSet: {},
+      options: {
+        realTimeScatter: { range },
+        legend: {},
+      },
+      seriesInfo: { charts: { scatter: [...scatterIds] } },
+      seriesList: Object.fromEntries(scatterIds.map((id) => [id, { show: true }])),
+    });
+    return store;
+  };
+
+  it('(a)범위 밖 + (b)신규 점 없음을 만족하는 즉시 해당 series 만 제거된다', () => {
+    const store = buildStore({ range: 5 });
+    const t0 = Math.floor(Date.now() / SECOND) * SECOND;
+
+    // tick1: a,b,c 모두 점 → 3개 모두 보존
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0, y: 1 }],
+      b: [{ x: t0, y: 2 }],
+      c: [{ x: t0, y: 3 }],
+    });
+    expect(Object.keys(store.dataSet).sort()).toEqual(['a', 'b', 'c']);
+
+    // tick2: a,b 만 6초 뒤로 전진(c 의 점은 윈도우 밖) / c 는 빈 배열 → (a)+(b) 즉시 만족 → c 제거
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0 + 6 * SECOND, y: 1 }],
+      b: [{ x: t0 + 6 * SECOND, y: 2 }],
+      c: [],
+    });
+
+    expect(store.dataSet.c).toBeUndefined();
+    expect(store.dataSet.a).toBeDefined();
+    expect(store.dataSet.b).toBeDefined();
+    expect(store.seriesList.c).toBeUndefined();
+    expect(store.seriesList.a).toBeDefined();
+    expect(store.seriesInfo.charts.scatter).toEqual(['a', 'b']);
+    expect(store.prunedRealTimeScatterSeries.has('c')).toBe(true);
+  });
+
+  it('데이터 틱에 키가 아예 없어도(빈 배열 아님) 동일하게 제거된다', () => {
+    const store = buildStore({ range: 5 });
+    const t0 = Math.floor(Date.now() / SECOND) * SECOND;
+
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0, y: 1 }],
+      b: [{ x: t0, y: 2 }],
+      c: [{ x: t0, y: 3 }],
+    });
+    // 이후 틱은 c 키 자체를 보내지 않는다 — (b) 는 !datas[c]?.length 로 판정하므로 동일하게 만료.
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0 + 6 * SECOND, y: 1 }],
+      b: [{ x: t0 + 6 * SECOND, y: 2 }],
+    });
+
+    expect(store.dataSet.c).toBeUndefined();
+    expect(store.dataSet.a).toBeDefined();
+  });
+
+  it('가시 범위 안에 점이 하나라도 있으면(=최근 점) 신규 점이 없어도 제거하지 않는다', () => {
+    const store = buildStore({ range: 10 });
+    const t0 = Math.floor(Date.now() / SECOND) * SECOND;
+
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0, y: 1 }],
+      b: [{ x: t0, y: 2 }],
+      c: [{ x: t0, y: 3 }],
+    });
+
+    // a,b 를 range(10s) 안에서만 전진 → c 의 t0 점이 여전히 윈도우 안 → (a) false → 보존
+    for (let s = 1; s <= 5; s++) {
+      store.createRealTimeScatterDataSet({
+        a: [{ x: t0 + s * SECOND, y: 1 }],
+        b: [{ x: t0 + s * SECOND, y: 2 }],
+        c: [],
+      });
+    }
+
+    expect(store.dataSet.c).toBeDefined();
+    expect(store.seriesInfo.charts.scatter).toContain('c');
+  });
+
+  it('범위 밖이라도 이번 틱에 (오래된) 신규 점을 보내면(b=false) 제거하지 않는다', () => {
+    const store = buildStore({ range: 5 });
+    const t0 = Math.floor(Date.now() / SECOND) * SECOND;
+
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0, y: 1 }],
+      b: [{ x: t0, y: 2 }],
+      c: [{ x: t0, y: 3 }],
+    });
+
+    // a,b 는 전진하여 c 의 점이 윈도우 밖((a) true)이 되지만, c 는 같은 틱에 (오래된) 점을 보낸다.
+    // 활성 series 로 보고 보존해야 한다((b) false).
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0 + 6 * SECOND, y: 1 }],
+      b: [{ x: t0 + 6 * SECOND, y: 2 }],
+      c: [{ x: t0, y: 3 }],
+    });
+
+    expect(store.dataSet.c).toBeDefined();
+    expect(store.seriesInfo.charts.scatter).toContain('c');
+  });
+
+  it('별도 옵션(expire) 없이 realTimeScatter 기본 동작으로 만료 제거된다', () => {
+    // options.realTimeScatter 에 range 만 있고 expire 설정이 전혀 없어도 제거되어야 한다.
+    const store = buildStore({ range: 5 });
+    expect(store.options.realTimeScatter.expire).toBeUndefined();
+    const t0 = Math.floor(Date.now() / SECOND) * SECOND;
+
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0, y: 1 }],
+      b: [{ x: t0, y: 2 }],
+      c: [{ x: t0, y: 3 }],
+    });
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0 + 6 * SECOND, y: 1 }],
+      b: [{ x: t0 + 6 * SECOND, y: 2 }],
+      c: [],
+    });
+
+    expect(store.dataSet.c).toBeUndefined();
+    expect(store.prunedRealTimeScatterSeries.has('c')).toBe(true);
+  });
+
+  it('제거된 series 는 가드 때문에 신규 점이 와도 데이터 레이어에서 재생성되지 않는다', () => {
+    const store = buildStore({ range: 5 });
+    const t0 = Math.floor(Date.now() / SECOND) * SECOND;
+
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0, y: 1 }],
+      b: [{ x: t0, y: 2 }],
+      c: [{ x: t0, y: 3 }],
+    });
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0 + 6 * SECOND, y: 1 }],
+      b: [{ x: t0 + 6 * SECOND, y: 2 }],
+      c: [],
+    });
+    expect(store.dataSet.c).toBeUndefined();
+
+    // c 키에 신규 점이 와도 prunedRealTimeScatterSeries 가드가 메인 루프에서 skip → 재생성 안 됨.
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0 + 8 * SECOND, y: 1 }],
+      b: [{ x: t0 + 8 * SECOND, y: 2 }],
+      c: [{ x: t0 + 8 * SECOND, y: 3 }],
+    });
+    expect(store.dataSet.c).toBeUndefined();
+
+    // 부활(가드 해제, reconcileSeriesSet 가 하는 일)을 시뮬레이션하면 다시 누적된다.
+    store.prunedRealTimeScatterSeries.delete('c');
+    store.createRealTimeScatterDataSet({
+      a: [{ x: t0 + 9 * SECOND, y: 1 }],
+      b: [{ x: t0 + 9 * SECOND, y: 2 }],
+      c: [{ x: t0 + 9 * SECOND, y: 3 }],
+    });
+    expect(store.dataSet.c).toBeDefined();
+  });
+});
+
 describe('model.store createDataSet stack (누적 top 기반)', () => {
   /**
    * 세로 스택 막대 그룹 컨텍스트를 만든다.
@@ -888,20 +1061,28 @@ describe('getVisibleWindowMaxSeries', () => {
 
   it('윈도우 안의 최댓값 시리즈/인덱스/값을 반환한다', () => {
     const store = buildStore({
-      a: barSeries('a', [10, 20, 100, 30, 40]),  // 전역 max 100 at idx=2
-      b: barSeries('b', [5, 50, 25, 60, 15]),    // 전역 max 60 at idx=3
+      a: barSeries('a', [10, 20, 100, 30, 40]), // 전역 max 100 at idx=2
+      b: barSeries('b', [5, 50, 25, 60, 15]), // 전역 max 60 at idx=3
     });
     // window [3, 4]: a는 30,40 / b는 60,15 → b의 idx=3, value=60이 윈도우 max
-    expect(store.getVisibleWindowMaxSeries(3, 4))
-      .toEqual({ sId: 'b', value: 60, index: 3, domain: 3 });
+    expect(store.getVisibleWindowMaxSeries(3, 4)).toEqual({
+      sId: 'b',
+      value: 60,
+      index: 3,
+      domain: 3,
+    });
   });
 
   it('전역 max가 윈도우 안이면 그대로 그 시리즈를 반환한다', () => {
     const store = buildStore({
       a: barSeries('a', [10, 20, 100, 30, 40]),
     });
-    expect(store.getVisibleWindowMaxSeries(1, 3))
-      .toEqual({ sId: 'a', value: 100, index: 2, domain: 2 });
+    expect(store.getVisibleWindowMaxSeries(1, 3)).toEqual({
+      sId: 'a',
+      value: 100,
+      index: 2,
+      domain: 2,
+    });
   });
 
   it('horizontal 차트는 p.x를 비교하고 domain은 p.y가 된다', () => {
@@ -911,13 +1092,21 @@ describe('getVisibleWindowMaxSeries', () => {
           sId: 'a',
           type: 'bar',
           show: true,
-          data: [{ x: 5, y: 0 }, { x: 99, y: 1 }, { x: 7, y: 2 }],
+          data: [
+            { x: 5, y: 0 },
+            { x: 99, y: 1 },
+            { x: 7, y: 2 },
+          ],
         },
       },
       options: { horizontal: true },
     });
-    expect(store.getVisibleWindowMaxSeries(0, 2))
-      .toEqual({ sId: 'a', value: 99, index: 1, domain: 1 });
+    expect(store.getVisibleWindowMaxSeries(0, 2)).toEqual({
+      sId: 'a',
+      value: 99,
+      index: 1,
+      domain: 1,
+    });
   });
 
   it('show=false 시리즈는 무시한다', () => {
@@ -925,8 +1114,12 @@ describe('getVisibleWindowMaxSeries', () => {
       a: { ...barSeries('a', [10, 20, 30]), show: false },
       b: barSeries('b', [5, 50, 15]),
     });
-    expect(store.getVisibleWindowMaxSeries(0, 2))
-      .toEqual({ sId: 'b', value: 50, index: 1, domain: 1 });
+    expect(store.getVisibleWindowMaxSeries(0, 2)).toEqual({
+      sId: 'b',
+      value: 50,
+      index: 1,
+      domain: 1,
+    });
   });
 
   // 회귀 가드(시나리오 2 — combo line+bar): line이 윈도우 max면 line을 반환해야 한다.
@@ -936,8 +1129,12 @@ describe('getVisibleWindowMaxSeries', () => {
       bar: barSeries('bar', [5, 50, 15]),
       line: { ...barSeries('line', [10, 80, 20]), type: 'line' },
     });
-    expect(store.getVisibleWindowMaxSeries(0, 2))
-      .toEqual({ sId: 'line', value: 80, index: 1, domain: 1 });
+    expect(store.getVisibleWindowMaxSeries(0, 2)).toEqual({
+      sId: 'line',
+      value: 80,
+      index: 1,
+      domain: 1,
+    });
   });
 
   // 회귀 가드(시나리오 1 — line-only 카테고리 축): bar가 없어도 null이 아니라
@@ -947,21 +1144,37 @@ describe('getVisibleWindowMaxSeries', () => {
       a: { ...barSeries('a', [10, 70, 30]), type: 'line' },
       b: { ...barSeries('b', [5, 40, 60]), type: 'line' },
     });
-    expect(store.getVisibleWindowMaxSeries(0, 2))
-      .toEqual({ sId: 'a', value: 70, index: 1, domain: 1 });
+    expect(store.getVisibleWindowMaxSeries(0, 2)).toEqual({
+      sId: 'a',
+      value: 70,
+      index: 1,
+      domain: 1,
+    });
   });
 
   it('윈도우가 data 길이 밖으로 넘어가도 안전하게 clamp 한다', () => {
     const store = buildStore({
       a: barSeries('a', [10, 20, 30]),
     });
-    expect(store.getVisibleWindowMaxSeries(0, 100))
-      .toEqual({ sId: 'a', value: 30, index: 2, domain: 2 });
+    expect(store.getVisibleWindowMaxSeries(0, 100)).toEqual({
+      sId: 'a',
+      value: 30,
+      index: 2,
+      domain: 2,
+    });
   });
 
   it('윈도우 안 모든 값이 null/undefined면 null을 반환한다', () => {
     const store = buildStore({
-      a: { sId: 'a', type: 'bar', show: true, data: [{ x: 0, y: null }, { x: 1, y: null }] },
+      a: {
+        sId: 'a',
+        type: 'bar',
+        show: true,
+        data: [
+          { x: 0, y: null },
+          { x: 1, y: null },
+        ],
+      },
     });
     expect(store.getVisibleWindowMaxSeries(0, 1)).toBeNull();
   });
@@ -970,16 +1183,36 @@ describe('getVisibleWindowMaxSeries', () => {
   // 탈락해 윈도우와 무관한 전역 max로 조용히 폴백). 유한한 실제 윈도우 max를 골라야 한다.
   it('NaN/Infinity 값은 후보에서 제외하고 유한한 max를 반환한다', () => {
     const store = buildStore({
-      a: { sId: 'a', type: 'bar', show: true,
-        data: [{ x: 0, y: NaN }, { x: 1, y: Infinity }, { x: 2, y: 42 }] },
+      a: {
+        sId: 'a',
+        type: 'bar',
+        show: true,
+        data: [
+          { x: 0, y: NaN },
+          { x: 1, y: Infinity },
+          { x: 2, y: 42 },
+        ],
+      },
     });
-    expect(store.getVisibleWindowMaxSeries(0, 2))
-      .toEqual({ sId: 'a', value: 42, index: 2, domain: 2 });
+    expect(store.getVisibleWindowMaxSeries(0, 2)).toEqual({
+      sId: 'a',
+      value: 42,
+      index: 2,
+      domain: 2,
+    });
   });
 
   it('윈도우 안 값이 NaN/Infinity뿐이면 null을 반환한다', () => {
     const store = buildStore({
-      a: { sId: 'a', type: 'bar', show: true, data: [{ x: 0, y: NaN }, { x: 1, y: Infinity }] },
+      a: {
+        sId: 'a',
+        type: 'bar',
+        show: true,
+        data: [
+          { x: 0, y: NaN },
+          { x: 1, y: Infinity },
+        ],
+      },
     });
     expect(store.getVisibleWindowMaxSeries(0, 1)).toBeNull();
   });
@@ -988,11 +1221,23 @@ describe('getVisibleWindowMaxSeries', () => {
   // 0이 제대로 max로 뽑히는지 막아두는 테스트.
   it('value 0도 유효한 max로 선정한다(음수만 있는 윈도우)', () => {
     const store = buildStore({
-      a: { sId: 'a', type: 'bar', show: true,
-        data: [{ x: 0, y: -5 }, { x: 1, y: 0 }, { x: 2, y: -3 }] },
+      a: {
+        sId: 'a',
+        type: 'bar',
+        show: true,
+        data: [
+          { x: 0, y: -5 },
+          { x: 1, y: 0 },
+          { x: 2, y: -3 },
+        ],
+      },
     });
-    expect(store.getVisibleWindowMaxSeries(0, 2))
-      .toEqual({ sId: 'a', value: 0, index: 1, domain: 1 });
+    expect(store.getVisibleWindowMaxSeries(0, 2)).toEqual({
+      sId: 'a',
+      value: 0,
+      index: 1,
+      domain: 1,
+    });
   });
 
   it('minIndex/maxIndex가 비유한이면 null을 반환한다 (가드)', () => {
@@ -1012,15 +1257,40 @@ describe('getVisibleWindowMaxSeries', () => {
   // 별도 분기 없이 일반 max 스캔만으로 양수 stack 차트가 자동 지원됨을 가드한다.
   it('stack 차트(양수): top 시리즈가 stack 총합으로 윈도우 max를 결정한다', () => {
     const store = buildStore({
-      base: { sId: 'base', type: 'bar', show: true,
-        data: [{ x: 0, y: 10, o: 10, b: 0 }, { x: 1, y: 20, o: 20, b: 0 }] },
-      mid:  { sId: 'mid',  type: 'bar', show: true,
-        data: [{ x: 0, y: 15, o: 5,  b: 10 }, { x: 1, y: 30, o: 10, b: 20 }] },
-      top:  { sId: 'top',  type: 'bar', show: true,
-        data: [{ x: 0, y: 18, o: 3,  b: 15 }, { x: 1, y: 35, o: 5,  b: 30 }] },
+      base: {
+        sId: 'base',
+        type: 'bar',
+        show: true,
+        data: [
+          { x: 0, y: 10, o: 10, b: 0 },
+          { x: 1, y: 20, o: 20, b: 0 },
+        ],
+      },
+      mid: {
+        sId: 'mid',
+        type: 'bar',
+        show: true,
+        data: [
+          { x: 0, y: 15, o: 5, b: 10 },
+          { x: 1, y: 30, o: 10, b: 20 },
+        ],
+      },
+      top: {
+        sId: 'top',
+        type: 'bar',
+        show: true,
+        data: [
+          { x: 0, y: 18, o: 3, b: 15 },
+          { x: 1, y: 35, o: 5, b: 30 },
+        ],
+      },
     });
     // 윈도우 [0, 1]: idx=1 stack 총합 35가 max, top 시리즈가 그 값을 보유.
-    expect(store.getVisibleWindowMaxSeries(0, 1))
-      .toEqual({ sId: 'top', value: 35, index: 1, domain: 1 });
+    expect(store.getVisibleWindowMaxSeries(0, 1)).toEqual({
+      sId: 'top',
+      value: 35,
+      index: 1,
+      domain: 1,
+    });
   });
 });

--- a/src/components/chart/model/reconcileSeriesSet.spec.js
+++ b/src/components/chart/model/reconcileSeriesSet.spec.js
@@ -78,7 +78,12 @@ describe('reconcileSeriesSet — series 증분 재조정', () => {
     const first = { ...ctx.seriesList };
 
     // 순서를 뒤집어 입력(앞에 신규를 넣어 index 를 민다)
-    const next = mkSeries({ s0: { name: 's0', color: '#000' }, s1: defs.s1, s2: defs.s2, s3: defs.s3 });
+    const next = mkSeries({
+      s0: { name: 's0', color: '#000' },
+      s1: defs.s1,
+      s2: defs.s2,
+      s3: defs.s3,
+    });
     reconcile(ctx, next);
 
     expect(ctx.seriesList.s1).toBe(first.s1);
@@ -150,5 +155,61 @@ describe('reconcileSeriesSet — series 증분 재조정', () => {
 
     reconcile(ctx, mkSeries(defs));
     expect(ctx.seriesList.s1.show).toBe(true); // opt.show(기본 true) 로 리셋
+  });
+});
+
+/**
+ * realTimeScatter 만료(prune) 후 부활 경로 가드.
+ * reconcileSeriesSet 이 재추가 방지 가드(prunedRealTimeScatterSeries)의 단일 해제 지점이다:
+ *  - 신규 점이 들어온 pruned 키 → 가드에서 빼고 일반 경로로 재생성(부활)
+ *  - 신규 점이 없는 pruned 키 → data.series 에 키가 남아 있어도 재생성 대상에서 제외(비부활)
+ */
+describe('reconcileSeriesSet — realTimeScatter 만료 series 부활 가드 해제', () => {
+  const makeCtx = () => ({
+    ...modules,
+    options: {
+      overlapping: { use: false },
+      realTimeScatter: { use: true },
+      legend: { type: 'plain' },
+      horizontal: false,
+    },
+    seriesInfo: { charts: { pie: [], bar: [], line: [], scatter: [], heatMap: [] }, count: 0 },
+    seriesList: {},
+  });
+
+  const reconcile = (ctx, series) => {
+    const prev = ctx.seriesList;
+    ctx.seriesInfo = { charts: { pie: [], bar: [], line: [], scatter: [], heatMap: [] }, count: 0 };
+    ctx.reconcileSeriesSet(series, 'line', false, [], prev);
+    return ctx.seriesList;
+  };
+
+  const series = {
+    active: { name: 'active', color: '#a11' },
+    dead: { name: 'dead', color: '#11a' },
+  };
+
+  it('신규 점이 들어온 pruned 키는 가드에서 빠지고 seriesList 에 부활한다', () => {
+    const ctx = makeCtx();
+    ctx.prunedRealTimeScatterSeries = new Set(['dead']);
+    ctx.data = { data: { active: [{ x: 1, y: 1 }], dead: [{ x: 2, y: 2 }] } };
+
+    reconcile(ctx, series);
+
+    expect(ctx.prunedRealTimeScatterSeries.has('dead')).toBe(false); // 가드 해제(부활)
+    expect(ctx.seriesList.dead).toBeDefined();
+    expect(ctx.seriesList.active).toBeDefined();
+  });
+
+  it('신규 점이 없는 pruned 키는 가드에 남고 seriesList 에서 제외된다(비부활)', () => {
+    const ctx = makeCtx();
+    ctx.prunedRealTimeScatterSeries = new Set(['dead']);
+    ctx.data = { data: { active: [{ x: 1, y: 1 }], dead: [] } };
+
+    reconcile(ctx, series);
+
+    expect(ctx.prunedRealTimeScatterSeries.has('dead')).toBe(true); // 가드 유지
+    expect(ctx.seriesList.dead).toBeUndefined(); // 재생성 제외
+    expect(ctx.seriesList.active).toBeDefined();
   });
 });


### PR DESCRIPTION
# 작업 배경

`realTimeScatter` 는 수신 데이터를 누적 저장소에 계속 쌓기만 했다. 특정 series 가 가시 범위(`range`) 밖으로 모두 밀려나고 신규 점도 끊기면, 화면에 그려지지 않는데도 누적 저장소·범례에 **영구히 남아** 메모리가 무한정 늘고 죽은 범례 항목이 노출됐다.

# 변경 사항 요약(Key changes)

`realTimeScatter` 의 **기본 동작**으로 개별 series 자동 만료를 추가한다(별도 옵션 없음).

- **`model.store.js`**
  - `pruneExpiredRealTimeScatterSeries(datas)` 신설 — append 직후 스캔하여 만료 series 제거 + 범례 rebuild.
  - `removeRealTimeScatterSeries(sId)` 신설 — `dataSet`·`seriesList`·`seriesInfo.charts.scatter`·선택 상태에서 제거하고 재추가 방지 가드(`prunedRealTimeScatterSeries`)에 등록.
  - `createRealTimeScatterDataSet` — 가드에 등록된 키는 누적 재생성에서 제외(죽은 키의 orphan 부활 방지).
- **`model.series.js`** — `reconcileSeriesSet` 에서 가드 해제를 **일원화**: 신규 점이 온 키만 가드에서 빼 일반 경로로 부활, 신규 점 없는 키는 제외.
- **`Chart.vue`** — 만료된 series 가 신규 점과 함께 돌아오면 `updateSeries` 를 강제(`isRevived`)해 인스턴스·baseline·범례를 복구. 전체 리셋 시 가드 clear.
- **docs/example** — `scatterChart.md` 기본 동작 문서화, `RealTimeScatter.vue` 에 series 별 공급 on/off 토글 데모 추가(`range` min/step 10s 하향, 1초 격자 데이터).

# 기존 동작
https://github.com/user-attachments/assets/cc3863d2-73eb-46bf-9539-be451a70b601

가시 범위 밖으로 완전히 밀려나고 신규 점도 끊긴 series 가 누적 저장소·범례에 **영구 잔존**한다. 소비자가 죽은 키를 빈 배열로 보내거나 키를 빼도 정리되지 않는다.

# 기대 동작
https://github.com/user-attachments/assets/67971a7e-3451-40c6-bdc0-fe2bf53ad20c

아래 **(a)+(b)** 를 모두 만족하면 해당 series 를 **즉시**(grace 없음) 누적 저장소·범례·선택 상태에서 제거한다.

- **(a)** 가시 윈도우 `[xMax - range, xMax]` 안에 점이 하나도 없음 (`toTime < windowStart`, O(1)).
- **(b)** 이번 틱에 그 series 의 신규 점이 없음.

> **"series 키 부재"로 판정하지 않는다** — 죽은 키가 `data.series`/`data.data` 에 남아 있을 수 있어, 오직 데이터 조건 (a)+(b)로만 판정한다.

제거된 series 는 **신규 점이 다시 오면 자동 부활**(재생성)한다. `v-model:realTimeScatterReset` 과 독립적으로 동작한다.

# 테스트 가이드

1. `docs/views/scatterChart/example/RealTimeScatter.vue` 실행, `range` 를 `10s` 로 낮춘다.
2. series1/series2 데이터가 실시간으로 쌓이는지 확인한다.
3. **series2 공급** 토글을 끈다.
4. series2 의 점이 가시 범위 밖으로 모두 밀려난 뒤(약 10초), series2 가 그래프·범례에서 **사라지는지** 확인한다.
5. 다시 토글을 켜면 series2 가 **부활**하는지 확인한다.
