### PR TITLE
[#2334]fix(chart): time 축 day 틱을 DST 관측 타임존에서 자정에 정렬

### DIFF
--- a/docs/views/lineChart/example/DstDayTick.vue
+++ b/docs/views/lineChart/example/DstDayTick.vue
@@ -1,0 +1,165 @@
+<template>
+  <div class="case dst-cases">
+    <div v-for="scenario in scenarios" :key="scenario.key" class="dst-case">
+      <div class="dst-case__head">
+        <strong>{{ scenario.name }}</strong>
+        <span>결함: {{ scenario.note }}</span>
+      </div>
+      <resizable-wrapper height="180px">
+        <ev-chart :data="scenario.chartData" :options="scenario.chartOptions" />
+      </resizable-wrapper>
+    </div>
+  </div>
+
+  <div class="description">
+    <div class="section">
+      <h3 class="section-title">브라우저 타임존</h3>
+      <div class="section-body section-body--col">
+        <div class="section-item">
+          <label>timeZone</label>
+          <strong>{{ tzInfo.zone }}</strong>
+        </div>
+        <div class="section-item">
+          <label>UTC offset</label>
+          <span>1월 {{ tzInfo.january }} / 7월 {{ tzInfo.july }}</span>
+        </div>
+        <div class="section-item">
+          <label>DST 관측</label>
+          <strong>{{ tzInfo.observesDst ? 'YES' : 'NO' }}</strong>
+        </div>
+      </div>
+    </div>
+
+    <div class="section">
+      <h3 class="section-title">기대</h3>
+      <div class="section-body section-body--col">
+        <div class="section-item">
+          모든 차트의 x축 tick 은 전 구간 <strong>00:00</strong> 이어야 한다.
+        </div>
+        <div class="section-item">
+          DST 미관측 존(<code>Asia/Seoul</code>·<code>UTC</code>)에서는 재현되지 않는다.
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import dayjs from 'dayjs';
+
+/**
+ * time 축 day 틱의 DST 앵커 결함 재현용 임시 예시 (ex-em/EVUI#2334).
+ * timeFormat 에 시각을 넣어야 밀린 tick 이 보이므로 'MM-DD HH:mm' 을 쓴다.
+ * 전환일은 US/멕시코 북부 국경(3월 2주차 일요일 / 11월 1주차 일요일) 기준이다.
+ */
+const SCENARIOS = [
+  {
+    key: 'spring',
+    name: '봄 전환 포함 (03-05 ~ 03-12)',
+    from: '2026-03-05 00:00:00',
+    to: '2026-03-12 00:00:00',
+    interval: 'day',
+    note: '전환(03-08) 이후 tick 이 01:00 으로 밀린다.',
+  },
+  {
+    key: 'fall',
+    name: '가을 전환 포함 (10-29 ~ 11-05)',
+    from: '2026-10-29 00:00:00',
+    to: '2026-11-05 00:00:00',
+    interval: 'day',
+    note: '전환(11-01) 이전 tick 이 01:00 으로 밀린다.',
+  },
+  {
+    key: 'dstOnly',
+    name: 'DST 구간 전체 (06-01 ~ 06-09, 전환 미포함)',
+    from: '2026-06-01 00:00:00',
+    to: '2026-06-09 00:00:00',
+    interval: 'day',
+    note: '구간 안에 전환이 없어도 연초 앵커와 offset 이 달라 전 구간이 밀린다.',
+  },
+  {
+    key: 'month',
+    name: '31일 조회 (02-20 ~ 03-23, 봄 전환 포함)',
+    from: '2026-02-20 00:00:00',
+    to: '2026-03-23 00:00:00',
+    interval: 'day',
+    note: '실사용 형태. 전환일을 기점으로 00:00 → 01:00 으로 바뀐다.',
+  },
+  {
+    key: 'day8',
+    name: '8일 간격 ({ time: 8, unit: day })',
+    from: '2026-02-20 00:00:00',
+    to: '2026-03-23 00:00:00',
+    interval: { time: 8, unit: 'day' },
+    note: '다일 간격도 전환 이후 01:00 으로 밀린다.',
+  },
+];
+
+const buildChartData = ({ from, to }) => {
+  const end = dayjs(to);
+  const labels = [];
+  const values = [];
+  for (let cursor = dayjs(from); !cursor.isAfter(end); cursor = cursor.add(1, 'hour')) {
+    labels.push(cursor);
+    values.push(50 + Math.round(30 * Math.sin(labels.length / 12)));
+  }
+  return { series: { series1: { name: 'value' } }, labels, data: { series1: values } };
+};
+
+const buildChartOptions = ({ interval }) => ({
+  type: 'line',
+  width: '100%',
+  legend: { show: false },
+  axesX: [{ type: 'time', showGrid: true, timeFormat: 'MM-DD HH:mm', interval }],
+  axesY: [{ type: 'linear', showGrid: true, startToZero: true }],
+});
+
+const formatOffset = (minutes) => {
+  const sign = minutes < 0 ? '-' : '+';
+  const abs = Math.abs(minutes);
+  const hh = String(Math.floor(abs / 60)).padStart(2, '0');
+  const mm = String(abs % 60).padStart(2, '0');
+  return `${sign}${hh}:${mm}`;
+};
+
+export default {
+  setup() {
+    const scenarios = SCENARIOS.map((scenario) => ({
+      ...scenario,
+      chartData: buildChartData(scenario),
+      chartOptions: buildChartOptions(scenario),
+    }));
+
+    const januaryOffset = -new Date(2026, 0, 1).getTimezoneOffset();
+    const julyOffset = -new Date(2026, 6, 1).getTimezoneOffset();
+    const tzInfo = {
+      zone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      january: formatOffset(januaryOffset),
+      july: formatOffset(julyOffset),
+      observesDst: januaryOffset !== julyOffset,
+    };
+
+    return { scenarios, tzInfo };
+  },
+};
+</script>
+
+<style lang="scss">
+.dst-cases {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dst-case__head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0 0 4px;
+  font-size: 12px;
+
+  span {
+    opacity: 0.7;
+  }
+}
+</style>

--- a/docs/views/lineChart/props.js
+++ b/docs/views/lineChart/props.js
@@ -36,6 +36,8 @@ import ExternalLegend from './example/ExternalLegend';
 import ExternalLegendRaw from './example/ExternalLegend?raw';
 import Segments from './example/Segments';
 import SegmentsRaw from './example/Segments?raw';
+import DstDayTick from './example/DstDayTick';
+import DstDayTickRaw from './example/DstDayTick?raw';
 import Interpolation from './example/Interpolation';
 import InterpolationRaw from './example/Interpolation?raw';
 import LegendClickMode from './example/LegendClickMode';
@@ -140,6 +142,13 @@ export default {
         'passingValue를 설정하여 특정 시점에 line을 끊지 않고 자연스럽게 이을 수 있습니다.',
       component: PassingValue,
       parsedData: parse(PassingValueRaw).descriptor,
+      devOnly: true,
+    },
+    DstDayTick: {
+      description:
+        '[임시 · ex-em/EVUI#2334] time 축 day 틱의 DST 앵커 결함 재현용. 브라우저 타임존이 DST 관측 존일 때 tick 이 자정에서 벗어난다.',
+      component: DstDayTick,
+      parsedData: parse(DstDayTickRaw).descriptor,
       devOnly: true,
     },
     Interpolation: {

--- a/src/components/chart/scale/SPEC.md
+++ b/src/components/chart/scale/SPEC.md
@@ -114,7 +114,8 @@ axis 옵션의 `type`(`linear`/`time`/`log`/`step`)과 `categoryMode` 로 구현
   `{ steps: ticks.length−1, interval, baseInterval, graphMin, graphMax, ticks }`.
 - **boundary anchor 규칙** (`ceilToBoundary`): sub-day(ms/s/m/h) → 해당일
   `startOf('day')`, day → 연초 기준 캘린더 일수(`startOf('year').add(n, 'day')`),
-  week → 연초 기준 월요일, month/quarter → 달력 기반 연초, year → epoch 2000년.
+  week → 연초 기준 월요일에서 캘린더 주수, month/quarter → 달력 기반 연초,
+  year → epoch 2000년.
   number interval → `Math.ceil(ts/ms)*ms` (epoch 0 기준). `time > 1` 도 정확한 배수
   boundary 에 맞춘다(예: 10분 → :00/:10/:20…).
 - **maxSteps 확장** (`expandIntervalMeta`): `fixedSteps` 면 확장하지 않는다.
@@ -186,19 +187,18 @@ axis 옵션의 `type`(`linear`/`time`/`log`/`step`)과 `categoryMode` 로 구현
   수용된 예외로 명시): DST 전환일(23h/25h)의 **sub-day** 격자와 연말(day 이상 단위의 다일
   확장 시 anchor 교체) 경계에서 라벨이 일회성으로 점프할 수 있다. KST 는 DST 미시행이라
   영향 없음.
-- TimeScale 의 day 단위 tick 은 DST 관측 타임존에서도 자정에 정렬된다. 정렬(연초 기준
-  캘린더 일수)과 가산(`add(t, 'day').startOf('day')`) 모두 달력 연산이다. wall-clock 자정을
-  유지하는 대가로 DST 전환일의 실제 tick 간격은 23h/25h 가 되어 `ms` 로 보고되는 `interval`
-  과 불일치한다. 검증: `scale.time.dst.spec.js`.
-- 위 불변의 예외: 그 존에 자정이 존재하지 않는 전환일(00:00 → 01:00 로 점프)은 그날 tick 만
-  `01:00` 이고 다음 tick 부터 자정으로 복귀한다. 2026 기준 해당 존은 `America/Santiago`(9/6)·
-  `America/Havana`(3/8)·`Asia/Beirut`(3/29)·`Africa/Cairo`(4/24)·`Atlantic/Azores`(3/29) 다.
+- TimeScale 의 day·week 단위 tick 은 DST 관측 타임존에서도 자정에 정렬된다. 정렬(연초 기준
+  캘린더 일수/주수)과 가산(`add(n, 'day').startOf('day')`) 모두 달력 연산이다. wall-clock
+  자정을 유지하는 대가로 DST 전환일이 낀 tick 간격은 23h/25h 만큼 어긋나 `ms` 로 보고되는
+  `interval` 과 불일치한다. 검증: `scale.time.dst.spec.js`.
+- 위 불변의 예외: 그 존에 자정이 존재하지 않는 전환일(00:00 → 01:00 로 점프)이 tick 에
+  걸리면 그 tick 만 `01:00` 이고 다음 tick 부터 자정으로 복귀한다. 2026 기준 해당 존은
+  `America/Santiago`(9/6)·`America/Havana`(3/8)·`Asia/Beirut`(3/29)·`Africa/Cairo`(4/24)·
+  `Atlantic/Azores`(3/29) 다.
 - day 단위의 maxSteps 확장 판정(`expandIntervalMeta` 의 `floor(span / ms) + 1`)은 ms 산술이라
   봄 전환을 포함한 구간에서 tick 수를 1 적게 본다. 확장 없이 통과한 뒤 실제 tick 이
   maxSteps + 1 개가 될 수 있다(수용된 한계 — `steps` 는 maxSteps 와 같아 소비자 off-by-one 은
   없고 x축 라벨 밀도만 영향).
-- TimeScale 의 week 단위 tick 정렬은 아직 고정 ms 산술이라 DST 관측 타임존에서 자정을
-  벗어난다(day 와 동일 원인, 미해결 — ex-em/EVUI#2336).
 - TimeCategoryScale 은 labels 가 오름차순(시간순) 정렬돼 있다고 가정한다. 소비자는
   `maxIndex ≥ minIndex` 를 확인한 뒤에만 minIndex 를 시작 인덱스로 사용해야 한다
   (sentinel `{0, -1}` = 빈 윈도우).

--- a/src/components/chart/scale/SPEC.md
+++ b/src/components/chart/scale/SPEC.md
@@ -187,11 +187,18 @@ axis 옵션의 `type`(`linear`/`time`/`log`/`step`)과 `categoryMode` 로 구현
   확장 시 anchor 교체) 경계에서 라벨이 일회성으로 점프할 수 있다. KST 는 DST 미시행이라
   영향 없음.
 - TimeScale 의 day 단위 tick 은 DST 관측 타임존에서도 자정에 정렬된다. 정렬(연초 기준
-  캘린더 일수)과 가산(`add(t, 'day')`) 모두 달력 연산이므로, wall-clock 자정을 유지하는
-  대가로 DST 전환일의 실제 tick 간격만 23h/25h 가 된다(`ms` 로 보고되는 `interval` 과
-  불일치). 검증: `scale.time.dst.spec.js`.
+  캘린더 일수)과 가산(`add(t, 'day').startOf('day')`) 모두 달력 연산이다. wall-clock 자정을
+  유지하는 대가로 DST 전환일의 실제 tick 간격은 23h/25h 가 되어 `ms` 로 보고되는 `interval`
+  과 불일치한다. 검증: `scale.time.dst.spec.js`.
+- 위 불변의 예외: 그 존에 자정이 존재하지 않는 전환일(00:00 → 01:00 로 점프)은 그날 tick 만
+  `01:00` 이고 다음 tick 부터 자정으로 복귀한다. 2026 기준 해당 존은 `America/Santiago`(9/6)·
+  `America/Havana`(3/8)·`Asia/Beirut`(3/29)·`Africa/Cairo`(4/24)·`Atlantic/Azores`(3/29) 다.
+- day 단위의 maxSteps 확장 판정(`expandIntervalMeta` 의 `floor(span / ms) + 1`)은 ms 산술이라
+  봄 전환을 포함한 구간에서 tick 수를 1 적게 본다. 확장 없이 통과한 뒤 실제 tick 이
+  maxSteps + 1 개가 될 수 있다(수용된 한계 — `steps` 는 maxSteps 와 같아 소비자 off-by-one 은
+  없고 x축 라벨 밀도만 영향).
 - TimeScale 의 week 단위 tick 정렬은 아직 고정 ms 산술이라 DST 관측 타임존에서 자정을
