### PR TITLE
feat(tabs): 오버플로우/선택 상태 변화에 헤더 스크롤이 반응하도록 개선

### DIFF
--- a/docs/views/tab/example/Default.vue
+++ b/docs/views/tab/example/Default.vue
@@ -74,6 +74,31 @@
       <button class="btn" @click="toggleComp4">Toggle Component 4</button>
     </div>
   </div>
+  <div class="case">
+    <p class="case-title">Scroll To Active Tab (has-scroll)</p>
+    <div class="tab-wrapper scroll-tab-wrapper">
+      <ev-tabs v-model="selectedValue3" v-model:panels="tabPanels3">
+        <ev-tab-panel
+          v-for="(item, idx) in tabPanels3"
+          :key="`${item.value}_${idx}`"
+          :text="item.text"
+          :value="item.value"
+        >
+          <div class="scroll-tab-content">{{ item.content }}</div>
+        </ev-tab-panel>
+      </ev-tabs>
+    </div>
+    <div class="description">
+      선택된 탭:
+      <b>{{ selectedValue3 }}</b>
+      <br />
+      <button class="btn" @click="selectValue3('tab1')">첫 탭 선택</button>
+      &nbsp;&nbsp;&nbsp;
+      <button class="btn" @click="selectValue3('tab8')">중간 탭 선택</button>
+      &nbsp;&nbsp;&nbsp;
+      <button class="btn" @click="selectValue3('tab15')">마지막 탭 선택</button>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -158,6 +183,19 @@ export default {
       },
     ]);
 
+    // has-scroll 상태에서 선택 탭 자동 스크롤 데모 (초기값을 마지막 탭으로 지정)
+    const selectedValue3 = ref('tab15');
+    const tabPanels3 = ref(
+      Array.from({ length: 15 }, (_, i) => ({
+        text: `LABEL${i + 1}`,
+        value: `tab${i + 1}`,
+        content: `content${i + 1}`,
+      })),
+    );
+    const selectValue3 = (val) => {
+      selectedValue3.value = val;
+    };
+
     const toggleComp4 = () => {
       const comp4Idx = tabPanels2.value.findIndex((v) => v.value === 'comp4');
       if (comp4Idx < 0) {
@@ -183,6 +221,10 @@ export default {
       selectedValue2,
       tabPanels2,
       toggleComp4,
+
+      selectedValue3,
+      tabPanels3,
+      selectValue3,
     };
   },
 };
@@ -209,5 +251,15 @@ export default {
   .ev-tabs-title {
     width: 150px;
   }
+}
+
+// 탭 15개가 폭을 넘겨 has-scroll 이 확실히 발생하도록 래퍼 폭 제한
+.scroll-tab-wrapper {
+  width: 500px;
+  max-width: 100%;
+}
+
+.scroll-tab-content {
+  padding: 20px;
 }
 </style>

