### PR TITLE
feat(chart): plotLine/plotBand 라벨에 valueFormatter 옵션 추가

### DIFF
--- a/docs/specs/plotline-plotband-label-spec.md
+++ b/docs/specs/plotline-plotband-label-spec.md
@@ -118,6 +118,8 @@ plotBands: [{
 2. `showValue: false` → 기존처럼 **`text` 그대로** (완전 하위호환).
 
 > `valueFormatter`는 라벨 값만 축과 다르게 포맷할 때 쓴다(예: 축은 소수점 2자리, 임계선 라벨은 원본 정밀도). value-only/hover 등 반응형 동작은 `showValue: true` 경로에서 그대로 유지된다.
+>
+> 계약은 `(value) => string`. `valueFormatter`가 `null`/`undefined`를 반환하면(예: `return` 누락) 리터럴 `"null"`/`"undefined"` 노출을 막기 위해 **축 formatter로 폴백**한다. `number` 등 그 외 반환값은 문자열로 변환해 사용한다(폴백 아님).
 
 ### 4.2 반응형 3단계 (`responsive`)
 

--- a/docs/specs/plotline-plotband-label-spec.md
+++ b/docs/specs/plotline-plotband-label-spec.md
@@ -71,6 +71,8 @@ label: {
                              // | 'innerStart'(plot 안 좌측 끝)
                              // | 'innerEnd'(plot 안 우측 끝)
   showValue: false,          // true → "text value" 합성 (value = 축 formatter)
+  valueFormatter: null,      // showValue=true 시 value 포맷 override. (value) => string.
+                             //   null이면 축 formatter 사용. 축과 다른 정밀도/단위로 값을 표시할 때 사용
   responsive: {              // 차트(plot) 너비 기준 3단계 축약. 둘 다 null이면 항상 풀 표시
     valueOnlyBelow: null,    //   너비 < 이 값 → value만 표시
     hideBelow: null,         //   너비 < 이 값 → 라벨 미노출(선/밴드 본체는 유지)
@@ -112,8 +114,10 @@ plotBands: [{
 
 ### 4.1 라벨 텍스트 결정
 
-1. `showValue: true` → `"{text} {value}"` 합성 (`text`가 null이면 value만). value는 축 formatter 적용.
+1. `showValue: true` → `"{text} {value}"` 합성 (`text`가 null이면 value만). value는 `valueFormatter`가 있으면 그것으로, 없으면 축 formatter로 포맷.
 2. `showValue: false` → 기존처럼 **`text` 그대로** (완전 하위호환).
+
+> `valueFormatter`는 라벨 값만 축과 다르게 포맷할 때 쓴다(예: 축은 소수점 2자리, 임계선 라벨은 원본 정밀도). value-only/hover 등 반응형 동작은 `showValue: true` 경로에서 그대로 유지된다.
 
 ### 4.2 반응형 3단계 (`responsive`)
 

--- a/docs/views/lineChart/api/lineChart.md
+++ b/docs/views/lineChart/api/lineChart.md
@@ -255,6 +255,7 @@ const chartData =
 | show            | Boolean                     | false     | label 표시 여부                                                    | true / false                          |
 | text            | String \| null              | null      | 라벨 텍스트(=alias). `showValue: false`면 이 값을 그대로 표시       |                                       |
 | showValue       | Boolean                     | false     | `true` → `"{text} {value}"` 합성(value는 해당 축 formatter 적용)   | true / false                          |
+| valueFormatter  | Function \| null            | null      | `showValue: true`일 때 value 포맷 override. `(value) => string`. `null`이면 축 formatter 사용 | `(v) => \`${v}%\`` |
 | fontSize        | Number                      | 12        | 폰트 크기                                                          |                                       |
 | fontColor       | Hex, RGB, RGBA Code(String) | '#FF0000' | 폰트 색상                                                          |                                       |
 | fillColor       | Hex, RGB, RGBA Code(String) | '#FFFFFF' | 박스 배경 색상. `rgba(...)`로 투명도 지정 가능                      |                                       |

--- a/src/components/chart/helpers/helpers.constant.js
+++ b/src/components/chart/helpers/helpers.constant.js
@@ -197,6 +197,7 @@ export const PLOT_LINE_LABEL_OPTION = {
   },
   position: 'outside', // 'outside'(plot 밖 우측 여백) | 'innerStart'(plot 안 좌측) | 'innerEnd'(plot 안 우측)
   showValue: false, // true → "text value" 합성 (value = 축 formatter)
+  valueFormatter: null, // showValue=true 일 때 값 포맷 override. (value) => string. null 이면 축 formatter 사용
   responsive: {
     valueOnlyBelow: null, // plot 너비 < 이 값 → value만
     hideBelow: null, // plot 너비 < 이 값 → 라벨 미노출

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -814,14 +814,18 @@ class Scale {
     // 텍스트 결정 (alias=text, value=라벨 valueFormatter 우선, 없으면 축 formatter)
     const aliasText = merged.text != null ? String(merged.text) : '';
     const hasValue = !Util.isNullOrUndefined(value) && Number.isFinite(+value);
-    const formattedValue =
-      merged.showValue && hasValue
-        ? String(
-            typeof merged.valueFormatter === 'function'
-              ? merged.valueFormatter(value)
-              : this.getLabelFormat(value),
-          )
-        : '';
+    // valueFormatter 계약은 (value) => string. 단, return 누락 등으로 null/undefined 를 반환하면
+    // 리터럴 "null"/"undefined" 가 라벨에 그려지므로 축 formatter 로 폴백한다.
+    // (number 등 그 외 반환값은 String() 으로 변환해 계산 결과를 살린다 — 축 formatter 폴백 아님)
+    let formattedValue = '';
+    if (merged.showValue && hasValue) {
+      if (typeof merged.valueFormatter === 'function') {
+        const custom = merged.valueFormatter(value);
+        formattedValue = custom == null ? String(this.getLabelFormat(value)) : String(custom);
+      } else {
+        formattedValue = String(this.getLabelFormat(value));
+      }
+    }
 
     let label;
     if (merged.showValue) {

--- a/src/components/chart/scale/scale.js
+++ b/src/components/chart/scale/scale.js
@@ -811,10 +811,17 @@ class Scale {
     const valueOnly =
       !hidden && !Util.isNullOrUndefined(valueOnlyBelow) && plotWidth < valueOnlyBelow;
 
-    // 텍스트 결정 (alias=text, value=축 formatter)
+    // 텍스트 결정 (alias=text, value=라벨 valueFormatter 우선, 없으면 축 formatter)
     const aliasText = merged.text != null ? String(merged.text) : '';
     const hasValue = !Util.isNullOrUndefined(value) && Number.isFinite(+value);
-    const formattedValue = merged.showValue && hasValue ? String(this.getLabelFormat(value)) : '';
+    const formattedValue =
+      merged.showValue && hasValue
+        ? String(
+            typeof merged.valueFormatter === 'function'
+              ? merged.valueFormatter(value)
+              : this.getLabelFormat(value),
+          )
+        : '';
 
     let label;
     if (merged.showValue) {

--- a/src/components/chart/scale/scale.spec.js
+++ b/src/components/chart/scale/scale.spec.js
@@ -157,5 +157,33 @@ describe('Scale', () => {
       expect(opts.valueOnly).toBe(true);
       expect(opts.label).toBe('81.9999%');
     });
+
+    it('valueFormatter 가 null/undefined 를 반환하면 축 formatter 로 폴백한다', () => {
+      const scale = setupScale();
+      // return 누락 등으로 undefined 반환 → 리터럴 "undefined" 대신 축 formatter 사용
+      const undefResult = scale.getNormalizedLabelOptions(
+        { chartWidth: 400, width: 500 },
+        { show: true, showValue: true, text: '임계치', valueFormatter: () => undefined },
+        82,
+      );
+      expect(undefResult.label).toBe('임계치 axis:82');
+
+      const nullResult = scale.getNormalizedLabelOptions(
+        { chartWidth: 400, width: 500 },
+        { show: true, showValue: true, text: '임계치', valueFormatter: () => null },
+        82,
+      );
+      expect(nullResult.label).toBe('임계치 axis:82');
+    });
+
+    it('valueFormatter 가 숫자를 반환하면 문자열로 변환해 사용한다(폴백 아님)', () => {
+      const scale = setupScale();
+      const opts = scale.getNormalizedLabelOptions(
+        { chartWidth: 400, width: 500 },
+        { show: true, showValue: true, text: '임계치', valueFormatter: (value) => value * 2 },
+        82,
+      );
+      expect(opts.label).toBe('임계치 164');
+    });
   });
 });

--- a/src/components/chart/scale/scale.spec.js
+++ b/src/components/chart/scale/scale.spec.js
@@ -104,4 +104,58 @@ describe('Scale', () => {
       });
     });
   });
+
+  describe('getNormalizedLabelOptions - 값 포맷', () => {
+    const setupScale = () => {
+      const scale = createScale();
+      scale.type = 'y';
+      scale.ctx = {
+        save() {},
+        restore() {},
+        measureText: (text) => ({ width: text.length * 6 }),
+        font: '',
+      };
+      // 축 기본 formatter (valueFormatter 미지정 시 사용)
+      scale.getLabelFormat = (value) => `axis:${value}`;
+      return scale;
+    };
+
+    it('valueFormatter 가 없으면 축 formatter(getLabelFormat)로 값을 합성한다', () => {
+      const scale = setupScale();
+      const opts = scale.getNormalizedLabelOptions(
+        { chartWidth: 400, width: 500 },
+        { show: true, showValue: true, text: '임계치' },
+        82,
+      );
+      expect(opts.label).toBe('임계치 axis:82');
+    });
+
+    it('valueFormatter 가 있으면 축 formatter 대신 그 결과로 값을 합성한다', () => {
+      const scale = setupScale();
+      const opts = scale.getNormalizedLabelOptions(
+        { chartWidth: 400, width: 500 },
+        { show: true, showValue: true, text: '임계치', valueFormatter: (value) => `${value}%` },
+        81.9999,
+      );
+      // 축 formatter(반올림) 대신 원본 값 그대로
+      expect(opts.label).toBe('임계치 81.9999%');
+    });
+
+    it('value-only 상태에서도 valueFormatter 결과(값)만 표시한다', () => {
+      const scale = setupScale();
+      const opts = scale.getNormalizedLabelOptions(
+        { chartWidth: 300, width: 500 }, // valueOnlyBelow(320) 미만 → value-only
+        {
+          show: true,
+          showValue: true,
+          text: '임계치',
+          valueFormatter: (value) => `${value}%`,
+          responsive: { valueOnlyBelow: 320, hideBelow: 205 },
+        },
+        81.9999,
+      );
+      expect(opts.valueOnly).toBe(true);
+      expect(opts.label).toBe('81.9999%');
+    });
+  });
 });


### PR DESCRIPTION
## 배경

plotLine/plotBand 라벨의 값(`showValue: true`)은 항상 **축 formatter**로 포맷된다. 그래서 축 Decimal 옵션(소수점 자리수)이 라벨 값에도 그대로 적용되어, 축과 다른 정밀도로 값을 표시할 수 없다.

소비 측 요구사항: **축은 소수점 2자리**를 유지하되 **임계선 라벨은 반올림 없이 원본 값**을 표시. 기존 구조로는 라벨만 축과 다르게 포맷할 방법이 없었다.

## 변경

- 라벨 옵션에 `valueFormatter?: (value) => string` 추가.
  - `showValue: true`일 때 값 포맷을 이 함수로 override.
  - 미지정(`null`)이면 기존처럼 축 formatter 사용 → **완전 하위호환**.
- `value-only` / `hover 이름 표시` / `hideBelow` 등 반응형 동작은 `showValue` 경로를 그대로 타므로 **모두 유지**된다.
- plotBand는 `showValue` 시 from/to 양 끝 라벨 각각에 `valueFormatter`가 적용된다.

### 변경 파일

| 파일 | 내용 |
|---|---|
| `src/components/chart/helpers/helpers.constant.js` | `PLOT_LINE_LABEL_OPTION`에 `valueFormatter: null` 기본값 |
| `src/components/chart/scale/scale.js` | `getNormalizedLabelOptions`에서 함수면 `valueFormatter`, 아니면 `getLabelFormat` 사용 |
| `src/components/chart/scale/scale.spec.js` | 테스트 3개 추가(폴백 / override / value-only 상태 적용) |
| `docs/specs/plotline-plotband-label-spec.md`, `docs/views/lineChart/api/lineChart.md` | 옵션 문서화 |

## 테스트

- `scale` 스펙 171개 통과, eslint clean.
- 기본값 `null`이라 기존 차트 라벨 동작은 변화 없음(하위호환).

## 사용 예

```js
plotLines: [{
  value: 81.9999,
  label: {
    show: true,
    showValue: true,
    text: '임계치',
    valueFormatter: (v) => `${v}%`, // 축 Decimal 과 무관하게 원본 값 표시
  },
}]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