-  벗어날 수 있다(day 와 동일 원인, 미해결).
+  벗어난다(day 와 동일 원인, 미해결 — ex-em/EVUI#2336).
 - TimeCategoryScale 은 labels 가 오름차순(시간순) 정렬돼 있다고 가정한다. 소비자는
   `maxIndex ≥ minIndex` 를 확인한 뒤에만 minIndex 를 시작 인덱스로 사용해야 한다
   (sentinel `{0, -1}` = 빈 윈도우).

--- a/src/components/chart/scale/SPEC.md
+++ b/src/components/chart/scale/SPEC.md
@@ -113,9 +113,10 @@ axis 옵션의 `type`(`linear`/`time`/`log`/`step`)과 `categoryMode` 로 구현
   만든다(상한 MAX_TICKS 10000). min/max 가 null 이거나 min ≥ max 면 빈 ticks. 반환:
   `{ steps: ticks.length−1, interval, baseInterval, graphMin, graphMax, ticks }`.
 - **boundary anchor 규칙** (`ceilToBoundary`): sub-day(ms/s/m/h) → 해당일
-  `startOf('day')`, day → `startOf('year')`, week → 연초 기준 월요일, month/quarter →
-  달력 기반 연초, year → epoch 2000년. number interval → `Math.ceil(ts/ms)*ms`
-  (epoch 0 기준). `time > 1` 도 정확한 배수 boundary 에 맞춘다(예: 10분 → :00/:10/:20…).
+  `startOf('day')`, day → 연초 기준 캘린더 일수(`startOf('year').add(n, 'day')`),
+  week → 연초 기준 월요일, month/quarter → 달력 기반 연초, year → epoch 2000년.
+  number interval → `Math.ceil(ts/ms)*ms` (epoch 0 기준). `time > 1` 도 정확한 배수
+  boundary 에 맞춘다(예: 10분 → :00/:10/:20…).
 - **maxSteps 확장** (`expandIntervalMeta`): `fixedSteps` 면 확장하지 않는다.
   sub-day 단위이고 base interval 이 하루(86,400,000ms)를 나누어떨어지면 확장 후보를
   "하루의 약수가 되는 base 의 배수"로 제한해(divisor 캐시 사용) 자정 경계에서 격자가
@@ -182,8 +183,15 @@ axis 옵션의 `type`(`linear`/`time`/`log`/`step`)과 `categoryMode` 로 구현
 - TimeScale 은 tick 만 boundary 로 정렬할 뿐 graphMin/graphMax 를 절대 변경하지 않는다
   (실시간 슬라이딩 윈도우에서 plot 영역이 흔들리지 않게 하는 전제).
 - TimeScale 의 sub-day interval 확장은 "하루의 약수"로 제한된다. 알려진 한계(코드 주석에
-  수용된 예외로 명시): DST 전환일(23h/25h)과 연말(day 이상 단위의 다일 확장 시 anchor 교체)
-  경계에서 라벨이 일회성으로 점프할 수 있다. KST 는 DST 미시행이라 영향 없음.
+  수용된 예외로 명시): DST 전환일(23h/25h)의 **sub-day** 격자와 연말(day 이상 단위의 다일
+  확장 시 anchor 교체) 경계에서 라벨이 일회성으로 점프할 수 있다. KST 는 DST 미시행이라
+  영향 없음.
+- TimeScale 의 day 단위 tick 은 DST 관측 타임존에서도 자정에 정렬된다. 정렬(연초 기준
+  캘린더 일수)과 가산(`add(t, 'day')`) 모두 달력 연산이므로, wall-clock 자정을 유지하는
+  대가로 DST 전환일의 실제 tick 간격만 23h/25h 가 된다(`ms` 로 보고되는 `interval` 과
+  불일치). 검증: `scale.time.dst.spec.js`.
+- TimeScale 의 week 단위 tick 정렬은 아직 고정 ms 산술이라 DST 관측 타임존에서 자정을
+  벗어날 수 있다(day 와 동일 원인, 미해결).
 - TimeCategoryScale 은 labels 가 오름차순(시간순) 정렬돼 있다고 가정한다. 소비자는
   `maxIndex ≥ minIndex` 를 확인한 뒤에만 minIndex 를 시작 인덱스로 사용해야 한다
   (sentinel `{0, -1}` = 빈 윈도우).