--- a/src/components/tabs/Tabs.spec.js
+++ b/src/components/tabs/Tabs.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 import EvTabs from './Tabs.vue';
 
 describe('EvTabs Component', () => {
@@ -100,6 +100,215 @@ describe('EvTabs Component', () => {
 
       expect(wrapper.emitted('change')).toBeTruthy();
       expect(wrapper.emitted('change')[0][0]).toBe('tab2');
+    });
+  });
+
+  describe('has-scroll 시 선택 탭 자동 스크롤', () => {
+    const TAB_WIDTH = 100; // .ev-tabs-title 너비
+    const WRAPPER_WIDTH = 300; // 헤더 뷰포트 (탭 3개 정도만 보임)
+    const manyPanels = Array.from({ length: 12 }, (_, i) => ({
+      text: `탭${i + 1}`,
+      value: `tab${i + 1}`,
+    }));
+
+    // jsdom 은 레이아웃을 계산하지 않으므로 offset 값을 목킹한다.
+    // NOTE: 'li.offsetLeft 이 ul 기준' 이라는 좌표계 가정 자체는 여기서 검증되지 않는다
+    //       (실브라우저에선 ul 의 v-resize 가 position:relative 를 걸어 offsetParent 가 ul 로 확정됨).
+    //       실제 좌표/스크롤 픽셀 검증은 docs/views/tab/example/Default.vue 데모로 수행한다.
+    const mockLayout = (wrapper) => {
+      const listWrapperEl = wrapper.find('.ev-tabs-list-wrapper').element;
+      const listEl = wrapper.find('.ev-tabs-list').element;
+      const tabEls = wrapper.findAll('.ev-tabs-title').map((w) => w.element);
+
+      Object.defineProperty(listWrapperEl, 'offsetWidth', {
+        configurable: true,
+        get: () => WRAPPER_WIDTH,
+      });
+      Object.defineProperty(listEl, 'offsetWidth', {
+        configurable: true,
+        get: () => TAB_WIDTH * tabEls.length,
+      });
+      Object.defineProperty(listEl, 'offsetLeft', {
+        configurable: true,
+        get: () => 0,
+      });
+      tabEls.forEach((el, i) => {
+        Object.defineProperty(el, 'offsetLeft', {
+          configurable: true,
+          get: () => TAB_WIDTH * i,
+        });
+        Object.defineProperty(el, 'offsetWidth', {
+          configurable: true,
+          get: () => TAB_WIDTH,
+        });
+      });
+    };
+
+    const getTranslateX = (wrapper) => {
+      const listEl = wrapper.find('.ev-tabs-list').element;
+      const m = /translateX\((-?\d+(?:\.\d+)?)px\)/.exec(listEl.style.transform || '');
+      return m ? parseFloat(m[1]) : 0;
+    };
+
+    // 선택 탭이 뷰포트 [viewLeft, viewRight] 안에 완전히 보이는지 판정
+    const isActiveTabVisible = (wrapper, activeIdx) => {
+      const translateX = getTranslateX(wrapper);
+      const viewLeft = -translateX;
+      const viewRight = viewLeft + WRAPPER_WIDTH;
+      const activeLeft = TAB_WIDTH * activeIdx;
+      const activeRight = activeLeft + TAB_WIDTH;
+      return activeLeft >= viewLeft && activeRight <= viewRight;
+    };
+
+    it('탭이 넘치면 has-scroll 이 활성화된다', async () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: manyPanels },
+        ...globalConfig,
+      });
+
+      mockLayout(wrapper);
+      wrapper.vm.onResize();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('.ev-tabs-nav-wrapper').classes()).toContain('has-scroll');
+    });
+
+    it('마지막(오른쪽 끝) 탭이 선택된 채 마운트되면 헤더가 그 탭으로 스크롤된다', async () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab12', panels: manyPanels },
+        ...globalConfig,
+      });
+
+      mockLayout(wrapper);
+      wrapper.vm.onResize(); // 최초 렌더/가시성/리사이즈 시점 재계산
+      await flushPromises();
+
+      // 오른쪽 끝 정렬: translateX = WRAPPER_WIDTH - listWidth = 300 - 1200 = -900
+      expect(getTranslateX(wrapper)).toBe(WRAPPER_WIDTH - TAB_WIDTH * manyPanels.length);
+      expect(isActiveTabVisible(wrapper, 11)).toBe(true);
+    });
+
+    it('modelValue 를 뷰포트 밖 탭으로 변경하면 헤더가 따라 스크롤된다', async () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: manyPanels },
+        ...globalConfig,
+      });
+
+      mockLayout(wrapper);
+      wrapper.vm.onResize();
+      await flushPromises();
+
+      // tab1 은 처음부터 보이므로 스크롤 없음
+      expect(getTranslateX(wrapper)).toBe(0);
+
+      // 오른쪽 끝 탭으로 변경
+      await wrapper.setProps({ modelValue: 'tab12' });
+      await flushPromises();
+
+      expect(isActiveTabVisible(wrapper, 11)).toBe(true);
+      expect(getTranslateX(wrapper)).toBe(WRAPPER_WIDTH - TAB_WIDTH * manyPanels.length);
+    });
+
+    it('오른쪽으로 스크롤된 상태에서 첫 탭을 선택하면 왼쪽으로 스크롤된다', async () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab12', panels: manyPanels },
+        ...globalConfig,
+      });
+
+      mockLayout(wrapper);
+      wrapper.vm.onResize();
+      await flushPromises();
+      expect(getTranslateX(wrapper)).toBeLessThan(0);
+
+      await wrapper.setProps({ modelValue: 'tab1' });
+      await flushPromises();
+
+      // tab1 좌측 정렬 → translateX = 0
+      expect(getTranslateX(wrapper)).toBe(0);
+      expect(isActiveTabVisible(wrapper, 0)).toBe(true);
+    });
+
+    it('스크롤이 없으면(탭이 적으면) translateX 는 0 을 유지한다', async () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab3', panels: defaultPanels },
+        ...globalConfig,
+      });
+
+      const listWrapperEl = wrapper.find('.ev-tabs-list-wrapper').element;
+      const listEl = wrapper.find('.ev-tabs-list').element;
+      Object.defineProperty(listWrapperEl, 'offsetWidth', { configurable: true, get: () => 600 });
+      Object.defineProperty(listEl, 'offsetWidth', { configurable: true, get: () => 300 });
+
+      wrapper.vm.onResize();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('.ev-tabs-nav-wrapper').classes()).not.toContain('has-scroll');
+      expect(getTranslateX(wrapper)).toBe(0);
+    });
+  });
+
+  describe('패널 추가/삭제 시 has-scroll 재계산', () => {
+    const TAB_WIDTH = 100; // .ev-tabs-title 너비
+    const WRAPPER_WIDTH = 300; // 헤더 뷰포트 (탭 3개 정도만 보임)
+
+    const makePanels = (n) =>
+      Array.from({ length: n }, (_, i) => ({ text: `탭${i + 1}`, value: `tab${i + 1}` }));
+
+    // jsdom 은 레이아웃을 계산하지 않으므로 offsetWidth 를 목킹한다.
+    // 래퍼 폭은 300 고정(섹션 폭은 변하지 않는 상황), 리스트 폭은 살아있는 li 개수에 비례.
+    const mockDynamicLayout = (wrapper) => {
+      const listWrapperEl = wrapper.find('.ev-tabs-list-wrapper').element;
+      const listEl = wrapper.find('.ev-tabs-list').element;
+
+      Object.defineProperty(listWrapperEl, 'offsetWidth', {
+        configurable: true,
+        get: () => WRAPPER_WIDTH,
+      });
+      Object.defineProperty(listEl, 'offsetWidth', {
+        configurable: true,
+        get: () => TAB_WIDTH * listEl.children.length,
+      });
+    };
+
+    it('마운트 후 패널을 추가해 리스트가 래퍼를 넘치면 has-scroll 이 나타난다', async () => {
+      // 탭 2개 → 200 < 300 → 스크롤 없음
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: makePanels(2) },
+        ...globalConfig,
+      });
+
+      mockDynamicLayout(wrapper);
+      wrapper.vm.onResize(); // 최초 가시성/리사이즈 시점 측정
+      await flushPromises();
+      expect(wrapper.find('.ev-tabs-nav-wrapper').classes()).not.toContain('has-scroll');
+
+      // 탭 6개 → 600 > 300 → 넘침. 섹션 폭은 그대로라 섹션 v-resize 로는 못 잡던 케이스.
+      // 실브라우저에선 ul 의 v-resize(ResizeObserver)가 리스트 폭 변화를 감지해 자동 재계산하지만,
+      // jsdom 은 RO/디렉티브가 스텁이라 그 트리거를 onResize() 수동 호출로 대체한다.
+      await wrapper.setProps({ panels: makePanels(6) });
+      wrapper.vm.onResize();
+      await flushPromises();
+
+      expect(wrapper.find('.ev-tabs-nav-wrapper').classes()).toContain('has-scroll');
+    });
+
+    it('패널을 제거해 더 이상 넘치지 않으면 has-scroll 이 사라진다', async () => {
+      const wrapper = mount(EvTabs, {
+        props: { modelValue: 'tab1', panels: makePanels(6) },
+        ...globalConfig,
+      });
+
+      mockDynamicLayout(wrapper);
+      wrapper.vm.onResize();
+      await flushPromises();
+      expect(wrapper.find('.ev-tabs-nav-wrapper').classes()).toContain('has-scroll');
+
+      // 실브라우저에선 ul 의 v-resize(ResizeObserver)가 담당하는 재계산을, jsdom 에선 수동 트리거.
+      await wrapper.setProps({ panels: makePanels(2) });
+      wrapper.vm.onResize();
+      await flushPromises();
+
+      expect(wrapper.find('.ev-tabs-nav-wrapper').classes()).not.toContain('has-scroll');
     });
   });
 

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -27,7 +27,10 @@
           </span>
         </template>
         <div ref="listWrapperRef" class="ev-tabs-list-wrapper">
