### PR TITLE
fix(docs): 플레이그라운드 Apply 시 함수 옵션이 터지는 문제 수정

### DIFF
--- a/docs/components/ChartPlaygroundEditor.vue
+++ b/docs/components/ChartPlaygroundEditor.vue
@@ -32,7 +32,197 @@ const isPlainObject = (v) => (
   v !== null && typeof v === 'object' && !Array.isArray(v)
 );
 
-const toJSLiteral = (value, indent = 0) => {
+/** 들여쓰기 차이를 무시하고 함수 본문을 비교하기 위한 키 */
+const normalizeFnSource = (src) => src.replace(/\s+/g, ' ').trim();
+
+/* ------------------------------------------------------------------ *
+ * 예제 원문에서 함수 소스 추출
+ *
+ * Function.prototype.toString 은 번들러가 남긴 코드를 그대로 돌려준다.
+ * 프로덕션 빌드는 모듈 스코프 식별자를 압축하므로(dayjs → ie 등) 그대로
+ * 보여주면 읽을 수도 고칠 수도 없다. 예제 .vue 원문(?raw)에서 같은 자리의
+ * 함수 소스를 찾아 에디터에 보여준다.
+ * ------------------------------------------------------------------ */
+
+const OPENERS = '([{';
+const CLOSERS = ')]}';
+
+const isTokenStart = (src, i) => {
+  const c = src[i];
+  return c === '"' || c === "'" || c === '`'
+    || (c === '/' && (src[i + 1] === '/' || src[i + 1] === '*'));
+};
+
+/** src[i] 에서 시작하는 문자열/템플릿/주석을 건너뛴 다음 인덱스 */
+const skipToken = (src, i) => {
+  const c = src[i];
+  if (c === '/' && src[i + 1] === '/') {
+    const end = src.indexOf('\n', i);
+    return end < 0 ? src.length : end;
+  }
+  if (c === '/' && src[i + 1] === '*') {
+    const end = src.indexOf('*/', i + 2);
+    return end < 0 ? src.length : end + 2;
+  }
+  let j = i + 1;
+  while (j < src.length) {
+    if (src[j] === '\\') {
+      j += 2;
+    } else if (src[j] === c) {
+      return j + 1;
+    } else if (c === '`' && src[j] === '$' && src[j + 1] === '{') {
+      // eslint-disable-next-line no-use-before-define
+      j = scanBalanced(src, j + 1);
+    } else {
+      j += 1;
+    }
+  }
+  return src.length;
+};
+
+/** src[start] 의 여는 괄호와 짝이 맞는 닫는 괄호 바로 다음 인덱스 */
+const scanBalanced = (src, start) => {
+  let depth = 0;
+  let j = start;
+  while (j < src.length) {
+    if (isTokenStart(src, j)) {
+      j = skipToken(src, j);
+    } else if (OPENERS.includes(src[j])) {
+      depth += 1;
+      j += 1;
+    } else if (CLOSERS.includes(src[j])) {
+      depth -= 1;
+      j += 1;
+      if (depth === 0) return j;
+    } else {
+      j += 1;
+    }
+  }
+  return src.length;
+};
+
+/** 값 하나가 끝나는 위치 — 깊이 0 에서 만나는 `,` 또는 닫는 괄호 */
+const readValueEnd = (src, i) => {
+  let depth = 0;
+  let j = i;
+  while (j < src.length) {
+    if (isTokenStart(src, j)) {
+      j = skipToken(src, j);
+    } else if (OPENERS.includes(src[j])) {
+      depth += 1;
+      j += 1;
+    } else if (CLOSERS.includes(src[j])) {
+      if (depth === 0) return j;
+      depth -= 1;
+      j += 1;
+    } else if (src[j] === ',' && depth === 0) {
+      return j;
+    } else {
+      j += 1;
+    }
+  }
+  return src.length;
+};
+
+const FN_HEAD = /^(async\s+)?(function\b|\(|[A-Za-z_$][\w$]*\s*=>)/;
+
+/** 값 위치 i 가 함수 리터럴이면 그 소스 텍스트, 아니면 null */
+const readFunctionAt = (src, i) => {
+  const text = src.slice(i, readValueEnd(src, i)).trim();
+  if (!FN_HEAD.test(text)) return null;
+  // `(a + b)` 처럼 괄호로 시작할 뿐인 표현식은 제외
+  if (!text.includes('=>') && !/^(async\s+)?function\b/.test(text)) return null;
+  try {
+    // 실행하지 않고 구문만 검증한다 — 생성자 호출 시점에 컴파일된다
+    // eslint-disable-next-line no-new, no-new-func
+    new Function(`return (\n${text}\n)`);
+  } catch {
+    return null;
+  }
+  return text;
+};
+
+const KEY_RE = /([A-Za-z_$][\w$]*)\s*:\s*/y;
+
+/** 블록 안의 함수형 프로퍼티를 키 이름별로 등장 순서대로 모은다 */
+const collectRawFunctions = (block) => {
+  const found = new Map();
+  let j = 0;
+  while (j < block.length) {
+    if (isTokenStart(block, j)) {
+      j = skipToken(block, j);
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    KEY_RE.lastIndex = j;
+    const matched = KEY_RE.exec(block);
+    // 식별자 중간이나 `.` 뒤에서 잘못 걸리지 않게 앞 글자를 확인한다
+    const atKeyStart = matched && (j === 0 || !/[\w$.]/.test(block[j - 1]));
+    const fnSrc = atKeyStart
+      ? readFunctionAt(block, j + matched[0].length)
+      : null;
+    if (fnSrc) {
+      const list = found.get(matched[1]) ?? [];
+      list.push(fnSrc);
+      found.set(matched[1], list);
+      j += matched[0].length + fnSrc.length;
+    } else {
+      j += 1;
+    }
+  }
+  return found;
+};
+
+/** 원문에서 `<varName> = ref(...)` 의 인자 블록을 잘라낸다 */
+const extractRefBlock = (script, varName) => {
+  const matched = new RegExp(`\\b${varName}\\s*=\\s*ref\\s*\\(`).exec(script);
+  if (!matched) return null;
+  const open = matched.index + matched[0].length - 1;
+  return script.slice(open + 1, scanBalanced(script, open) - 1);
+};
+
+/** 실제 객체에 들어 있는 함수 개수를 키 이름별로 센다 */
+const countFunctionKeys = (node, counts = new Map()) => {
+  if (!node || typeof node !== 'object' || node.$isDayjsObject) return counts;
+  const isArray = Array.isArray(node);
+  const keys = isArray ? node.map((_, i) => i) : Object.keys(node);
+  keys.forEach((key) => {
+    const child = node[key];
+    if (typeof child === 'function') {
+      if (!isArray) counts.set(key, (counts.get(key) ?? 0) + 1);
+    } else {
+      countFunctionKeys(child, counts);
+    }
+  });
+  return counts;
+};
+
+/**
+ * 키 이름 → 원문 함수 소스 배열. 원문과 실제 객체의 함수 개수가 정확히
+ * 일치하는 키만 쓴다 — 어긋난 채로 순서만 맞추면 엉뚱한 소스가 붙는다.
+ */
+const buildRawFnMap = (rawScript, sourceVar, model) => {
+  if (!rawScript || !/^[A-Za-z_$][\w$]*$/.test(sourceVar)) return null;
+  const block = extractRefBlock(rawScript, sourceVar);
+  if (!block) return null;
+  const live = countFunctionKeys(model);
+  const usable = new Map();
+  collectRawFunctions(block).forEach((list, key) => {
+    if (live.get(key) === list.length) usable.set(key, list);
+  });
+  return usable.size ? usable : null;
+};
+
+/** 해당 키의 다음 원문 함수 소스를 하나 꺼낸다 */
+const takeRawFnSource = (ctx, key) => {
+  const list = key ? ctx?.rawFns?.get(key) : null;
+  if (!list) return null;
+  const used = ctx.counters.get(key) ?? 0;
+  ctx.counters.set(key, used + 1);
+  return list[used] ?? null;
+};
+
+const toJSLiteral = (value, indent = 0, ctx = null, key = null) => {
   const pad = ' '.repeat(indent);
   const inner = ' '.repeat(indent + 2);
 
@@ -45,7 +235,12 @@ const toJSLiteral = (value, indent = 0) => {
   if (typeof value === 'string') return JSON.stringify(value);
 
   if (typeof value === 'function') {
-    const src = value.toString();
+    const raw = takeRawFnSource(ctx, key);
+    const src = raw ?? value.toString();
+    // 압축본과 원문 양쪽을 등록해 둔다 — 어느 쪽이 에디터에 실렸든
+    // 사용자가 손대지 않았다면 원본 참조로 되돌릴 수 있어야 한다.
+    ctx?.fnRegistry?.set(normalizeFnSource(value.toString()), value);
+    if (raw) ctx?.fnRegistry?.set(normalizeFnSource(raw), value);
     const lines = src.split('\n');
     if (lines.length <= 1) return src;
     const rest = lines.slice(1);
@@ -66,7 +261,7 @@ const toJSLiteral = (value, indent = 0) => {
   if (Array.isArray(value)) {
     if (!value.length) return '[]';
     const items = value.map(
-      (v) => `${inner}${toJSLiteral(v, indent + 2)}`,
+      (v) => `${inner}${toJSLiteral(v, indent + 2, ctx, key)}`,
     );
     return `[\n${items.join(',\n')},\n${pad}]`;
   }
@@ -75,10 +270,10 @@ const toJSLiteral = (value, indent = 0) => {
     const entries = Object.entries(value);
     if (!entries.length) return '{}';
     const rows = entries.map(([k, v]) => {
-      const key = /^[a-zA-Z_$]\w*$/.test(k)
+      const label = /^[a-zA-Z_$]\w*$/.test(k)
         ? k
         : JSON.stringify(k);
-      return `${inner}${key}: ${toJSLiteral(v, indent + 2)}`;
+      return `${inner}${label}: ${toJSLiteral(v, indent + 2, ctx, k)}`;
     });
     return `{\n${rows.join(',\n')},\n${pad}}`;
   }
@@ -86,10 +281,38 @@ const toJSLiteral = (value, indent = 0) => {
   return String(value);
 };
 
-const evaluate = (code) => {
+/**
+ * new Function 으로 재평가된 함수는 원본의 클로저를 잃는다. 프로덕션 번들은
+ * 모듈 스코프 식별자를 압축하므로(dayjs → ie 등) 재평가된 본문이 참조하는
+ * 자유 변수가 ReferenceError 를 낸다. 사용자가 손대지 않은 함수는 원본 참조로
+ * 되돌려 클로저를 보존한다 — 편집된 함수는 그대로 두어 evaluate 스코프
+ * (dayjs) 로 동작하게 한다.
+ */
+const restoreFunctions = (node, fnRegistry) => {
+  if (!node || typeof node !== 'object' || node.$isDayjsObject) return;
+  const keys = Array.isArray(node)
+    ? node.map((_, i) => i)
+    : Object.keys(node);
+  keys.forEach((key) => {
+    const child = node[key];
+    if (typeof child === 'function') {
+      const original = fnRegistry.get(normalizeFnSource(child.toString()));
+      if (original) node[key] = original;
+    } else {
+      restoreFunctions(child, fnRegistry);
+    }
+  });
+};
+
+const evaluate = (code, fnRegistry) => {
   // eslint-disable-next-line no-new-func
   const fn = new Function('dayjs', `return (\n${code}\n)`);
-  return fn(dayjs);
+  const result = fn(dayjs);
+  if (typeof result === 'function') {
+    return fnRegistry.get(normalizeFnSource(result.toString())) ?? result;
+  }
+  restoreFunctions(result, fnRegistry);
+  return result;
 };
 
 export default {
@@ -104,6 +327,16 @@ export default {
       type: Array,
       default: null,
     },
+    /** 예제 .vue 의 <script> 원문 — 함수 값을 원본 소스로 보여주는 데 쓴다 */
+    rawScript: {
+      type: String,
+      default: '',
+    },
+    /** 원문에서 찾을 변수 이름 (예: 'chartOptions') */
+    sourceVar: {
+      type: String,
+      default: '',
+    },
   },
   emits: ['apply'],
   setup(props, { emit }) {
@@ -111,10 +344,16 @@ export default {
     const error = ref('');
     let view = null;
     let initialJS = '';
+    /** 직렬화된 원본 함수: 정규화된 소스 → 원본 참조 */
+    const fnRegistry = new Map();
 
     onMounted(() => {
       if (!props.modelValue) return;
-      initialJS = toJSLiteral(props.modelValue);
+      initialJS = toJSLiteral(props.modelValue, 0, {
+        fnRegistry,
+        rawFns: buildRawFnMap(props.rawScript, props.sourceVar, props.modelValue),
+        counters: new Map(),
+      });
       view = new EditorView({
         state: EditorState.create({
           doc: initialJS,
@@ -161,7 +400,7 @@ export default {
       if (!view) return;
       error.value = '';
       try {
-        emit('apply', evaluate(view.state.doc.toString()));
+        emit('apply', evaluate(view.state.doc.toString(), fnRegistry));
       } catch (e) {
         error.value = `${e.message}`;
       }
@@ -178,7 +417,7 @@ export default {
         },
       });
       try {
-        emit('apply', evaluate(initialJS));
+        emit('apply', evaluate(initialJS, fnRegistry));
       } catch (e) {
         error.value = `${e.message}`;
       }

--- a/docs/components/Example.vue
+++ b/docs/components/Example.vue
@@ -42,6 +42,8 @@
           >
             <chart-playground-editor
               :model-value="snapshotData"
+              :raw-script="parsedData?.script?.content"
+              source-var="chartData"
               @apply="onApplyData"
             />
           </div>
@@ -54,6 +56,8 @@
           >
             <chart-playground-editor
               :model-value="snapshotOptions"
+              :raw-script="parsedData?.script?.content"
+              source-var="chartOptions"
               @apply="onApplyOptions"
             />
           </div>


### PR DESCRIPTION
## 문제

문서 사이트 플레이그라운드에서 **Apply 를 누르면** 콘솔에 에러가 나고 차트가 그려지지 않습니다.

```
Uncaught ReferenceError: ie is not defined
    at Fee.formatter (eval at Kk (index-*.js), <anonymous>:22:30)
```

`legend.show` 값과는 무관하고, `formatter` 가 import 를 참조하는 예제(`lineChart/Fill`, `barChart/Column`)에서 **Apply 를 누르는 모든 경우**에 발생합니다.

## 원인

플레이그라운드는 `chartData`/`chartOptions` 를 소스 문자열로 직렬화한 뒤 `new Function('dayjs', ...)` 으로 재평가하는데, **함수는 소스만 남고 클로저를 잃습니다**.

개발 서버에서는 식별자가 그대로라 `dayjs` 파라미터로 해결되지만, 프로덕션 번들은 모듈 스코프 식별자를 압축합니다. 빌드된 문서의 에디터에 실제로 찍히던 내용:

```js
formatter: i=>{const a=ie(i).format("MM/DD");return a==="10/25"?`${a} (Peak!)`:a},
```

`ie` 는 압축된 `dayjs` 입니다. 재평가된 함수의 스코프에는 `ie` 가 없으니, 차트가 축 라벨을 그리며 formatter 를 호출하는 순간 터집니다.

## 수정

두 가지를 함께 넣었습니다.

**1. 클로저 보존 (크래시 수정)**

직렬화할 때 원본 함수를 정규화된 소스로 등록해 두고, 재평가 후 **사용자가 손대지 않은 함수는 원본 참조로 되돌립니다**. 본문을 편집한 함수는 그대로 두어 기존처럼 `evaluate` 스코프(`dayjs`)로 동작합니다.

**2. 원본 소스 표시**

압축된 본문을 그대로 보여주면 읽을 수도 고칠 수도 없습니다. 예제 `.vue` 원문(`?raw` — Full Code 탭이 이미 쓰던 `parsedData`)에서 같은 자리의 함수 소스를 찾아 에디터에 싣습니다.

```js
formatter: (value) => {
  const day = dayjs(value).format('MM/DD');

  if (day === '10/25') {
    return `${day} (Peak!)`;
  }

  return day;
},
```

- 원문에서 `<var> = ref(...)` 인자 블록만 잘라낸 뒤, 그 안의 함수형 프로퍼티를 키 이름별·등장 순서대로 수집합니다. 문자열·템플릿 리터럴·주석을 건너뛰며 괄호 균형을 세므로 문자열 속 콜론이나 주석 처리된 `formatter:` 에 속지 않습니다.
- **원문과 실제 객체의 함수 개수가 정확히 일치하는 키만** 매핑합니다. 어긋나면 순서만 맞춰 엉뚱한 소스를 붙일 수 있으므로, 그런 키는 기존 동작(압축본)으로 떨어집니다.
- 레지스트리에 압축본과 원문 **양쪽**을 등록해, 에디터에 어느 쪽이 실렸든 미편집이면 원본 참조로 복원됩니다.

2번 덕분에 **함수 본문을 편집해도 정상 동작**합니다. 1번만으로는 사용자가 압축된 본문을 편집하면서 `ie` 를 남기면 같은 에러가 재발하고, 그 에러는 Apply 시점이 아니라 렌더 시점에 나기 때문에 에디터 에러 배너에도 잡히지 않습니다.

## 검증

프로덕션 빌드(`npm run build:docs`) 후 preview 로 확인했습니다.

- 수정 전 로직을 동일한 에디터 문서에 적용 → `ie is not defined` 재현
- **lineChart/Fill** — 원본 소스 표시, `legend.show: false` Apply 시 에러 0, 축 라벨 정상 렌더
- formatter 의 `'MM/DD'` → `'YYYY/DD'` 로 **편집** 후 Apply → x축이 `2026/03 … 2026/09` 로 변경 (편집본이 `dayjs` 스코프로 실행됨)
- **barChart/Column** — 표현식 본문 + 구조분해 파라미터(`({ y }) => \`${y}\``) 추출, Apply 후 호버 시 툴팁에 `250.123` (formatter 원값) 렌더
- **scatterChart/PlotLine, heatMap/Default, pieChart/Doughnut** — 양 탭 Apply 시 에러 0, 차트 정상 렌더
- 파싱 헬퍼 20개 케이스 통과 (SFC 파일에서 코드를 직접 잘라와 실행): 블록 분리, 주석/문자열 오탐, `function` 키워드형, 개수 불일치 시 비활성, 미편집 → 원본 참조 복원, 편집 → 재평가본, 원문 없을 때 fallback, dayjs 인스턴스 보존
- `eslint --no-ignore` 통과 (`Example.vue` 의 기존 에러 2건은 이번 변경 전부터 있던 것)

## 남는 제약

원문 매핑이 실패하는 경우(예제가 `ref({...})` 리터럴이 아닌 형태로 옵션을 만들거나 함수 개수가 어긋나는 경우) 조용히 압축본 표시로 되돌아갑니다. 크래시는 나지 않지만 읽기 어려운 코드가 다시 보일 수 있습니다. 현재 플레이그라운드를 쓰는 5개 예제는 모두 매핑에 성공합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