--- a/src/components/chart/scale/scale.time.dst.spec.js
+++ b/src/components/chart/scale/scale.time.dst.spec.js
@@ -26,6 +26,8 @@ const createScale = (overrides = {}) => {
 const ts = (str) => dayjs(str).valueOf();
 const times = (ticks) => ticks.map((tick) => dayjs(tick).format('HH:mm'));
 const dates = (ticks) => ticks.map((tick) => dayjs(tick).format('YYYY-MM-DD'));
+const stamps = (ticks) => ticks.map((tick) => dayjs(tick).format('MM-DD HH:mm'));
+const isAscending = (ticks) => ticks.every((tick, i) => i === 0 || tick > ticks[i - 1]);
 
 const useTZ = (tz) => {
   beforeAll(() => {
@@ -117,8 +119,83 @@ describe('TimeScale day tick — DST 관측 타임존', () => {
     });
   });
 
+  describe('America/Santiago — 자정이 없는 전환일', () => {
+    useTZ('America/Santiago');
+
+    it('TZ 주입이 실제로 적용됐다', () => {
+      expect(new Date(2026, 0, 1).getTimezoneOffset()).toBe(180); // -03 (DST)
+      expect(new Date(2026, 6, 1).getTimezoneOffset()).toBe(240); // -04 (표준시)
+    });
+
+    it('전환일(2026-09-06)만 01:00 이고 다음 날부터 자정으로 복귀한다', () => {
+      const scale = createScale({ interval: 'day' });
+
+      const result = scale.calculateSteps({
+        minValue: ts('2026-09-04 00:00:00'),
+        maxValue: ts('2026-09-08 00:00:00'),
+        maxSteps: 10,
+      });
+
+      // 09-06 은 그 존에 자정이 존재하지 않아 01:00 이 불가피하다.
+      expect(stamps(result.ticks)).toEqual([
+        '09-04 00:00',
+        '09-05 00:00',
+        '09-06 01:00',
+        '09-07 00:00',
+        '09-08 00:00',
+      ]);
+    });
+
+    it('전환일을 지나도 tick 이 단조 증가한다', () => {
+      const scale = createScale({ interval: 'day' });
+
+      // 증가하지 않으면 generateVisibleTicks 가 MAX_TICKS 까지 도는 것으로만 드러난다.
+      const result = scale.calculateSteps({
+        minValue: ts('2026-09-01 00:00:00'),
+        maxValue: ts('2026-09-30 00:00:00'),
+        maxSteps: 40,
+      });
+
+      expect(isAscending(result.ticks)).toBe(true);
+      expect(result.ticks.length).toBe(30);
+    });
+  });
+
+  describe('America/Havana — 자정이 두 번 오는 전환일', () => {
+    useTZ('America/Havana');
+
+    it('TZ 주입이 실제로 적용됐다', () => {
+      expect(new Date(2026, 0, 1).getTimezoneOffset()).toBe(300); // CST (UTC-5)
+      expect(new Date(2026, 6, 1).getTimezoneOffset()).toBe(240); // CDT (UTC-4)
+    });
+
+    it('중복 자정 구간에서도 tick 이 자정에 정렬되고 날짜가 중복되지 않는다', () => {
+      const scale = createScale({ interval: 'day' });
+
+      const result = scale.calculateSteps({
+        minValue: ts('2026-10-30 00:00:00'),
+        maxValue: ts('2026-11-03 00:00:00'),
+        maxSteps: 10,
+      });
+
+      expect(stamps(result.ticks)).toEqual([
+        '10-30 00:00',
+        '10-31 00:00',
+        '11-01 00:00',
+        '11-02 00:00',
+        '11-03 00:00',
+      ]);
+    });
+  });
+
   describe('Australia/Sydney — 남반구(연초가 DST 구간)', () => {
     useTZ('Australia/Sydney');
+
+    it('TZ 주입이 실제로 적용됐다', () => {
+      // 이 블록의 단정은 DST 미관측 호스트에서도 만족되므로 주입 실패 시 위양성 통과한다.
+      expect(new Date(2026, 0, 1).getTimezoneOffset()).toBe(-660); // AEDT (UTC+11)
+      expect(new Date(2026, 6, 1).getTimezoneOffset()).toBe(-600); // AEST (UTC+10)
+    });
 
     it('표준시 구간 조회 시 tick 이 전날 23시로 밀리지 않는다', () => {
       const scale = createScale({ interval: 'day' });

--- a/src/components/chart/scale/scale.time.dst.spec.js
+++ b/src/components/chart/scale/scale.time.dst.spec.js
@@ -292,5 +292,23 @@ describe('TimeScale day/week tick — DST 관측 타임존', () => {
         expect(tick - result.ticks[i]).toBe(DAY);
       });
     });
+
+    it('week interval 출력도 월요일 자정으로 동일하게 유지된다', () => {
+      const scale = createScale({ interval: 'week' });
+
+      const result = scale.calculateSteps({
+        minValue: ts('2026-01-01 00:00:00'),
+        maxValue: ts('2026-04-01 00:00:00'),
+        maxSteps: 20,
+      });
+
+      expect(result.ticks.length).toBe(13);
+      expect(new Set(times(result.ticks))).toEqual(new Set(['00:00']));
+      expect(result.ticks.every((tick) => dayjs(tick).day() === 1)).toBe(true);
+      const WEEK = 7 * 24 * 60 * 60 * 1000;
+      result.ticks.slice(1).forEach((tick, i) => {
+        expect(tick - result.ticks[i]).toBe(WEEK);
+      });
+    });
   });
 });