-          <ul ref="listRef" class="ev-tabs-list" :style="listRefStyle">
+          <!-- ul 폭(탭 개수·라벨·아이콘 변화) 자체를 감시해 has-scroll 을 재계산한다.
+               섹션 v-resize 는 뷰포트(섹션) 폭만 잡으므로 리스트 콘텐츠 폭 변화는 여기서 담당.
+               (부수효과로 resize 디렉티브가 position:relative 를 걸어 li 의 offsetParent 가 ul 로 확정됨) -->
+          <ul ref="listRef" v-resize="onResize" class="ev-tabs-list" :style="listRefStyle">
             <li
               v-for="(item, idx) in computedTabList"
               :key="`${item.value}_${idx}`"
@@ -63,7 +66,16 @@
 </template>
 
 <script>
-import { ref, reactive, computed, provide, triggerRef, onBeforeUpdate, nextTick } from 'vue';
+import {
+  ref,
+  reactive,
+  computed,
+  provide,
+  triggerRef,
+  onBeforeUpdate,
+  nextTick,
+  watch,
+} from 'vue';
 import { ObserveVisibility as vObserveVisibility } from 'vue3-observe-visibility';
 import { resize } from '@/directives/resize';
 
@@ -156,6 +168,47 @@ export default {
     }));
 
     /**
+     * 선택된(active) 탭이 헤더 뷰포트 밖에 있으면 뷰포트 안으로 들어오도록 스크롤한다.
+     * modelValue 변경 및 최초 렌더/리사이즈 시점에 호출된다.
+     */
+    const scrollToActiveTab = () => {
+      if (!hasScroll.value || !listRef.value || !listWrapperRef.value) {
+        return;
+      }
+      const activeIdx = computedTabList.value.findIndex((v) => v.value === mv.value);
+      if (activeIdx < 0) {
+        return;
+      }
+      const activeEl = listRef.value.children[activeIdx];
+      if (!activeEl) {
+        return;
+      }
+      const listWrapperWidth = listWrapperRef.value.offsetWidth;
+      const listWidth = listRef.value.offsetWidth;
+      const widthLimit = listWrapperWidth - listWidth;
+      // ul(listRef)에는 transform 이 걸려 있어 offsetParent 가 ul 이 되므로,
+      // li 의 offsetLeft 는 이미 ul(=translateX 가 슬라이드하는 좌표계) 기준이다.
+      const activeLeft = activeEl.offsetLeft;
+      const activeRight = activeLeft + activeEl.offsetWidth;
+      const viewLeft = -translateScroll.x;
+      const viewRight = viewLeft + listWrapperWidth;
+
+      const lastIdx = computedTabList.value.length - 1;
+      let nextX = translateScroll.x;
+      if (activeLeft < viewLeft) {
+        // 선택 탭이 뷰포트 왼쪽 밖 → 왼쪽 끝을 뷰포트 시작에 맞춤
+        // 첫 탭이면 0 으로 스냅해 리스트(ul) 좌측 border 까지 노출
+        nextX = activeIdx === 0 ? 0 : -activeLeft;
+      } else if (activeRight > viewRight) {
+        // 선택 탭이 뷰포트 오른쪽 밖 → 오른쪽 끝을 뷰포트 끝에 맞춤
+        // 마지막 탭이면 widthLimit(절대 끝)으로 스냅해 리스트(ul) 우측 border 까지 노출
+        nextX = activeIdx === lastIdx ? widthLimit : listWrapperWidth - activeRight;
+      }
+      // 스크롤 가능 범위 [widthLimit, 0] 로 클램프
+      translateScroll.x = Math.min(0, Math.max(widthLimit, nextX));
+    };
+
+    /**
      * 상단 탭 nav의 element 길이를 감시 및 계산하여 스크롤 여부 확인
      * UL의 길이가 긴 경우 양쪽에 버튼 노출
      */
@@ -169,10 +222,18 @@ export default {
         if (widthLimit > translateScroll.x) {
           translateScroll.x = widthLimit;
         }
+        // has-scroll 전환 시 화살표 padding(좌우 40px)이 적용되어 뷰포트 폭이 바뀌므로,
+        // DOM 갱신 이후의 폭을 기준으로 스크롤 위치를 계산한다.
+        nextTick(scrollToActiveTab);
       } else {
         translateScroll.x = 0;
       }
     };
+
+    // modelValue(선택 탭) 변경 시 헤더가 선택 탭을 따라 스크롤되도록 함
+    watch(mv, () => {
+      nextTick(scrollToActiveTab);
+    });
 
     onBeforeUpdate(() => {
       // 삭제된 탭이 선택된 경우 탭선택 인덱스를 변경하는 로직

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -186,8 +186,9 @@ export default {
       const listWrapperWidth = listWrapperRef.value.offsetWidth;
       const listWidth = listRef.value.offsetWidth;
       const widthLimit = listWrapperWidth - listWidth;
-      // ul(listRef)에는 transform 이 걸려 있어 offsetParent 가 ul 이 되므로,
-      // li 의 offsetLeft 는 이미 ul(=translateX 가 슬라이드하는 좌표계) 기준이다.
+      // ul(listRef)은 v-resize 디렉티브가 position:relative 를 걸어 li 의 offsetParent 가 되므로,
+      // li 의 offsetLeft 는 ul(=translateX 가 슬라이드하는 좌표계) 기준이다.
+      // (transform 은 이 좌표계를 시각적으로 슬라이드할 뿐 offsetLeft 값 자체는 바꾸지 않는다.)
       const activeLeft = activeEl.offsetLeft;
       const activeRight = activeLeft + activeEl.offsetWidth;
       const viewLeft = -translateScroll.x;


### PR DESCRIPTION
## 배경
ev-tabs에서 탭 목록이 헤더 폭을 넘칠 때, 넘친 탭(특히 마지막 탭)에 접근할 수 없는
두 가지 결함이 있었습니다. 두 결함 모두 **"오버플로우/선택 상태 변화에 헤더 스크롤이
반응하지 않는다"**는 같은 뿌리에서 비롯됩니다.

## 결함 및 원인

### 결함 A — panels가 마운트 이후 늘어나 오버플로우돼도 화살표(‹ ›)가 안 나타남
- **원인**: `has-scroll` 계산(`observeListEl`)이 섹션 `v-resize`(뷰포트 폭 변화)와
  `v-observe-visibility(once)`로만 트리거됨. 마운트 후 panels만 늘어나면 섹션 폭은
  그대로라 재계산이 일어나지 않아 `has-scroll`이 `false`로 고정됨.
  
  
<img width="1958" height="1118" alt="Jul-22-2026 17-40-26" src="https://github.com/user-attachments/assets/38d13d19-c96e-4c95-8c2b-0ab8bcb8ed8c" />


### 결함 B — 선택된 탭(modelValue)이 뷰포트 밖이어도 그 위치로 스크롤되지 않음
- **원인**: 선택 탭을 뷰포트 안으로 들이는 로직 자체가 없음. 헤더가 `translateX(0)`
  (맨 왼쪽)에 고정돼, content(body)는 정상 렌더되지만 헤더의 선택 탭은 `overflow:hidden`에 잘림.

## 수정

### 결함 A → ul에 `v-resize`(ResizeObserver) 적용
- 리스트(ul) **콘텐츠 폭 변화 자체**(탭 개수·라벨 텍스트·아이콘)를 감지해 `has-scroll` 재계산.
- 섹션 `v-resize`는 뷰포트 폭만 담당하고, 콘텐츠 폭 변화는 ul이 담당하도록 역할 분리.

### 결함 B → `scrollToActiveTab()` + 트리거 배선
- 선택 탭이 뷰포트 밖이면 안으로 스크롤. 첫 탭은 `0`, 마지막 탭은 스크롤 끝으로 스냅해
  리스트 좌우 border까지 노출하고, 스크롤 범위 `[widthLimit, 0]`로 클램프.
- 호출 시점:
  - `watch(mv)` — `modelValue` 변경 시
  - `observeListEl → nextTick(scrollToActiveTab)` — 최초 렌더/가시성/리사이즈 시점
    (초기 modelValue가 뷰포트 밖 탭인 경우까지 커버)
    
<img width="1958" height="1118" alt="Jul-22-2026 17-41-08" src="https://github.com/user-attachments/assets/7b14b014-bf93-48c4-a065-7bf7ef61b3c5" />

## 기대 동작 충족
- ✅ 리스트가 헤더를 넘치면(panels가 나중에 바뀌어도) `has-scroll`이 켜져 ‹ › 화살표 표시
- ✅ 선택된 탭은 마운트/`modelValue` 변경 시 항상 헤더 뷰포트 안에 보이도록 스크롤

## 구현 / 코드리뷰 반영
- 초기 구현의 `watch(탭 개수)` 방식은 개수 변화만 잡고 라벨 텍스트/폰트 변화를 놓치는
  갭이 있어 `ul`의 `ResizeObserver`로 대체(결함 A를 더 넓게 커버).
  - RO 콜백이 바꾸는 값(`hasScroll`→조상 padding, `translateScroll.x`→transform)은
    ul의 content-box 크기를 건드리지 않아 **ResizeObserver 루프 없음**
  - resize 디렉티브가 ul에 `position:relative`를 걸어 `li`의 `offsetParent`가 ul로 확정 →
    좌표 계산이 transform 의존에서 spec 준수 방식으로 강화

## 테스트
- `Tabs.spec.js` **18개 전부 통과**, ESLint 클린
- 커버: 오버플로우 시 `has-scroll` 활성화 / 마지막 탭 선택 마운트 시 스크롤 /
  `modelValue` 변경 추적(양방향) / 스크롤 없을 때 `translateX(0)` 유지 /
  **패널 추가·삭제 시 `has-scroll` 재계산(결함 A)**