--- a/src/components/chart/scale/scale.time.dst.spec.js
+++ b/src/components/chart/scale/scale.time.dst.spec.js
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import TimeScale from './scale.time';
 
 /**
- * DST 관측 타임존에서 day 단위 tick 이 자정에 정렬되는지 검증한다.
+ * DST 관측 타임존에서 day/week 단위 tick 이 자정에 정렬되는지 검증한다.
  * 프로세스 TZ 를 바꿔야만 재현되므로 다른 spec 과 파일을 분리했다.
  */
 
@@ -38,7 +38,7 @@ const useTZ = (tz) => {
   });
 };
 
-describe('TimeScale day tick — DST 관측 타임존', () => {
+describe('TimeScale day/week tick — DST 관측 타임존', () => {
   describe('America/Los_Angeles', () => {
     useTZ('America/Los_Angeles');
 
@@ -117,6 +117,35 @@ describe('TimeScale day tick — DST 관측 타임존', () => {
         expect(dayjs(tick).diff(dayjs(result.ticks[i]).add(8, 'day'))).toBe(0);
       });
     });
+
+    it('week interval: 봄 전환을 포함해도 월요일 자정에 정렬된다', () => {
+      const scale = createScale({ interval: 'week' });
+
+      const result = scale.calculateSteps({
+        minValue: ts('2026-02-20 00:00:00'),
+        maxValue: ts('2026-04-20 00:00:00'),
+        maxSteps: 40,
+      });
+
+      expect(new Set(times(result.ticks))).toEqual(new Set(['00:00']));
+      expect(new Set(result.ticks.map((tick) => dayjs(tick).day()))).toEqual(new Set([1]));
+      expect(dates(result.ticks)[0]).toBe('2026-02-23');
+    });
+
+    it('{ time: 2, unit: week }: 2주 간격도 월요일 자정에 정렬된다', () => {
+      const scale = createScale({ interval: { time: 2, unit: 'week' } });
+
+      const result = scale.calculateSteps({
+        minValue: ts('2026-02-20 00:00:00'),
+        maxValue: ts('2026-04-20 00:00:00'),
+        maxSteps: 10,
+      });
+
+      expect(new Set(times(result.ticks))).toEqual(new Set(['00:00']));
+      result.ticks.slice(1).forEach((tick, i) => {
+        expect(dayjs(tick).diff(dayjs(result.ticks[i]).add(14, 'day'))).toBe(0);
+      });
+    });
   });
 
   describe('America/Santiago — 자정이 없는 전환일', () => {
@@ -158,6 +187,25 @@ describe('TimeScale day tick — DST 관측 타임존', () => {
 
       expect(isAscending(result.ticks)).toBe(true);
       expect(result.ticks.length).toBe(30);
+    });
+
+    it('week interval: 전환일이 주 안에 있어도 월요일 자정에 정렬된다', () => {
+      const scale = createScale({ interval: 'week' });
+
+      const result = scale.calculateSteps({
+        minValue: ts('2026-08-24 00:00:00'),
+        maxValue: ts('2026-09-28 00:00:00'),
+        maxSteps: 40,
+      });
+
+      expect(stamps(result.ticks)).toEqual([
+        '08-24 00:00',
+        '08-31 00:00',
+        '09-07 00:00',
+        '09-14 00:00',
+        '09-21 00:00',
+        '09-28 00:00',
+      ]);
     });
   });
 
@@ -208,6 +256,20 @@ describe('TimeScale day tick — DST 관측 타임존', () => {
 
       expect(new Set(times(result.ticks))).toEqual(new Set(['00:00']));
       expect(dates(result.ticks)[0]).toBe('2026-06-01');
+    });
+
+    it('week interval: 표준시 구간에서도 tick 이 전날 23시로 밀리지 않는다', () => {
+      const scale = createScale({ interval: 'week' });
+
+      const result = scale.calculateSteps({
+        minValue: ts('2026-06-01 00:00:00'),
+        maxValue: ts('2026-07-06 00:00:00'),
+        maxSteps: 20,
+      });
+
+      expect(new Set(times(result.ticks))).toEqual(new Set(['00:00']));
+      expect(dates(result.ticks)[0]).toBe('2026-06-01');
+      expect(dates(result.ticks).at(-1)).toBe('2026-07-06');
     });
   });
 

--- a/src/components/chart/scale/scale.time.dst.spec.js
+++ b/src/components/chart/scale/scale.time.dst.spec.js
@@ -1,0 +1,157 @@
+import dayjs from 'dayjs';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import TimeScale from './scale.time';
+
+/**
+ * DST 관측 타임존에서 day 단위 tick 이 자정에 정렬되는지 검증한다.
+ * 프로세스 TZ 를 바꿔야만 재현되므로 다른 spec 과 파일을 분리했다.
+ */
+
+// Node 는 TZ 를 한 번 대입하면 delete 로 시스템 존으로 되돌아가지 않는다. 미설정 상태로
+// 복원할 방법이 없으므로 진입 시점의 존을 명시 문자열로 잡아 두고 그것으로 되돌린다.
+// (복원에 실패하면 같은 워커의 뒤 테스트 파일이 이 파일의 TZ 로 돌아간다)
+const ORIGINAL_TZ = process.env.TZ ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+const createScale = (overrides = {}) => {
+  const scale = Object.create(TimeScale.prototype);
+  scale.interval = null;
+  scale.range = null;
+  scale.fixedSteps = false;
+  scale.labelStyle = {};
+  scale.options = { type: 'line' };
+  Object.assign(scale, overrides);
+  return scale;
+};
+
+const ts = (str) => dayjs(str).valueOf();
+const times = (ticks) => ticks.map((tick) => dayjs(tick).format('HH:mm'));
+const dates = (ticks) => ticks.map((tick) => dayjs(tick).format('YYYY-MM-DD'));
+
+const useTZ = (tz) => {
+  beforeAll(() => {
+    process.env.TZ = tz;
+  });
+  afterAll(() => {
+    process.env.TZ = ORIGINAL_TZ;
+  });
+};
+
+describe('TimeScale day tick — DST 관측 타임존', () => {
+  describe('America/Los_Angeles', () => {
+    useTZ('America/Los_Angeles');
+
+    it('TZ 주입이 실제로 적용됐다', () => {
+      // 미적용 시 아래 DST 케이스가 전부 위양성 통과한다.
+      expect(new Date(2026, 6, 1).getTimezoneOffset()).toBe(420); // PDT (UTC-7)
+      expect(new Date(2026, 0, 1).getTimezoneOffset()).toBe(480); // PST (UTC-8)
+    });
+
+    it('봄 전환(2026-03-08)을 포함한 31일 조회: 모든 tick 이 자정이다', () => {
+      const scale = createScale({ interval: 'day' });
+
+      const result = scale.calculateSteps({
+        minValue: ts('2026-02-20 00:00:00'),
+        maxValue: ts('2026-03-23 00:00:00'),
+        maxSteps: 40,
+      });
+
+      expect(result.ticks.length).toBe(32);
+      expect(new Set(times(result.ticks))).toEqual(new Set(['00:00']));
+      expect(dates(result.ticks)[0]).toBe('2026-02-20');
+      expect(dates(result.ticks).at(-1)).toBe('2026-03-23');
+    });
+
+    it('봄 전환일의 tick 간격은 23시간이다 (wall-clock 자정 유지의 결과)', () => {
+      const scale = createScale({ interval: 'day' });
+
+      const result = scale.calculateSteps({
+        minValue: ts('2026-03-07 00:00:00'),
+        maxValue: ts('2026-03-10 00:00:00'),
+        maxSteps: 10,
+      });
+
+      const gaps = result.ticks.slice(1).map((tick, i) => tick - result.ticks[i]);
+      expect(gaps).toEqual([24, 23, 24].map((h) => h * 60 * 60 * 1000));
+    });
+
+    it('가을 전환일의 tick 간격은 25시간이다', () => {
+      const scale = createScale({ interval: 'day' });
+
+      const result = scale.calculateSteps({
+        minValue: ts('2026-10-31 00:00:00'),
+        maxValue: ts('2026-11-03 00:00:00'),
+        maxSteps: 10,
+      });
+
+      const gaps = result.ticks.slice(1).map((tick, i) => tick - result.ticks[i]);
+      expect(gaps).toEqual([24, 25, 24].map((h) => h * 60 * 60 * 1000));
+    });
+
+    it('가을 전환(2026-11-01)을 포함한 31일 조회: 날짜가 밀리지 않는다', () => {
+      const scale = createScale({ interval: 'day' });
+
+      const result = scale.calculateSteps({
+        minValue: ts('2026-10-20 00:00:00'),
+        maxValue: ts('2026-11-20 00:00:00'),
+        maxSteps: 40,
+      });
+
+      expect(new Set(times(result.ticks))).toEqual(new Set(['00:00']));
+      expect(dates(result.ticks)).toContain('2026-11-01');
+      expect(dates(result.ticks)).toContain('2026-11-02');
+    });
+
+    it('{ time: 8, unit: day }: 8일 간격도 자정에 정렬된다', () => {
+      const scale = createScale({ interval: { time: 8, unit: 'day' } });
+
+      const result = scale.calculateSteps({
+        minValue: ts('2026-02-20 00:00:00'),
+        maxValue: ts('2026-03-23 00:00:00'),
+        maxSteps: 10,
+      });
+
+      expect(new Set(times(result.ticks))).toEqual(new Set(['00:00']));
+      result.ticks.slice(1).forEach((tick, i) => {
+        expect(dayjs(tick).diff(dayjs(result.ticks[i]).add(8, 'day'))).toBe(0);
+      });
+    });
+  });
+
+  describe('Australia/Sydney — 남반구(연초가 DST 구간)', () => {
+    useTZ('Australia/Sydney');
+
+    it('표준시 구간 조회 시 tick 이 전날 23시로 밀리지 않는다', () => {
+      const scale = createScale({ interval: 'day' });
+
+      const result = scale.calculateSteps({
+        minValue: ts('2026-06-01 00:00:00'),
+        maxValue: ts('2026-06-16 00:00:00'),
+        maxSteps: 20,
+      });
+
+      expect(new Set(times(result.ticks))).toEqual(new Set(['00:00']));
+      expect(dates(result.ticks)[0]).toBe('2026-06-01');
+    });
+  });
+
+  describe('Asia/Seoul — DST 미관측 회귀', () => {
+    useTZ('Asia/Seoul');
+
+    it('출력이 자정 정렬로 동일하게 유지된다', () => {
+      const scale = createScale({ interval: 'day' });
+
+      const result = scale.calculateSteps({
+        minValue: ts('2026-03-01 00:00:00'),
+        maxValue: ts('2026-04-01 00:00:00'),
+        maxSteps: 40,
+      });
+
+      expect(result.ticks.length).toBe(32);
+      expect(new Set(times(result.ticks))).toEqual(new Set(['00:00']));
+      const DAY = 24 * 60 * 60 * 1000;
+      result.ticks.slice(1).forEach((tick, i) => {
+        expect(tick - result.ticks[i]).toBe(DAY);
+      });
+    });
+  });
+});

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -51,7 +51,7 @@ function getIntervalMeta(interval) {
 
 /**
  * dayjs 객체에 interval 한 단위를 더한다.
- * month/quarter/year는 dayjs를 사용하여 달력 기반으로 증가한다.
+ * day/week/month/quarter/year는 dayjs를 사용하여 달력 기반으로 증가한다.
  *
  * @param {dayjs.Dayjs} d dayjs 객체
  * @param {{ unit: string|null, time: number|null, ms: number }} meta interval 메타 정보
@@ -72,6 +72,8 @@ function addIntervalDayjs(d, meta) {
       return d.add(t, 'year');
     case 'week':
       return d.add(t * 7, 'day');
+    case 'day':
+      return d.add(t, 'day');
     default:
       return dayjs(d.valueOf() + meta.ms);
   }
@@ -126,12 +128,17 @@ function ceilToBoundary(timestamp, meta) {
     return anchor + Math.ceil(elapsed / intervalMs) * intervalMs;
   }
 
-  // --- day: start of year 기준 ms 연산 ---
+  // --- day: start of year 기준 캘린더 일수 연산 ---
   if (meta.unit === 'day') {
-    const anchor = d.startOf('year').valueOf();
-    const intervalMs = TIME_INTERVALS.day.size * time;
-    const elapsed = timestamp - anchor;
-    return anchor + Math.ceil(elapsed / intervalMs) * intervalMs;
+    const yearStart = d.startOf('year');
+    const dayStart = d.startOf('day');
+    // DST 로 자정 간 간격이 23h/25h 가 되어도 12h 를 넘게 벌어지지 않아 round 가 정확한 일수를 준다
+    const dayIndex = Math.round(
+      (dayStart.valueOf() - yearStart.valueOf()) / TIME_INTERVALS.day.size,
+    );
+    const offset = dayStart.valueOf() >= timestamp ? dayIndex : dayIndex + 1;
+    const aligned = Math.ceil(offset / time) * time;
+    return yearStart.add(aligned, 'day').valueOf();
   }
 
   // --- week: start of year 기준 Monday에서 ms 연산 ---

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -50,6 +50,22 @@ function getIntervalMeta(interval) {
 }
 
 /**
+ * dayjs 객체를 그날의 자정으로 되돌린다. 이미 자정이면 그대로 반환한다.
+ * 정렬된 tick 을 누적하는 경로에서는 대부분 이미 자정이라, 매번 재정규화하면
+ * tick 하나당 dayjs 객체를 하나 더 만든다.
+ *
+ * @param {dayjs.Dayjs} d dayjs 객체
+ * @returns {dayjs.Dayjs} 자정으로 정렬된 dayjs 객체
+ */
+function toStartOfDay(d) {
+  const isMidnight = d.hour() === 0
+    && d.minute() === 0
+    && d.second() === 0
+    && d.millisecond() === 0;
+  return isMidnight ? d : d.startOf('day');
+}
+
+/**
  * dayjs 객체에 interval 한 단위를 더한다.
  * day/week/month/quarter/year는 dayjs를 사용하여 달력 기반으로 증가한다.
  *
@@ -73,9 +89,9 @@ function addIntervalDayjs(d, meta) {
     // day/week: 자정이 없는 DST 전환일(00:00 → 01:00)을 지나면 wall-clock 이 01:00 으로
     // 고정되므로 매 가산마다 그날의 자정으로 되돌린다. 전환일 당일은 자정이 없어 01:00 이 유지된다.
     case 'week':
-      return d.add(t * 7, 'day').startOf('day');
+      return toStartOfDay(d.add(t * 7, 'day'));
     case 'day':
-      return d.add(t, 'day').startOf('day');
+      return toStartOfDay(d.add(t, 'day'));
     default:
       return dayjs(d.valueOf() + meta.ms);
   }

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -73,7 +73,9 @@ function addIntervalDayjs(d, meta) {
     case 'week':
       return d.add(t * 7, 'day');
     case 'day':
-      return d.add(t, 'day');
+      // 자정이 없는 DST 전환일(00:00 → 01:00)을 지나면 wall-clock 이 01:00 으로 고정되므로
+      // 매 가산마다 그날의 자정으로 되돌린다. 전환일 당일은 자정이 없어 01:00 이 유지된다.
+      return d.add(t, 'day').startOf('day');
     default:
       return dayjs(d.valueOf() + meta.ms);
   }

--- a/src/components/chart/scale/scale.time.js
+++ b/src/components/chart/scale/scale.time.js
@@ -70,11 +70,11 @@ function addIntervalDayjs(d, meta) {
       return d.add(t * 3, 'month');
     case 'year':
       return d.add(t, 'year');
+    // day/week: 자정이 없는 DST 전환일(00:00 → 01:00)을 지나면 wall-clock 이 01:00 으로
+    // 고정되므로 매 가산마다 그날의 자정으로 되돌린다. 전환일 당일은 자정이 없어 01:00 이 유지된다.
     case 'week':
-      return d.add(t * 7, 'day');
+      return d.add(t * 7, 'day').startOf('day');
     case 'day':
-      // 자정이 없는 DST 전환일(00:00 → 01:00)을 지나면 wall-clock 이 01:00 으로 고정되므로
-      // 매 가산마다 그날의 자정으로 되돌린다. 전환일 당일은 자정이 없어 01:00 이 유지된다.
       return d.add(t, 'day').startOf('day');
     default:
       return dayjs(d.valueOf() + meta.ms);
@@ -143,15 +143,18 @@ function ceilToBoundary(timestamp, meta) {
     return yearStart.add(aligned, 'day').valueOf();
   }
 
-  // --- week: start of year 기준 Monday에서 ms 연산 ---
+  // --- week: start of year 기준 Monday에서 캘린더 주수 연산 ---
   if (meta.unit === 'week') {
-    let anchor = d.startOf('year');
-    const dow = anchor.day();
-    anchor = anchor.subtract((dow + 6) % 7, 'day');
-    const anchorMs = anchor.valueOf();
-    const intervalMs = TIME_INTERVALS.week.size * time;
-    const elapsed = timestamp - anchorMs;
-    return anchorMs + Math.ceil(elapsed / intervalMs) * intervalMs;
+    const yearStart = d.startOf('year');
+    const anchor = yearStart.subtract((yearStart.day() + 6) % 7, 'day');
+    const weekStart = d.subtract((d.day() + 6) % 7, 'day').startOf('day');
+    // DST 로 주 경계 간 간격이 ±1h 흔들려도 반 주를 넘지 않아 round 가 정확한 주수를 준다
+    const weekIndex = Math.round(
+      (weekStart.valueOf() - anchor.valueOf()) / TIME_INTERVALS.week.size,
+    );
+    const offset = weekStart.valueOf() >= timestamp ? weekIndex : weekIndex + 1;
+    const aligned = Math.ceil(offset / time) * time;
+    return anchor.add(aligned * 7, 'day').valueOf();
   }
 
   // --- month: 달력 기반 ---


### PR DESCRIPTION
# 작업 배경

`interval` 이 day 단위인 time 축(또는 maxSteps 확장으로 day 로 승격된 축)에서, 브라우저(PC) 타임존이 DST 를 관측하면 tick 이 자정에서 벗어난다. tick 값 자체가 밀리므로 라벨·격자선·눈금이 함께 어긋난다.

원인은 하루를 고정 86,400,000ms 로 다룬 두 곳이다. `ceilToBoundary` 의 day 분기는 연초 자정을 앵커로 잡고 경과 ms 를 24h 로 나누는데, 그 사이에 DST 전환이 끼면 경과가 `일수 × 24h` 가 아니다. `addIntervalDayjs` 는 같은 `switch` 에서 week·month·quarter·year 를 달력 가산으로 처리하면서 day 만 `default`(ms 가산)로 떨어뜨려, 첫 tick 을 고쳐도 이후 tick 이 다시 밀렸다. (base: `3.4`, closes #2334)

# 변경 사항 요약(Key changes)

- **day 앵커 정렬을 캘린더 일수 연산으로 교체** — 연초 기준 일수를 구해 `startOf('year').add(n, 'day')` 로 boundary 를 만든다. 자정 간 간격이 23h/25h 로 흔들려도 12h 를 넘지 않아 일수 산출이 정확하다.
- **day 가산을 달력 경로로 분리** — `case 'day': d.add(t, 'day')`. week 이상과 같은 경로가 된다.
- **TZ 고정 회귀 테스트 8종 추가**(`scale.time.dst.spec.js`) — 봄/가을 전환, `{ time: 8, unit: 'day' }`, 남반구(연초가 DST 구간), `Asia/Seoul` 무변화. 프로세스 TZ 를 바꿔야 재현되므로 파일을 분리했고, **TZ 주입이 실제로 적용됐는지 검증하는 가드**를 넣었다 — 미적용 시 모든 케이스가 위양성으로 통과한다.
- **`scale/SPEC.md` 갱신** — day anchor 규칙, DST 알려진 한계의 범위(sub-day 로 한정), day 단위 자정 정렬 불변, week 미해결.

> wall-clock 자정을 유지하는 대가로 **DST 전환일의 실제 tick 간격은 23h/25h** 가 되어 반환값 `interval`(ms)과 일치하지 않는다. 그날은 하루 자체가 23h/25h 이므로 자정 정렬과 동시에 만족시킬 수 없다. 테스트로 계약을 고정했고 SPEC 에도 적었다.

# 기존 동작
<img width="1920" height="1049" alt="1" src="https://github.com/user-attachments/assets/2cd25bba-ba18-4955-8705-181cb9b3f8de" />

`interval: 'day'`, 브라우저 타임존 `America/Tijuana`(UTC-8, DST 관측) 실측:

| 조회 범위 | x축 tick |
|---|---|
| 03-05 ~ 03-12 (봄 전환 03-08 포함) | `03-06 00:00` · `03-08 00:00` · **`03-10 01:00`** |
| 10-29 ~ 11-05 (가을 전환 11-01 포함) | **`10-30 01:00`** · **`11-01 01:00`** · `11-03 00:00` · `11-05 00:00` |
| 06-01 ~ 06-09 (구간 안에 전환 없음) | **전 구간 `01:00`** — 연초 앵커와 offset 이 달라 통째로 밀린다 |
| 02-20 ~ 03-23, `{ time: 8, unit: 'day' }` | `02-26 00:00` · `03-06 00:00` · **`03-14 01:00`** · **`03-22 01:00`** |

02-20 ~ 03-23 을 1일 간격으로 조회하면 tick 이 32개가 아니라 31개다 — 누적된 1h 만큼 밀려 마지막 자정이 graphMax 를 넘어간다. 남반구(`Australia/Sydney` 등 연초가 DST 구간)에서는 반대 방향으로 밀려 전날 `23:00` 에 그려지고, 날짜만 표시하는 `timeFormat` 에서는 라벨이 하루 이르게 보인다.

# 기대 동작
<img width="1920" height="1049" alt="2" src="https://github.com/user-attachments/assets/c5828e84-aa56-4207-bfea-1dbdce614f2f" />

- 위 네 케이스 모두 tick 이 전 구간 `00:00`, 1일 간격 31일 조회는 tick 32개.
- DST 미관측 존(`Asia/Seoul`·`UTC`)과 표준시 구간의 출력은 종전과 동일 — 변경 없음.
- 격자선·눈금도 같이 정렬된다. tick 값 자체가 맞기 때문이다.

# 테스트 가이드

PC 타임존을 서머타임(DST)이 존재하는 시간대로 변경(ex: UTC-8 메히칼리 - 멕시코)하여 아래 코드 반영하여 http://localhost:9999/EVUI/api-docs/lineChart?dev&example=DstDayTick&exampleFrom=/lineChart 에서 테스트

**현재 브랜치에 아래 테스트 코드 임시로 반영해뒀습니다.**

<details><summary>테스트 코드 DstDayTick.vue</summary>

```vue
<template>
  <div class="case dst-cases">
    <div v-for="scenario in scenarios" :key="scenario.key" class="dst-case">
      <div class="dst-case__head">
        <strong>{{ scenario.name }}</strong>
        <span>결함: {{ scenario.note }}</span>
      </div>
      <resizable-wrapper height="180px">
        <ev-chart :data="scenario.chartData" :options="scenario.chartOptions" />
      </resizable-wrapper>
    </div>
  </div>

  <div class="description">
    <div class="section">
      <h3 class="section-title">브라우저 타임존</h3>
      <div class="section-body section-body--col">
        <div class="section-item">
          <label>timeZone</label>
          <strong>{{ tzInfo.zone }}</strong>
        </div>
        <div class="section-item">
          <label>UTC offset</label>
          <span>1월 {{ tzInfo.january }} / 7월 {{ tzInfo.july }}</span>
        </div>
        <div class="section-item">
          <label>DST 관측</label>
          <strong>{{ tzInfo.observesDst ? 'YES' : 'NO' }}</strong>
        </div>
      </div>
    </div>

    <div class="section">
      <h3 class="section-title">기대</h3>
      <div class="section-body section-body--col">
        <div class="section-item">
          모든 차트의 x축 tick 은 전 구간 <strong>00:00</strong> 이어야 한다.
        </div>
        <div class="section-item">
          DST 미관측 존(<code>Asia/Seoul</code>·<code>UTC</code>)에서는 재현되지 않는다.
        </div>
      </div>
    </div>
  </div>
</template>

<script>
import dayjs from 'dayjs';

/**
 * time 축 day 틱의 DST 앵커 결함 재현용 임시 예시 (ex-em/EVUI#2334).
 * timeFormat 에 시각을 넣어야 밀린 tick 이 보이므로 'MM-DD HH:mm' 을 쓴다.
 * 전환일은 US/멕시코 북부 국경(3월 2주차 일요일 / 11월 1주차 일요일) 기준이다.
 */
const SCENARIOS = [
  {
    key: 'spring',
    name: '봄 전환 포함 (03-05 ~ 03-12)',
    from: '2026-03-05 00:00:00',
    to: '2026-03-12 00:00:00',
    interval: 'day',
    note: '전환(03-08) 이후 tick 이 01:00 으로 밀린다.',
  },
  {
    key: 'fall',
    name: '가을 전환 포함 (10-29 ~ 11-05)',
    from: '2026-10-29 00:00:00',
    to: '2026-11-05 00:00:00',
    interval: 'day',
    note: '전환(11-01) 이전 tick 이 01:00 으로 밀린다.',
  },
  {
    key: 'dstOnly',
    name: 'DST 구간 전체 (06-01 ~ 06-09, 전환 미포함)',
    from: '2026-06-01 00:00:00',
    to: '2026-06-09 00:00:00',
    interval: 'day',
    note: '구간 안에 전환이 없어도 연초 앵커와 offset 이 달라 전 구간이 밀린다.',
  },
  {
    key: 'month',
    name: '31일 조회 (02-20 ~ 03-23, 봄 전환 포함)',
    from: '2026-02-20 00:00:00',
    to: '2026-03-23 00:00:00',
    interval: 'day',
    note: '실사용 형태. 전환일을 기점으로 00:00 → 01:00 으로 바뀐다.',
  },
  {
    key: 'day8',
    name: '8일 간격 ({ time: 8, unit: day })',
    from: '2026-02-20 00:00:00',
    to: '2026-03-23 00:00:00',
    interval: { time: 8, unit: 'day' },
    note: '다일 간격도 전환 이후 01:00 으로 밀린다.',
  },
];

const buildChartData = ({ from, to }) => {
  const end = dayjs(to);
  const labels = [];
  const values = [];
  for (let cursor = dayjs(from); !cursor.isAfter(end); cursor = cursor.add(1, 'hour')) {
    labels.push(cursor);
    values.push(50 + Math.round(30 * Math.sin(labels.length / 12)));
  }
  return { series: { series1: { name: 'value' } }, labels, data: { series1: values } };
};

const buildChartOptions = ({ interval }) => ({
  type: 'line',
  width: '100%',
  legend: { show: false },
  axesX: [{ type: 'time', showGrid: true, timeFormat: 'MM-DD HH:mm', interval }],
  axesY: [{ type: 'linear', showGrid: true, startToZero: true }],
});

const formatOffset = (minutes) => {
  const sign = minutes < 0 ? '-' : '+';
  const abs = Math.abs(minutes);
  const hh = String(Math.floor(abs / 60)).padStart(2, '0');
  const mm = String(abs % 60).padStart(2, '0');
  return `${sign}${hh}:${mm}`;
};

export default {
  setup() {
    const scenarios = SCENARIOS.map((scenario) => ({
      ...scenario,
      chartData: buildChartData(scenario),
      chartOptions: buildChartOptions(scenario),
    }));

    const januaryOffset = -new Date(2026, 0, 1).getTimezoneOffset();
    const julyOffset = -new Date(2026, 6, 1).getTimezoneOffset();
    const tzInfo = {
      zone: Intl.DateTimeFormat().resolvedOptions().timeZone,
      january: formatOffset(januaryOffset),
      july: formatOffset(julyOffset),
      observesDst: januaryOffset !== julyOffset,
    };

    return { scenarios, tzInfo };
  },
};
</script>

<style lang="scss">
.dst-cases {
  display: flex;
  flex-direction: column;
  gap: 16px;
}

.dst-case__head {
  display: flex;
  flex-direction: column;
  gap: 2px;
  padding: 0 0 4px;
  font-size: 12px;

  span {
    opacity: 0.7;
  }
}
</style>

```

</details> 

<details><summary>테스트 코드 props.js</summary>

```js
import { parse } from '@vue/compiler-sfc';
import mdText from './api/lineChart.md?raw';
import Default from './example/Default';
import DefaultRaw from './example/Default?raw';
import Fill from './example/Fill';
import FillRaw from './example/Fill?raw';
import FillWithNull from './example/FillWithNull';
import FillWithNullRaw from './example/FillWithNull?raw';
import Stack from './example/Stack';
import StackRaw from './example/Stack?raw';
import Event from './example/Event';
import EventRaw from './example/Event?raw';
import DragSelection from './example/DragSelection';
import DragSelectionRaw from './example/DragSelection?raw';
import Tooltip from './example/Tooltip';
import TooltipRaw from './example/Tooltip?raw';
import CustomTooltip from './example/CustomTooltip';
import CustomTooltipRaw from './example/CustomTooltip?raw';
import ExternalTooltip from './example/ExternalTooltip';
import ExternalTooltipRaw from './example/ExternalTooltip?raw';
import PlotLine from './example/PlotLine';
import PlotLineRaw from './example/PlotLine?raw';
import SelectLabel from './example/SelectLabel';
import SelectLabelRaw from './example/SelectLabel?raw';
import SelectSeries from './example/SelectSeries';
import SelectSeriesRaw from './example/SelectSeries?raw';
import AxisTitle from './example/AxisTitle';
import AxisTitleRaw from './example/AxisTitle?raw';
import PassingValue from './example/PassingValue';
import PassingValueRaw from './example/PassingValue?raw';
import HoverWithGroup from './example/HoverWithGroup';
import HoverWithGroupRaw from './example/HoverWithGroup?raw';
import LegendVirtualScroll from './example/LegendVirtualScroll';
import LegendVirtualScrollRaw from './example/LegendVirtualScroll?raw';
import ExternalLegend from './example/ExternalLegend';
import ExternalLegendRaw from './example/ExternalLegend?raw';
import Segments from './example/Segments';
import SegmentsRaw from './example/Segments?raw';
import DstDayTick from './example/DstDayTick';
import DstDayTickRaw from './example/DstDayTick?raw';
import Interpolation from './example/Interpolation';
import InterpolationRaw from './example/Interpolation?raw';
import LegendClickMode from './example/LegendClickMode';
import LegendClickModeRaw from './example/LegendClickMode?raw';
import AxesScaleChange from './example/AxesScaleChange';
import AxesScaleChangeRaw from './example/AxesScaleChange?raw';
import DisplayOverflow from './example/DisplayOverflow';
import DisplayOverflowRaw from './example/DisplayOverflow?raw';
import UnSelectedOpacity from './example/UnSelectedOpacity';
import UnSelectedOpacityRaw from './example/UnSelectedOpacity?raw';
import PerfStressSingle from './example/PerfStressSingle';
import PerfStressSingleRaw from './example/PerfStressSingle?raw';
import Annotations from './example/Annotations';
import AnnotationsRaw from './example/Annotations?raw';

export default {
  mdText,
  components: {
    Default: {
      description:
        'Line Chart는 각각의 데이터를 선으로 연결하여 추이를 시각적으로 인지하는 차트입니다.',
      component: Default,
      parsedData: parse(DefaultRaw).descriptor,
    },
    Fill: {
      description:
        'Line Chart의 Fill 옵션을 이용하여 각 계열 데이터의 양을 좀 더 쉽게 인지할 수 있도록 합니다.',
      component: Fill,
      parsedData: parse(FillRaw).descriptor,
    },
    'Fill (with null)': {
      description:
        'Area(fill) 시리즈 2개 중 한쪽에 null 값이 섞여 있을 때, 해당 라벨의 빈 영역을 클릭하면 null 시리즈가 아닌 값이 존재하는 시리즈가 선택되는지 검증하는 예제입니다.',
      component: FillWithNull,
      parsedData: parse(FillWithNullRaw).descriptor,
      devOnly: true,
    },
    Stack: {
      description:
        'Stack Line Chart는 계열의 순서에 맞춰 데이터를 누적하여 각 계열의 데이터 비교를 시각적으로 판단하는데 도움을 줍니다.',
      component: Stack,
      parsedData: parse(StackRaw).descriptor,
    },
    Event: {
      description: 'Click, Double Click 등 이벤트 등록이 가능합니다.',
      component: Event,
      parsedData: parse(EventRaw).descriptor,
    },
    'Select Label': {
      description: '차트 전체에서 선택한 라벨 내 모든 아이템이 하이라이트 되는 기능입니다.',
      component: SelectLabel,
      parsedData: parse(SelectLabelRaw).descriptor,
    },
    'Select Series': {
      description: '선택한 시리즈가 하이라이트 되어 보이는 기능입니다.',
      component: SelectSeries,
      parsedData: parse(SelectSeriesRaw).descriptor,
    },
    UnSelectedOpacity: {
      description: 'unSelectedOpacity 옵션으로 비선택 요소의 opacity를 설정할 수 있습니다',
      component: UnSelectedOpacity,
      parsedData: parse(UnSelectedOpacityRaw).descriptor,
      devOnly: true,
    },
    DragSelection: {
      description: 'Drag Select 이벤트 등록이 가능 합니다',
      component: DragSelection,
      parsedData: parse(DragSelectionRaw).descriptor,
    },
    Tooltip: {
      description: 'Tooltip 기능으로 마우스가 위치한 곳의 값을 볼 수 있습니다.',
      component: Tooltip,
      parsedData: parse(TooltipRaw).descriptor,
    },
    'Custom Tooltip': {
      description: 'Tooltip의 내용을 HTML로 가공하여 구성할 수 있습니다.',
      component: CustomTooltip,
      parsedData: parse(CustomTooltipRaw).descriptor,
    },
    'External Tooltip': {
      description: 'Tooltip의 내용을 외부에서 제어할 수 있습니다.',
      component: ExternalTooltip,
      parsedData: parse(ExternalTooltipRaw).descriptor,
    },
    'External Tooltip': {
      description: 'Tooltip의 내용을 외부에서 제어할 수 있습니다.',
      component: ExternalTooltip,
      parsedData: parse(ExternalTooltipRaw).descriptor,
    },
    'Plot line & Plot band': {
      description: '차트 배경에 선 및 영역을 표시할 수 있습니다.',
      component: PlotLine,
      parsedData: parse(PlotLineRaw).descriptor,
    },
    AxisTitle: {
      description: '차트 축에 title을 설정할 수 있습니다.',
      component: AxisTitle,
      parsedData: parse(AxisTitleRaw).descriptor,
    },
    PassingValue: {
      description:
        'passingValue를 설정하여 특정 시점에 line을 끊지 않고 자연스럽게 이을 수 있습니다.',
      component: PassingValue,
      parsedData: parse(PassingValueRaw).descriptor,
      devOnly: true,
    },
    DstDayTick: {
      description:
        '[임시 · ex-em/EVUI#2334] time 축 day 틱의 DST 앵커 결함 재현용. 브라우저 타임존이 DST 관측 존일 때 tick 이 자정에서 벗어난다.',
      component: DstDayTick,
      parsedData: parse(DstDayTickRaw).descriptor,
      devOnly: true,
    },
    Interpolation: {
      description: 'Interpolation 옵션을 설정하여 null Data를 보간하여 선을 그릴 수 있습니다.',
      component: Interpolation,
      parsedData: parse(InterpolationRaw).descriptor,
    },
    HoverWithGroup: {
      description: '',
      component: HoverWithGroup,
      parsedData: parse(HoverWithGroupRaw).descriptor,
      devOnly: true,
    },
    LegendVirtualScroll: {
      description: 'Legend Virtual Scroll',
      component: LegendVirtualScroll,
      parsedData: parse(LegendVirtualScrollRaw).descriptor,
      devOnly: true,
    },
    ExternalLegend: {
      description: 'External Legend를 사용하여 차트 외부에서 범례를 커스터마이징할 수 있습니다.',
      component: ExternalLegend,
      parsedData: parse(ExternalLegendRaw).descriptor,
    },
    Segments: {
      description: 'Segments',
      component: Segments,
      parsedData: parse(SegmentsRaw).descriptor,
      devOnly: true,
    },
    LegendClickMode: {
      description: 'Legend Click Mode',
      component: LegendClickMode,
      parsedData: parse(LegendClickModeRaw).descriptor,
      devOnly: true,
    },
    AxesScaleChange: {
      description:
        '차트 사이즈를 변경하면 axes-scale-change 이벤트로 재계산된 minSteps, maxSteps를 확인할 수 있습니다.',
      component: AxesScaleChange,
      parsedData: parse(AxesScaleChangeRaw).descriptor,
      devOnly: true,
    },
    DisplayOverflow: {
      description:
        'displayOverflow 옵션으로 값 축(Y) range를 초과한 데이터를 상단 경계에 기본 시리즈 색으로 모아 표시할 수 있습니다. false(기본값)면 range 밖 데이터는 숨겨집니다.',
      component: DisplayOverflow,
      parsedData: parse(DisplayOverflowRaw).descriptor,
      devOnly: true,
    },
    PerfStressSingle: {
      description:
        'A 프로파일 성능 stress 예제 — line 만 개 시리즈 단일 차트를 초당 1회 갱신합니다. ' +
        '시리즈 수·포인트 수는 상수로 조절하며, append(슬라이딩 윈도우)/full-replace 갱신을 토글할 수 있습니다.',
      component: PerfStressSingle,
      parsedData: parse(PerfStressSingleRaw).descriptor,
      devOnly: true,
    },
    Annotations: {
      description:
        'annotations 옵션으로 차트 위에 어노테이션/뱃지를 표시합니다. type(text/badge/callout/circle), '
        + 'position(axis/pixel/series), content 토큰·콜백, connector(연결선)를 지원합니다.',
      component: Annotations,
      parsedData: parse(AnnotationsRaw).descriptor,
    },
  },
};

```

</details> 

- [ ] `npx vitest run src/components/chart/scale` — 181 tests(DST 8종 신규), `npm run lint` 통과
- [ ] TZ 주입 경로 확인: `TZ=Asia/Seoul npx vitest run src/components/chart/scale/scale.time.dst.spec.js` — 가드가 TZ 를 강제하므로 호스트 TZ 와 무관하게 통과해야 한다
- [ ] 수동: OS(브라우저) 타임존을 DST 관측 존으로 바꾸고 `interval: 'day'` 을 쓰는 예시(`docs/views/lineChart/example/Event.vue` 등)에서 `timeFormat` 에 `HH:mm` 을 포함시켜 tick 이 `00:00` 인지 확인. 현재 예시들은 `timeFormat: 'YYYY-MM-DD'` 라 시각이 가려져 있다
- [ ] 수동: 타임존을 `Asia/Seoul` 로 되돌려 동일 화면에 회귀가 없는지 확인
- [ ] 결함 재현 확인(선택): `ceilToBoundary` 의 day 분기를 ms 산술로 되돌리면 DST 테스트 5종이 실패한다

